### PR TITLE
Fixes help desc. spo site set. Closes #1768

### DIFF
--- a/src/m365/spo/commands/site/site-set.ts
+++ b/src/m365/spo/commands/site/site-set.ts
@@ -550,7 +550,7 @@ class SpoSiteSetCommand extends SpoCommand {
       ${this.name} --url https://contoso.sharepoint.com/sites/sales --title "My new site"
 
     Restrict external sharing to already available external users only
-      ${this.name} --url https://contoso.sharepoint.com/sites/sales --sharingCapabilities ExternalUserSharingOnly
+      ${this.name} --url https://contoso.sharepoint.com/sites/sales --sharingCapability ExternalUserSharingOnly
 `);
   }
 }


### PR DESCRIPTION
> ### Fixes bug - Updated  help description for parameter sharingCapability. Closes 1768
>This is PR which fixes the help description which was mentioned wrong for the parameter `sharingCapability`


> ### Linked Issue

Closes #1768 
