### PR TITLE
Whitelist Register-CLIM365Completion.ps1 in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@ coverage
 docs
 node_modules
 scripts/*
-!scripts/Register-O365CLICompletion.ps1
+!scripts/Register-CLIM365Completion.ps1
 src
 types
 .gitignore


### PR DESCRIPTION
> ### Fixes tab completion script missing from npm package build in v3.x
- Renames the tab completion script to Register-CLIM365Completion.ps1 in .npmignore

> ### Linked Issue

Related to original fix at #1551