### PR TITLE
Extend tenant status list with workload. Closes #1743

### DIFF
--- a/docs/docs/cmd/tenant/status/status-list.md
+++ b/docs/docs/cmd/tenant/status/status-list.md
@@ -13,6 +13,7 @@ tenant status list [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
+`-w, --workload [workload]`|Allows retrieval of current service status of only one particular service. If not provided, list the current service status of all services will be returned.
 `--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
@@ -24,6 +25,12 @@ Get health status of the different services in Microsoft 365
 
 ```sh
 tenant status list
+```
+
+Gets health status for a particular service. For e.g. :  SharePoint Online
+
+```sh
+tenant status list -w "SharePoint"
 ```
 
 ## More information

--- a/src/m365/tenant/commands/status/status-list.spec.ts
+++ b/src/m365/tenant/commands/status/status-list.spec.ts
@@ -274,4 +274,108 @@ describe(commands.TENANT_STATUS_LIST, () => {
     });
   });
 
+  it('gets the status of Microsoft 365 services - JSON Output With Workload', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      requests.push(opts);
+      if ((opts.url as string).indexOf('CurrentStatus') > -1) {
+        return Promise.resolve(jsonOutput);
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({
+      options: {
+        workload: 'Forms',
+        output: 'json',
+        debug: false
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith(jsonOutput));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the status of Microsoft 365 services - JSON Output With Workload (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      requests.push(opts);
+      if ((opts.url as string).indexOf('CurrentStatus') > -1) {
+        return Promise.resolve(jsonOutput);
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({
+      options: {
+        workload: 'Forms',
+        output: 'json',
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith(jsonOutput));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the status of Microsoft 365 services - text Output With Workload', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      requests.push(opts);
+      if ((opts.url as string).indexOf('CurrentStatus') > -1) {
+        return Promise.resolve(jsonOutput);
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({
+      options: {
+        workload: 'Forms',
+        output: 'text',
+        debug: false
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith(textOutput));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the status of Microsoft 365 services - text Output With Workload (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      requests.push(opts);
+      if ((opts.url as string).indexOf('CurrentStatus') > -1) {
+        return Promise.resolve(jsonOutput);
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({
+      options: {
+        workload: 'Forms',
+        output: 'text',
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith(textOutput));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
 });


### PR DESCRIPTION
> ### Extend tenant status list with filter for workload. Closes #1743 

Extends 'tenant status list' with support for optional filter for workload. Closes #1743 

> ### Linked Issue

Closes #1743 
