### PR TITLE
Fixes long running copy operations. Closes #1698

### DIFF
--- a/src/m365/spo/commands/file/file-copy.spec.ts
+++ b/src/m365/spo/commands/file/file-copy.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError, CommandCancel } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
@@ -63,7 +63,7 @@ describe(commands.FILE_COPY, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     sinon.stub((command as any), 'getRequestDigest').callsFake(() => Promise.resolve({
       FormDigestValue: 'abc'
     }));
@@ -145,6 +145,55 @@ describe(commands.FILE_COPY, () => {
     }, () => {
       try {
         assert(cmdInstanceLogSpy.callCount === 0);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should complete successfully in 4 tries. ', (done) => {
+    var counter = 4;
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/recycle()') > -1) {
+        return Promise.resolve();
+      }
+
+      if ((opts.url as string).indexOf('/_api/site/CreateCopyJobs') > -1) {
+        return Promise.resolve({ value: [{ "EncryptionKey": "6G35dpTMegtzqT3rsZ/av6agpsqx/SUyaAHBs9fJE6A=", "JobId": "cee65dc5-8d05-41cc-8657-92a12d213f76", "JobQueueUri": "https://spobn1sn1m001pr.queue.core.windows.net:443/1246pq20180429-5305d83990eb483bb93e7356252715b4?sv=2014-02-14&sig=JUwFF1B0KVC2h0o5qieHPUG%2BQE%2BEhJHNpbzFf8QmCGc%3D&st=2018-04-28T07%3A00%3A00Z&se=2018-05-20T07%3A00%3A00Z&sp=rap" }] });
+      }
+
+      if ((opts.url as string).indexOf('/_api/site/GetCopyJobProgress') > -1) {
+        // substract jobstate untill we hit jobstate = 0 (success)
+        counter = (counter - 1);
+
+        return Promise.resolve({
+          JobState: counter,
+          Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    stubAllGetRequests();
+
+    sinon.stub(global as NodeJS.Global, 'setTimeout').callsFake((fn, to) => {
+      fn();
+      return {} as any;
+    });
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        sourceUrl: 'abc/abc.pdf',
+        targetUrl: 'abc'
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.lastCall.args[0] === 'DONE');
         done();
       }
       catch (e) {
@@ -363,173 +412,6 @@ describe(commands.FILE_COPY, () => {
     });
   });
 
-  it('should setTimeout when waitForJobResult JobState is not 0', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    postRequests.onFirstCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:29.945\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Export\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{}\",\r\n  \"ObjectsStatsByType\": \"{}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobLogFileCreate\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.539\",\r\n  \"FileName\": \"Import-7be2c14c-b998-4b30-9b43-c2be0f95d8b9-0.log\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobStart\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.570\",\r\n  \"SiteId\": \"956c8970-f858-42ac-a06f-bbdca4a0374b\",\r\n  \"WebId\": \"d6d96969-217f-4306-b15b-fe35b6b754cc\",\r\n  \"DBId\": \"eb30ff26-a12c-431e-bb10-68fdac21ce28\",\r\n  \"FarmId\": \"67b76b49-9245-4dfc-a1f7-b4503cf6ea69\",\r\n  \"ServerId\": \"2a00b725-2871-4e42-98fd-e41c577ed494\",\r\n  \"SubscriptionId\": \"ea1787c6-7ce2-4e71-be47-5e0deb30f9e4\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}"]
-    });
-
-    postRequests.onSecondCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 5
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert(resp === undefined);
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert.fail('waitForJobResult couldn\'t resolve.');
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should setTimeout when waitForJobResult reject, but retry limit not reached', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    // GetCopyJobProgress reject
-    postRequests.onFirstCall().rejects('error');
-    // GetCopyJobProgress #2 JobState = 0
-    postRequests.onSecondCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 1
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert(resp === undefined);
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert.fail('waitForJobResult couldn\'t resolve.');
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should show error when waitForJobResult reject and retry limit reached', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    postRequests.onFirstCall().rejects('error');
-    postRequests.onSecondCall().rejects('error');
-    postRequests.onThirdCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 1
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert.fail('waitForJobResult shouldn\'t resolve, but reject.');
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert(e !== undefined);
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should waitForJobResult timeout', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    // GetCopyJobProgress #1 JobState = 4
-    postRequests.onFirstCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:29.945\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Export\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{}\",\r\n  \"ObjectsStatsByType\": \"{}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobLogFileCreate\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.539\",\r\n  \"FileName\": \"Import-7be2c14c-b998-4b30-9b43-c2be0f95d8b9-0.log\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobStart\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.570\",\r\n  \"SiteId\": \"956c8970-f858-42ac-a06f-bbdca4a0374b\",\r\n  \"WebId\": \"d6d96969-217f-4306-b15b-fe35b6b754cc\",\r\n  \"DBId\": \"eb30ff26-a12c-431e-bb10-68fdac21ce28\",\r\n  \"FarmId\": \"67b76b49-9245-4dfc-a1f7-b4503cf6ea69\",\r\n  \"ServerId\": \"2a00b725-2871-4e42-98fd-e41c577ed494\",\r\n  \"SubscriptionId\": \"ea1787c6-7ce2-4e71-be47-5e0deb30f9e4\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}"]
-    });
-    // GetCopyJobProgress #2 JobState = 0
-    postRequests.onSecondCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 1,
-      progressPollInterval: 0,
-      progressRetryAttempts: 5
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert.fail('waitForJobResult shouldn\'t resolve, but reject.');
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert(e !== undefined);
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
   it('should complete successfully where baseUrl has a trailing /', (done) => {
     let actual: string = '';
     const expected: string = JSON.stringify({
@@ -665,6 +547,24 @@ describe(commands.FILE_COPY, () => {
         done(e);
       }
     });
+  });
+
+  it('can be cancelled', () => {
+    assert(command.cancel());
+  });
+
+  it('clears pending connection on cancel', () => {
+    (command as any).timeout = {};
+    const clearTimeoutSpy = sinon.spy(global, 'clearTimeout');
+    (command.cancel() as CommandCancel)();
+    Utils.restore(global.clearTimeout);
+    assert(clearTimeoutSpy.called);
+  });
+
+  it('doesn\'t fail on cancel if no connection pending', () => {
+    (command as any).timeout = undefined;
+    (command.cancel() as CommandCancel)();
+    assert(true);
   });
 
   it('supports debug mode', () => {

--- a/src/m365/spo/commands/file/file-move.spec.ts
+++ b/src/m365/spo/commands/file/file-move.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError, CommandCancel } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
@@ -63,7 +63,7 @@ describe(commands.FILE_MOVE, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     sinon.stub((command as any), 'getRequestDigest').callsFake(() => Promise.resolve({
       FormDigestValue: 'abc'
     }));
@@ -144,6 +144,50 @@ describe(commands.FILE_MOVE, () => {
     }, () => {
       try {
         assert(cmdInstanceLogSpy.callCount === 0);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should complete successfully in 4 tries. ', (done) => {
+    var counter = 4;
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/recycle()') > -1) {
+        return Promise.resolve();
+      }
+
+      if ((opts.url as string).indexOf('/_api/site/CreateCopyJobs') > -1) {
+        return Promise.resolve({ value: [{ "EncryptionKey": "6G35dpTMegtzqT3rsZ/av6agpsqx/SUyaAHBs9fJE6A=", "JobId": "cee65dc5-8d05-41cc-8657-92a12d213f76", "JobQueueUri": "https://spobn1sn1m001pr.queue.core.windows.net:443/1246pq20180429-5305d83990eb483bb93e7356252715b4?sv=2014-02-14&sig=JUwFF1B0KVC2h0o5qieHPUG%2BQE%2BEhJHNpbzFf8QmCGc%3D&st=2018-04-28T07%3A00%3A00Z&se=2018-05-20T07%3A00%3A00Z&sp=rap" }] });
+      }
+
+      if ((opts.url as string).indexOf('/_api/site/GetCopyJobProgress') > -1) {
+        // substract jobstate untill we hit jobstate = 0 (success)
+        counter = (counter - 1);
+
+        return Promise.resolve({
+          JobState: counter,
+          Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    stubAllGetRequests();
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        sourceUrl: 'abc/abc.pdf',
+        targetUrl: 'abc'
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.lastCall.args[0] === 'DONE');
         done();
       }
       catch (e) {
@@ -362,173 +406,6 @@ describe(commands.FILE_MOVE, () => {
     });
   });
 
-  it('should setTimeout when waitForJobResult JobState is not 0', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    postRequests.onFirstCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:29.945\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Export\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{}\",\r\n  \"ObjectsStatsByType\": \"{}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobLogFileCreate\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.539\",\r\n  \"FileName\": \"Import-7be2c14c-b998-4b30-9b43-c2be0f95d8b9-0.log\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobStart\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.570\",\r\n  \"SiteId\": \"956c8970-f858-42ac-a06f-bbdca4a0374b\",\r\n  \"WebId\": \"d6d96969-217f-4306-b15b-fe35b6b754cc\",\r\n  \"DBId\": \"eb30ff26-a12c-431e-bb10-68fdac21ce28\",\r\n  \"FarmId\": \"67b76b49-9245-4dfc-a1f7-b4503cf6ea69\",\r\n  \"ServerId\": \"2a00b725-2871-4e42-98fd-e41c577ed494\",\r\n  \"SubscriptionId\": \"ea1787c6-7ce2-4e71-be47-5e0deb30f9e4\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}"]
-    });
-
-    postRequests.onSecondCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 5
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert(resp === undefined);
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert.fail('waitForJobResult couldn\'t resolve.');
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should setTimeout when waitForJobResult reject, but retry limit not reached', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    // GetCopyJobProgress reject
-    postRequests.onFirstCall().rejects('error');
-    // GetCopyJobProgress #2 JobState = 0
-    postRequests.onSecondCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 1
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert(resp === undefined);
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert.fail('waitForJobResult couldn\'t resolve.');
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should show error when waitForJobResult reject and retry limit reached', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    postRequests.onFirstCall().rejects('error');
-    postRequests.onSecondCall().rejects('error');
-    postRequests.onThirdCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 1
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert.fail('waitForJobResult shouldn\'t resolve, but reject.');
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert(e !== undefined);
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should waitForJobResult timeout', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    // GetCopyJobProgress #1 JobState = 4
-    postRequests.onFirstCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:29.945\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Export\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{}\",\r\n  \"ObjectsStatsByType\": \"{}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobLogFileCreate\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.539\",\r\n  \"FileName\": \"Import-7be2c14c-b998-4b30-9b43-c2be0f95d8b9-0.log\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobStart\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.570\",\r\n  \"SiteId\": \"956c8970-f858-42ac-a06f-bbdca4a0374b\",\r\n  \"WebId\": \"d6d96969-217f-4306-b15b-fe35b6b754cc\",\r\n  \"DBId\": \"eb30ff26-a12c-431e-bb10-68fdac21ce28\",\r\n  \"FarmId\": \"67b76b49-9245-4dfc-a1f7-b4503cf6ea69\",\r\n  \"ServerId\": \"2a00b725-2871-4e42-98fd-e41c577ed494\",\r\n  \"SubscriptionId\": \"ea1787c6-7ce2-4e71-be47-5e0deb30f9e4\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}"]
-    });
-    // GetCopyJobProgress #2 JobState = 0
-    postRequests.onSecondCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 1,
-      progressPollInterval: 0,
-      progressRetryAttempts: 5
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert.fail('waitForJobResult shouldn\'t resolve, but reject.');
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert(e !== undefined);
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
 
   it('should complete successfully where baseUrl has a trailing /', (done) => {
     let actual: string = '';
@@ -668,6 +545,24 @@ describe(commands.FILE_MOVE, () => {
         done(e);
       }
     });
+  });
+
+  it('can be cancelled', () => {
+    assert(command.cancel());
+  });
+
+  it('clears pending connection on cancel', () => {
+    (command as any).timeout = {};
+    const clearTimeoutSpy = sinon.spy(global, 'clearTimeout');
+    (command.cancel() as CommandCancel)();
+    Utils.restore(global.clearTimeout);
+    assert(clearTimeoutSpy.called);
+  });
+
+  it('doesn\'t fail on cancel if no connection pending', () => {
+    (command as any).timeout = undefined;
+    (command.cancel() as CommandCancel)();
+    assert(true);
   });
 
   it('supports debug mode', () => {

--- a/src/m365/spo/commands/file/file-move.ts
+++ b/src/m365/spo/commands/file/file-move.ts
@@ -3,7 +3,8 @@ import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import {
   CommandOption,
-  CommandValidate
+  CommandValidate,
+  CommandCancel
 } from '../../../../Command';
 import SpoCommand from '../../../base/SpoCommand';
 import { ContextInfo } from '../../spo';
@@ -23,30 +24,10 @@ interface Options extends GlobalOptions {
   allowSchemaMismatch?: boolean;
 }
 
-interface JobProgressOptions {
-  webUrl: string;
-  /**
-   * Response object retrieved from /_api/site/CreateCopyJobs
-   */
-  copyJopInfo: any;
-  /**
-   * Poll interval to call /_api/site/GetCopyJobProgress
-   */
-  progressPollInterval: number;
-  /**
-   * Max poll intervals to call /_api/site/GetCopyJobProgress
-   * after which to give up
-   */
-  progressMaxPollAttempts: number;
-  /**
-   * Retry attempts before give up.
-   * Give up if /_api/site/GetCopyJobProgress returns 
-   * X reject promises in a row
-   */
-  progressRetryAttempts: number;
-}
-
 class SpoFileMoveCommand extends SpoCommand {
+  private dots?: string;
+  private timeout?: NodeJS.Timer;
+
   public get name(): string {
     return commands.FILE_MOVE;
   }
@@ -69,7 +50,7 @@ class SpoFileMoveCommand extends SpoCommand {
 
     // Check if the source file exists.
     // Called on purpose, we explicitly check if user specified file
-    // in the sourceUrl option. 
+    // in the sourceUrl option.
     // The CreateCopyJobs endpoint accepts file, folder or batch from both.
     // A user might enter folder instead of file as source url by mistake
     // then there are edge cases when deleteIfAlreadyExists flag is set
@@ -110,15 +91,16 @@ class SpoFileMoveCommand extends SpoCommand {
         return request.post(requestOptions);
       })
       .then((jobInfo: any): Promise<any> => {
-        const jobProgressOptions: JobProgressOptions = {
-          webUrl: webUrl,
-          copyJopInfo: jobInfo.value[0],
-          progressMaxPollAttempts: 1000, // 1 sec.
-          progressPollInterval: 30 * 60, // approx. 30 mins. if interval is 1000
-          progressRetryAttempts: 5
-        }
+        return new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
+          this.dots = '';
 
-        return this.waitForJobResult(jobProgressOptions, cmd);
+          const copyJobInfo: any = jobInfo.value[0];
+          const progressPollInterval: number = 1800; // 30 * 60; //used previously implemented interval. The API does not provide guidance on what value should be used.
+
+          this.timeout = setTimeout(() => {
+            this.waitUntilCopyJobFinished(copyJobInfo, webUrl, progressPollInterval, resolve, reject, cmd, this.dots, this.timeout)
+          }, progressPollInterval);
+        });
       })
       .then((): void => {
         if (this.verbose) {
@@ -146,82 +128,6 @@ class SpoFileMoveCommand extends SpoCommand {
     };
 
     return request.get(requestOptions);
-  }
-
-  /**
-   * A polling function that awaits the 
-   * queued copy job to return JobStatus = 0 meaning it is done with the task.
-   */
-  private waitForJobResult(opts: JobProgressOptions, cmd: CommandInstance): Promise<void> {
-    let pollCount: number = 0;
-    let retryAttemptsCount: number = 0;
-
-    const checkCondition = (resolve: () => void, reject: (error: any) => void): void => {
-      pollCount++;
-      const requestUrl: string = `${opts.webUrl}/_api/site/GetCopyJobProgress`;
-      const requestOptions: any = {
-        url: requestUrl,
-        headers: {
-          'accept': 'application/json;odata=nometadata'
-        },
-        body: { "copyJobInfo": opts.copyJopInfo },
-        json: true
-      };
-
-      request.post<{ JobState?: number, Logs: string[] }>(requestOptions).then((resp: { JobState?: number, Logs: string[] }): void => {
-        retryAttemptsCount = 0; // clear retry on promise success 
-
-        if (this.verbose) {
-          if (resp.JobState && resp.JobState === 4) {
-            cmd.log(`Check #${pollCount}. Copy job in progress... JobState: ${resp.JobState}`);
-          }
-          else {
-            cmd.log(`Check #${pollCount}. JobState: ${resp.JobState}`);
-          }
-        }
-
-        for (const item of resp.Logs) {
-          const log = JSON.parse(item);
-
-          // reject if progress error 
-          if (log.Event === "JobError" || log.Event === "JobFatalError") {
-            return reject(log.Message);
-          }
-        }
-
-        // three possible scenarios
-        // job done = success promise returned
-        // job in progress = recursive call using setTimeout returned
-        // max poll attempts flag raised = reject promise returned
-        if (resp.JobState === 0) {
-          // job done
-          resolve();
-          return;
-        }
-
-        if (pollCount < opts.progressMaxPollAttempts) {
-          // if the condition isn't met but the timeout hasn't elapsed, go again
-          setTimeout(checkCondition, opts.progressPollInterval, resolve, reject);
-        }
-        else {
-          reject(new Error('waitForJobResult timed out'));
-        }
-      },
-        (error: any): void => {
-          retryAttemptsCount++;
-
-          // let's retry x times in row before we give up since
-          // this is progress check and even if rejects a promise
-          // the actual move process can success.
-          if (retryAttemptsCount <= opts.progressRetryAttempts) {
-            setTimeout(checkCondition, opts.progressPollInterval, resolve, reject);
-          } else {
-            reject(error);
-          }
-        });
-    }
-
-    return new Promise<void>(checkCondition);
   }
 
   /**
@@ -280,28 +186,12 @@ class SpoFileMoveCommand extends SpoCommand {
     });
   }
 
-  /**
-   * Combines base and relative url considering any missing slashes
-   * @param baseUrl https://contoso.com
-   * @param relativeUrl sites/abc
-   */
-  private urlCombine(baseUrl: string, relativeUrl: string): string {
-    // remove last '/' of base if exists
-    if (baseUrl.lastIndexOf('/') === baseUrl.length - 1) {
-      baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+  public cancel(): CommandCancel {
+    return (): void => {
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
     }
-
-    // remove '/' at 0
-    if (relativeUrl.charAt(0) === '/') {
-      relativeUrl = relativeUrl.substring(1, relativeUrl.length);
-    }
-
-    // remove last '/' of next if exists
-    if (relativeUrl.lastIndexOf('/') === relativeUrl.length - 1) {
-      relativeUrl = relativeUrl.substring(0, relativeUrl.length - 1);
-    }
-
-    return `${baseUrl}/${relativeUrl}`;
   }
 
   public options(): CommandOption[] {
@@ -360,12 +250,12 @@ class SpoFileMoveCommand extends SpoCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Remarks:
-  
+
     When you move a file using the ${chalk.grey(this.name)} command,
     all of the versions are being moved.
-        
+
   Examples:
-  
+
     Move file to a document library in another site collection
       ${commands.FILE_MOVE} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/sp1.pdf --targetUrl /sites/test2/Shared%20Documents/
 
@@ -376,10 +266,10 @@ class SpoFileMoveCommand extends SpoCommand {
     the same name already exists in the target document library, move it
     to the recycle bin
         ${commands.FILE_MOVE} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/sp1.pdf --targetUrl /sites/test2/Shared%20Documents/ --deleteIfAlreadyExists
-    
+
     Moves file to a document library in another site collection. Will ignore any missing fields in the target destination and move anyway
       ${commands.FILE_MOVE} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/sp1.pdf --targetUrl /sites/test2/Shared%20Documents/ --allowSchemaMismatch
-   
+
   More information:
 
     Move items from a SharePoint document library

--- a/src/m365/spo/commands/folder/folder-copy.spec.ts
+++ b/src/m365/spo/commands/folder/folder-copy.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError, CommandCancel } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
@@ -149,6 +149,51 @@ describe(commands.FOLDER_COPY, () => {
     });
   });
 
+  it('should complete successfully in 4 tries. ', (done) => {
+    var counter = 4;
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/recycle()') > -1) {
+        return Promise.resolve();
+      }
+
+      if ((opts.url as string).indexOf('/_api/site/CreateCopyJobs') > -1) {
+        return Promise.resolve({ value: [{ "EncryptionKey": "6G35dpTMegtzqT3rsZ/av6agpsqx/SUyaAHBs9fJE6A=", "JobId": "cee65dc5-8d05-41cc-8657-92a12d213f76", "JobQueueUri": "https://spobn1sn1m001pr.queue.core.windows.net:443/1246pq20180429-5305d83990eb483bb93e7356252715b4?sv=2014-02-14&sig=JUwFF1B0KVC2h0o5qieHPUG%2BQE%2BEhJHNpbzFf8QmCGc%3D&st=2018-04-28T07%3A00%3A00Z&se=2018-05-20T07%3A00%3A00Z&sp=rap" }] });
+      }
+
+      if ((opts.url as string).indexOf('/_api/site/GetCopyJobProgress') > -1) {
+        // substract jobstate untill we hit jobstate = 0 (success)
+        counter = (counter - 1);
+
+        return Promise.resolve({
+          JobState: counter,
+          Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
+        });
+      }
+
+      return Promise.reject('Invalid request');
+
+    });
+
+    stubAllGetRequests();
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        sourceUrl: 'abc/abc.pdf',
+        targetUrl: 'abc'
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.lastCall.args[0] === 'DONE');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('should show error when waitForJobResult rejects with JobError', (done) => {
     const waitForJobResult = new Promise<any>((resolve, reject) => {
       const log = JSON.stringify({ Event: 'JobError', Message: 'error1' });
@@ -199,174 +244,6 @@ describe(commands.FOLDER_COPY, () => {
         done(e);
       }
     });
-  });
-
-  it('should setTimeout when waitForJobResult JobState is not 0', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    postRequests.onFirstCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:29.945\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Export\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{}\",\r\n  \"ObjectsStatsByType\": \"{}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobLogFolderCreate\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.539\",\r\n  \"FolderName\": \"Import-7be2c14c-b998-4b30-9b43-c2be0f95d8b9-0.log\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobStart\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.570\",\r\n  \"SiteId\": \"956c8970-f858-42ac-a06f-bbdca4a0374b\",\r\n  \"WebId\": \"d6d96969-217f-4306-b15b-fe35b6b754cc\",\r\n  \"DBId\": \"eb30ff26-a12c-431e-bb10-68fdac21ce28\",\r\n  \"FarmId\": \"67b76b49-9245-4dfc-a1f7-b4503cf6ea69\",\r\n  \"ServerId\": \"2a00b725-2871-4e42-98fd-e41c577ed494\",\r\n  \"SubscriptionId\": \"ea1787c6-7ce2-4e71-be47-5e0deb30f9e4\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}"]
-    });
-
-    postRequests.onSecondCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 5
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert(resp === undefined);
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert.fail('waitForJobResult couldn\'t resolve.');
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should setTimeout when waitForJobResult reject, but retry limit not reached', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    // GetCopyJobProgress reject
-    postRequests.onFirstCall().rejects('error');
-    // GetCopyJobProgress #2 JobState = 0
-    postRequests.onSecondCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 1
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert(resp === undefined);
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert.fail('waitForJobResult couldn\'t resolve.');
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should show error when waitForJobResult reject and retry limit reached', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    postRequests.onFirstCall().rejects('error');
-    postRequests.onSecondCall().rejects('error');
-    postRequests.onThirdCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 1
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert.fail('waitForJobResult shouldn\'t resolve, but reject.');
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert(e !== undefined);
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should waitForJobResult timeout', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    // GetCopyJobProgress #1 JobState = 4
-    postRequests.onFirstCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:29.945\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Export\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{}\",\r\n  \"ObjectsStatsByType\": \"{}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobLogFolderCreate\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.539\",\r\n  \"FolderName\": \"Import-7be2c14c-b998-4b30-9b43-c2be0f95d8b9-0.log\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobStart\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.570\",\r\n  \"SiteId\": \"956c8970-f858-42ac-a06f-bbdca4a0374b\",\r\n  \"WebId\": \"d6d96969-217f-4306-b15b-fe35b6b754cc\",\r\n  \"DBId\": \"eb30ff26-a12c-431e-bb10-68fdac21ce28\",\r\n  \"FarmId\": \"67b76b49-9245-4dfc-a1f7-b4503cf6ea69\",\r\n  \"ServerId\": \"2a00b725-2871-4e42-98fd-e41c577ed494\",\r\n  \"SubscriptionId\": \"ea1787c6-7ce2-4e71-be47-5e0deb30f9e4\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}"]
-    });
-    // GetCopyJobProgress #2 JobState = 0
-    postRequests.onSecondCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      accessToken: 'abc',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 1,
-      progressPollInterval: 0,
-      progressRetryAttempts: 5
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).waitForJobResult(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert.fail('waitForJobResult shouldn\'t resolve, but reject.');
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert(e !== undefined);
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
   });
 
   it('should complete successfully where baseUrl has a trailing /', (done) => {
@@ -500,6 +377,25 @@ describe(commands.FOLDER_COPY, () => {
       }
     });
   });
+
+  it('can be cancelled', () => {
+    assert(command.cancel());
+  });
+
+  it('clears pending connection on cancel', () => {
+    (command as any).timeout = {};
+    const clearTimeoutSpy = sinon.spy(global, 'clearTimeout');
+    (command.cancel() as CommandCancel)();
+    Utils.restore(global.clearTimeout);
+    assert(clearTimeoutSpy.called);
+  });
+
+  it('doesn\'t fail on cancel if no connection pending', () => {
+    (command as any).timeout = undefined;
+    (command.cancel() as CommandCancel)();
+    assert(true);
+  });
+
 
   it('supports debug mode', () => {
     const options = (command.options() as CommandOption[]);

--- a/src/m365/spo/commands/folder/folder-copy.ts
+++ b/src/m365/spo/commands/folder/folder-copy.ts
@@ -3,7 +3,8 @@ import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import {
   CommandOption,
-  CommandValidate
+  CommandValidate,
+  CommandCancel
 } from '../../../../Command';
 import SpoCommand from '../../../base/SpoCommand';
 import * as url from 'url';
@@ -21,36 +22,22 @@ interface Options extends GlobalOptions {
   allowSchemaMismatch?: boolean;
 }
 
-interface JobProgressOptions {
-  webUrl: string;
-  /**
-   * Response object retrieved from /_api/site/CreateCopyJobs
-   */
-  copyJopInfo: any;
-  /**
-   * Poll interval to call /_api/site/GetCopyJobProgress
-   */
-  progressPollInterval: number;
-  /**
-   * Max poll intervals to call /_api/site/GetCopyJobProgress
-   * after which to give up
-   */
-  progressMaxPollAttempts: number;
-  /**
-   * Retry attempts before give up.
-   * Give up if /_api/site/GetCopyJobProgress returns 
-   * X reject promises in a row
-   */
-  progressRetryAttempts: number;
-}
-
 class SpoFolderCopyCommand extends SpoCommand {
+  private dots?: string;
+  private timeout?: NodeJS.Timer;
+
   public get name(): string {
     return commands.FOLDER_COPY;
   }
 
   public get description(): string {
     return 'Copies a folder to another location';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.allowSchemaMismatch = args.options.allowSchemaMismatch || false;
+    return telemetryProps;
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
@@ -79,16 +66,17 @@ class SpoFolderCopyCommand extends SpoCommand {
 
     request
       .post(requestOptions)
-      .then((jobInfo: any): Promise<any> => {
-        const jobProgressOptions: JobProgressOptions = {
-          webUrl: webUrl,
-          copyJopInfo: jobInfo.value[0],
-          progressMaxPollAttempts: 1000, // 1 sec.
-          progressPollInterval: 30 * 60, // approx. 30 mins. if interval is 1000
-          progressRetryAttempts: 5
-        }
+      .then((jobInfo: any): Promise<void> => {
+        return new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
+          this.dots = '';
 
-        return this.waitForJobResult(jobProgressOptions, cmd);
+          const copyJobInfo: any = jobInfo.value[0];
+          const progressPollInterval: number = 30 * 60; //used previously implemented interval. The API does not provide guidance on what value should be used.
+
+          this.timeout = setTimeout(() => {
+            this.waitUntilCopyJobFinished(copyJobInfo, webUrl, progressPollInterval, resolve, reject, cmd, this.dots, this.timeout)
+          }, progressPollInterval);
+        });
       })
       .then((): void => {
         if (this.verbose) {
@@ -99,105 +87,12 @@ class SpoFolderCopyCommand extends SpoCommand {
       }, (err: any): void => this.handleRejectedODataJsonPromise(err, cmd, cb));
   }
 
-  /**
-   * A polling function that awaits the 
-   * Azure queued copy job to return JobStatus = 0 meaning it is done with the task.
-   */
-  private waitForJobResult(opts: JobProgressOptions, cmd: CommandInstance):
-    Promise<void> {
-
-    let pollCount: number = 0;
-    let retryAttemptsCount: number = 0;
-
-    const checkCondition = (resolve: () => void, reject: (error: any) => void): void => {
-      pollCount++;
-      const requestUrl: string = `${opts.webUrl}/_api/site/GetCopyJobProgress`;
-      const requestOptions: any = {
-        url: requestUrl,
-        headers: {
-          'accept': 'application/json;odata=nometadata'
-        },
-        body: { "copyJobInfo": opts.copyJopInfo },
-        json: true
-      };
-
-      request.post(requestOptions).then((resp: any): void => {
-        retryAttemptsCount = 0; // clear retry on promise success 
-
-        if (this.verbose) {
-          if (resp.JobState && resp.JobState === 4) {
-            cmd.log(`Check #${pollCount}. Copy job in progress... JobState: ${resp.JobState}`);
-          }
-          else {
-            cmd.log(`Check #${pollCount}. JobState: ${resp.JobState}`);
-          }
-        }
-
-        for (const item of resp.Logs) {
-          const log = JSON.parse(item);
-
-          // reject if progress error 
-          if (log.Event === "JobError" || log.Event === "JobFatalError") {
-            return reject(log.Message);
-          }
-        }
-
-        // three possible scenarios
-        // job done = success promise returned
-        // job in progress = recursive call using setTimeout returned
-        // max poll attempts flag raised = reject promise returned
-        if (resp.JobState === 0) {
-          // job done
-          resolve();
-        }
-        else if (pollCount < opts.progressMaxPollAttempts) {
-          // if the condition isn't met but the timeout hasn't elapsed, go again
-          setTimeout(checkCondition, opts.progressPollInterval, resolve, reject);
-        }
-        else {
-          reject(new Error('waitForJobResult timed out'));
-        }
-      },
-        (error: any) => {
-          retryAttemptsCount++;
-
-          // let's retry x times in row before we give up since
-          // this is progress check and even if rejects a promise
-          // the actual copy process can success.
-          if (retryAttemptsCount <= opts.progressRetryAttempts) {
-            setTimeout(checkCondition, opts.progressPollInterval, resolve, reject);
-          }
-          else {
-            reject(error);
-          }
-        });
-    };
-
-    return new Promise<void>(checkCondition);
-  }
-
-  /**
-   * Combines base and relative url considering any missing slashes
-   * @param baseUrl https://contoso.com
-   * @param relativeUrl sites/abc
-   */
-  private urlCombine(baseUrl: string, relativeUrl: string): string {
-    // remove last '/' of base if exists
-    if (baseUrl.lastIndexOf('/') === baseUrl.length - 1) {
-      baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+  public cancel(): CommandCancel {
+    return (): void => {
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
     }
-
-    // remove '/' at 0
-    if (relativeUrl.charAt(0) === '/') {
-      relativeUrl = relativeUrl.substring(1, relativeUrl.length);
-    }
-
-    // remove last '/' of next if exists
-    if (relativeUrl.lastIndexOf('/') === relativeUrl.length - 1) {
-      relativeUrl = relativeUrl.substring(0, relativeUrl.length - 1);
-    }
-
-    return `${baseUrl}/${relativeUrl}`;
   }
 
   public options(): CommandOption[] {
@@ -252,12 +147,12 @@ class SpoFolderCopyCommand extends SpoCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Remarks:
-  
+
     When you copy a folder with documents that have version history,
     only the latest document version is copied.
-        
+
   Examples:
-  
+
     Copies folder from a document library located in one site collection to
     another site collection
       ${commands.FOLDER_COPY} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/MyFolder --targetUrl /sites/test2/Shared%20Documents/
@@ -265,7 +160,7 @@ class SpoFolderCopyCommand extends SpoCommand {
     Copies folder from a document library to another site in the same site
     collection
       ${commands.FOLDER_COPY} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/MyFolder --targetUrl /sites/test1/HRDocuments/
-      
+
     Copy folder to a document library in another site collection. Will ignore any missing fields in the target destination and copy anyway
       ${commands.FILE_COPY} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/MyFolder --targetUrl /sites/test2/Shared%20Documents/ --allowSchemaMismatch
 

--- a/src/m365/spo/commands/folder/folder-move.spec.ts
+++ b/src/m365/spo/commands/folder/folder-move.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError, CommandCancel } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
@@ -65,7 +65,7 @@ describe(commands.FOLDER_MOVE, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
   });
 
@@ -151,6 +151,51 @@ describe(commands.FOLDER_MOVE, () => {
     });
   });
 
+  it('should complete successfully in 4 tries. ', (done) => {
+    var counter = 4;
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/recycle()') > -1) {
+        return Promise.resolve();
+      }
+
+      if ((opts.url as string).indexOf('/_api/site/CreateCopyJobs') > -1) {
+        return Promise.resolve({ value: [{ "EncryptionKey": "6G35dpTMegtzqT3rsZ/av6agpsqx/SUyaAHBs9fJE6A=", "JobId": "cee65dc5-8d05-41cc-8657-92a12d213f76", "JobQueueUri": "https://spobn1sn1m001pr.queue.core.windows.net:443/1246pq20180429-5305d83990eb483bb93e7356252715b4?sv=2014-02-14&sig=JUwFF1B0KVC2h0o5qieHPUG%2BQE%2BEhJHNpbzFf8QmCGc%3D&st=2018-04-28T07%3A00%3A00Z&se=2018-05-20T07%3A00%3A00Z&sp=rap" }] });
+      }
+
+      if ((opts.url as string).indexOf('/_api/site/GetCopyJobProgress') > -1) {
+        // substract jobstate untill we hit jobstate = 0 (success)
+        counter = (counter - 1);
+
+        return Promise.resolve({
+          JobState: counter,
+          Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
+        });
+      }
+
+      return Promise.reject('Invalid request');
+
+    });
+
+    stubAllGetRequests();
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        sourceUrl: 'abc/abc.pdf',
+        targetUrl: 'abc'
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.lastCall.args[0] === 'DONE');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('should show error when getCopyJobProgress rejects with JobError', (done) => {
     const getCopyJobProgress = new Promise<any>((resolve, reject) => {
       const log = JSON.stringify({ Event: 'JobError', Message: 'error1' });
@@ -201,170 +246,6 @@ describe(commands.FOLDER_MOVE, () => {
         done(e);
       }
     });
-  });
-
-  it('should setTimeout when getCopyJobProgress JobState is not 0', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    postRequests.onFirstCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:29.945\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Export\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{}\",\r\n  \"ObjectsStatsByType\": \"{}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobLogFolderCreate\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.539\",\r\n  \"FolderName\": \"Import-7be2c14c-b998-4b30-9b43-c2be0f95d8b9-0.log\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobStart\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.570\",\r\n  \"SiteId\": \"956c8970-f858-42ac-a06f-bbdca4a0374b\",\r\n  \"WebId\": \"d6d96969-217f-4306-b15b-fe35b6b754cc\",\r\n  \"DBId\": \"eb30ff26-a12c-431e-bb10-68fdac21ce28\",\r\n  \"FarmId\": \"67b76b49-9245-4dfc-a1f7-b4503cf6ea69\",\r\n  \"ServerId\": \"2a00b725-2871-4e42-98fd-e41c577ed494\",\r\n  \"SubscriptionId\": \"ea1787c6-7ce2-4e71-be47-5e0deb30f9e4\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}"]
-    });
-
-    postRequests.onSecondCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 5
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).getCopyJobProgress(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert(resp === undefined);
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert.fail('getCopyJobProgress couldn\'t resolve.');
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should setTimeout when getCopyJobProgress reject, but retry limit not reached', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    // GetCopyJobProgress reject
-    postRequests.onFirstCall().rejects('error');
-    // GetCopyJobProgress #2 JobState = 0
-    postRequests.onSecondCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 1
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).getCopyJobProgress(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert(resp === undefined);
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert.fail('getCopyJobProgress couldn\'t resolve.');
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should show error when getCopyJobProgress reject and retry limit reached', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    postRequests.onFirstCall().rejects('error');
-    postRequests.onSecondCall().rejects('error');
-    postRequests.onThirdCall().resolves({
-      JobState: 0,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 2,
-      progressPollInterval: 0,
-      progressRetryAttempts: 1
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).getCopyJobProgress(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert.fail('getCopyJobProgress shouldn\'t resolve, but reject.');
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert(e !== undefined);
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('should getCopyJobProgress timeout', (done) => {
-    const postRequests = sinon.stub(request, 'post');
-    // GetCopyJobProgress #1 JobState = 4
-    postRequests.onFirstCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:29.945\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Export\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{}\",\r\n  \"ObjectsStatsByType\": \"{}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobLogFolderCreate\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.539\",\r\n  \"FolderName\": \"Import-7be2c14c-b998-4b30-9b43-c2be0f95d8b9-0.log\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}", "{\r\n  \"Event\": \"JobStart\",\r\n  \"JobId\": \"7be2c14c-b998-4b30-9b43-c2be0f95d8b9\",\r\n  \"Time\": \"04/29/2018 23:39:30.570\",\r\n  \"SiteId\": \"956c8970-f858-42ac-a06f-bbdca4a0374b\",\r\n  \"WebId\": \"d6d96969-217f-4306-b15b-fe35b6b754cc\",\r\n  \"DBId\": \"eb30ff26-a12c-431e-bb10-68fdac21ce28\",\r\n  \"FarmId\": \"67b76b49-9245-4dfc-a1f7-b4503cf6ea69\",\r\n  \"ServerId\": \"2a00b725-2871-4e42-98fd-e41c577ed494\",\r\n  \"SubscriptionId\": \"ea1787c6-7ce2-4e71-be47-5e0deb30f9e4\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CorrelationId\": \"355f629e-707d-5000-634c-4c5cdd1e62d2\"\r\n}"]
-    });
-    // GetCopyJobProgress #2 JobState = 0
-    postRequests.onSecondCall().resolves({
-      JobState: 4,
-      Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FoldersCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFolderStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFolder\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-    });
-
-    const jobProgressOptions: any = {
-      webUrl: 'https://contoso.sharepoint.com',
-      copyJopInfo: 'abc',
-      progressMaxPollAttempts: 1,
-      progressPollInterval: 0,
-      progressRetryAttempts: 5
-    }
-    const log: any = [];
-    const cmdInstance = {
-      log: (msg: string) => {
-        log.push(msg);
-      }
-    };
-
-    try {
-      (command as any).getCopyJobProgress(jobProgressOptions, cmdInstance).then((resp: any) => {
-        assert.fail('getCopyJobProgress shouldn\'t resolve, but reject.');
-        postRequests.restore();
-        done();
-      }, (e: any) => {
-        assert(e !== undefined);
-        postRequests.restore();
-        done();
-      });
-    }
-    catch (e) {
-      done(e);
-    }
   });
 
   it('should complete successfully where baseUrl has a trailing /', (done) => {
@@ -500,6 +381,24 @@ describe(commands.FOLDER_MOVE, () => {
         done(e);
       }
     });
+  });
+
+  it('can be cancelled', () => {
+    assert(command.cancel());
+  });
+
+  it('clears pending connection on cancel', () => {
+    (command as any).timeout = {};
+    const clearTimeoutSpy = sinon.spy(global, 'clearTimeout');
+    (command.cancel() as CommandCancel)();
+    Utils.restore(global.clearTimeout);
+    assert(clearTimeoutSpy.called);
+  });
+
+  it('doesn\'t fail on cancel if no connection pending', () => {
+    (command as any).timeout = undefined;
+    (command.cancel() as CommandCancel)();
+    assert(true);
   });
 
   it('supports debug mode', () => {

--- a/src/m365/spo/commands/folder/folder-move.ts
+++ b/src/m365/spo/commands/folder/folder-move.ts
@@ -3,7 +3,8 @@ import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import {
   CommandOption,
-  CommandValidate
+  CommandValidate,
+  CommandCancel
 } from '../../../../Command';
 import SpoCommand from '../../../base/SpoCommand';
 import * as url from 'url';
@@ -21,36 +22,22 @@ interface Options extends GlobalOptions {
   allowSchemaMismatch: boolean;
 }
 
-interface JobProgressOptions {
-  webUrl: string;
-  /**
-   * Response object retrieved from /_api/site/CreateCopyJobs
-   */
-  copyJopInfo: any;
-  /**
-   * Poll interval to call /_api/site/GetCopyJobProgress
-   */
-  progressPollInterval: number;
-  /**
-   * Max poll intervals to call /_api/site/GetCopyJobProgress
-   * after which to give up
-   */
-  progressMaxPollAttempts: number;
-  /**
-   * Retry attempts before give up.
-   * Give up if /_api/site/GetCopyJobProgress returns 
-   * X reject promises in a row
-   */
-  progressRetryAttempts: number;
-}
-
 class SpoFolderMoveCommand extends SpoCommand {
+  private dots?: string;
+  private timeout?: NodeJS.Timer;
+
   public get name(): string {
     return commands.FOLDER_MOVE;
   }
 
   public get description(): string {
     return 'Moves a folder to another location';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.allowSchemaMismatch = args.options.allowSchemaMismatch || false;
+    return telemetryProps;
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
@@ -81,15 +68,16 @@ class SpoFolderMoveCommand extends SpoCommand {
     request
       .post(requestOptions)
       .then((jobInfo: any): Promise<void> => {
-        const jobProgressOptions: JobProgressOptions = {
-          webUrl: webUrl,
-          copyJopInfo: jobInfo.value[0],
-          progressMaxPollAttempts: 1000, // 1 sec.
-          progressPollInterval: 30 * 60, // approx. 30 mins. if interval is 1000
-          progressRetryAttempts: 5
-        };
+        return new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
+          this.dots = '';
 
-        return this.getCopyJobProgress(jobProgressOptions, cmd);
+          const copyJobInfo: any = jobInfo.value[0];
+          const progressPollInterval: number = 30 * 60; //used previously implemented interval. The API does not provide guidance on what value should be used.
+
+          this.timeout = setTimeout(() => {
+            this.waitUntilCopyJobFinished(copyJobInfo, webUrl, progressPollInterval, resolve, reject, cmd, this.dots, this.timeout)
+          }, progressPollInterval);
+        });
       })
       .then((): void => {
         if (this.verbose) {
@@ -100,111 +88,12 @@ class SpoFolderMoveCommand extends SpoCommand {
       }, (err: any): void => this.handleRejectedODataJsonPromise(err, cmd, cb));
   }
 
-  /**
-   * A polling function that awaits the 
-   * Azure queued copy job to return JobStatus = 0 meaning it is done with the task.
-   */
-  private getCopyJobProgress(opts: JobProgressOptions, cmd: CommandInstance):
-    Promise<void> {
-    let pollCount: number = 0;
-    let retryAttemptsCount: number = 0;
-
-    const checkCondition = (resolve: () => void, reject: (error: any) => void): void => {
-      pollCount++;
-      const requestUrl: string = `${opts.webUrl}/_api/site/GetCopyJobProgress`;
-      const requestOptions: any = {
-        url: requestUrl,
-        headers: {
-          'accept': 'application/json;odata=nometadata'
-        },
-        body: { "copyJobInfo": opts.copyJopInfo },
-        json: true
-      };
-
-      request
-        .post<{ JobState?: number, Logs: string[] }>(requestOptions)
-        .then((resp: { JobState?: number, Logs: string[] }): void => {
-          retryAttemptsCount = 0; // clear retry on promise success 
-
-          if (this.debug) {
-            cmd.log('getCopyJobProgress response...');
-            cmd.log(resp);
-          }
-
-          if (this.verbose) {
-            if (resp.JobState && resp.JobState === 4) {
-              cmd.log(`Check #${pollCount}. Copy job in progress... JobState: ${resp.JobState}`);
-            }
-            else {
-              cmd.log(`Check #${pollCount}. JobState: ${resp.JobState}`);
-            }
-          }
-
-          for (const item of resp.Logs) {
-            const log: { Event: string; Message: string } = JSON.parse(item);
-
-            // reject if progress error 
-            if (log.Event === "JobError" || log.Event === "JobFatalError") {
-              return reject(log.Message);
-            }
-          }
-
-          // three possible scenarios
-          // job done = success promise returned
-          // job in progress = recursive call using setTimeout returned
-          // max poll attempts flag raised = reject promise returned
-          if (resp.JobState === 0) {
-            // job done
-            resolve();
-          }
-          else if (pollCount < opts.progressMaxPollAttempts) {
-            // if the condition isn't met but the timeout hasn't elapsed, go again
-            setTimeout(checkCondition, opts.progressPollInterval, resolve, reject);
-          }
-          else {
-            reject(new Error('getCopyJobProgress timed out'));
-          }
-        },
-          (error: any) => {
-            retryAttemptsCount++;
-
-            // let's retry x times in row before we give up since
-            // this is progress check and even if rejects a promise
-            // the actual move process can success.
-            if (retryAttemptsCount <= opts.progressRetryAttempts) {
-              setTimeout(checkCondition, opts.progressPollInterval, resolve, reject);
-            }
-            else {
-              reject(error);
-            }
-          });
-    };
-
-    return new Promise<void>(checkCondition);
-  }
-
-  /**
-   * Combines base and relative url considering any missing slashes
-   * @param baseUrl https://contoso.com
-   * @param relativeUrl sites/abc
-   */
-  private urlCombine(baseUrl: string, relativeUrl: string): string {
-    // remove last '/' of base if exists
-    if (baseUrl.lastIndexOf('/') === baseUrl.length - 1) {
-      baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+  public cancel(): CommandCancel {
+    return (): void => {
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
     }
-
-    // remove '/' at 0
-    if (relativeUrl.charAt(0) === '/') {
-      relativeUrl = relativeUrl.substring(1, relativeUrl.length);
-    }
-
-    // remove last '/' of next if exists
-    if (relativeUrl.lastIndexOf('/') === relativeUrl.length - 1) {
-      relativeUrl = relativeUrl.substring(0, relativeUrl.length - 1);
-    }
-
-    return `${baseUrl}/${relativeUrl}`;
   }
 
   public options(): CommandOption[] {
@@ -258,12 +147,12 @@ class SpoFolderMoveCommand extends SpoCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Remarks:
-  
+
     When you move a folder with documents that have version history,
     all of the versions are being moved.
-        
+
   Examples:
-  
+
     Moves folder from a document library located in one site collection to
     another site collection
       ${commands.FOLDER_MOVE} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/MyFolder --targetUrl /sites/test2/Shared%20Documents/
@@ -271,7 +160,7 @@ class SpoFolderMoveCommand extends SpoCommand {
     Moves folder from a document library to another site in the same site
     collection
       ${commands.FOLDER_MOVE} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/MyFolder --targetUrl /sites/test1/HRDocuments/
-    
+
     Moves folder to a document library in another site collection. Will ignore any missing fields in the target destination and move anyway
       ${commands.FOLDER_MOVE} --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/MyFolder --targetUrl /sites/test2/Shared%20Documents/ --allowSchemaMismatch
 


### PR DESCRIPTION
### Fixes long running copy operations. Closes #1698

Implemented the option for long running operations on methods using the CreateCopyJobs API (including refactoring and moving of previous implementation). 

Impacts commands: 
- `spo file move`
- `spo file copy`
- `spo folder move`
- `spo folder copy`


### Linked Issue
Closes #1698 