### PR TITLE
Fixes 'Using your own Azure AD Identity' documentation bug. Closes #1824

### DIFF
--- a/docs/docs/user-guide/using-own-identity.md
+++ b/docs/docs/user-guide/using-own-identity.md
@@ -103,7 +103,7 @@ $env:CLIMICROSOFT365_TENANT="e8954f17-a373-4b61-b54d-45c038fe3188"
 If you are using Linux or macOS, you can set the environment variables using the `export` command from your terminal prompt.
 
 ```sh
-m365 export CLIMICROSOFT365_AADAPPID=506af689-32aa-46c8-afb5-972ebf9d218a
+export CLIMICROSOFT365_AADAPPID=506af689-32aa-46c8-afb5-972ebf9d218a
 export CLIMICROSOFT365_TENANT=e8954f17-a373-4b61-b54d-45c038fe3188
 ```
 


### PR DESCRIPTION
Fixes `Using your own Azure AD Identity` documentation bug by removing the `m365` alias from the command to set the `CLIMICROSOFT365_AADAPPID` environment variable on Linux or macOS. Closes #1824