### PR TITLE
fixes wrong telemetry param 'workload'. Closes #1820

### DIFF
--- a/src/m365/tenant/commands/status/status-list.ts
+++ b/src/m365/tenant/commands/status/status-list.ts
@@ -24,7 +24,7 @@ class TenantStatusListCommand extends SpoCommand {
 
   public getTelemetryProperties(args: CommandArgs): any {
     const telemetryProps: any = super.getTelemetryProperties(args);
-    telemetryProps.sharingCapabilities = args.options.workload;
+    telemetryProps.workload = args.options.workload;
     return telemetryProps;
   }
 


### PR DESCRIPTION
> ### Fixes wrong telemetry param 'workload'

- `tenant status list`. Fixes wrongly mentioned parameter `workload `for `getTelemetryProperties `method.  Closes #1820 

> ### Linked Issue

Closes #1820 