### PR TITLE
Fixes 'Logging in to Microsoft 365' documentation bug. Closes #1876

### DIFF
--- a/docs/docs/user-guide/connecting-office-365.md
+++ b/docs/docs/user-guide/connecting-office-365.md
@@ -79,7 +79,7 @@ Generally, you should use the default device code flow. If you need to use a non
 Create a new self signed certificate:
 
 ```sh
-m365 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout privateKey.key -out certificate.cer
+openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout privateKey.key -out certificate.cer
 ```
 
 Create a new Personal Information Exchange (.pfx) file
@@ -93,7 +93,7 @@ At this point the `protected.pfx` file can be used to log in the CLI for Microso
 If login with the .pfx file does not work then extract the private key from a protected .pfx and unprotect it:
 
 ```sh
-m365 openssl pkcs12 -in protected.pfx -out privateKeyWithPassphrase.pem -nodes
+openssl pkcs12 -in protected.pfx -out privateKeyWithPassphrase.pem -nodes
 ```
 
 At this point the `privateKeyWithPassphrase.pem` file can be used to log in the CLI for Microsoft 365 following the instructions above for logging in using a PEM certificate.


### PR DESCRIPTION
Fixes [Logging in to Microsoft 365](https://pnp.github.io/cli-microsoft365/user-guide/connecting-office-365/#log-in-using-a-certificate) documentation bug by removing the `m365` alias from OpenSSL commands. Closes #1876