### PR TITLE
New Command: aad approleassignment remove. Closes #1872

### DIFF
--- a/docs/docs/cmd/aad/approleassignment/approleassignment-remove.md
+++ b/docs/docs/cmd/aad/approleassignment/approleassignment-remove.md
@@ -1,0 +1,78 @@
+# aad approleassignment add
+
+Deletes an app role assignment for the specified Azure AD Application Registration
+
+## Usage
+
+```sh
+m365 aad approleassignment remove [options]
+```
+
+## Options
+
+`-h, --help`
+: output usage information
+
+`--appId [appId]`
+: Application appId also known as clientId of the App Registration for which the configured scopes (app roles) should be deleted
+
+`--objectId [objectId]`
+: Application objectId of the App Registration for which the configured scopes (app roles) should be deleted
+
+`--displayName [displayName]`
+: Application name of the App Registration for which the configured scopes (app roles) should be deleted
+
+`-r, --resource <resource>`
+: Service principal name, appId or objectId that has the scopes (roles) ex. `SharePoint`
+
+`-s, --scope <scope>`
+: Permissions known also as scopes and roles to be deleted from the application. If multiple permissions have to be deleted, they have to be comma separated ex. `Sites.Read.All`,`Sites.ReadWrite.All`
+
+`--confirm`
+: Don't prompt for confirming removing the all role assignment
+
+`--query [query]`
+: JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
+
+`-o, --output [output]`
+: Output type. `json,text`. Default `text`
+
+`--verbose`
+: Runs command with verbose logging
+
+`--debug`
+: Runs command with debug logging
+
+## Remarks
+
+This command requires tenant administrator permissions.
+
+Specify either the `appId`, `objectId` or `displayName` but not both. If you specify more than one option value, the command will fail with an error.
+
+Autocomplete values for the `resource` option do not mean allowed values. The autocomplete will just suggest some known names, but that doesn't restrict you to use name of your own custom application or other application within your tenant.
+
+This command can also be used to assign permissions to system or user-assigned managed identity.
+
+## Examples
+
+Deletes SharePoint _Sites.Read.All_ application permissions from Azure AD application with app id _57907bf8-73fa-43a6-89a5-1f603e29e451_
+
+```sh
+m365 aad approleassignment remove --appId "57907bf8-73fa-43a6-89a5-1f603e29e451" --resource "SharePoint" --scope "Sites.Read.All"
+```
+
+Deletes multiple Microsoft Graph application permissions from an Azure AD application with name _MyAppName_
+
+```sh
+m365 aad approleassignment remove --displayName "MyAppName" --resource "Microsoft Graph" --scope "Mail.Read,Mail.Send"
+```
+
+Deletes Microsoft Graph _Mail.Read_ application permissions from a system managed identity app with objectId _57907bf8-73fa-43a6-89a5-1f603e29e451_
+
+```sh
+m365 aad approleassignment remove --objectId "57907bf8-73fa-43a6-89a5-1f603e29e451" --resource "Microsoft Graph" --scope "Mail.Read"
+```
+
+## More information
+
+- Microsoft Graph permissions reference: [https://docs.microsoft.com/en-us/graph/permissions-reference](https://docs.microsoft.com/en-us/graph/permissions-reference)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - approleassignment:
         - approleassignment add: 'cmd/aad/approleassignment/approleassignment-add.md'
         - approleassignment list: 'cmd/aad/approleassignment/approleassignment-list.md'
+        - approleassignment remove: 'cmd/aad/approleassignment/approleassignment-remove.md'
       - groupsetting:
         - groupsetting add: 'cmd/aad/groupsetting/groupsetting-add.md'
         - groupsetting get: 'cmd/aad/groupsetting/groupsetting-get.md'

--- a/src/m365/aad/commands.ts
+++ b/src/m365/aad/commands.ts
@@ -3,6 +3,7 @@ const prefix: string = 'aad';
 export default {
   APPROLEASSIGNMENT_ADD: `${prefix} approleassignment add`,
   APPROLEASSIGNMENT_LIST: `${prefix} approleassignment list`,
+  APPROLEASSIGNMENT_REMOVE: `${prefix} approleassignment remove`,
   GROUPSETTING_ADD: `${prefix} groupsetting add`,
   GROUPSETTING_GET: `${prefix} groupsetting get`,
   GROUPSETTING_LIST: `${prefix} groupsetting list`,

--- a/src/m365/aad/commands/approleassignment/approleassignment-remove.spec.ts
+++ b/src/m365/aad/commands/approleassignment/approleassignment-remove.spec.ts
@@ -1,0 +1,439 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Cli, Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import commands from '../../commands';
+const command: Command = require('./approleassignment-remove');
+
+describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
+  let log: string[];
+  let logger: Logger;
+  let promptOptions: any;
+
+  let deleteRequestStub: sinon.SinonStub;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      promptOptions = options;
+      cb({ continue: false });
+    });
+    promptOptions = undefined;
+    sinon.stub(request, 'get').callsFake((opts: any) => {
+      if ((opts.url as string).indexOf(`/v1.0/servicePrincipals?`) > -1) {
+        // fake first call for getting service principal
+        if (opts.url.indexOf('startswith') === -1) {
+          return Promise.resolve({ "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals(appRoleAssignments())", "value": [{ "id": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "deletedDateTime": null, "accountEnabled": true, "alternativeNames": [], "appDisplayName": "myapp", "appDescription": null, "appId": "dc311e81-e099-4c64-bd66-c7183465f3f2", "applicationTemplateId": null, "appOwnerOrganizationId": "c8e571e1-d528-43d9-8776-dc51157d615a", "appRoleAssignmentRequired": false, "createdDateTime": "2020-04-21T06:50:56Z", "description": null, "displayName": "myapp", "homepage": null, "loginUrl": null, "logoutUrl": null, "notes": null, "notificationEmailAddresses": [], "preferredSingleSignOnMode": null, "preferredTokenSigningKeyThumbprint": null, "replyUrls": [], "resourceSpecificApplicationPermissions": [], "samlSingleSignOnSettings": null, "servicePrincipalNames": ["dc311e81-e099-4c64-bd66-c7183465f3f2"], "servicePrincipalType": "Application", "signInAudience": "AzureADandPersonalMicrosoftAccount", "tags": ["WindowsAzureActiveDirectoryIntegratedApp"], "tokenEncryptionKeyId": null, "verifiedPublisher": { "displayName": null, "verifiedPublisherId": null, "addedDateTime": null }, "addIns": [], "appRoles": [], "info": { "logoUrl": null, "marketingUrl": null, "privacyStatementUrl": null, "supportUrl": null, "termsOfServiceUrl": null }, "keyCredentials": [], "oauth2PermissionScopes": [], "passwordCredentials": [], "appRoleAssignments@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals('3e64c22f-3f14-4bce-a267-cb44c9a08e17')/appRoleAssignments", "appRoleAssignments": [{ "id": "L8JkPhQ_zkuiZ8tEyaCOF8xDeJC6Z09PiQhDnXpNuYI", "deletedDateTime": null, "appRoleId": "d13f72ca-a275-4b96-b789-48ebcc4da984", "createdDateTime": "2020-10-25T12:04:13.6550724Z", "principalDisplayName": "myapp", "principalId": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "principalType": "ServicePrincipal", "resourceDisplayName": "Office 365 SharePoint Online", "resourceId": "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c" }, { "id": "L8JkPhQ_zkuiZ8tEyaCOFxSPOO7XQmlKmMHk580MMAg", "deletedDateTime": null, "appRoleId": "678536fe-1083-478a-9c59-b99265e6b0d3", "createdDateTime": "2020-10-17T15:08:29.6907782Z", "principalDisplayName": "myapp", "principalId": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "principalType": "ServicePrincipal", "resourceDisplayName": "Office 365 SharePoint Online", "resourceId": "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c" }] }] });
+        }
+        // second get request for searching for service principals by resource options value specified
+        return Promise.resolve({ "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals", "value": [{ "id": "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c", "deletedDateTime": null, "accountEnabled": true, "alternativeNames": [], "appDisplayName": "Office 365 SharePoint Online", "appDescription": null, "appId": "00000003-0000-0ff1-ce00-000000000000", "applicationTemplateId": null, "appOwnerOrganizationId": "f8cdef31-a31e-4b4a-93e4-5f571e91255a", "appRoleAssignmentRequired": false, "createdDateTime": "2019-01-11T07:34:21Z", "description": null, "displayName": "Office 365 SharePoint Online", "homepage": null, "loginUrl": null, "logoutUrl": "https://signout.sharepoint.com/_layouts/15/expirecookies.aspx", "notes": null, "notificationEmailAddresses": [], "preferredSingleSignOnMode": null, "preferredTokenSigningKeyThumbprint": null, "replyUrls": ["https://www180015.066dapp.com/_layouts/15/spolanding.aspx", "https://www167017.080dapp.com/_layouts/15/spolanding.aspx", "https://www174015.019dapp.com/_layouts/15/spolanding.aspx", "https://www162015.079dapp.com/_layouts/15/spolanding.aspx", "https://www156015.077dapp.com/_layouts/15/spolanding.aspx", "https://www158015.075dapp.com/_layouts/15/spolanding.aspx", "https://www145007.074dapp.com/_layouts/15/spolanding.aspx", "https://www148015.030dapp.com/_layouts/15/spolanding.aspx", "https://www141017.028dapp.com/_layouts/15/spolanding.aspx", "https://www143020.025dapp.com/_layouts/15/spolanding.aspx", "https://www138015.076dapp.com/_layouts/15/spolanding.aspx", "https://www136028.062dapp.com/_layouts/15/spolanding.aspx", "https://www129017.072dapp.com/_layouts/15/spolanding.aspx", "https://www127017.005dapp.com/_layouts/15/spolanding.aspx", "https://www124016.032dapp.com/_layouts/15/spolanding.aspx", "https://www117017.063dapp.com/_layouts/15/spolanding.aspx", "https://www115014.071dapp.com/_layouts/15/spolanding.aspx", "https://www111031.045dapp.com/_layouts/15/spolanding.aspx", "https://www113025.044dapp.com/_layouts/15/spolanding.aspx", "https://www105021.059dapp.com/_layouts/15/spolanding.aspx", "https://www92050.065dapp.com/_layouts/15/spolanding.aspx", "https://www32058.050dapp.com/_layouts/15/spolanding.aspx", "https://www29079.048dapp.com/_layouts/15/spolanding.aspx", "https://www39085.034dapp.com/_layouts/15/spolanding.aspx", "https://www38024.068dapp.com/_layouts/15/spolanding.aspx", "https://www37045.007dapp.com/_layouts/15/spolanding.aspx", "https://www30090.054dapp.com/_layouts/15/spolanding.aspx", "https://www95027.027dapp.com/_layouts/15/spolanding.aspx", "https://www75007.023dapp.com/_layouts/15/spolanding.aspx", "https://www70030.035dapp.com/_layouts/15/spolanding.aspx", "https://www60140.098dspoapp.com/_layouts/15/spolanding.aspx", "https://www160015.078dapp.com/_layouts/15/spolanding.aspx", "https://www154017.003dapp.com/_layouts/15/spolanding.aspx", "https://www102027.067dapp.com/_layouts/15/spolanding.aspx", "https://www100039.017dapp.com/_layouts/15/spolanding.aspx", "https://www87072.042dapp.com/_layouts/15/spolanding.aspx", "https://www90082.053dapp.com/_layouts/15/spolanding.aspx", "https://www80033.011dapp.com/_layouts/15/spolanding.aspx", "https://www65158.013dspoapp.com/_layouts/15/spolanding.aspx", "https://www139017.073dapp.com/_layouts/15/spolanding.aspx", "https://www133018.046dapp.com/_layouts/15/spolanding.aspx", "https://www97058.085dspoapp.com/_layouts/15/spolanding.aspx"], "resourceSpecificApplicationPermissions": [], "samlSingleSignOnSettings": null, "servicePrincipalNames": ["00000003-0000-0ff1-ce00-000000000000/*.sharepoint.com", "00000003-0000-0ff1-ce00-000000000000", "https://microsoft.sharepoint-df.com"], "servicePrincipalType": "Application", "signInAudience": "AzureADMultipleOrgs", "tags": [], "tokenEncryptionKeyId": null, "verifiedPublisher": { "displayName": null, "verifiedPublisherId": null, "addedDateTime": null }, "addIns": [], "appRoles": [{ "allowedMemberTypes": ["Application"], "description": "Allows the app to create, read, update, and delete documents and list items in all site collections without a signed in user.", "displayName": "Read and write items in all site collections", "id": "fbcd29d2-fcca-4405-aded-518d457caae4", "isEnabled": true, "origin": "Application", "value": "Sites.ReadWrite.All" }, { "allowedMemberTypes": ["Application"], "description": "Allows the app to read documents and list items in all site collections without a signed in user.", "displayName": "Read items in all site collections", "id": "d13f72ca-a275-4b96-b789-48ebcc4da984", "isEnabled": true, "origin": "Application", "value": "Sites.Read.All" }, { "allowedMemberTypes": ["Application"], "description": "Allows the app to have full control of all site collections without a signed in user.", "displayName": "Have full control of all site collections", "id": "678536fe-1083-478a-9c59-b99265e6b0d3", "isEnabled": true, "origin": "Application", "value": "Sites.FullControl.All" }, { "allowedMemberTypes": ["Application"], "description": "Allows the app to read, create, update, and delete document libraries and lists in all site collections without a signed in user.", "displayName": "Read and write items and lists in all site collections", "id": "9bff6588-13f2-4c48-bbf2-ddab62256b36", "isEnabled": true, "origin": "Application", "value": "Sites.Manage.All" }, { "allowedMemberTypes": ["Application"], "description": "Allows the app to read enterprise managed metadata and to read basic site info without a signed in user.", "displayName": "Read managed metadata", "id": "2a8d57a5-4090-4a41-bf1c-3c621d2ccad3", "isEnabled": true, "origin": "Application", "value": "TermStore.Read.All" }, { "allowedMemberTypes": ["Application"], "description": "Allows the app to write enterprise managed metadata and to read basic site info without a signed in user.", "displayName": "Read and write managed metadata", "id": "c8e3537c-ec53-43b9-bed3-b2bd3617ae97", "isEnabled": true, "origin": "Application", "value": "TermStore.ReadWrite.All" }, { "allowedMemberTypes": ["Application"], "description": "Allows the app to read and update user profiles and to read basic site info without a signed in user.", "displayName": "Read and write user profiles", "id": "741f803b-c850-494e-b5df-cde7c675a1ca", "isEnabled": true, "origin": "Application", "value": "User.ReadWrite.All" }, { "allowedMemberTypes": ["Application"], "description": "Allows the app to read user profiles without a signed in user.", "displayName": "Read user profiles", "id": "df021288-bdef-4463-88db-98f22de89214", "isEnabled": true, "origin": "Application", "value": "User.Read.All" }], "info": { "logoUrl": null, "marketingUrl": null, "privacyStatementUrl": null, "supportUrl": null, "termsOfServiceUrl": null }, "keyCredentials": [], "oauth2PermissionScopes": [{ "adminConsentDescription": "Allows the app to read all OData reporting data from all ProjectWebApp site collections for the signed-in user.", "adminConsentDisplayName": "Read ProjectWebApp OData reporting data", "id": "a4c14cd7-8bd6-4337-8e87-78623dfc023b", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read all OData reporting data from all ProjectWebApp site collections for the signed-in user.", "userConsentDisplayName": "Read ProjectWebApp OData reporting data", "value": "ProjectWebAppReporting.Read" }, { "adminConsentDescription": "Allows the app to submit project task status updates the signed-in user.", "adminConsentDisplayName": "Submit project task status updates", "id": "c4258712-0efb-41f1-b6bc-be58e4e32f3f", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to submit project task status updates the signed-in user.", "userConsentDisplayName": "Submit project task status updates", "value": "TaskStatus.Submit" }, { "adminConsentDescription": "Allows the app to read, create, update, and delete the current user’s enterprise resources.", "adminConsentDisplayName": "Read and write user project enterprise resources", "id": "2511a087-5795-4cae-9123-d5b7d6ec4844", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read, create, update, and delete the current user’s enterprise resources.", "userConsentDisplayName": "Read and write user project enterprise resources", "value": "EnterpriseResource.Write" }, { "adminConsentDescription": "Allows the app to read the current user's enterprise resources.", "adminConsentDisplayName": "Read user project enterprise resources", "id": "b8341dab-4143-49da-8eb9-3d8c073f9e77", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read the current user's enterprise resources.", "userConsentDisplayName": "Read user project enterprise resources", "value": "EnterpriseResource.Read" }, { "adminConsentDescription": "Allows the app to read, create, update, and delete the current users’ projects.", "adminConsentDisplayName": "Read and write user projects", "id": "d75a7b17-f04e-40d9-8e35-79b949bdb891", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read, create, update, and delete the current users’ projects.", "userConsentDisplayName": "Read and write user projects", "value": "Project.Write" }, { "adminConsentDescription": "Allows the app to read the current user's projects.", "adminConsentDisplayName": "Read user projects", "id": "2beb830c-70d1-4f5b-a983-79cbdb0c6c6a", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read the current user's projects.", "userConsentDisplayName": "Read user projects", "value": "Project.Read" }, { "adminConsentDescription": "Allows the app to have full control of all ProjectWebApp site collections the signed-in user.", "adminConsentDisplayName": "Have full control of all ProjectWebApp site collections", "id": "e7e732bd-932b-45c4-8ce5-40d60a7daad9", "isEnabled": true, "type": "Admin", "userConsentDescription": "Allows the app to have full control of all ProjectWebApp site collections the signed-in user.", "userConsentDisplayName": "Have full control of all ProjectWebApp site collections", "value": "ProjectWebApp.FullControl" }, { "adminConsentDescription": "Allows the app to read managed metadata and to read basic site info on behalf of the signed-in user.", "adminConsentDisplayName": "Read managed metadata", "id": "a468ea40-458c-4cc2-80c4-51781af71e41", "isEnabled": true, "type": "Admin", "userConsentDescription": "Allows the app to read managed metadata and to read basic site info on your behalf.", "userConsentDisplayName": "Read managed metadata", "value": "TermStore.Read.All" }, { "adminConsentDescription": "Allows the app to read, create, update, and delete managed metadata and to read basic site info on behalf of the signed-in user.", "adminConsentDisplayName": "Read and write managed metadata", "id": "59a198b5-0420-45a8-ae59-6da1cb640505", "isEnabled": true, "type": "Admin", "userConsentDescription": "Allows the app to read, create, update, and delete managed metadata and to read basic site info on your behalf.", "userConsentDisplayName": "Read and write managed metadata", "value": "TermStore.ReadWrite.All" }, { "adminConsentDescription": "Allows the app to run search queries and to read basic site info on behalf of the current signed-in user. Search results are based on the user's permissions instead of the app's permissions.", "adminConsentDisplayName": "Run search queries as a user", "id": "1002502a-9a71-4426-8551-69ab83452fab", "isEnabled": true, "type": "Admin", "userConsentDescription": "Allows the app to run search queries and to read basic site info on your behalf. Search results are based on your permissions.", "userConsentDisplayName": "Run search queries ", "value": "Sites.Search.All" }, { "adminConsentDescription": "Allows the app to read documents and list items in all site collections on behalf of the signed-in user.", "adminConsentDisplayName": "Read items in all site collections", "id": "4e0d77b0-96ba-4398-af14-3baa780278f4", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read documents and list items in all site collections on your behalf.", "userConsentDisplayName": "Read items in all site collections", "value": "AllSites.Read" }, { "adminConsentDescription": "Allows the app to create, read, update, and delete documents and list items in all site collections on behalf of the signed-in user.", "adminConsentDisplayName": "Read and write items in all site collections", "id": "640ddd16-e5b7-4d71-9690-3f4022699ee7", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to create, read, update, and delete documents and list items in all site collections on your behalf.", "userConsentDisplayName": "Read and write items in all site collections", "value": "AllSites.Write" }, { "adminConsentDescription": "Allows the app to read, create, update, and delete document libraries and lists in all site collections on behalf of the signed-in user.", "adminConsentDisplayName": "Read and write items and lists in all site collections", "id": "b3f70a70-8a4b-4f95-9573-d71c496a53f4", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read, create, update, and delete document libraries and lists in all site collections on your behalf.", "userConsentDisplayName": "Read and write items and lists in all site collections", "value": "AllSites.Manage" }, { "adminConsentDescription": "Allows the app to have full control of all site collections on behalf of the signed-in user.", "adminConsentDisplayName": "Have full control of all site collections", "id": "56680e0d-d2a3-4ae1-80d8-3c4f2100e3d0", "isEnabled": true, "type": "Admin", "userConsentDescription": "Allows the app to have full control of all site collections on your behalf.", "userConsentDisplayName": "Have full control of all site collections", "value": "AllSites.FullControl" }, { "adminConsentDescription": "Allows the app to read the current user's files.", "adminConsentDisplayName": "Read user files", "id": "dd2c8d78-58e1-46d7-82dd-34d411282686", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read your files.", "userConsentDisplayName": "Read your files", "value": "MyFiles.Read" }, { "adminConsentDescription": "Allows the app to read, create, update, and delete the current user's files.", "adminConsentDisplayName": "Read and write user files", "id": "2cfdc887-d7b4-4798-9b33-3d98d6b95dd2", "isEnabled": true, "type": "User", "userConsentDescription": "Allows the app to read, create, update, and delete your files.", "userConsentDisplayName": "Read and write your files", "value": "MyFiles.Write" }, { "adminConsentDescription": "Allows the app to read and update user profiles and to read basic site info on behalf of the signed-in user.", "adminConsentDisplayName": "Read and write user profiles", "id": "82866913-39a9-4be7-8091-f4fa781088ae", "isEnabled": true, "type": "Admin", "userConsentDescription": "Allows the app to read and update user profiles and to read basic site info on your behalf.", "userConsentDisplayName": "Read and write user profiles", "value": "User.ReadWrite.All" }, { "adminConsentDescription": "Allows the app to read user profiles and to read basic site info on behalf of the signed-in user.", "adminConsentDisplayName": "Read user profiles", "id": "0cea5a30-f6f8-42b5-87a0-84cc26822e02", "isEnabled": true, "type": "Admin", "userConsentDescription": "Allows the app to read user profiles and basic site info on your behalf.", "userConsentDisplayName": "Read user profiles", "value": "User.Read.All" }], "passwordCredentials": [] }] });
+      }
+      return Promise.reject();
+    });
+    deleteRequestStub = sinon.stub(request, 'delete').callsFake((opts: any) => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/servicePrincipals/3e64c22f-3f14-4bce-a267-cb44c9a08e17/appRoleAssignments/L8JkPhQ_zkuiZ8tEyaCOF8xDeJC6Z09PiQhDnXpNuYI' ||
+        opts.url === 'https://graph.microsoft.com/v1.0/servicePrincipals/3e64c22f-3f14-4bce-a267-cb44c9a08e17/appRoleAssignments/L8JkPhQ_zkuiZ8tEyaCOFxSPOO7XQmlKmMHk580MMAg') {
+        return Promise.resolve();
+      }
+      return Promise.reject();
+    });
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      request.get,
+      request.delete,
+      Cli.prompt
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.APPROLEASSIGNMENT_REMOVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('prompts before removing the app role assignment when confirm option not passed', (done) => {
+    command.action(logger, { options: { debug: false, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scope: 'Sites.Read.All' } }, () => {
+      let promptIssued = false;
+
+      if (promptOptions && promptOptions.type === 'confirm') {
+        promptIssued = true;
+      }
+
+      try {
+        assert(promptIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('prompts before removing the app role assignment when confirm option not passed (debug)', (done) => {
+    command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scope: 'Sites.Read.All' } }, () => {
+      let promptIssued = false;
+
+      if (promptOptions && promptOptions.type === 'confirm') {
+        promptIssued = true;
+      }
+
+      try {
+        assert(promptIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts removing the app role assignment when prompt not confirmed', (done) => {
+    Utils.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: false });
+    });
+    command.action(logger, { options: { displayName: 'myapp', resource: 'SharePoint', scope: 'Sites.Read.All' } }, () => {
+      try {
+        assert(deleteRequestStub.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('deletes app role assignment when prompt confirmed (debug)', (done) => {
+    Utils.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: true });
+    });
+    command.action(logger, { options: { debug: true, displayName: 'myapp', resource: 'SharePoint', scope: 'Sites.Read.All' } }, () => {
+      try {
+        assert(deleteRequestStub.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('deletes app role assignments for service principal with specified displayName', (done) => {
+    command.action(logger, { options: { displayName: 'myapp', resource: 'SharePoint', scope: 'Sites.Read.All', confirm: true } }, () => {
+      try {
+        assert(deleteRequestStub.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('deletes app role assignments for service principal with specified objectId and multiple scopes', (done) => {
+    command.action(logger, { options: { objectId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scope: 'Sites.Read.All,Sites.FullControl.All', confirm: true } }, () => {
+      try {
+        assert(deleteRequestStub.calledTwice);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('deletes app role assignments for service principal with specified appId (debug)', (done) => {
+    command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scope: 'Sites.Read.All', confirm: true } }, () => {
+      try {
+        assert(deleteRequestStub.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('handles intune alias for the resource option value', (done) => {
+    command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'intune', scope: 'Sites.Read.All', confirm: true } }, () => {
+      try {
+        assert(deleteRequestStub.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('handles exchange alias for the resource option value', (done) => {
+    command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'exchange', scope: 'Sites.Read.All', confirm: true } }, () => {
+      try {
+        assert(deleteRequestStub.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('handles appId for the resource option value', (done) => {
+    command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'fff194f1-7dce-4428-8301-1badb5518201', scope: 'Sites.Read.All', confirm: true } }, () => {
+      try {
+        assert(deleteRequestStub.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('rejects if no resource is found', (done) => {
+    Utils.restore(request.get);
+    sinon.stub(request, 'get').callsFake((opts: any): Promise<any> => {
+      if ((opts.url as string).indexOf(`/v1.0/servicePrincipals?`) > -1) {
+        // fake first call for getting service principal
+        if (opts.url.indexOf('startswith') === -1) {
+          return Promise.resolve({ "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals(appRoleAssignments())", "value": [{ "id": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "deletedDateTime": null, "accountEnabled": true, "alternativeNames": [], "appDisplayName": "myapp", "appDescription": null, "appId": "dc311e81-e099-4c64-bd66-c7183465f3f2", "applicationTemplateId": null, "appOwnerOrganizationId": "c8e571e1-d528-43d9-8776-dc51157d615a", "appRoleAssignmentRequired": false, "createdDateTime": "2020-04-21T06:50:56Z", "description": null, "displayName": "myapp", "homepage": null, "loginUrl": null, "logoutUrl": null, "notes": null, "notificationEmailAddresses": [], "preferredSingleSignOnMode": null, "preferredTokenSigningKeyThumbprint": null, "replyUrls": [], "resourceSpecificApplicationPermissions": [], "samlSingleSignOnSettings": null, "servicePrincipalNames": ["dc311e81-e099-4c64-bd66-c7183465f3f2"], "servicePrincipalType": "Application", "signInAudience": "AzureADandPersonalMicrosoftAccount", "tags": ["WindowsAzureActiveDirectoryIntegratedApp"], "tokenEncryptionKeyId": null, "verifiedPublisher": { "displayName": null, "verifiedPublisherId": null, "addedDateTime": null }, "addIns": [], "appRoles": [], "info": { "logoUrl": null, "marketingUrl": null, "privacyStatementUrl": null, "supportUrl": null, "termsOfServiceUrl": null }, "keyCredentials": [], "oauth2PermissionScopes": [], "passwordCredentials": [], "appRoleAssignments@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals('3e64c22f-3f14-4bce-a267-cb44c9a08e17')/appRoleAssignments", "appRoleAssignments": [{ "id": "L8JkPhQ_zkuiZ8tEyaCOF8xDeJC6Z09PiQhDnXpNuYI", "deletedDateTime": null, "appRoleId": "d13f72ca-a275-4b96-b789-48ebcc4da984", "createdDateTime": "2020-10-25T12:04:13.6550724Z", "principalDisplayName": "myapp", "principalId": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "principalType": "ServicePrincipal", "resourceDisplayName": "Office 365 SharePoint Online", "resourceId": "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c" }, { "id": "L8JkPhQ_zkuiZ8tEyaCOFxSPOO7XQmlKmMHk580MMAg", "deletedDateTime": null, "appRoleId": "678536fe-1083-478a-9c59-b99265e6b0d3", "createdDateTime": "2020-10-17T15:08:29.6907782Z", "principalDisplayName": "myapp", "principalId": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "principalType": "ServicePrincipal", "resourceDisplayName": "Office 365 SharePoint Online", "resourceId": "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c" }] }] });
+        }
+        // second get request for searching for service principals by resource options value specified
+        return Promise.resolve({ "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals", "value": [] });
+      }
+      return Promise.reject();
+    });
+
+    command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scope: 'Sites.Read.All', confirm: true } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Resource not found`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('rejects if no app roles found for the specified resource', (done) => {
+    Utils.restore(request.get);
+    sinon.stub(request, 'get').callsFake((opts: any): Promise<any> => {
+      if ((opts.url as string).indexOf(`/v1.0/servicePrincipals?`) > -1) {
+        // fake first call for getting service principal
+        if (opts.url.indexOf('startswith') === -1) {
+          return Promise.resolve({ "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals(appRoleAssignments())", "value": [{ "id": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "deletedDateTime": null, "accountEnabled": true, "alternativeNames": [], "appDisplayName": "myapp", "appDescription": null, "appId": "dc311e81-e099-4c64-bd66-c7183465f3f2", "applicationTemplateId": null, "appOwnerOrganizationId": "c8e571e1-d528-43d9-8776-dc51157d615a", "appRoleAssignmentRequired": false, "createdDateTime": "2020-04-21T06:50:56Z", "description": null, "displayName": "myapp", "homepage": null, "loginUrl": null, "logoutUrl": null, "notes": null, "notificationEmailAddresses": [], "preferredSingleSignOnMode": null, "preferredTokenSigningKeyThumbprint": null, "replyUrls": [], "resourceSpecificApplicationPermissions": [], "samlSingleSignOnSettings": null, "servicePrincipalNames": ["dc311e81-e099-4c64-bd66-c7183465f3f2"], "servicePrincipalType": "Application", "signInAudience": "AzureADandPersonalMicrosoftAccount", "tags": ["WindowsAzureActiveDirectoryIntegratedApp"], "tokenEncryptionKeyId": null, "verifiedPublisher": { "displayName": null, "verifiedPublisherId": null, "addedDateTime": null }, "addIns": [], "appRoles": [], "info": { "logoUrl": null, "marketingUrl": null, "privacyStatementUrl": null, "supportUrl": null, "termsOfServiceUrl": null }, "keyCredentials": [], "oauth2PermissionScopes": [], "passwordCredentials": [], "appRoleAssignments@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals('3e64c22f-3f14-4bce-a267-cb44c9a08e17')/appRoleAssignments", "appRoleAssignments": [{ "id": "L8JkPhQ_zkuiZ8tEyaCOF8xDeJC6Z09PiQhDnXpNuYI", "deletedDateTime": null, "appRoleId": "d13f72ca-a275-4b96-b789-48ebcc4da984", "createdDateTime": "2020-10-25T12:04:13.6550724Z", "principalDisplayName": "myapp", "principalId": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "principalType": "ServicePrincipal", "resourceDisplayName": "Office 365 SharePoint Online", "resourceId": "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c" }, { "id": "L8JkPhQ_zkuiZ8tEyaCOFxSPOO7XQmlKmMHk580MMAg", "deletedDateTime": null, "appRoleId": "678536fe-1083-478a-9c59-b99265e6b0d3", "createdDateTime": "2020-10-17T15:08:29.6907782Z", "principalDisplayName": "myapp", "principalId": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "principalType": "ServicePrincipal", "resourceDisplayName": "Office 365 SharePoint Online", "resourceId": "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c" }] }] });
+        }
+        // second get request for searching for service principals by resource options value specified
+        return Promise.resolve({ "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals", "value": [{ "id": "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c", "appRoles": [] }] });
+      }
+      return Promise.reject();
+    });
+
+    command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scope: 'Sites.Read.All', confirm: true } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The resource 'SharePoint' does not have any application permissions available.`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('rejects if no app roles found for the specified resource option value', (done) => {
+    Utils.restore(request.get);
+    sinon.stub(request, 'get').callsFake((opts: any): Promise<any> => {
+      if ((opts.url as string).indexOf(`/v1.0/servicePrincipals?`) > -1) {
+        // fake first call for getting service principal
+        if (opts.url.indexOf('startswith') === -1) {
+          return Promise.resolve({ "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals", "value": [{ "id": "3e64c22f-3f14-4bce-a267-cb44c9a08e17", "deletedDateTime": null, "accountEnabled": true, "alternativeNames": [], "appDisplayName": "myapp", "appDescription": null, "appId": "dc311e81-e099-4c64-bd66-c7183465f3f2", "applicationTemplateId": null, "appOwnerOrganizationId": "c8e571e1-d528-43d9-8776-dc51157d615a", "appRoleAssignmentRequired": false, "createdDateTime": "2020-08-29T18:35:13Z", "description": null, "displayName": "myapp", "homepage": null, "loginUrl": null, "logoutUrl": null, "notes": null, "notificationEmailAddresses": [], "preferredSingleSignOnMode": null, "preferredTokenSigningKeyThumbprint": null, "replyUrls": ["https://login.microsoftonline.com/common/oauth2/nativeclient"], "resourceSpecificApplicationPermissions": [], "samlSingleSignOnSettings": null, "servicePrincipalNames": ["dc311e81-e099-4c64-bd66-c7183465f3f2"], "servicePrincipalType": "Application", "signInAudience": "AzureADMyOrg", "tags": ["WindowsAzureActiveDirectoryIntegratedApp"], "tokenEncryptionKeyId": null, "verifiedPublisher": { "displayName": null, "verifiedPublisherId": null, "addedDateTime": null }, "addIns": [], "appRoles": [], "info": { "logoUrl": null, "marketingUrl": null, "privacyStatementUrl": null, "supportUrl": null, "termsOfServiceUrl": null }, "keyCredentials": [], "oauth2PermissionScopes": [], "passwordCredentials": [] }] });
+        }
+        // second get request for searching for service principals by resource options value specified
+        return Promise.resolve({ "value": [{ id: "5edf62fd-ae7a-4a99-af2e-fc5950aaed07", "appRoles": [{ value: 'Scope1', id: '1' }, { value: 'Scope2', id: '2' }] }] });
+      }
+      return Promise.reject();
+    });
+
+    command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scope: 'Sites.Read.All', confirm: true } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The scope value 'Sites.Read.All' you have specified does not exist for SharePoint. ${os.EOL}Available scopes (application permissions) are: ${os.EOL}Scope1${os.EOL}Scope2`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('rejects if no service principal found', (done) => {
+    Utils.restore(request.get);
+    sinon.stub(request, 'get').callsFake((opts: any): Promise<any> => {
+      if ((opts.url as string).indexOf(`/v1.0/servicePrincipals?`) > -1) {
+        // fake first call for getting service principal
+        if (opts.url.indexOf('startswith') === -1) {
+          return Promise.resolve({ "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals", "value": [] });
+        }
+        // second get request for searching for service principals by resource options value specified
+        return Promise.resolve({ "value": [{ objectId: "df3d00f0-a24d-45a9-ba8b-3b0934ec3a6c", "appRoles": [{ value: 'Scope1', id: '1' }, { value: 'Scope2', id: '2' }] }] });
+      }
+      return Promise.reject();
+    });
+
+    command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scope: 'Sites.Read.All', confirm: true } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("app registration not found")));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('rejects if app role assignment is not found', (done) => {
+    command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scope: 'Sites.ReadWrite.All', confirm: true } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("App role assignment not found")));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles API OData error', (done) => {
+    Utils.restore(request.get);
+    sinon.stub(request, 'get').callsFake((opts) => {
+      return Promise.reject({
+        error: {
+          'odata.error': {
+            code: '-1, InvalidOperationException',
+            message: {
+              value: `Resource '' does not exist or one of its queried reference-property objects are not present`
+            }
+          }
+        }
+      });
+    });
+
+    command.action(logger, { options: { debug: false, appId: '36e3a540-6f25-4483-9542-9f5fa00bb633', confirm: true } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails validation if neither appId, objectId nor displayName are not specified', () => {
+    const actual = command.validate({ options: { resource: 'abc', scope: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the appId is not a valid GUID', () => {
+    const actual = command.validate({ options: { appId: '123', resource: 'abc', scope: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the objectId is not a valid GUID', () => {
+    const actual = command.validate({ options: { objectId: '123', resource: 'abc', scope: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both appId and displayName are specified', () => {
+    const actual = command.validate({ options: { appId: '123', displayName: 'abc', resource: 'abc', scope: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both objectId and displayName are specified', () => {
+    const actual = command.validate({ options: { objectId: '123', displayName: 'abc', resource: 'abc', scope: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both objectId, appId and displayName are specified', () => {
+    const actual = command.validate({ options: { appId: '123', objectId: '123', displayName: 'abc', resource: 'abc', scope: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  })
+
+  it('passes validation when the appId option specified', () => {
+    const actual = command.validate({ options: { appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', resource: 'abc', scope: 'abc' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying appId', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--appId') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying displayName', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--displayName') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying confirmation flag', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--confirm') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+});
+

--- a/src/m365/aad/commands/approleassignment/approleassignment-remove.ts
+++ b/src/m365/aad/commands/approleassignment/approleassignment-remove.ts
@@ -1,0 +1,248 @@
+import * as chalk from 'chalk';
+import { Cli, Logger } from '../../../../cli';
+import * as os from 'os';
+import {
+  CommandOption
+} from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import GraphCommand from '../../../base/GraphCommand';
+import commands from '../../commands';
+import { AppRoleAssignment } from './AppRoleAssignment';
+import { AppRole, ServicePrincipal } from './ServicePrincipal';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  appId?: string;
+  displayName?: string;
+  objectId?: string;
+  resource: string;
+  scope: string;
+  confirm?: boolean;
+}
+
+class AadAppRoleAssignmentRemoveCommand extends GraphCommand {
+  public get name(): string {
+    return commands.APPROLEASSIGNMENT_REMOVE;
+  }
+
+  public get description(): string {
+    return 'Deletes an app role assignment for the specified Azure AD Application Registration';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.appId = typeof args.options.appId !== 'undefined';
+    telemetryProps.displayName = typeof args.options.displayName !== 'undefined';
+    telemetryProps.objectId = typeof args.options.objectId !== 'undefined';
+    telemetryProps.confirm = (!!args.options.confirm).toString();
+    return telemetryProps;
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    const removeAppRoleAssignment: () => void = (): void => {
+      let sp: ServicePrincipal;
+      // get the service principal associated with the appId
+      let spMatchQuery: string = '';
+      if (args.options.appId) {
+        spMatchQuery = `appId eq '${encodeURIComponent(args.options.appId)}'`;
+      }
+      else if (args.options.objectId) {
+        spMatchQuery = `id eq '${encodeURIComponent(args.options.objectId)}'`;
+      }
+      else {
+        spMatchQuery = `displayName eq '${encodeURIComponent(args.options.displayName as string)}'`;
+      }
+
+      this
+        .getServicePrincipalForApp(spMatchQuery)
+        .then((resp: { value: ServicePrincipal[] }): Promise<{ value: ServicePrincipal[] }> => {
+          if (!resp.value.length) {
+            return Promise.reject('app registration not found');
+          }
+
+          sp = resp.value[0];
+          let resource: string = encodeURIComponent(args.options.resource);
+
+          // try resolve aliases that the user might enter since these are seen in the Azure portal
+          switch (args.options.resource.toLocaleLowerCase()) {
+            case 'sharepoint':
+              resource = 'Office 365 SharePoint Online';
+              break;
+            case 'intune':
+              resource = 'Microsoft Intune API';
+              break;
+            case 'exchange':
+              resource = 'Office 365 Exchange Online';
+              break;
+          }
+
+          // will perform resource name, appId or objectId search
+          let filter: string = `$filter=(displayName eq '${resource}' or startswith(displayName,'${resource}'))`;
+
+          if (Utils.isValidGuid(resource)) {
+            filter += ` or appId eq '${resource}' or id eq '${resource}'`;
+          }
+          const requestOptions: any = {
+            url: `${this.resource}/v1.0/servicePrincipals?${filter}`,
+            headers: {
+              'accept': 'application/json'
+            },
+            responseType: 'json'
+          };
+
+          return request.get<{ value: ServicePrincipal[] }>(requestOptions);
+        })
+        .then((resp: { value: ServicePrincipal[] }): Promise<AppRole[]> => {
+          if (!resp.value.length) {
+            return Promise.reject('Resource not found');
+          }
+
+          const appRolesToBeDeleted: AppRole[] = [];
+          const appRolesFound: AppRole[] = resp.value[0].appRoles;
+
+          if (!appRolesFound.length) {
+            return Promise.reject(`The resource '${args.options.resource}' does not have any application permissions available.`);
+          }
+
+          for (const scope of args.options.scope.split(',')) {
+            const existingRoles = appRolesFound.filter((role: AppRole) => {
+              return role.value.toLocaleLowerCase() === scope.toLocaleLowerCase().trim();
+            });
+            if (!existingRoles.length) {
+              // the role specified in the scope option does not belong to the found service principles
+              // throw an error and show list with available roles (scopes)
+              let availableRoles: string = '';
+              appRolesFound.map((r: AppRole) => availableRoles += `${os.EOL}${r.value}`);
+
+              return Promise.reject(`The scope value '${scope}' you have specified does not exist for ${args.options.resource}. ${os.EOL}Available scopes (application permissions) are: ${availableRoles}`);
+            }
+
+            appRolesToBeDeleted.push(existingRoles[0]);
+          }
+          const tasks: Promise<any>[] = [];
+
+          for (const appRole of appRolesToBeDeleted) {
+            const appRoleAssignment = sp.appRoleAssignments.filter((role: AppRoleAssignment) => role.appRoleId === appRole.id);
+            if (!appRoleAssignment.length) {
+              return Promise.reject('App role assignment not found');
+            }
+            tasks.push(this.removeAppRoleAssignmentForServicePrincipal(sp.id, appRoleAssignment[0].id));
+          };
+
+          return Promise.all(tasks);
+        }).then((): void => {
+          if (this.verbose) {
+            logger.log(chalk.green('DONE'));
+          }
+
+          cb();
+        }, (res: any): void => this.handleRejectedODataJsonPromise(res, logger, cb));;
+    }
+
+    if (args.options.confirm) {
+      removeAppRoleAssignment();
+    }
+    else {
+      Cli.prompt(
+        {
+          type: 'confirm',
+          name: 'continue',
+          default: false,
+          message: `Are you sure you want to remove the appRoleAssignment with scope ${args.options.scope} for resource ${args.options.resource}?`
+        },
+        (result: { continue: boolean }): void => {
+          if (!result.continue) {
+            cb();
+          }
+          else {
+            removeAppRoleAssignment();
+          }
+        }
+      );
+    }
+  }
+
+  private getServicePrincipalForApp(filterParam: string): Promise<{ value: ServicePrincipal[] }> {
+    const spRequestOptions: any = {
+      url: `${this.resource}/v1.0/servicePrincipals?$expand=appRoleAssignments&$filter=${filterParam}`,
+      headers: {
+        accept: 'application/json'
+      },
+      responseType: 'json'
+    };
+
+    return request.get<{ value: ServicePrincipal[] }>(spRequestOptions);
+  }
+
+  private removeAppRoleAssignmentForServicePrincipal(spId: string, appRoleAssignmentId: string): Promise<ServicePrincipal> {
+    const spRequestOptions: any = {
+      url: `${this.resource}/v1.0/servicePrincipals/${spId}/appRoleAssignments/${appRoleAssignmentId}`,
+      headers: {
+        'accept': 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    return request.delete(spRequestOptions);
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --appId [appId]',
+        description: 'Application (client) Id of the App Registration for which the configured app roles should be retrieved'
+      },
+      {
+        option: '-n, --displayName [displayName]',
+        description: 'Display name of the application for which the configured app roles should be retrieved'
+      },
+      {
+        option: '--objectId [objectId]',
+        description: 'ObjectId of the application for which the configured app roles should be retrieved'
+      },
+      {
+        option: '-r, --resource <resource>',
+        description: 'Service principal name, appId or objectId that has the scopes (roles) ex. SharePoint',
+        autocomplete: ['Microsoft Graph', 'SharePoint', 'OneNote', 'Exchange', 'Microsoft Forms', 'Azure Active Directory Graph', 'Skype for Business']
+      },
+      {
+        option: '-s, --scope <scope>',
+        description: 'Permissions known also as scopes and roles to grant the application with. If multiple permissions have to be granted, they have to be comma separated ex. \'Sites.Read.All,Sites.ReadWrite.all\''
+      },
+      {
+        option: '--confirm',
+        description: 'Don\'t prompt for confirmation'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    let optionsSpecified: number = 0;
+    optionsSpecified += args.options.appId ? 1 : 0;
+    optionsSpecified += args.options.displayName ? 1 : 0;
+    optionsSpecified += args.options.objectId ? 1 : 0;
+    if (optionsSpecified !== 1) {
+      return 'Specify either appId, objectId or displayName';
+    }
+
+    if (args.options.appId && !Utils.isValidGuid(args.options.appId)) {
+      return `${args.options.appId} is not a valid GUID`;
+    }
+
+    if (args.options.objectId && !Utils.isValidGuid(args.options.objectId)) {
+      return `${args.options.objectId} is not a valid GUID`;
+    }
+
+    return true;
+  }
+}
+
+module.exports = new AadAppRoleAssignmentRemoveCommand();


### PR DESCRIPTION
New Command: `aad approleassignment remove` that deletes an app role assignment for the specified Azure AD Application Registration. Closes #1872 