### PR TITLE
Excludes missing global options in 'aad user list'. Closes #1909

### DIFF
--- a/src/m365/aad/commands/user/user-list.ts
+++ b/src/m365/aad/commands/user/user-list.ts
@@ -58,9 +58,13 @@ class AadUserListCommand extends GraphItemsListCommand<any> {
     const filters: any = {};
     const excludeOptions: string[] = [
       'properties',
+      'p',
       'debug',
       'verbose',
-      'output'
+      'output',
+      'o',
+      'query',
+      '_'
     ];
 
     Object.keys(options).forEach(key => {


### PR DESCRIPTION
Excludes missing global options in 'aad user list'. Closes #1909