### PR TITLE
Extends `teams channel get` command with support for teamName and channelName options

### DIFF
--- a/docs/docs/cmd/teams/channel/channel-get.md
+++ b/docs/docs/cmd/teams/channel/channel-get.md
@@ -13,11 +13,17 @@ m365 teams channel get [options]
 `-h, --help`
 : output usage information
 
-`-i, --teamId <teamId>`
-: The ID of the team to which the channel belongs
+`-i, --teamId [teamId]`
+: The ID of the team to which the channel belongs to. Specify either teamId or teamName but not both
+
+`--teamName [teamName]`
+: The display name of the team to which the channel belongs to. Specify either teamId or teamName but not both
 
 `-c, --channelId <channelId>`
-: The ID of the channel for which to retrieve more information
+: The ID of the channel for which to retrieve more information. Specify either channelId or channelName but not both
+
+`--channelName [channelName]`
+: The display name of the channel for which to retrieve more information. Specify either channelId or channelName but not both
 
 `--query [query]`
 : JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
@@ -36,5 +42,11 @@ m365 teams channel get [options]
 Get information about Microsoft Teams team channel with id _19:493665404ebd4a18adb8a980a31b4986@thread.skype_
 
 ```sh
-m365 teams channel get --teamId '00000000-0000-0000-0000-000000000000' --channelId '19:493665404ebd4a18adb8a980a31b4986@thread.skype'
+m365 teams channel get --teamId 00000000-0000-0000-0000-000000000000 --channelId 19:493665404ebd4a18adb8a980a31b4986@thread.skype
+```
+
+Get information about Microsoft Teams team channel with name _Channel Name_
+
+```sh
+m365 teams channel get --teamName "Team Name" --channelName "Channel Name"
 ```

--- a/src/m365/teams/commands/channel/channel-get.spec.ts
+++ b/src/m365/teams/commands/channel/channel-get.spec.ts
@@ -201,7 +201,7 @@ describe(commands.TEAMS_CHANNEL_GET, () => {
 
   it('fails to get team when team does not exists', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/me/joinedTeams?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '`) > -1) {
         return Promise.resolve({ value: [] });
       }
       return Promise.reject('The specified team does not exist in the Microsoft Teams');
@@ -227,7 +227,7 @@ describe(commands.TEAMS_CHANNEL_GET, () => {
 
   it('fails when multiple teams with same name exists', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/me/joinedTeams?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '`) > -1) {
         return Promise.resolve({
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
           "@odata.count": 2,
@@ -356,7 +356,7 @@ describe(commands.TEAMS_CHANNEL_GET, () => {
 
   it('should get channel information for the Microsoft Teams team by name', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/me/joinedTeams?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '`) > -1) {
         return Promise.resolve({
           "value": [
             {

--- a/src/m365/teams/commands/channel/channel-get.spec.ts
+++ b/src/m365/teams/commands/channel/channel-get.spec.ts
@@ -13,10 +13,10 @@ describe(commands.TEAMS_CHANNEL_GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerSpy: sinon.SinonSpy;
-  
+
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
   });
 
@@ -53,6 +53,54 @@ describe(commands.TEAMS_CHANNEL_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('fails validation if both teamId and teamName options are not passed', (done) => {
+    const actual = command.validate({
+      options: {
+        channelId: '19:00000000000000000000000000000000@thread.skype',
+        tabId: '00000000-0000-0000-0000-000000000000'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation if both teamId and teamName options are passed', (done) => {
+    const actual = command.validate({
+      options: {
+        teamId: '26b48cd6-3da7-493d-8010-1b246ef552d6',
+        teamName: 'Team Name',
+        channelId: '19:00000000000000000000000000000000@thread.skype',
+        tabId: '00000000-0000-0000-0000-000000000000'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation if both channelId and channelName options are not passed', (done) => {
+    const actual = command.validate({
+      options: {
+        teamId: '26b48cd6-3da7-493d-8010-1b246ef552d6',
+        tabId: '00000000-0000-0000-0000-000000000000'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation if both channelId and channelName options are passed', (done) => {
+    const actual = command.validate({
+      options: {
+        teamId: '26b48cd6-3da7-493d-8010-1b246ef552d6',
+        channelId: '19:00000000000000000000000000000000@thread.skype',
+        channelName: 'Channel Name',
+        tabId: '00000000-0000-0000-0000-000000000000'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
   it('fails validation if the teamId is not a valid guid.', () => {
     const actual = command.validate({
       options: {
@@ -61,6 +109,50 @@ describe(commands.TEAMS_CHANNEL_GET, () => {
       }
     });
     assert.notStrictEqual(actual, true);
+  });
+
+
+  it('fails validation if the teamId is not provided.', (done) => {
+    const actual = command.validate({
+      options: {
+        channelId: '19:00000000000000000000000000000000@thread.skype',
+        tabId: '00000000-0000-0000-0000-000000000000'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation if the channelId is not provided.', (done) => {
+    const actual = command.validate({
+      options: {
+        teamId: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validates for a incorrect channelId missing leading 19:.', (done) => {
+    const actual = command.validate({
+      options: {
+        teamId: '00000000-0000-0000-0000-000000000000',
+        channelId: '00000000000000000000000000000000@thread.skype',
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validates for a incorrect channelId missing trailing @thread.skpye.', (done) => {
+    const actual = command.validate({
+      options: {
+        teamId: '00000000-0000-0000-0000-000000000000',
+        channelId: '19:552b7125655c46d5b5b86db02ee7bfdf@thread',
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
   });
 
   it('correctly validates the when all options are valid', () => {
@@ -107,7 +199,127 @@ describe(commands.TEAMS_CHANNEL_GET, () => {
     });
   });
 
-  it('should get channel information for the Microsoft Teams team', (done) => {
+  it('fails to get team when team does not exists', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/me/joinedTeams?$filter=displayName eq '`) > -1) {
+        return Promise.resolve({ value: [] });
+      }
+      return Promise.reject('The specified team does not exist in the Microsoft Teams');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        teamName: 'Team Name',
+        channelName: 'Channel Name',
+        tabName: 'Tab Name'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified team does not exist in the Microsoft Teams`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails when multiple teams with same name exists', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/me/joinedTeams?$filter=displayName eq '`) > -1) {
+        return Promise.resolve({
+          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
+          "@odata.count": 2,
+          "value": [
+            {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "createdDateTime": null,
+              "displayName": "Team Name",
+              "description": "Team Description",
+              "internalId": null,
+              "classification": null,
+              "specialization": null,
+              "visibility": null,
+              "webUrl": null,
+              "isArchived": false,
+              "isMembershipLimitedToOwners": null,
+              "memberSettings": null,
+              "guestSettings": null,
+              "messagingSettings": null,
+              "funSettings": null,
+              "discoverySettings": null
+            },
+            {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "createdDateTime": null,
+              "displayName": "Team Name",
+              "description": "Team Description",
+              "internalId": null,
+              "classification": null,
+              "specialization": null,
+              "visibility": null,
+              "webUrl": null,
+              "isArchived": false,
+              "isMembershipLimitedToOwners": null,
+              "memberSettings": null,
+              "guestSettings": null,
+              "messagingSettings": null,
+              "funSettings": null,
+              "discoverySettings": null
+            }
+          ]
+        }
+        );
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        teamName: 'Team Name',
+        channelName: 'Channel Name',
+        tabName: 'Tab Name'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple Microsoft Teams teams with name Team Name found: 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails to get channel when channel does not exists', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/channels?$filter=displayName eq '`) > -1) {
+        return Promise.resolve({ value: [] });
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        teamId: '00000000-0000-0000-0000-000000000000',
+        channelName: 'Channel Name',
+        tabName: 'Tab Name'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified channel does not exist in the Microsoft Teams team`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should get channel information for the Microsoft Teams team by id', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/teams/39958f28-eefb-4006-8f83-13b6ac2a4a7f/channels/19%3A493665404ebd4a18adb8a980a31b4986%40thread.skype`) {
         return Promise.resolve({
@@ -131,6 +343,81 @@ describe(commands.TEAMS_CHANNEL_GET, () => {
         const call: sinon.SinonSpyCall = loggerSpy.lastCall;
         assert.strictEqual(call.args[0].id, '19:493665404ebd4a18adb8a980a31b4986@thread.skype');
         assert.strictEqual(call.args[0].displayName, 'channel1');
+        assert.strictEqual(call.args[0].description, null);
+        assert.strictEqual(call.args[0].email, '');
+        assert.strictEqual(call.args[0].webUrl, 'https://teams.microsoft.com/l/channel/19%3a493665404ebd4a18adb8a980a31b4986%40thread.skype/channel1?groupId=39958f28-eefb-4006-8f83-13b6ac2a4a7f&tenantId=ea1787c6-7ce2-4e71-be47-5e0deb30f9e4');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should get channel information for the Microsoft Teams team by name', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/me/joinedTeams?$filter=displayName eq '`) > -1) {
+        return Promise.resolve({
+          "value": [
+            {
+              "id": "39958f28-eefb-4006-8f83-13b6ac2a4a7f",
+              "createdDateTime": null,
+              "displayName": "Team Name",
+              "description": "Team Description",
+              "internalId": null,
+              "classification": null,
+              "specialization": null,
+              "visibility": null,
+              "webUrl": null,
+              "isArchived": false,
+              "isMembershipLimitedToOwners": null,
+              "memberSettings": null,
+              "guestSettings": null,
+              "messagingSettings": null,
+              "funSettings": null,
+              "discoverySettings": null
+            }
+          ]
+        });
+      }
+
+      if ((opts.url as string).indexOf(`/channels?$filter=displayName eq '`) > -1) {
+        return Promise.resolve({
+          "value": [
+            {
+              "id": "19:493665404ebd4a18adb8a980a31b4986@thread.skype",
+              "displayName": "Channel Name",
+              "description": null,
+              "email": "",
+              "webUrl": "https://teams.microsoft.com/l/channel/19%3a493665404ebd4a18adb8a980a31b4986%40thread.skype/channel1?groupId=39958f28-eefb-4006-8f83-13b6ac2a4a7f&tenantId=ea1787c6-7ce2-4e71-be47-5e0deb30f9e4",
+              "membershipType": "standard"
+            }
+          ]
+        });
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/39958f28-eefb-4006-8f83-13b6ac2a4a7f/channels/19%3A493665404ebd4a18adb8a980a31b4986%40thread.skype`) {
+        return Promise.resolve({
+          "id": "19:493665404ebd4a18adb8a980a31b4986@thread.skype",
+          "displayName": "Channel Name",
+          "description": null,
+          "email": "",
+          "webUrl": "https://teams.microsoft.com/l/channel/19%3a493665404ebd4a18adb8a980a31b4986%40thread.skype/channel1?groupId=39958f28-eefb-4006-8f83-13b6ac2a4a7f&tenantId=ea1787c6-7ce2-4e71-be47-5e0deb30f9e4"
+        });
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        teamName: 'Team Name',
+        channelName: 'Channel Name'
+      }
+    }, () => {
+      try {
+        const call: sinon.SinonSpyCall = loggerSpy.lastCall;
+        assert.strictEqual(call.args[0].id, '19:493665404ebd4a18adb8a980a31b4986@thread.skype');
+        assert.strictEqual(call.args[0].displayName, 'Channel Name');
         assert.strictEqual(call.args[0].description, null);
         assert.strictEqual(call.args[0].email, '');
         assert.strictEqual(call.args[0].webUrl, 'https://teams.microsoft.com/l/channel/19%3a493665404ebd4a18adb8a980a31b4986%40thread.skype/channel1?groupId=39958f28-eefb-4006-8f83-13b6ac2a4a7f&tenantId=ea1787c6-7ce2-4e71-be47-5e0deb30f9e4');

--- a/src/m365/teams/commands/channel/channel-get.ts
+++ b/src/m365/teams/commands/channel/channel-get.ts
@@ -8,6 +8,7 @@ import request from '../../../../request';
 import Utils from '../../../../Utils';
 import GraphCommand from '../../../base/GraphCommand';
 import { Channel } from '../../Channel';
+import { Team } from '../../Team';
 import commands from '../../commands';
 
 interface CommandArgs {
@@ -15,11 +16,15 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  channelId: string;
-  teamId: string;
+  teamId?: string;
+  teamName?: string;
+  channelId?: string;
+  channelName?: string;
 }
 
 class TeamsChannelGetCommand extends GraphCommand {
+  private teamId: string = "";
+
   public get name(): string {
     return `${commands.TEAMS_CHANNEL_GET}`;
   }
@@ -28,17 +33,90 @@ class TeamsChannelGetCommand extends GraphCommand {
     return 'Gets information about the specific Microsoft Teams team channel';
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    const requestOptions: any = {
-      url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.teamId)}/channels/${encodeURIComponent(args.options.channelId)}`,
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.teamId = typeof args.options.teamId !== 'undefined';
+    telemetryProps.teamName = typeof args.options.teamName !== 'undefined';
+    telemetryProps.channelId = typeof args.options.channelId !== 'undefined';
+    telemetryProps.channelName = typeof args.options.channelName !== 'undefined';
+    return telemetryProps;
+  }
+
+  private getTeamId(args: CommandArgs): Promise<string> {
+    if (args.options.teamId) {
+      return Promise.resolve(args.options.teamId);
+    }
+
+    const teamRequestOptions: any = {
+      url: `${this.resource}/v1.0/me/joinedTeams?$filter=displayName eq '${encodeURIComponent(args.options.teamName as string)}'`,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },
       responseType: 'json'
+    };
+
+    return request
+      .get<{ value: Team[] }>(teamRequestOptions)
+      .then(response => {
+        const teamItem: Team | undefined = response.value[0];
+
+        if (!teamItem) {
+          return Promise.reject(`The specified team does not exist in the Microsoft Teams`);
+        }
+
+        if (response.value.length > 1) {
+          return Promise.reject(`Multiple Microsoft Teams teams with name ${args.options.teamName} found: ${response.value.map(x => x.id)}`);
+        }
+
+        return Promise.resolve(teamItem.id);
+      });
+  }
+
+  private getChannelId(args: CommandArgs): Promise<string> {
+    if (args.options.channelId) {
+      return Promise.resolve(args.options.channelId);
     }
 
-    request
-      .get<Channel>(requestOptions)
+    const channelRequestOptions: any = {
+      url: `${this.resource}/v1.0/teams/${encodeURIComponent(this.teamId)}/channels?$filter=displayName eq '${encodeURIComponent(args.options.channelName as string)}'`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    return request
+      .get<{ value: Channel[] }>(channelRequestOptions)
+      .then(response => {
+        const channelItem: Channel | undefined = response.value[0];
+
+        if (!channelItem) {
+          return Promise.reject(`The specified channel does not exist in the Microsoft Teams team`);
+        }
+
+        return Promise.resolve(channelItem.id);
+      });
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    this
+      .getTeamId(args)
+      .then((teamId: string): Promise<string> => {
+        this.teamId = teamId;
+        return this.getChannelId(args);
+      })
+      .then((channelId: string): Promise<Channel> => {
+        const requestOptions: any = {
+          url: `${this.resource}/v1.0/teams/${encodeURIComponent(this.teamId)}/channels/${encodeURIComponent(channelId)}`,
+          headers: {
+            accept: 'application/json;odata.metadata=none'
+          },
+          responseType: 'json'
+        }
+
+        return request
+          .get<Channel>(requestOptions);
+      })
       .then((res: Channel): void => {
         logger.log(res);
 
@@ -53,12 +131,20 @@ class TeamsChannelGetCommand extends GraphCommand {
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       {
-        option: '-i, --teamId <teamId>',
-        description: 'The ID of the team to which the channel belongs'
+        option: '-i, --teamId [teamId]',
+        description: 'The ID of the team to which the channel belongs to. Specify either teamId or teamName but not both'
       },
       {
-        option: '-c, --channelId <channelId>',
-        description: 'The ID of the channel for which to retrieve more information'
+        option: '--teamName [teamName]',
+        description: 'The display name of the team to which the channel belongs to. Specify either teamId or teamName but not both'
+      },
+      {
+        option: '-c, --channelId [channelId]',
+        description: 'The ID of the channel for which to retrieve more information. Specify either channelId or channelName but not both'
+      },
+      {
+        option: '--channelName [channelName]',
+        description: 'The display name of the channel for which to retrieve more information. Specify either channelId or channelName but not both'
       }
     ];
 
@@ -67,8 +153,28 @@ class TeamsChannelGetCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (!Utils.isValidGuid(args.options.teamId)) {
+    if (args.options.teamId && args.options.teamName) {
+      return 'Specify either teamId or teamName, but not both.';
+    }
+
+    if (!args.options.teamId && !args.options.teamName) {
+      return 'Specify teamId or teamName, one is required';
+    }
+
+    if (args.options.teamId && !Utils.isValidGuid(args.options.teamId as string)) {
       return `${args.options.teamId} is not a valid GUID`;
+    }
+
+    if (args.options.channelId && args.options.channelName) {
+      return 'Specify either channelId or channelName, but not both.';
+    }
+
+    if (!args.options.channelId && !args.options.channelName) {
+      return 'Specify channelId or channelName, one is required';
+    }
+
+    if (args.options.channelId && !Utils.isValidTeamsChannelId(args.options.channelId as string)) {
+      return `${args.options.channelId} is not a valid Teams ChannelId`;
     }
 
     return true;

--- a/src/m365/teams/commands/channel/channel-get.ts
+++ b/src/m365/teams/commands/channel/channel-get.ts
@@ -1,14 +1,11 @@
 import * as chalk from 'chalk';
 import { Logger } from '../../../../cli';
-import {
-  CommandOption
-} from '../../../../Command';
+import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import Utils from '../../../../Utils';
 import GraphCommand from '../../../base/GraphCommand';
 import { Channel } from '../../Channel';
-import { Team } from '../../Team';
 import commands from '../../commands';
 
 interface CommandArgs {
@@ -47,8 +44,8 @@ class TeamsChannelGetCommand extends GraphCommand {
       return Promise.resolve(args.options.teamId);
     }
 
-    const teamRequestOptions: any = {
-      url: `${this.resource}/v1.0/me/joinedTeams?$filter=displayName eq '${encodeURIComponent(args.options.teamName as string)}'`,
+    const requestOptions: any = {
+      url: `${this.resource}/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '${encodeURIComponent(args.options.teamName as string)}'`,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },
@@ -56,11 +53,11 @@ class TeamsChannelGetCommand extends GraphCommand {
     };
 
     return request
-      .get<{ value: Team[] }>(teamRequestOptions)
+      .get<{ value: [{ id: string }] }>(requestOptions)
       .then(response => {
-        const teamItem: Team | undefined = response.value[0];
+        const groupItem: { id: string } | undefined = response.value[0];
 
-        if (!teamItem) {
+        if (!groupItem) {
           return Promise.reject(`The specified team does not exist in the Microsoft Teams`);
         }
 
@@ -68,7 +65,7 @@ class TeamsChannelGetCommand extends GraphCommand {
           return Promise.reject(`Multiple Microsoft Teams teams with name ${args.options.teamName} found: ${response.value.map(x => x.id)}`);
         }
 
-        return Promise.resolve(teamItem.id);
+        return Promise.resolve(groupItem.id);
       });
   }
 


### PR DESCRIPTION
Extended `teams channel get` command with support to get information using `teamName` and `channelName` as options.
Closes #1887