### PR TITLE
Fixes `m365 help` not displaying command groups in alphabetical order

### DIFF
--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -558,7 +558,7 @@ export class Cli {
       Cli.log();
 
       //Sort commands groups (because of aliased commands)
-      const sortedCommandGroupsToPrint = Object.keys(commandGroupsToPrint).sort().reduce(function (object: any, key: string) {object[key] = commandGroupsToPrint[key];return object;}, {})
+      const sortedCommandGroupsToPrint = Object.keys(commandGroupsToPrint).sort().reduce((object: { [group: string]: number }, key: string) => { object[key] = commandGroupsToPrint[key]; return object; }, {});
 
       for (let commandGroup in sortedCommandGroupsToPrint) {
         Cli.log(`  ${`${commandGroup} *`.padEnd(maxLength, ' ')}  ${commandGroupsToPrint[commandGroup]} command${commandGroupsToPrint[commandGroup] === 1 ? '' : 's'}`);

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -557,7 +557,10 @@ export class Cli {
       Cli.log(`Commands groups:`);
       Cli.log();
 
-      for (let commandGroup in commandGroupsToPrint) {
+      //Sort commands groups (because of aliased commands)
+      const sortedCommandGroupsToPrint = Object.keys(commandGroupsToPrint).sort().reduce(function (object: any, key: string) {object[key] = commandGroupsToPrint[key];return object;}, {})
+
+      for (let commandGroup in sortedCommandGroupsToPrint) {
         Cli.log(`  ${`${commandGroup} *`.padEnd(maxLength, ' ')}  ${commandGroupsToPrint[commandGroup]} command${commandGroupsToPrint[commandGroup] === 1 ? '' : 's'}`);
       }
     }


### PR DESCRIPTION

Fixes `m365 help` not displaying command groups in alphabetical order. Closes #1922 

![sortedCommands](https://user-images.githubusercontent.com/36161889/98051226-b09a4e00-1e33-11eb-8408-b2553a632220.PNG)
