### PR TITLE
Adds `m365 spo page control set`. Closes #1934

### DIFF
--- a/docs/docs/cmd/spo/page/page-control-set.md
+++ b/docs/docs/cmd/spo/page/page-control-set.md
@@ -45,11 +45,11 @@ When specifying the JSON string with web part properties on Windows, you have to
 Update the web part data for the control with ID _3ede60d3-dc2c-438b-b5bf-cc40bb2351e1_ placed on a modern page with name _home.aspx_
 
 ```sh
-m365 spo page control get --id 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx --webPartData '{"title":"New WP Title","properties": {"description": "New description"}}'
+m365 spo page control set --id 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx --webPartData '{"title":"New WP Title","properties": {"description": "New description"}}'
 ```
 
 Update the web part properties for the control with ID _3ede60d3-dc2c-438b-b5bf-cc40bb2351e1_ placed on a modern page with name _home.aspx_
 
 ```sh
-m365 spo page control get --id 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx --webPartProperties '{"description": "New description"}'
+m365 spo page control set --id 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx --webPartProperties '{"description": "New description"}'
 ```

--- a/docs/docs/cmd/spo/page/page-control-set.md
+++ b/docs/docs/cmd/spo/page/page-control-set.md
@@ -1,0 +1,55 @@
+# spo page control set
+
+Allows you to set or update control web part data or properties on a modern page.
+
+## Usage
+
+```sh
+m365 spo page control set [options]
+```
+
+## Options
+
+`-h, --help`
+: output usage information
+
+`-i, --id <id>`
+: ID of the control to set new properties for
+
+`-n, --name <name>`
+: Name of the page where the control is located
+
+`-u, --webUrl <webUrl>`
+: URL of the site where the page to retrieve is located
+
+`--webPartData [webPartData]`
+: JSON string with web part data as retrieved from the web part maintenance mode. Specify webPartProperties or webPartData but not both
+
+`--webPartProperties [webPartProperties]`
+: JSON string with web part data as retrieved from the web part maintenance mode. Specify webPartProperties or webPartData but not both
+
+`--verbose`
+: Runs command with verbose logging
+
+`--debug`
+: Runs command with debug logging
+
+## Remarks
+
+If the specified `name` doesn't refer to an existing modern page, you will get a `File doesn't exists` error.
+
+When specifying the JSON string with web part properties on Windows, you have to escape double quotes in a specific way. Considering the following value for the _webPartProperties_ option: `{"Foo":"Bar"}`, you should specify the value as \`"{""Foo"":""Bar""}"\`. In addition, when using PowerShell, you should use the `--%` argument.
+
+## Examples
+
+Update the web part data for the control with ID _3ede60d3-dc2c-438b-b5bf-cc40bb2351e1_ placed on a modern page with name _home.aspx_
+
+```sh
+m365 spo page control get --id 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx --webPartData '{"title":"New WP Title","properties": {"description": "New description"}}'
+```
+
+Update the web part properties for the control with ID _3ede60d3-dc2c-438b-b5bf-cc40bb2351e1_ placed on a modern page with name _home.aspx_
+
+```sh
+m365 spo page control get --id 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1 --webUrl https://contoso.sharepoint.com/sites/team-a --name home.aspx --webPartProperties '{"description": "New description"}'
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -300,6 +300,7 @@ nav:
         - page column list: 'cmd/spo/page/page-column-list.md'
         - page control get: 'cmd/spo/page/page-control-get.md'
         - page control list: 'cmd/spo/page/page-control-list.md'
+        - page control set: 'cmd/spo/page/page-control-set.md'
         - page header set: 'cmd/spo/page/page-header-set.md'
         - page section add: 'cmd/spo/page/page-section-add.md'
         - page section get: 'cmd/spo/page/page-section-get.md'

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -127,6 +127,7 @@ export default {
   PAGE_COLUMN_LIST: `${prefix} page column list`,
   PAGE_CONTROL_GET: `${prefix} page control get`,
   PAGE_CONTROL_LIST: `${prefix} page control list`,
+  PAGE_CONTROL_SET: `${prefix} page control set`,
   PAGE_HEADER_SET: `${prefix} page header set`,
   PAGE_SECTION_ADD: `${prefix} page section add`,
   PAGE_SECTION_GET: `${prefix} page section get`,

--- a/src/m365/spo/commands/page/ClientSideControl.ts
+++ b/src/m365/spo/commands/page/ClientSideControl.ts
@@ -1,0 +1,37 @@
+export interface ClientSideControl {
+  controlType: number;
+  displayMode: number;
+  id: string;
+  position: Position;
+  webPartId: string;
+  addedFromPersistedData: boolean;
+  reservedHeight: number;
+  reservedWidth: number;
+  webPartData: WebPartData;
+}
+
+export interface WebPartData {
+  id: string;
+  instanceId: string;
+  title: string;
+  description: string;
+  dataVersion: string;
+  properties: Properties;
+  serverProcessedContent?: ServerProcessedContent;
+}
+
+export interface Properties {
+  [name: string]: any;
+}
+
+export interface ServerProcessedContent {
+  [name: string]: any;
+}
+
+export interface Position {
+  zoneIndex: number;
+  sectionIndex: number;
+  sectionFactor: number;
+  layoutIndex: number;
+  controlIndex: number;
+}

--- a/src/m365/spo/commands/page/ClientSidePageProperties.ts
+++ b/src/m365/spo/commands/page/ClientSidePageProperties.ts
@@ -1,0 +1,36 @@
+export interface ClientSidePageProperties {
+  AbsoluteUrl: string;
+  AuthorByline?: any;
+  BannerImageUrl: string;
+  BannerThumbnailUrl: string;
+  ContentTypeId: string;
+  Description: string;
+  DoesUserHaveEditPermission: boolean;
+  FileName: string;
+  FirstPublished: string;
+  Id: number;
+  IsPageCheckedOutToCurrentUser: boolean;
+  IsWebWelcomePage: boolean;
+  Modified: string;
+  PageLayoutType: string;
+  Path: Path;
+  PromotedState: number;
+  Title: string;
+  TopicHeader?: any;
+  UniqueId: string;
+  Url: string;
+  Version: string;
+  VersionInfo: VersionInfo;
+  AlternativeUrlMap: string;
+  CanvasContent1: string;
+  LayoutWebpartsContent: string;
+}
+
+export interface VersionInfo {
+  LastVersionCreated: string;
+  LastVersionCreatedBy: string;
+}
+
+export interface Path {
+  DecodedUrl: string;
+}

--- a/src/m365/spo/commands/page/Page.spec.ts
+++ b/src/m365/spo/commands/page/Page.spec.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon';
 import { Logger } from '../../../../cli';
 import request from '../../../../request';
 import Utils from '../../../../Utils';
+import { ClientSidePageProperties } from './ClientSidePageProperties';
 import { ClientSidePage } from './clientsidepages';
 import { Page } from './Page';
 
@@ -21,7 +22,8 @@ describe('Page', () => {
 
   afterEach(() => {
     Utils.restore([
-      request.get
+      request.get,
+      request.post
     ]);
   });
 
@@ -202,6 +204,116 @@ describe('Page', () => {
         done();
       });
       assert(getCallIssued)
+  });
+
+
+  it('correctly handles checking out modern page', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      return Promise.resolve({});
+    });
+
+    Page
+      .checkout('page.aspx', 'https://contoso.sharepoint.com', logger, false, false)
+      .then((page: ClientSidePageProperties): void => {
+        done();
+      }, (error: any): void => {
+        done();
+      });
+  });
+
+
+  it('correctly handles error when checking out modern page with no data returned', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      return Promise.resolve(null);
+    });
+
+    Page
+      .checkout('page.aspx', 'https://contoso.sharepoint.com', logger, false, false)
+      .then((page: ClientSidePageProperties): void => {
+        done(new Error('Parsing page didn\'t fail while expected'));
+      }, (error: any): void => {
+        done();
+      });
+  });
+
+
+  it('correctly handles error in checking out modern page request', (done) => {
+    let getCallIssued = false;
+
+    sinon.stub(request, 'post').callsFake((opts) => {
+      getCallIssued = true;
+      return Promise.reject(null);
+    });
+
+    Page
+      .checkout('page.aspx', 'https://contoso.sharepoint.com', logger, false, false)
+      .then((page: ClientSidePageProperties): void => {
+        done(new Error('Parsing page didn\'t fail while expected'));
+      }, (error: any): void => {
+        done();
+      });
+
+    assert(getCallIssued);
+  });
+
+
+  it('correctly handles error when saving page without canvas data', (done) => {
+    let getCallIssued = false;
+
+    sinon.stub(request, 'post').callsFake((opts) => {
+      getCallIssued = true;
+      return Promise.reject();
+    });
+
+    Page
+      .save('page.aspx', 'https://contoso.sharepoint.com', null, logger, false, false)
+      .then((): void => {
+        done(new Error('No canvas content provided'));
+      }, (error: any): void => {
+        done();
+      });
+    
+    assert(!getCallIssued);
+  });
+  
+
+  it('correctly handles error when saving modern page', (done) => {
+    let getCallIssued = false;
+
+    sinon.stub(request, 'post').callsFake((opts) => {
+      getCallIssued = true;
+      return Promise.reject();
+    });
+
+    Page
+      .save('page.aspx', 'https://contoso.sharepoint.com', {}, logger, false, false)
+      .then((): void => {
+        done();
+      }, (error: any): void => {
+        done();
+      });
+    
+    assert(getCallIssued);
+  });
+
+
+  it('correctly handles saving modern page', (done) => {
+    let getCallIssued = false;
+
+    sinon.stub(request, 'post').callsFake((opts) => {
+      getCallIssued = true;
+      return Promise.resolve();
+    });
+
+    Page
+      .save('page.aspx', 'https://contoso.sharepoint.com', {}, logger, false, false)
+      .then((): void => {
+        done();
+      }, (error: any): void => {
+        done();
+      });
+    
+    assert(getCallIssued);
   });
 
 });

--- a/src/m365/spo/commands/page/Page.ts
+++ b/src/m365/spo/commands/page/Page.ts
@@ -1,20 +1,19 @@
 import { Logger } from '../../../../cli';
 import request from '../../../../request';
 import Utils from '../../../../Utils';
+import { ClientSidePageProperties } from './ClientSidePageProperties';
 import { CanvasColumn, CanvasSection, ClientSidePage, ClientSidePart } from './clientsidepages';
 import { PageItem } from './PageItem';
 
 export class Page {
+
   public static getPage(name: string, webUrl: string, logger: Logger, debug: boolean, verbose: boolean): Promise<ClientSidePage> {
     return new Promise((resolve: (page: ClientSidePage) => void, reject: (error: any) => void): void => {
       if (verbose) {
         logger.log(`Retrieving information about the page...`);
       }
 
-      let pageName: string = name;
-      if (pageName.indexOf('.aspx') < 0) {
-        pageName += '.aspx';
-      }
+      let pageName: string = this.getPageNameWithExtension(name);
 
       const requestOptions: any = {
         url: `${webUrl}/_api/web/getfilebyserverrelativeurl('${Utils.getServerRelativeSiteUrl(webUrl)}/SitePages/${encodeURIComponent(pageName)}')?$expand=ListItemAllFields/ClientSideApplicationId`,
@@ -35,10 +34,83 @@ export class Page {
 
           try {
             resolve(ClientSidePage.fromHtml(res.ListItemAllFields.CanvasContent1));
-          }
-          catch (e) {
+          } catch (e) {
             reject(e);
           }
+        }, (error: any): void => {
+          reject(error);
+        });
+    });
+  }
+
+  public static checkout(name: string, webUrl: string, logger: Logger, debug: boolean, verbose: boolean): Promise<ClientSidePageProperties> {
+    return new Promise<ClientSidePageProperties>((resolve: (page: ClientSidePageProperties) => void, reject: (error: any) => void): void => {
+      if (verbose) {
+        logger.log(`Checking out ${name} page...`);
+      }
+
+      let pageName: string = this.getPageNameWithExtension(name);
+
+      const requestOptions: any = {
+        url: `${webUrl}/_api/sitepages/pages/GetByUrl('sitepages/${encodeURIComponent(pageName)}')/checkoutpage`,
+        headers: {
+          'accept': 'application/json;odata=nometadata'
+        },
+        responseType: 'json'
+      };
+
+      request
+        .post<ClientSidePageProperties>(requestOptions)
+        .then((pageData: ClientSidePageProperties) => {
+          if (!pageData) {
+            reject(`Page ${name} information not retrieved with the checkout`);
+            return;
+          }
+
+          if (verbose) {
+            logger.log(`Page ${name} is now checked out`);
+          }
+
+          resolve(pageData);
+        }, (error: any): void => {
+          reject(error);
+        });
+    });
+  }
+
+  public static save(name: string, webUrl: string, canvasContent: any, logger: Logger, debug: boolean, verbose: boolean): Promise<void> {
+    return new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
+      if (verbose) {
+        logger.log(`Saving ${name} page...`);
+      }
+
+      if (!canvasContent) {
+        reject('No canvas content was provided');
+        return;
+      }
+
+      let pageName: string = this.getPageNameWithExtension(name);
+
+      const requestOptions: any = {
+        url: `${webUrl}/_api/sitepages/pages/GetByUrl('sitepages/${encodeURIComponent(pageName)}')/savepage`,
+        headers: {
+          'accept': 'application/json;odata=nometadata',
+          'content-type': 'application/json;odata=nometadata'
+        },
+        data: {
+          CanvasContent1: JSON.stringify(canvasContent)
+        },
+        responseType: 'json'
+      };
+
+      request
+        .post(requestOptions)
+        .then((res: any) => {
+          if (verbose) {
+            logger.log(res);
+          }
+          
+          resolve();
         }, (error: any): void => {
           reject(error);
         });
@@ -96,5 +168,13 @@ export class Page {
       order: section.order,
       columns: section.columns.map(column => this.getColumnsInformation(column, isJSONOutput))
     }
+  }
+
+  private static getPageNameWithExtension(name: string): string {
+    let pageName: string = name;
+    if (pageName.indexOf('.aspx') < 0) {
+      pageName += '.aspx';
+    }
+    return pageName;
   }
 }

--- a/src/m365/spo/commands/page/page-clientsidewebpart-add.ts
+++ b/src/m365/spo/commands/page/page-clientsidewebpart-add.ts
@@ -337,12 +337,12 @@ class SpoPageClientSideWebPartAddCommand extends SpoCommand {
   }
 
   /**
- * Provides functionality to extend the given object by doing a shallow copy
- *
- * @param target The object to which properties will be copied
- * @param source The source object from which properties will be copied
- *
- */
+   * Provides functionality to extend the given object by doing a shallow copy
+   *
+   * @param target The object to which properties will be copied
+   * @param source The source object from which properties will be copied
+   *
+   */
   private extend(target: any, source: any): any {
     return Object.getOwnPropertyNames(source)
       .reduce((t: any, v: string) => {

--- a/src/m365/spo/commands/page/page-control-set.mock.ts
+++ b/src/m365/spo/commands/page/page-control-set.mock.ts
@@ -1,0 +1,114 @@
+export const mockPage = {
+  "ListItemAllFields": {
+    "CommentsDisabled": false,
+    "FileSystemObjectType": 0,
+    "Id": 1,
+    "ServerRedirectedEmbedUri": null,
+    "ServerRedirectedEmbedUrl": "",
+    "ContentTypeId": "0x0101009D1CB255DA76424F860D91F20E6C41180062FDF2882AB3F745ACB63105A3C623C9",
+    "FileLeafRef": "Home.aspx",
+    "ComplianceAssetId": null,
+    "WikiField": null,
+    "Title": "Home",
+    "ClientSideApplicationId": "b6917cb1-93a0-4b97-a84d-7cf49975d4ec",
+    "PageLayoutType": "Home",
+    "CanvasContent1": "<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;3,&quot;displayMode&quot;&#58;2,&quot;id&quot;&#58;&quot;ede2ee65-157d-4523-b4ed-87b9b64374a6&quot;,&quot;position&quot;&#58;&#123;&quot;zoneIndex&quot;&#58;1,&quot;sectionIndex&quot;&#58;1,&quot;controlIndex&quot;&#58;0.5,&quot;sectionFactor&quot;&#58;8&#125;,&quot;webPartId&quot;&#58;&quot;34b617b3-5f5d-4682-98ed-fc6908dc0f4c&quot;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"><div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" data-sp-webpartdata=\"&#123;&quot;id&quot;&#58;&quot;34b617b3-5f5d-4682-98ed-fc6908dc0f4c&quot;,&quot;instanceId&quot;&#58;&quot;ede2ee65-157d-4523-b4ed-87b9b64374a6&quot;,&quot;title&quot;&#58;&quot;Minified HelloWorld&quot;,&quot;description&quot;&#58;&quot;HelloWorld description&quot;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;description&quot;&#58;&quot;HelloWorld&quot;&#125;&#125;\"><div data-sp-componentid=\"\">34b617b3-5f5d-4682-98ed-fc6908dc0f4c</div><div data-sp-htmlproperties=\"\"></div></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;3,&quot;webPartId&quot;&#58;&quot;8c88f208-6c77-4bdb-86a0-0c47b4316588&quot;,&quot;position&quot;&#58;&#123;&quot;zoneIndex&quot;&#58;1,&quot;sectionIndex&quot;&#58;1,&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;8&#125;,&quot;displayMode&quot;&#58;2,&quot;addedFromPersistedData&quot;&#58;true,&quot;id&quot;&#58;&quot;3ede60d3-dc2c-438b-b5bf-cc40bb2351e5&quot;&#125;\"><div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" data-sp-webpartdata=\"&#123;&quot;id&quot;&#58;&quot;8c88f208-6c77-4bdb-86a0-0c47b4316588&quot;,&quot;instanceId&quot;&#58;&quot;3ede60d3-dc2c-438b-b5bf-cc40bb2351e5&quot;,&quot;title&quot;&#58;&quot;News&quot;,&quot;description&quot;&#58;&quot;Display recent news.&quot;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&quot;title&quot;&#58;&quot;News&quot;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&quot;baseUrl&quot;&#58;&quot;https&#58;//contoso.sharepoint.com/sites/team-a&quot;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;layoutId&quot;&#58;&quot;FeaturedNews&quot;,&quot;dataProviderId&quot;&#58;&quot;viewCounts&quot;,&quot;emptyStateHelpItemsCount&quot;&#58;1,&quot;newsDataSourceProp&quot;&#58;2,&quot;newsSiteList&quot;&#58;[],&quot;webId&quot;&#58;&quot;4f118c69-66e0-497c-96ff-d7855ce0713d&quot;,&quot;siteId&quot;&#58;&quot;016bd1f4-ea50-46a4-809b-e97efb96399c&quot;&#125;&#125;\"><div data-sp-componentid=\"\">8c88f208-6c77-4bdb-86a0-0c47b4316588</div><div data-sp-htmlproperties=\"\"><div data-sp-prop-name=\"title\" data-sp-searchableplaintext=\"true\">News</div><a data-sp-prop-name=\"baseUrl\" href=\"/sites/team-a\"></a></div></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;3,&quot;webPartId&quot;&#58;&quot;c70391ea-0b10-4ee9-b2b4-006d3fcad0cd&quot;,&quot;position&quot;&#58;&#123;&quot;zoneIndex&quot;&#58;1,&quot;sectionIndex&quot;&#58;2,&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;4&#125;,&quot;displayMode&quot;&#58;2,&quot;addedFromPersistedData&quot;&#58;true,&quot;id&quot;&#58;&quot;63da0d97-9db4-4847-a4bf-3ae019d4c6f2&quot;&#125;\"><div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" data-sp-webpartdata=\"&#123;&quot;id&quot;&#58;&quot;c70391ea-0b10-4ee9-b2b4-006d3fcad0cd&quot;,&quot;instanceId&quot;&#58;&quot;63da0d97-9db4-4847-a4bf-3ae019d4c6f2&quot;,&quot;title&quot;&#58;&quot;Quick links&quot;,&quot;description&quot;&#58;&quot;Add links to important documents and pages.&quot;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&quot;title&quot;&#58;&quot;Quick links&quot;,&quot;items[0].title&quot;&#58;&quot;Learn about a team site&quot;,&quot;items[1].title&quot;&#58;&quot;Learn how to add a page&quot;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&quot;baseUrl&quot;&#58;&quot;https&#58;//contoso.sharepoint.com/sites/team-a&quot;,&quot;items[0].url&quot;&#58;&quot;https&#58;//go.microsoft.com/fwlink/p/?linkid=827918&quot;,&quot;items[1].url&quot;&#58;&quot;https&#58;//go.microsoft.com/fwlink/p/?linkid=827919&quot;,&quot;items[0].renderInfo.linkUrl&quot;&#58;&quot;https&#58;//go.microsoft.com/fwlink/p/?linkid=827918&quot;,&quot;items[1].renderInfo.linkUrl&quot;&#58;&quot;https&#58;//go.microsoft.com/fwlink/p/?linkid=827919&quot;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;items&quot;&#58;[&#123;&quot;siteId&quot;&#58;&quot;00000000-0000-0000-0000-000000000000&quot;,&quot;webId&quot;&#58;&quot;00000000-0000-0000-0000-000000000000&quot;,&quot;uniqueId&quot;&#58;&quot;00000000-0000-0000-0000-000000000000&quot;,&quot;itemType&quot;&#58;2,&quot;fileExtension&quot;&#58;&quot;com/fwlink/p/?linkid=827918&quot;,&quot;progId&quot;&#58;&quot;&quot;,&quot;flags&quot;&#58;0,&quot;hasInvalidUrl&quot;&#58;false,&quot;renderInfo&quot;&#58;&#123;&quot;imageUrl&quot;&#58;&quot;&quot;,&quot;compactImageInfo&quot;&#58;&#123;&quot;iconName&quot;&#58;&quot;Globe&quot;,&quot;color&quot;&#58;&quot;&quot;,&quot;imageUrl&quot;&#58;&quot;&quot;,&quot;forceIconSize&quot;&#58;true&#125;,&quot;backupImageUrl&quot;&#58;&quot;&quot;,&quot;iconUrl&quot;&#58;&quot;&quot;,&quot;accentColor&quot;&#58;&quot;&quot;,&quot;imageFit&quot;&#58;0,&quot;forceStandardImageSize&quot;&#58;false,&quot;isFetching&quot;&#58;false&#125;,&quot;id&quot;&#58;1&#125;,&#123;&quot;siteId&quot;&#58;&quot;00000000-0000-0000-0000-000000000000&quot;,&quot;webId&quot;&#58;&quot;00000000-0000-0000-0000-000000000000&quot;,&quot;uniqueId&quot;&#58;&quot;00000000-0000-0000-0000-000000000000&quot;,&quot;itemType&quot;&#58;2,&quot;fileExtension&quot;&#58;&quot;com/fwlink/p/?linkid=827919&quot;,&quot;progId&quot;&#58;&quot;&quot;,&quot;flags&quot;&#58;0,&quot;hasInvalidUrl&quot;&#58;false,&quot;renderInfo&quot;&#58;&#123;&quot;imageUrl&quot;&#58;&quot;&quot;,&quot;compactImageInfo&quot;&#58;&#123;&quot;iconName&quot;&#58;&quot;Globe&quot;,&quot;color&quot;&#58;&quot;&quot;,&quot;imageUrl&quot;&#58;&quot;&quot;,&quot;forceIconSize&quot;&#58;true&#125;,&quot;backupImageUrl&quot;&#58;&quot;&quot;,&quot;iconUrl&quot;&#58;&quot;&quot;,&quot;accentColor&quot;&#58;&quot;&quot;,&quot;imageFit&quot;&#58;0,&quot;forceStandardImageSize&quot;&#58;false,&quot;isFetching&quot;&#58;false&#125;,&quot;id&quot;&#58;2&#125;],&quot;isMigrated&quot;&#58;true,&quot;layoutId&quot;&#58;&quot;CompactCard&quot;,&quot;shouldShowThumbnail&quot;&#58;true,&quot;hideWebPartWhenEmpty&quot;&#58;true,&quot;dataProviderId&quot;&#58;&quot;QuickLinks&quot;,&quot;webId&quot;&#58;&quot;4f118c69-66e0-497c-96ff-d7855ce0713d&quot;,&quot;siteId&quot;&#58;&quot;016bd1f4-ea50-46a4-809b-e97efb96399c&quot;&#125;&#125;\"><div data-sp-componentid=\"\">c70391ea-0b10-4ee9-b2b4-006d3fcad0cd</div><div data-sp-htmlproperties=\"\"><div data-sp-prop-name=\"title\" data-sp-searchableplaintext=\"true\">Quick links</div><div data-sp-prop-name=\"items[0].title\" data-sp-searchableplaintext=\"true\">Learn about a team site</div><div data-sp-prop-name=\"items[1].title\" data-sp-searchableplaintext=\"true\">Learn how to add a page</div><a data-sp-prop-name=\"baseUrl\" href=\"/sites/team-a\"></a><a data-sp-prop-name=\"items[0].url\" href=\"https&#58;//go.microsoft.com/fwlink/p/?linkid=827918\"></a><a data-sp-prop-name=\"items[1].url\" href=\"https&#58;//go.microsoft.com/fwlink/p/?linkid=827919\"></a><a data-sp-prop-name=\"items[0].renderInfo.linkUrl\" href=\"https&#58;//go.microsoft.com/fwlink/p/?linkid=827918\"></a><a data-sp-prop-name=\"items[1].renderInfo.linkUrl\" href=\"https&#58;//go.microsoft.com/fwlink/p/?linkid=827919\"></a></div></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;3,&quot;webPartId&quot;&#58;&quot;eb95c819-ab8f-4689-bd03-0c2d65d47b1f&quot;,&quot;position&quot;&#58;&#123;&quot;zoneIndex&quot;&#58;2,&quot;sectionIndex&quot;&#58;1,&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;8&#125;,&quot;displayMode&quot;&#58;2,&quot;addedFromPersistedData&quot;&#58;true,&quot;id&quot;&#58;&quot;4366ceff-b92b-4a12-905e-1dd2535f976d&quot;&#125;\"><div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" data-sp-webpartdata=\"&#123;&quot;id&quot;&#58;&quot;eb95c819-ab8f-4689-bd03-0c2d65d47b1f&quot;,&quot;instanceId&quot;&#58;&quot;4366ceff-b92b-4a12-905e-1dd2535f976d&quot;,&quot;title&quot;&#58;&quot;Site activity&quot;,&quot;description&quot;&#58;&quot;Show recent activities from your site.&quot;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;maxItems&quot;&#58;9&#125;&#125;\"><div data-sp-componentid=\"\">eb95c819-ab8f-4689-bd03-0c2d65d47b1f</div><div data-sp-htmlproperties=\"\"></div></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;3,&quot;webPartId&quot;&#58;&quot;f92bf067-bc19-489e-a556-7fe95f508720&quot;,&quot;position&quot;&#58;&#123;&quot;zoneIndex&quot;&#58;2,&quot;sectionIndex&quot;&#58;2,&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;4&#125;,&quot;addedFromPersistedData&quot;&#58;true,&quot;displayMode&quot;&#58;2,&quot;id&quot;&#58;&quot;456dfbc7-57be-4489-92ce-666224c4fcf1&quot;&#125;\"><div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" data-sp-webpartdata=\"&#123;&quot;id&quot;&#58;&quot;f92bf067-bc19-489e-a556-7fe95f508720&quot;,&quot;instanceId&quot;&#58;&quot;456dfbc7-57be-4489-92ce-666224c4fcf1&quot;,&quot;title&quot;&#58;&quot;Document library&quot;,&quot;description&quot;&#58;&quot;Add a document library.&quot;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;isDocumentLibrary&quot;&#58;true,&quot;showDefaultDocumentLibrary&quot;&#58;true,&quot;webpartHeightKey&quot;&#58;4,&quot;selectedListUrl&quot;&#58;&quot;&quot;,&quot;listTitle&quot;&#58;&quot;Documents&quot;&#125;&#125;\"><div data-sp-componentid=\"\">f92bf067-bc19-489e-a556-7fe95f508720</div><div data-sp-htmlproperties=\"\"></div></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;4,&quot;displayMode&quot;&#58;2,&quot;id&quot;&#58;&quot;d933a0dd-9536-48a6-bd85-888b85ede7d0&quot;,&quot;position&quot;&#58;&#123;&quot;zoneIndex&quot;&#58;3,&quot;sectionIndex&quot;&#58;1,&quot;controlIndex&quot;&#58;1&#125;,&quot;innerHTML&quot;&#58;&quot;&lt;p&gt;Lorem ipsum&lt;/p&gt;\\n\\n&lt;p&gt;Dolor samet&lt;/p&gt;\\n&quot;,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"><div data-sp-rte=\"\"><p>Lorem ipsum</p>\n\n<p>Dolor samet</p>\n</div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;4,&quot;displayMode&quot;&#58;2,&quot;id&quot;&#58;&quot;135f1d1a-2eb9-4655-a913-b9f23114b01f&quot;,&quot;position&quot;&#58;&#123;&quot;zoneIndex&quot;&#58;4,&quot;sectionIndex&quot;&#58;1,&quot;controlIndex&quot;&#58;1&#125;,&quot;innerHTML&quot;&#58;&quot;&lt;p&gt;Lorem ipsum&lt;/p&gt;\\n&quot;,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"><div data-sp-rte=\"\"><p>Lorem ipsum</p>\n</div></div></div>",
+    "BannerImageUrl": {
+      "Description": "/_layouts/15/images/sitepagethumbnail.png",
+      "Url": "https://contoso.sharepoint.com/_layouts/15/images/sitepagethumbnail.png"
+    },
+    "Description": "Lorem ipsum Dolor samet Lorem ipsum",
+    "PromotedState": null,
+    "FirstPublishedDate": null,
+    "LayoutWebpartsContent": null,
+    "AuthorsId": null,
+    "AuthorsStringId": null,
+    "OriginalSourceUrl": null,
+    "ID": 1,
+    "Created": "2018-01-20T09:54:41",
+    "AuthorId": 1073741823,
+    "Modified": "2018-04-12T12:42:47",
+    "EditorId": 12,
+    "OData__CopySource": null,
+    "CheckoutUserId": null,
+    "OData__UIVersionString": "7.0",
+    "GUID": "edaab907-e729-48dd-9e73-26487c0cf592"
+  },
+  "CheckInComment": "",
+  "CheckOutType": 2,
+  "ContentTag": "{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25,1",
+  "CustomizedPageStatus": 1,
+  "ETag": "\"{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25\"",
+  "Exists": true,
+  "IrmEnabled": false,
+  "Length": "805",
+  "Level": 1,
+  "LinkingUri": null,
+  "LinkingUrl": "",
+  "MajorVersion": 7,
+  "MinorVersion": 0,
+  "Name": "home.aspx",
+  "ServerRelativeUrl": "/sites/team-a/SitePages/home.aspx",
+  "TimeCreated": "2018-01-20T08:54:41Z",
+  "TimeLastModified": "2018-04-12T10:42:46Z",
+  "Title": "Home",
+  "UIVersion": 3584,
+  "UIVersionLabel": "7.0",
+  "UniqueId": "e82a21d1-ca2c-4854-98f2-012ac0e7fa09"
+};
+
+export const CanvasContent = {
+  "controlType": 3,
+  "displayMode": 2,
+  "id": "ede2ee65-157d-4523-b4ed-87b9b64374a6",
+  "position": {
+    "zoneIndex": 1,
+    "sectionIndex": 1,
+    "sectionFactor": 12,
+    "layoutIndex": 1,
+    "controlIndex": 1
+  },
+  "webPartId": "ede2ee65-157d-4523-b4ed-87b9b64374a6",
+  "emphasis": {},
+  "addedFromPersistedData": true,
+  "reservedHeight": 600,
+  "reservedWidth": 969,
+  "webPartData": {
+    "id": "ede2ee65-157d-4523-b4ed-87b9b64374a6",
+    "instanceId": "dcd01c36-24f9-42e5-8e03-76e4af572468",
+    "title": "valo-markdown",
+    "description": "Use markdown to add text, tables, links, and images to your page.",
+    "serverProcessedContent": {
+      "htmlStrings": {
+        "html": "<h2 id=\"this-is-just-a-test\">This is just a test</h2><p>Test for playbook 123</p><div class=\"react-codemirror2\"><div class=\"CodeMirror cm-s-monokai CodeMirror-wrap\"><div class=\"CodeMirror-vscrollbar\" tabindex=\"-1\" style=\"bottom:0px;\"><div style=\"min-width:1px;height:0px;\"></div></div><div class=\"CodeMirror-hscrollbar\" tabindex=\"-1\"><div style=\"height:100%;min-height:1px;width:0px;\"></div></div><div class=\"CodeMirror-scrollbar-filler\"></div><div class=\"CodeMirror-gutter-filler\"></div><div class=\"CodeMirror-scroll\" tabindex=\"-1\"><div class=\"CodeMirror-sizer\" style=\"margin-left:0px;margin-bottom:-8px;border-right-width:22px;min-height:290px;padding-right:0px;padding-bottom:0px;\"><div style=\"position:relative;top:0px;\"><div class=\"CodeMirror-lines\" role=\"presentation\"><div role=\"presentation\" style=\"position:relative;outline:none;\"><div class=\"CodeMirror-measure\"></div><div class=\"CodeMirror-measure\"></div><div style=\"position:relative;z-index:1;\"></div><div class=\"CodeMirror-cursors\"><div class=\"CodeMirror-cursor\" style=\"left:55.0089px;top:260.571px;height:21.7143px;\">&nbsp;</div></div><div class=\"CodeMirror-code\" role=\"presentation\"><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span class=\"cm-keyword\">const</span> { <span class=\"cm-def\">exec</span> } <span class=\"cm-operator\">=</span> <span class=\"cm-variable\">require</span>(<span class=\"cm-variable\">child_process</span>);</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span class=\"cm-keyword\">const</span> <span class=\"cm-def\">fs</span> <span class=\"cm-operator\">=</span> <span class=\"cm-variable\">require</span>(<span class=\"cm-variable\">fs</span>);</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span class=\"cm-keyword\">const</span> <span class=\"cm-def\">path</span> <span class=\"cm-operator\">=</span> <span class=\"cm-variable\">require</span>(<span class=\"cm-variable\">path</span>);</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span class=\"cm-keyword\">const</span> <span class=\"cm-def\">parseMarkdown</span> <span class=\"cm-operator\">=</span> <span class=\"cm-variable\">require</span>(<span class=\"cm-variable\">frontmatter</span>);</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span>&nbsp;</span></span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span class=\"cm-keyword\">const</span> <span class=\"cm-def\">valoWpTitle</span> <span class=\"cm-operator\">=</span> <span class=\"cm-string-2\">`valo-markdown`</span>;</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span class=\"cm-keyword\">const</span> <span class=\"cm-def\">siteUrl</span> <span class=\"cm-operator\">=</span> <span class=\"cm-string-2\">`https://estruyfdev2.sharepoint.com/sites/StaticPages`</span>;</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span>&nbsp;</span></span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\">(() <span class=\"cm-operator\">=&gt;</span> {</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"> &nbsp;<span class=\"cm-keyword\">if</span> (<span class=\"cm-atom\">true</span>) {</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\"><span>&nbsp;</span></span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\">  }</span></pre><pre class=\" CodeMirror-line \" role=\"presentation\"><span role=\"presentation\" style=\"padding-right:0.1px;\">})();</span></pre></div></div></div></div></div><div style=\"position:absolute;height:22px;width:1px;border-bottom:0px solid transparent;top:290px;\"></div><div class=\"CodeMirror-gutters\" style=\"display:none;height:312px;\"></div></div></div></div><p>!!! Warning\n    This is a warning of mkdocs</p><p>&lt;p style=\"color:red\"&gt;This is a paragraph&lt;/p&gt;</p>"
+      },
+      "searchablePlainTexts": {
+        "code": "\n# This is just a test\n\nTest for playbook 123\n\n```typescript\nconst { exec } = require(child_process);\nconst fs = require(fs);\nconst path = require(path);\nconst parseMarkdown = require(frontmatter);\n\nconst valoWpTitle = `valo-markdown`;\nconst siteUrl = `https://estruyfdev2.sharepoint.com/sites/StaticPages`;\n\n(() => {\n  if (true) {\n\n  }\n})();\n```\n\n\n!!! Warning\n    This is a warning of mkdocs\n\n\n<p style=\"color:red\">This is a paragraph</p>"
+      },
+      "imageSources": {},
+      "links": {}
+    },
+    "dataVersion": "2.0",
+    "properties": {
+      "displayPreview": true,
+      "lineWrapping": true,
+      "miniMap": {
+        "enabled": false
+      },
+      "previewState": "Show",
+      "theme": "Monokai"
+    }
+  }
+};
+
+
+export const mockPageData = {
+  "CanvasContent1": JSON.stringify([{...CanvasContent}])
+};
+
+export const mockPageDataFail = {
+  "CanvasContent1": JSON.stringify([{
+    ...CanvasContent,
+    id: "fake"
+  }])
+}

--- a/src/m365/spo/commands/page/page-control-set.spec.ts
+++ b/src/m365/spo/commands/page/page-control-set.spec.ts
@@ -1,0 +1,325 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import commands from '../../commands';
+import { ClientSidePage } from './clientsidepages';
+import { mockPage, mockPageData, mockPageDataFail } from './page-control-set.mock';
+const command: Command = require('./page-control-set');
+
+describe(commands.PAGE_CONTROL_SET, () => {
+  let log: string[];
+  let logger: Logger;
+  
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      request.get,
+      request.post,
+      ClientSidePage.fromHtml
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  // NAME and DESCRIPTION
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.PAGE_CONTROL_SET), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  // VALIDATE FUNCTIONALITY
+
+  it('correctly handles control not found', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+        return Promise.resolve(mockPage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/team-a', name: 'home.aspx', id: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e6' } }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("Control with ID 3ede60d3-dc2c-438b-b5bf-cc40bb2351e6 not found on page home.aspx")));
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+  it('correctly handles control found and handles error on page checkout error', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+        return Promise.resolve(mockPage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    
+    sinon.stub(request, 'post').callsFake((opts) => {
+      return Promise.reject('An error has occurred');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/team-a', name: 'home.aspx', id: 'ede2ee65-157d-4523-b4ed-87b9b64374a6' } }, (err) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+  it('correctly handles control found and handles page checkout correctly when no data is provided', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+        return Promise.resolve(mockPage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    
+    sinon.stub(request, 'post').callsFake((opts) => {
+      const checkOutPostUrl = `_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`;
+
+      if ((opts.url as string).indexOf(checkOutPostUrl) > -1) {
+        return Promise.resolve(null);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/team-a', name: 'home.aspx', id: 'ede2ee65-157d-4523-b4ed-87b9b64374a6' } }, (err: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Page home.aspx information not retrieved with the checkout')));
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+  it('correctly handles control not found after the page has been checked out', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+        return Promise.resolve(mockPage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    
+    sinon.stub(request, 'post').callsFake((opts) => {
+      const checkOutPostUrl = `_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`;
+
+      if ((opts.url as string).indexOf(checkOutPostUrl) > -1) {
+        return Promise.resolve(mockPageDataFail);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/team-a', name: 'home.aspx', id: 'ede2ee65-157d-4523-b4ed-87b9b64374a6' } }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Control with ID ede2ee65-157d-4523-b4ed-87b9b64374a6 not found on page home.aspx')));
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  
+  it('correctly handles control found and handles page checkout', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+        return Promise.resolve(mockPage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    
+    sinon.stub(request, 'post').callsFake((opts) => {
+      const checkOutPostUrl = `_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`;
+
+      if ((opts.url as string).indexOf(checkOutPostUrl) > -1) {
+        return Promise.resolve(mockPageData);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/team-a', name: 'home.aspx', id: 'ede2ee65-157d-4523-b4ed-87b9b64374a6' } }, (err) => {
+      try {
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+
+  it('correctly page save with webPartData', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+        return Promise.resolve(mockPage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    
+    sinon.stub(request, 'post').callsFake((opts) => {
+      const checkOutPostUrl = `_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`;
+      const savePagePostUrl = `_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/savepage`;
+
+      if ((opts.url as string).indexOf(checkOutPostUrl) > -1) {
+        return Promise.resolve(mockPageData);
+      }
+
+      if ((opts.url as string).indexOf(savePagePostUrl) > -1) {
+        return Promise.resolve({});
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/team-a', name: 'home.aspx', id: 'ede2ee65-157d-4523-b4ed-87b9b64374a6', webPartData: '{}' } }, (err?: any) => {
+      try {
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+
+  it('correctly page save with webPartProperties', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+        return Promise.resolve(mockPage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    
+    sinon.stub(request, 'post').callsFake((opts) => {
+      const checkOutPostUrl = `_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`;
+      const savePagePostUrl = `_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/savepage`;
+
+      if ((opts.url as string).indexOf(checkOutPostUrl) > -1) {
+        return Promise.resolve(mockPageData);
+      }
+
+      if ((opts.url as string).indexOf(savePagePostUrl) > -1) {
+        return Promise.resolve({});
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/team-a', name: 'home.aspx', id: 'ede2ee65-157d-4523-b4ed-87b9b64374a6', webPartProperties: '{}' } }, (err?: any) => {
+      try {
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+
+  it('correctly handles OData error when retrieving pages', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      return Promise.reject({ error: { 'odata.error': { message: { value: 'An error has occurred' } } } });
+    });
+
+    command.action(logger, { options: { debug: true, id: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e5', webPartData: "{}", webUrl: 'https://contoso.sharepoint.com', name: 'home.aspx' } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  // OPTIONS
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  // VALIDATION
+
+  it('fails validation if the specified id is not a valid GUID', () => {
+    const actual = command.validate({ options: { id: 'abc', name: 'home.aspx', webUrl: 'https://contoso.sharepoint.com' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the specified webPartProperties is not a valid JSON string', () => {
+    const actual = command.validate({ options: { webPartProperties: "abc", id: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e5', name: 'home.aspx', webUrl: 'https://contoso.sharepoint.com' } });
+    assert.notStrictEqual(actual, true);
+  });
+  
+  it('fails validation if the specified webPartData is not a valid JSON string', () => {
+    const actual = command.validate({ options: { webPartData: "abc", id: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e5', name: 'home.aspx', webUrl: 'https://contoso.sharepoint.com' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the webPartData and webPartProperties options are provided', () => {
+    const actual = command.validate({ options: { webPartProperties: "{}", webPartData: "{}", id: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e5', webUrl: 'foo', name: 'home.aspx' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the webUrl option is not a valid SharePoint site URL', () => {
+    const actual = command.validate({ options: { id: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e5', webUrl: 'foo', name: 'home.aspx' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when right properties are provided', () => {
+    const actual = command.validate({ options: { id: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e5', webPartData: "{}", webUrl: 'https://contoso.sharepoint.com', name: 'home.aspx' } });
+    assert.strictEqual(actual, true);
+  });
+  
+});

--- a/src/m365/spo/commands/page/page-control-set.ts
+++ b/src/m365/spo/commands/page/page-control-set.ts
@@ -1,0 +1,177 @@
+import * as chalk from 'chalk';
+import { Logger } from '../../../../cli';
+import { CommandOption } from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import Utils from '../../../../Utils';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+import { ClientSideControl } from './ClientSideControl';
+import { ClientSidePageProperties } from './ClientSidePageProperties';
+import { ClientSidePage, ClientSidePart } from './clientsidepages';
+import { Page } from './Page';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  id: string;
+  name: string;
+  webUrl: string;
+  webPartData?: string;
+  webPartProperties?: string;
+}
+
+class SpoPageControlSetCommand extends SpoCommand {
+
+  public get name(): string {
+    return `${commands.PAGE_CONTROL_SET}`;
+  }
+
+  public get description(): string {
+    return 'Allows you to set or update control webpart data or properties on a modern page';
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+    Page
+      .getPage(args.options.name, args.options.webUrl, logger, this.debug, this.verbose)
+      .then((clientSidePage: ClientSidePage): Promise<ClientSidePageProperties> => {
+        let control: ClientSidePart | null = clientSidePage.findControlById(args.options.id);
+
+        if (control) {
+          if (this.verbose) {
+            logger.log(`Control with ID ${args.options.id} found on the page`);
+          }
+
+          // Check out the page
+          return Page.checkout(args.options.name, args.options.webUrl, logger, this.debug, this.verbose);
+        } else {
+          return Promise.reject(`Control with ID ${args.options.id} not found on page ${args.options.name}`);
+        }
+      })
+      .then((page: ClientSidePageProperties) => {
+        // Update the web part data
+        const canvasContent: ClientSideControl[] = JSON.parse(page.CanvasContent1);
+        if (this.debug) {
+          logger.log(canvasContent);
+        }
+
+        let csControl = canvasContent.find(c => c.id === args.options.id);
+
+        if (csControl) {
+          if (args.options.webPartData) {
+            if (this.verbose) {
+              logger.log('WebPart data:');
+              logger.log(args.options.webPartData);
+              logger.log('');
+            }
+        
+            const webPartData = JSON.parse(args.options.webPartData);
+        
+            csControl.webPartData = {
+              ...csControl.webPartData,
+              ...webPartData,
+              id: csControl.webPartData.id,
+              instanceId: csControl.webPartData.instanceId
+            };
+            
+            if (this.verbose) {
+              logger.log('Updated webpart data:');
+              logger.log(csControl.webPartData);
+              logger.log('');
+            }
+          }
+          
+          if (args.options.webPartProperties) {
+            if (this.verbose) {
+              logger.log('webPartProperties data:');
+              logger.log(args.options.webPartProperties);
+              logger.log('');
+            }
+        
+            const webpartProperties = JSON.parse(args.options.webPartProperties);
+        
+            csControl.webPartData.properties = {
+              ...csControl.webPartData.properties,
+              ...webpartProperties
+            };        
+        
+            if (this.verbose) {
+              logger.log('Updated webpart properties:');
+              logger.log(csControl.webPartData.properties);
+              logger.log('');
+            }
+          }
+        
+          return Page.save(args.options.name, args.options.webUrl, canvasContent, logger, this.debug, this.verbose);
+        } else {
+          return Promise.reject(`Control with ID ${args.options.id} not found on page ${args.options.name}`);
+        }
+      })
+      .then(() => {
+        if (this.verbose) {
+          logger.log(chalk.green('DONE'));
+        }
+        cb();
+      })
+      .catch((err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --id <id>',
+        description: 'ID of the control to set new properties for'
+      },
+      {
+        option: '-n, --name <name>',
+        description: 'Name of the page where the control is located'
+      },
+      {
+        option: '-u, --webUrl <webUrl>',
+        description: 'URL of the site where the page to retrieve is located'
+      },
+      {
+        option: '--webPartData <webPartData>',
+        description: 'JSON string with web part data as retrieved from the web part maintenance mode. Specify webPartProperties or webPartData but not both'
+      },
+      {
+        option: '--webPartProperties <webPartProperties>',
+        description: 'JSON string with web part data as retrieved from the web part maintenance mode. Specify webPartProperties or webPartData but not both'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    if (!Utils.isValidGuid(args.options.id)) {
+      return `${args.options.id} is not a valid GUID`;
+    }
+
+    if (args.options.webPartProperties) {
+      try {
+        JSON.parse(args.options.webPartProperties);
+      } catch (e) {
+        return `Specified webPartProperties is not a valid JSON string. Input: ${args.options.webPartData}. Error: ${e}`;
+      }
+    }
+
+    if (args.options.webPartData) {
+      try {
+        JSON.parse(args.options.webPartData);
+      } catch (e) {
+        return `Specified webPartData is not a valid JSON string. Input: ${args.options.webPartData}. Error: ${e}`;
+      }
+    }
+
+    if (args.options.webPartData && args.options.webPartProperties) {
+      return 'Specify webPartProperties or webPartData but not both';
+    }
+
+    return SpoCommand.isValidSharePointUrl(args.options.webUrl);
+  }
+}
+
+module.exports = new SpoPageControlSetCommand();

--- a/src/m365/spo/commands/page/page-control-set.ts
+++ b/src/m365/spo/commands/page/page-control-set.ts
@@ -132,11 +132,11 @@ class SpoPageControlSetCommand extends SpoCommand {
         description: 'URL of the site where the page to retrieve is located'
       },
       {
-        option: '--webPartData <webPartData>',
+        option: '--webPartData [webPartData]',
         description: 'JSON string with web part data as retrieved from the web part maintenance mode. Specify webPartProperties or webPartData but not both'
       },
       {
-        option: '--webPartProperties <webPartProperties>',
+        option: '--webPartProperties [webPartProperties]',
         description: 'JSON string with web part data as retrieved from the web part maintenance mode. Specify webPartProperties or webPartData but not both'
       }
     ];


### PR DESCRIPTION
Closes #1934

This PR contains the new command to set the control properties / data on a modern page.

Usage: `m365 spo page control set --webUrl <siteUrl> --name <name> --id <control id> --webPartData '{}'`
