### PR TITLE
#1936 - Fix for excluding command and arguments as field values

### DIFF
--- a/src/m365/spo/commands/file/file-add.ts
+++ b/src/m365/spo/commands/file/file-add.ts
@@ -618,7 +618,12 @@ class SpoFileAddCommand extends SpoCommand {
       'publishComment',
       'debug',
       'verbose',
-      'output'
+      'output',
+      '_',
+      'u',
+      'p',
+      'f',
+      'o'
     ];
 
     Object.keys(options).forEach(key => {


### PR DESCRIPTION
This PR fixes an issue where the short names of arguments are passed for field validation when uploading a file. As `_` underscore is not allowed to be used, SharePoint returns a 400 status error. Check more on #1936.
