### PR TITLE
Bug report: `--help` not displaying interactive help for alias commands. Closes#1907

### DIFF
--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -435,7 +435,10 @@ export class Cli {
 
   private printCommandHelp(): void {
     let helpFilePath = '';
-    const commandNameWords = (this.optionsFromArgs as { options: minimist.ParsedArgs }).options._;
+    let commandNameWords: string[] = [];
+    if (this.commandToExecute) {
+       commandNameWords = (this.commandToExecute.name).split(' ');
+    }
     const pathChunks: string[] = [this.commandsFolder, '..', '..', 'docs', 'docs', 'cmd'];
 
     if (commandNameWords.length === 1) {


### PR DESCRIPTION
Closes #1907

**Aliased command**
![m365alias1](https://user-images.githubusercontent.com/36161889/98576611-13b83480-22bb-11eb-86a0-d60c0aceefe8.png)

**command**
![m365alias2](https://user-images.githubusercontent.com/36161889/98576631-1c106f80-22bb-11eb-9bbc-e46e05e86a34.png)



