### PR TITLE
Makes 'console.log()' synchronous. Closes #1266

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,14 @@ appInsights.trackEvent({
   name: 'started'
 });
 
+// required to make console.log() in combination with piped output synchronous
+// on Windows/in PowerShell so that the output is not trimmed by calling
+// process.exit() after executing the command, while the output is still
+// being processed; https://github.com/pnp/cli-microsoft365/issues/1266
+if ((process.stdout as any)._handle) {
+  (process.stdout as any)._handle.setBlocking(true);
+}
+
 updateNotifier({ pkg: packageJSON }).notify({ defer: false });
 
 fs.realpath(__dirname, (err: NodeJS.ErrnoException | null, resolvedPath: string): void => {


### PR DESCRIPTION
Makes 'console.log()' synchronous. Closes #1266