### PR TITLE
[DOCS] Update login command docs to include links to user-guide articles

### DIFF
--- a/docs/docs/cmd/login.md
+++ b/docs/docs/cmd/login.md
@@ -44,15 +44,16 @@ m365 login [options]
 
 Using the `login` command you can log in to Microsoft 365.
 
-By default, the `login` command uses device code OAuth flow to log in to Microsoft 365. Alternatively, you can authenticate using a user name and password or certificate, which are convenient for CI/CD scenarios, but which come with their own limitations. See the CLI for Microsoft 365 manual for more information.
+By default, the `login` command uses device code OAuth flow to log in to Microsoft 365. Alternatively, you can authenticate using a user name and password or certificate, which are convenient for CI/CD scenarios, but which come with their own limitations. See the [CLI for Microsoft 365 manual](../user-guide/connecting-office-365.md) for more information.
 
 When logging in to Microsoft 365, the `login` command stores in memory the access token and the refresh token. Both tokens are cleared from memory after exiting the CLI or by calling the [logout](logout.md) command.
 
 When logging in to Microsoft 365 using the user name and password, next to the access and refresh token, the CLI for Microsoft 365 will store the user credentials so that it can automatically re-authenticate if necessary. Similarly to the tokens, the credentials are removed by re-authenticating using the device code or by calling the [logout](logout.md) command.
 
-When logging in to Microsoft 365 using a certificate, the CLI for Microsoft 365 will store the contents of the certificate so that it can automatically re-authenticate if necessary. The contents of the certificate are removed by re-authenticating using the device code or by calling the [logout](logout.md) command.
+When logging in to Microsoft 365 using a certificate, the CLI for Microsoft 365 will store the contents of the certificate so that it can automatically re-authenticate if necessary. The contents of the certificate are removed by re-authenticating using the device code or by calling the [logout](logout.md) command.  
 
-To log in to Microsoft 365 using a certificate, you will typically create a custom Azure AD application. To use this application with the CLI for Microsoft 365, you will set the `CLIMICROSOFT365_AADAPPID` environment variable to the application's ID and the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Azure AD tenant, where you created the Azure AD application.
+To log in to Microsoft 365 using a certificate, you will typically [create a custom Azure AD application](../user-guide/using-own-identity.md). To use this application with the CLI for Microsoft 365, you will set the `CLIMICROSOFT365_AADAPPID` environment variable to the application's ID and the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Azure AD tenant, where you created the Azure AD application.  
+Please make sure to read about [the caveats when using the certificate login option](../user-guide/cli-certificate-caveats.md).
 
 Managed identity in Azure Cloud Shell is the identity of the user. It is neither system- nor user-assigned and it can't be configured. To log in to Microsoft 365 using managed identity in Azure Cloud Shell, set `authType` to `identity` and don't specify the `userName` option.
 


### PR DESCRIPTION
Added links to the more generic documentation, and especially the caveats article directly from the login command documentation.
It helps users more easily discover the global user guide articles when struggling with a specific action in the login command.