### PR TITLE
Added option certificateBase64Encoded to m365 login command. Closes #1971

### DIFF
--- a/docs/docs/cmd/login.md
+++ b/docs/docs/cmd/login.md
@@ -20,7 +20,10 @@ m365 login [options]
 : Password for the user. Required when `authType` is set to `password`
 
 `-c, --certificateFile [certificateFile]`
-: Path to the file with certificate private key. Required when `authType` is set to `certificate`
+: Path to the file with certificate private key. Required when `authType` is set to `certificate` and `certificateBase64Encoded` option is not specified
+
+`--certificateBase64Encoded [certificateBase64Encoded]`
+: Base64 encoded string with a certificate private key.  Required when `authType` is set to `certificate` and `certificateFile` option is not specified
 
 `--thumbprint [thumbprint]`
 : Certificate thumbprint. Required when `authType` is set to `certificate`

--- a/src/m365/commands/login.spec.ts
+++ b/src/m365/commands/login.spec.ts
@@ -110,10 +110,26 @@ describe(commands.LOGIN, () => {
     });
   });
 
-  it('logs in to Microsoft 365 using certificate when authType certificate set', (done) => {
+  it('logs in to Microsoft 365 using certificate when authType certificate set and certificateFile is provided', (done) => {
     sinon.stub(fs, 'readFileSync').callsFake(() => 'certificate');
 
     command.action(logger, { options: { debug: false, authType: 'certificate', certificateFile: 'certificate', thumbprint: 'thumbprint' } }, () => {
+      try {
+        assert.strictEqual(auth.service.authType, AuthType.Certificate, 'Incorrect authType set');
+        assert.strictEqual(auth.service.certificate, 'certificate', 'Incorrect certificate set');
+        assert.strictEqual(auth.service.thumbprint, 'thumbprint', 'Incorrect thumbprint set');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('logs in to Microsoft 365 using certificate when authType certificate set and certificateBase64Encoded is provided', (done) => {
+    sinon.stub(fs, 'readFileSync').callsFake(() => 'certificate');
+
+    command.action(logger, { options: { debug: false, authType: 'certificate', certificateBase64Encoded: 'certificate', thumbprint: 'thumbprint' } }, () => {
       try {
         assert.strictEqual(auth.service.authType, AuthType.Certificate, 'Incorrect authType set');
         assert.strictEqual(auth.service.certificate, 'certificate', 'Incorrect certificate set');
@@ -204,7 +220,12 @@ describe(commands.LOGIN, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if authType is set to certificate and certificateFile not specified', () => {
+  it('fails validation if authType is set to certificate and both certificateFile and certificateBase64Encoded are specified', () => {
+    const actual = command.validate({ options: { authType: 'certificate', certificateFile: 'certificate', certificateBase64Encoded: 'certificateB64', thumbprint: 'thumbprint' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if authType is set to certificate and both certificateFile and certificateBase64Encoded are not specified', () => {
     const actual = command.validate({ options: { authType: 'certificate', thumbprint: 'thumbprint' } });
     assert.notStrictEqual(actual, true);
   });

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -17,6 +17,7 @@ interface Options extends GlobalOptions {
   userName?: string;
   password?: string;
   certificateFile?: string;
+  certificateBase64Encoded?: string;
   thumbprint?: string;
 }
 
@@ -61,7 +62,7 @@ class LoginCommand extends Command {
           break;
         case 'certificate':
           auth.service.authType = AuthType.Certificate;
-          auth.service.certificate = fs.readFileSync(args.options.certificateFile as string, 'base64');
+          auth.service.certificate = args.options.certificateBase64Encoded ? args.options.certificateBase64Encoded : fs.readFileSync(args.options.certificateFile as string, 'base64');
           auth.service.thumbprint = args.options.thumbprint;
           auth.service.password = args.options.password;
           break;
@@ -138,7 +139,11 @@ class LoginCommand extends Command {
       },
       {
         option: '-c, --certificateFile [certificateFile]',
-        description: 'Path to the file with certificate private key. Required when authType is set to certificate'
+        description: 'Path to the file with certificate private key. When authType is set to certificate and certificateBase64Encoded option is not specified'
+      },
+      {
+        option: '--certificateBase64Encoded [certificateBase64Encoded]',
+        description: 'Base64 encoded string with a certificate private key. Required when authType is set to certificate and certificateFile option is not specified'
       },
       {
         option: '--thumbprint [thumbprint]',
@@ -162,12 +167,18 @@ class LoginCommand extends Command {
     }
 
     if (args.options.authType === 'certificate') {
-      if (!args.options.certificateFile) {
-        return 'Required option certificateFile missing';
+      if (args.options.certificateFile && args.options.certificateBase64Encoded) {
+        return 'Specify either certificateFile or certificateBase64Encoded, but not both.';
       }
 
-      if (!fs.existsSync(args.options.certificateFile)) {
-        return `File '${args.options.certificateFile}' does not exist`;
+      if (!args.options.certificateFile && !args.options.certificateBase64Encoded) {
+        return 'Specify atleast certificateFile or certificateBase64Encoded, but not both';
+      }
+
+      if (args.options.certificateFile) {
+        if (!fs.existsSync(args.options.certificateFile)) {
+          return `File '${args.options.certificateFile}' does not exist`;
+        }
       }
 
       if (!args.options.thumbprint) {


### PR DESCRIPTION
Adds an option to pass in a base64Encoded string of a certificate as an alternative to the filepath of a certificate.
Closes #1971 

NOTE: this one modifies similar files as PR's #1978 and #1978. I'll rebase them again when one is merged.