### PR TITLE
Fixes 'm365 spo sitedesign list' command. Closes #2006

### DIFF
--- a/src/m365/spo/commands/sitedesign/sitedesign-list.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-list.ts
@@ -4,7 +4,6 @@ import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
-import { ContextInfo } from '../../spo';
 import { SiteDesign } from './SiteDesign';
 
 interface CommandArgs {
@@ -25,19 +24,12 @@ class SpoSiteDesignListCommand extends SpoCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    let spoUrl: string = '';
-
     this
       .getSpoUrl(logger, this.debug)
-      .then((_spoUrl: string): Promise<ContextInfo> => {
-        spoUrl = _spoUrl;
-        return this.getRequestDigest(spoUrl);
-      })
-      .then((res: ContextInfo): Promise<{ value: SiteDesign[] }> => {
+      .then((spoUrl: string): Promise<{ value: SiteDesign[] }> => {
         const requestOptions: any = {
           url: `${spoUrl}/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesigns`,
           headers: {
-            'X-RequestDigest': res.FormDigestValue,
             accept: 'application/json;odata=nometadata'
           },
           responseType: 'json'


### PR DESCRIPTION
Closes #2006

Removed `request digest` from `m365 spo sitedesign list` implementation.