### PR TITLE
Add `wait-npm-publish` script to CI\CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,9 @@ jobs:
             echo "export PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $BASH_ENV
             source $BASH_ENV
       - run:
+          name: Wait for npm publish
+          command: node scripts/wait-npm-publish.js next $PACKAGE_VERSION
+      - run:
           name: Login to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - run: 
@@ -110,6 +113,9 @@ jobs:
           command: |
             echo "export PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $BASH_ENV
             source $BASH_ENV
+      - run:
+          name: Wait for npm publish
+          command: node scripts/wait-npm-publish.js latest $PACKAGE_VERSION
       - run:
           name: Login to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD

--- a/scripts/wait-npm-publish.js
+++ b/scripts/wait-npm-publish.js
@@ -1,0 +1,26 @@
+const { exec } = require('child_process');
+
+const args = process.argv.slice(2);
+const tag = args[0]
+const version = args[1];
+
+const waitForPublish = function (origResolve, origReject, tag, version) {
+  return new Promise((resolve, reject) => {
+    resolve = (origResolve) ? origResolve : resolve;
+    reject = (origReject) ? origReject : reject;
+    exec(`npm view @pnp/cli-microsoft365@${tag} version`, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+      }
+      if (stdout.trim() === version) {
+        resolve(version)
+      } else {
+        setTimeout(() => waitForPublish(resolve, reject, tag, version), 1000)
+      }
+    })
+  })
+}
+
+waitForPublish(null, null, tag, version)
+  .then(version => console.log(`DONE - ${version}`))
+  .catch(error => console.error(`ERROR - ${error}`))


### PR DESCRIPTION
This pull request will

- Add a new script which will check if a version has been published to `npm` and will wait until that version becomes available before continuing to the `docker` jobs
- Update CI\CD pipeline, adding the `wait-npm-publish` script as a step to the `docker` and `docker_next` job before the docker images are built