### PR TITLE
Fixes Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN apk add --no-cache \
   bash \
   shadow \
   bash-completion \
-  nodejs=12.18.4-r0 \
-  npm=12.18.4-r0
+  nodejs \
+  npm
 
 RUN adduser --system cli-microsoft365
 USER cli-microsoft365


### PR DESCRIPTION
This pull request will

- Remove pinned version of `nodejs` from the Dockerfile to fix the CI\CD build errors
  - apk removes old versions when they are updated, therefore changing to pull the latest version instead of a pinned version on install will ensure that builds continue to work if new versions are published on apk

Build error
```
ERROR: unsatisfiable constraints:
  nodejs-12.20.1-r0:
    breaks: world[nodejs=12.18.4-r0]
    satisfies: npm-12.20.1-r0[nodejs]
  npm-12.20.1-r0:
    breaks: world[npm=12.18.4-r0]
The command '/bin/sh -c apk add --no-cache   curl   sudo   bash   shadow   bash-completion   nodejs=12.18.4-r0   npm=12.18.4-r0' returned a non-zero code: 2
```