### PR TITLE
Removes warning from 'Delete all (non-group connected) modern SharePoint sites' sample script

### DIFF
--- a/docs/docs/sample-scripts/flow/inventory-flows-by-author.md
+++ b/docs/docs/sample-scripts/flow/inventory-flows-by-author.md
@@ -6,9 +6,6 @@ The [Power Automate Admin Center](https://admin.flow.microsoft.com) provides a l
 
 The `bash` version of this script uses an external file to process owner mapping. This is provided in the jq tab and should be saved to the same folder as the bash script and named `merge.jq`.
 
-!!! attention
-    There is a known issue when running scripts that retrieve large amounts of content. See issue [#1266](https://github.com/pnp/cli-microsoft365/issues/1266) for further detail. A best practice is to use a temporary file to enable processing large return sets.
-
 ```powershell tab="PowerShell Core"
 #!/usr/local/bin/pwsh -File
 

--- a/docs/docs/sample-scripts/spo/delete-non-group-connected-modern-sites.md
+++ b/docs/docs/sample-scripts/spo/delete-non-group-connected-modern-sites.md
@@ -4,9 +4,6 @@ Author: [Laura Kokkarinen](https://laurakokkarinen.com/does-it-spark-joy-powersh
 
 When you delete Microsoft 365 groups, the modern group-connected team sites get deleted with them. The script below handles the remaining modern sites: communication sites and groupless team sites.
 
-!!! attention
-    There is a known issue running this script using PowerShell Core on macOS, see issue [#1266](https://github.com/pnp/cli-microsoft365/issues/1266) for further detail
-
 ```powershell tab="PowerShell Core"
 $sparksjoy = "Cat Lovers United", "Extranet", "Hub"
 $sites = m365 spo site classic list -o json |ConvertFrom-Json


### PR DESCRIPTION
This pull request will

- Remove the warning from the 'Delete all (non-group connected) modern SharePoint sites' sample script
- Remove the warning from the 'Inventory Flows by Owner' sample script

The warnings are no longer required as #1266 has now been resolved.
