### PR TITLE
Enhances `aad app add` command to set the default secret expiration to 1. Closes #2064

### DIFF
--- a/docs/docs/cmd/aad/app/app-add.md
+++ b/docs/docs/cmd/aad/app/app-add.md
@@ -55,7 +55,7 @@ m365 aad app add [options]
 
 When specifying the value for the `uri`, you can use the `_appId_` token, to include the ID of the newly generated Azure AD app registration in the Application ID URI, eg. URI `api://caf406b91cd4.ngrok.io/_appId_` will become `api://caf406b91cd4.ngrok.io/ab3bd119-faf7-4db5-ba99-eb7e748f778a` where the last portion is the app ID of the created Azure AD app registration.
 
-When using the `withSecret` option, this command will automatically generate a secret and set it to expire in 100 years in the future.
+When using the `withSecret` option, this command will automatically generate a secret and set it to expire in 1 year in the future.
 
 After creating the Azure AD app registration, this command returns the app ID and object ID of the created app registration. If you used the `withSecret` option, it will also return the generated secret.
 

--- a/src/m365/aad/commands/app/app-add.ts
+++ b/src/m365/aad/commands/app/app-add.ts
@@ -289,7 +289,7 @@ class AadAppAddCommand extends GraphItemsListCommand<ServicePrincipalInfo> {
     }
 
     const secretExpirationDate = new Date();
-    secretExpirationDate.setFullYear(secretExpirationDate.getFullYear() + 100);
+    secretExpirationDate.setFullYear(secretExpirationDate.getFullYear() + 1);
 
     const requestOptions: any = {
       url: `${this.resource}/v1.0/myorganization/applications/${appInfo.id}/addPassword`,


### PR DESCRIPTION
Enhances `aad app add` command to change the default secret expiration from 100 years to 1 year. Closes #2064
