### PR TITLE
implements login --authType browser. solves #1979

### DIFF
--- a/docs/docs/cmd/login.md
+++ b/docs/docs/cmd/login.md
@@ -11,7 +11,7 @@ m365 login [options]
 ## Options
 
 `-t, --authType [authType]`
-: The type of authentication to use. Allowed values `certificate,deviceCode,password,identity`. Default `deviceCode`
+: The type of authentication to use. Allowed values `certificate,deviceCode,password,identity,browser`. Default `deviceCode`
 
 `-u, --userName [userName]`
 : Name of the user to authenticate. Required when `authType` is set to `password`
@@ -143,4 +143,10 @@ Log in to Microsoft 365 using your own Azure AD application that's restricted on
 
 ```sh
 m365 login --appId 31359c7f-bd7e-475c-86db-fdb8c937548c --tenant 31359c7f-bd7e-475c-86db-fdb8c937548a
+```
+
+Log in to Microsoft 365 using the interactive browser authentication. Uses the identity of the current user.
+
+```sh
+m365 login --authType browser
 ```

--- a/docs/docs/user-guide/connecting-office-365.md
+++ b/docs/docs/user-guide/connecting-office-365.md
@@ -98,6 +98,16 @@ openssl pkcs12 -in protected.pfx -out privateKeyWithPassphrase.pem -nodes
 
 At this point the `privateKeyWithPassphrase.pem` file can be used to log in the CLI for Microsoft 365 following the instructions above for logging in using a PEM certificate.
 
+#### Log in using a browser authentication
+
+Yet another way to log in to Microsoft 365 in the CLI for Microsoft 365 is by using a an interactive browser authentication. To use this authentication method, set the `CLIMICROSOFT365_AADAPPID` environment variable to the ID of the Azure AD application that you want to use to authenticate the CLI for Microsoft 365 and the `CLIMICROSOFT365_TENANT` environment variable to the ID of your Azure AD directory. When calling the login command, set the `authType` option to `browser`.
+
+To log in to Microsoft 365 using an interactive browser authentication, execute:
+
+```sh
+m365 login --authType browser
+```
+
 ### Check login status
 
 To see if you're logged in to Microsoft 365 and if so, with which account, use the `status` command.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1492,6 +1492,11 @@
         "ci-info": "^2.0.0"
       }
     },
+    "is-docker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1563,6 +1568,14 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -2172,6 +2185,15 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "open": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
+      "integrity": "sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "minimist": "^1.2.5",
     "node-forge": "^0.10.0",
     "omelette": "^0.4.15",
+    "open": "^7.3.1",
     "semver": "^7.3.4",
     "strip-json-comments": "^3.1.1",
     "typescript": "^4.1.3",

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as sinon from 'sinon';
-import { Auth, AuthType, Service, CertificateType } from './Auth';
+import { Auth, AuthType, Service, CertificateType, InteractiveAuthorizationCodeResponse } from './Auth';
 import { FileTokenStorage } from './auth/FileTokenStorage';
 import { TokenStorage } from './auth/TokenStorage';
 import { Logger } from './cli';
@@ -13,6 +13,7 @@ import Utils from './Utils';
 // if this is not included
 import 'adal-node';
 import 'node-forge';
+import { ErrorResponse } from 'adal-node';
 
 class MockTokenStorage implements TokenStorage {
   public get(): Promise<string> {
@@ -40,17 +41,27 @@ describe('Auth', () => {
   }
   const loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
   let readFileSyncStub: sinon.SinonStub;
-
+  let initializeServerStub: sinon.SinonStub;
+  
+  const httpServerResponse = <InteractiveAuthorizationCodeResponse>{
+    code: "secretCode",
+    redirectUri: "https://localhost:666"
+  };
+  
   beforeEach(() => {
     log = [];
     auth = new Auth();
     auth.service.appId = '9bc3ab49-b65d-410a-85ad-de819febfddc';
     auth.service.tenant = '9bc3ab49-b65d-410a-85ad-de819febfddd';
     readFileSyncStub = sinon.stub(fs, 'readFileSync').callsFake(() => 'certificate');
+    initializeServerStub = sinon.stub((auth as any)._authServer, 'initializeServer').callsFake((service: Service, resource: string, resolve: (error: InteractiveAuthorizationCodeResponse) => void, reject: (error: ErrorResponse) => void, logger: Logger, debug: boolean = false) => { 
+      resolve(httpServerResponse); 
+    });
   });
 
   afterEach(() => {
     readFileSyncStub.restore();
+    initializeServerStub.restore();
     Utils.restore([
       request.get
     ]);
@@ -483,6 +494,189 @@ describe('Auth', () => {
     }, (err) => {
       try {
         assert(loggerLogToStderrSpy.calledWith({ error_description: 'An error has occurred' }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('uses browser auth and retrieves a successful response', (done) => {
+    const acquireTokenWithAuthorizationCode = sinon.stub((auth as any).authCtx, 'acquireTokenWithAuthorizationCode').callsArgWith(5, undefined, {});
+    sinon.stub(auth as any, 'storeConnectionInfo').callsFake(() => Promise.resolve());
+
+    auth.service.authType = AuthType.Browser;
+    auth.ensureAccessToken(resource, logger, false).then((accessToken) => {
+      try {
+        assert(acquireTokenWithAuthorizationCode.called);
+        const args = acquireTokenWithAuthorizationCode.args[0];
+        assert(args[0].toString() === httpServerResponse.code, "Code is handled properly");    
+        assert(args[1].toString() === httpServerResponse.redirectUri, "RedirectURI should be passed");  
+        assert(args[3].toString() === auth.service.appId, "App id should be passed");    
+        assert(args[4].toString() === '', "Secret should not be passed");
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    }, (err) => {
+      done(err);
+    });
+  });
+
+  it('uses browser auth and retrieves a successful response (debug)', (done) => {
+    const acquireTokenWithAuthorizationCode = sinon.stub((auth as any).authCtx, 'acquireTokenWithAuthorizationCode').callsArgWith(5, undefined, {});
+    sinon.stub(auth as any, 'storeConnectionInfo').callsFake(() => Promise.resolve());
+
+    auth.service.authType = AuthType.Browser;
+    auth.ensureAccessToken(resource, logger, true).then((accessToken) => {
+      try {
+        assert(acquireTokenWithAuthorizationCode.called);
+        const args = acquireTokenWithAuthorizationCode.args[0];
+        assert(args[0].toString() === httpServerResponse.code, "Code is handled properly");    
+        assert(args[1].toString() === httpServerResponse.redirectUri, "RedirectURI should be passed");  
+        assert(args[3].toString() === auth.service.appId, "App id should be passed");    
+        assert(args[4].toString() === '', "Secret should not be passed");
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    }, (err) => {
+      done(err);
+    });
+  });
+
+  it('uses browser auth and retrieves an unsuccessful response', (done) => {
+    const error = <ErrorResponse>{
+      error: "shortError",
+      errorDescription: "errorHasOccurred"
+    };
+    const acquireTokenWithAuthorizationCode = sinon.stub((auth as any).authCtx, 'acquireTokenWithAuthorizationCode').callsArgWith(5, undefined, {});
+    
+    initializeServerStub.restore();
+    initializeServerStub = sinon.stub((auth as any)._authServer, 'initializeServer').callsFake((service: Service, resource: string, resolve: (error: InteractiveAuthorizationCodeResponse) => void, reject: (error: ErrorResponse) => void, logger: Logger, debug: boolean = false) => { 
+      reject(error); 
+    });
+    sinon.stub(auth as any, 'storeConnectionInfo').callsFake(() => Promise.resolve());
+
+    auth.service.authType = AuthType.Browser;
+    auth.ensureAccessToken(resource, logger, false).then(() => {
+      assert.fail("Should not be called");
+      done();
+    }, (err) => {
+      try {
+        assert(acquireTokenWithAuthorizationCode.notCalled);
+        assert(err === error.errorDescription);
+        done();
+      }
+      catch (e) {
+        done (e);
+      }
+    });
+  });
+
+  it('uses browser auth and retrieves an unsuccessful response (debug)', (done) => {
+    const error = <ErrorResponse>{
+      error: "shortError",
+      errorDescription: "errorHasOccurred"
+    };
+    const acquireTokenWithAuthorizationCode = sinon.stub((auth as any).authCtx, 'acquireTokenWithAuthorizationCode').callsArgWith(5, undefined, {});
+    
+    initializeServerStub.restore();
+    initializeServerStub = sinon.stub((auth as any)._authServer, 'initializeServer').callsFake((service: Service, resource: string, resolve: (error: InteractiveAuthorizationCodeResponse) => void, reject: (error: ErrorResponse) => void, logger: Logger, debug: boolean = false) => { 
+      reject(error); 
+    });
+    sinon.stub(auth as any, 'storeConnectionInfo').callsFake(() => Promise.resolve());
+
+    auth.service.authType = AuthType.Browser;
+    auth.ensureAccessToken(resource, logger, true).then(() => {
+      assert.fail("Should not be called");
+      done();
+    }, (err) => {
+      try {
+        assert(acquireTokenWithAuthorizationCode.notCalled);
+        assert(err === error.errorDescription);
+        done();
+      }
+      catch (e) {
+        done (e);
+      }
+    });
+  });
+
+  it('uses browser auth and retrieves an unsuccessful response', (done) => {
+    const error = <ErrorResponse>{
+      error: "shortError"
+    };
+    const acquireTokenWithAuthorizationCode = sinon.stub((auth as any).authCtx, 'acquireTokenWithAuthorizationCode').callsArgWith(5, undefined, {});
+    
+    initializeServerStub.restore();
+    initializeServerStub = sinon.stub((auth as any)._authServer, 'initializeServer').callsFake((service: Service, resource: string, resolve: (error: InteractiveAuthorizationCodeResponse) => void, reject: (error: ErrorResponse) => void, logger: Logger, debug: boolean = false) => { 
+      reject(error); 
+    });
+    sinon.stub(auth as any, 'storeConnectionInfo').callsFake(() => Promise.resolve());
+
+    auth.service.authType = AuthType.Browser;
+    auth.ensureAccessToken(resource, logger, false).then(() => {
+      assert.fail("Should not be called");
+      done();
+    }, (err) => {
+      try {
+        assert(acquireTokenWithAuthorizationCode.notCalled);
+        assert(err === error.error);
+        done();
+      }
+      catch (e) {
+        done (e);
+      }
+    });
+  });
+
+  it('uses browser auth and retrieves retrieving a token but acquisition failed', (done) => {
+    sinon.stub((auth as any).authCtx, 'acquireTokenWithAuthorizationCode').callsArgWith(5, { message: 'An error has occurred' }, undefined);
+
+    auth.service.authType = AuthType.Browser;
+    auth.ensureAccessToken(resource, logger).then((accessToken) => {
+      assert.fail('Got access token');
+    }, (err) => {
+      try {
+        assert.strictEqual(err, 'An error has occurred');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('uses browser auth and retrieves retrieving a token but acquisition failed (debug)', (done) => {
+    sinon.stub((auth as any).authCtx, 'acquireTokenWithAuthorizationCode').callsArgWith(5, { message: 'An error has occurred' }, undefined);
+
+    auth.service.authType = AuthType.Browser;
+    auth.ensureAccessToken(resource, logger, true).then((accessToken) => {
+      assert.fail('Got access token');
+    }, (err) => {
+      try {
+        assert.strictEqual(err, 'An error has occurred');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('logs error when retrieving token using brwoser auth failed (debug)', (done) => {
+    sinon.stub((auth as any).authCtx, 'acquireTokenWithAuthorizationCode').callsArgWith(5, { message: 'An error has occurred' }, { errorDescription: 'An error has occurred' });
+
+    auth.service.authType = AuthType.Browser;
+    auth.ensureAccessToken(resource, logger, true).then((accessToken) => {
+      assert.fail('Got access token');
+    }, (err) => {
+      try {
+        assert(loggerLogToStderrSpy.calledWith({ errorDescription: 'An error has occurred' }));
         done();
       }
       catch (e) {

--- a/src/AuthServer.spec.ts
+++ b/src/AuthServer.spec.ts
@@ -1,0 +1,161 @@
+import { Auth } from './Auth';
+import { Logger } from './cli';
+import authServer from './AuthServer';
+import * as assert from 'assert';
+import sinon = require('sinon');
+import { AddressInfo } from 'net';
+import Axios from 'axios';
+
+describe('AuthServer', () => {
+  let log: any[];
+  
+  let callbackResolveStub: sinon.SinonStub;
+  let callbackRejectStub: sinon.SinonStub;
+  let openStub: sinon.SinonStub;
+  let serverUrl: string = "";
+  let auth: Auth;
+  
+  const logger: Logger = {
+    log: (msg: any) => log.push(msg),
+    logRaw: (msg: any) => log.push(msg),
+    logToStderr: (msg: any) => log.push(msg)
+  }
+  
+  beforeEach(() => {
+    log = [];
+    auth = new Auth()
+    auth.service.appId = '9bc3ab49-b65d-410a-85ad-de819febfddc';
+    auth.service.tenant = '9bc3ab49-b65d-410a-85ad-de819febfddd';
+    openStub = sinon.stub(authServer as any, 'open').callsFake(_ => Promise.resolve());
+    callbackResolveStub = sinon.stub().callsFake(() => {})
+    callbackRejectStub = sinon.stub().callsFake(() => {})
+    authServer.initializeServer(auth.service, auth.defaultResource, callbackResolveStub, callbackRejectStub, logger, true);
+    const address = authServer.server.address() as AddressInfo;
+    serverUrl = `http://localhost:${address?.port}`;
+  });
+
+  afterEach(() => {
+    if (authServer.server.listening) {
+      authServer.server.close();
+    }
+    openStub.restore();
+  });
+
+  it('successfully listens', (done) => {  
+    const server = authServer.server;
+      
+    try {
+      assert(server !== undefined && server !== null);
+      assert(server.listening);
+      assert(serverUrl.indexOf("http://localhost:") > -1);
+      done();
+    }
+    catch (err) {
+      done(err);
+    }
+  });
+
+  it('successfully returns an auth code', (done) => {  
+    const server = authServer.server;
+      
+    try {
+      assert(server !== undefined && server !== null);
+      assert(server.listening);
+      assert(serverUrl.indexOf("http://localhost:") > -1);
+
+      Axios.get(`${serverUrl}/?code=1111`).then((response) => {
+        assert(response.data.indexOf("You have logged into CLI for Microsoft 365!") > -1);
+        assert(callbackResolveStub.called);
+        assert(callbackResolveStub.args[0][0].code === "1111");
+        assert(callbackResolveStub.args[0][0].redirectUri === serverUrl);
+        assert(callbackRejectStub.notCalled);
+        assert(authServer.server.listening === false, "server is closed after a successful request");
+        done();
+      }).catch((reason) => {
+        done(reason);        
+      })
+    }
+    catch (err) {
+      done(err);
+    }
+  });
+
+  it('successfully returns error message only', (done) => {  
+    try {
+      Axios.get(`${serverUrl}/?error=an error has occurred`).then((response) => {
+        assert(response.data.indexOf("Oops! Azure Active Directory replied with an error message.") > -1);
+        assert(callbackResolveStub.notCalled);
+        assert(callbackRejectStub.called);
+        assert(callbackRejectStub.args[0][0].error === "an error has occurred");
+        assert(callbackRejectStub.args[0][0].errorDescription === undefined);
+        assert(authServer.server.listening === false, "server is closed after a successful request");
+        done();
+      }).catch((reason) => {
+        done(reason);        
+      })
+    }
+    catch (err) {
+      done(err);
+    }
+  });
+
+  it('successfully returns error message and error description', (done) => {  
+    try {
+      Axios.get(`${serverUrl}/?error=an error has occurred&error_description=error description`).then((response) => {
+        assert(response.data.indexOf("Oops! Azure Active Directory replied with an error message.") > -1);
+        assert(callbackResolveStub.notCalled);
+        assert(callbackRejectStub.called);
+        assert(callbackRejectStub.args[0][0].error === "an error has occurred");
+        assert(callbackRejectStub.args[0][0].errorDescription === "error description");
+        assert(authServer.server.listening === false, "server is closed after a successful request");
+        done();
+      }).catch((reason) => {
+        done(reason);        
+      })
+    }
+    catch (err) {
+      done(err);
+    }
+  });
+
+  it('fails if there is an invalid request', (done) => {  
+    try {
+      Axios.get(`${serverUrl}/?requestingSomthingElse=true`).then((response) => {
+        assert(response.data.indexOf("Oops! This is an invalid request.") > -1);
+        assert(callbackResolveStub.notCalled);
+        assert(callbackRejectStub.called);
+        assert(callbackRejectStub.args[0][0].error === "invalid request");
+        assert(callbackRejectStub.args[0][0].errorDescription === "An invalid request has been received by the HTTP server");
+        assert(authServer.server.listening === false, "server is closed after a successful request");
+        done();
+      }).catch((reason) => {
+        done(reason);        
+      })
+    }
+    catch (err) {
+      done(err);
+    }
+  });
+
+  it('fails if open fails', (done) => {  
+    try {
+      if (authServer.server.listening) {
+        authServer.server.close();
+      }
+
+      openStub.restore();
+      openStub = sinon.stub(authServer as any, 'open').callsFake(_ => Promise.reject());
+      authServer.initializeServer(auth.service, auth.defaultResource, callbackResolveStub, callbackRejectStub, logger, true);
+      setTimeout(() => {
+        assert(callbackRejectStub.called);
+        assert(callbackRejectStub.args[0][0].error === "Can't open the default browser");
+        assert(callbackRejectStub.args[0][0].errorDescription === "Was not able to open a browser instance. Try again later or use a different authentication method.");
+        assert(authServer.server.listening === false, "server is closed after a successful request");
+        done();
+      }, 10);
+    }
+    catch (err) {
+      done(err);
+    }
+  });
+});

--- a/src/AuthServer.ts
+++ b/src/AuthServer.ts
@@ -1,0 +1,134 @@
+import { ErrorResponse } from 'adal-node';
+import { Logger } from './cli';
+import * as url from "url";
+import * as http from 'http';
+import * as open from 'open';
+//import { AddressInfo } from 'net';
+import { ParsedUrlQuery } from 'querystring';
+import { IncomingMessage, ServerResponse } from 'http';
+import { InteractiveAuthorizationCodeResponse } from './Auth';
+import { Service } from "./Auth";
+import { AddressInfo } from 'net';
+
+class AuthServer {
+  // assigned through this.initializeServer() hence !
+  private httpServer!: http.Server;
+  // assigned through this.initializeServer() hence !
+  private service!: Service;
+  // assigned through this.initializeServer() hence !
+  private resolve!: (error: InteractiveAuthorizationCodeResponse) => void;
+  // assigned through this.initializeServer() hence !
+  private reject!: (error: ErrorResponse) => void;
+  // assigned through this.initializeServer() hence !
+  private logger!: Logger;
+
+  private open = open;
+  private debug: boolean = false;
+  private resource : string = "";
+  private generatedServerUrl: string = "";
+
+  constructor() {
+  }
+
+  public get server(): http.Server {
+    return this.httpServer;
+  }
+
+  public initializeServer = (service: Service, resource: string, resolve: (error: InteractiveAuthorizationCodeResponse) => void, reject: (error: ErrorResponse) => void, logger: Logger, debug: boolean = false) => {
+    this.service = service;
+    this.resolve = resolve;
+    this.reject = reject;
+    this.logger = logger;
+    this.debug = debug;
+    this.resource = resource;
+    
+    this.httpServer = http.createServer(this.httpRequest).listen(0, this.httpListener);
+  }
+
+  private httpListener = () => {
+    const requestState = Math.random().toString(16).substr(2, 20);
+    const address = this.httpServer.address() as AddressInfo;
+    this.generatedServerUrl = `http://localhost:${address.port}`;
+    const url = `https://login.microsoftonline.com/${this.service.tenant}/oauth2/authorize?response_type=code&client_id=${this.service.appId}&redirect_uri=${this.generatedServerUrl}&state=${requestState}&resource=${this.resource}&prompt=select_account`;
+    if (this.debug) {
+      this.logger.logToStderr('Redirect URL:');
+      this.logger.logToStderr(url);
+      this.logger.logToStderr('');
+    }
+    this.openUrl(url);
+  }
+
+  private openUrl(url: string) {
+    this.open(url).then(() => {
+      this.logger.logToStderr("To sign in, use the web browser that just has been opened. Please sign-in there.")
+    }).catch(() => {
+      const errorResponse: ErrorResponse = {
+        error: "Can't open the default browser",
+        errorDescription: "Was not able to open a browser instance. Try again later or use a different authentication method."
+      }
+
+      this.reject(errorResponse);
+      this.httpServer.close();
+    });
+  }
+
+  private httpRequest = (request : IncomingMessage, response : ServerResponse) => {
+    if (this.debug) {
+      this.logger.logToStderr('Response:');
+      this.logger.logToStderr(request.url);
+      this.logger.logToStderr('');
+    }
+
+    const queryString: ParsedUrlQuery = url.parse(request.url as string, true).query;
+    const hasCode: boolean = queryString.code !== undefined;
+    const hasError: boolean = queryString.error !== undefined;
+    
+    let body: string = "";
+    if (hasCode === true) {
+      body = '<script type="text/JavaScript">setTimeout(function(){ window.location = "https://pnp.github.io/cli-microsoft365/"; },10000);</script>';
+      body += '<p><b>You have logged into CLI for Microsoft 365!</b></p>';
+      body += '<p>You can close this window, or we will redirect you to the <a href="https://pnp.github.io/cli-microsoft365/">CLI for Microsoft 365</a> documentation in 10 seconds.</p>';
+      
+      this.resolve(<InteractiveAuthorizationCodeResponse>{
+          code: queryString.code as string,
+          redirectUri: this.generatedServerUrl
+      });
+    }
+    
+    if (hasError === true) {
+      const errorMessage: ErrorResponse = {
+        error: queryString.error as string,
+        errorDescription: queryString.error_description as string
+      }
+
+      body = "<p>Oops! Azure Active Directory replied with an error message.</p>";
+      body += `<p>${errorMessage.error}</p>`;
+      if (errorMessage.errorDescription !== undefined) {
+        body += `<p>${errorMessage.errorDescription}</p>`;
+      }
+
+      this.reject(errorMessage);
+    }
+
+    if (hasCode === false && hasError === false) {
+      const errorMessage: ErrorResponse = {
+        error: "invalid request",
+        errorDescription: "An invalid request has been received by the HTTP server"
+      }
+
+      body = "<p>Oops! This is an invalid request.</p>";
+      body += `<p>${errorMessage.error}</p>`;
+      body += `<p>${errorMessage.errorDescription}</p>`;
+      
+      this.reject(errorMessage);
+    }
+
+    response.writeHead(200, {'Access-Control-Allow-Origin':'*','Content-Type': 'text/html'});
+    response.write(`<html><head><title>CLI for Microsoft 365</title></head><body>${body}</body></html>`);
+    response.end();  
+
+    this.httpServer.close();
+  }
+}
+
+export default new AuthServer();

--- a/src/m365/commands/login.spec.ts
+++ b/src/m365/commands/login.spec.ts
@@ -317,6 +317,20 @@ describe(commands.LOGIN, () => {
     });
   });
 
+  it('logs in to Microsoft 365 using browser authentication', (done) => {
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve(''));
+
+    command.action(logger, { options: { debug: false, authType: 'browser' } }, () => {
+      try {
+        assert.strictEqual(auth.service.authType, AuthType.Browser, 'Incorrect authType set');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('correctly handles error when clearing persisted auth information', (done) => {
     sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve('ABC'));
     Utils.restore(auth.clearConnectionInfo);

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -75,7 +75,10 @@ class LoginCommand extends Command {
         case 'identity':
           auth.service.authType = AuthType.Identity;
           auth.service.userName = args.options.userName;
-          break;
+          break;        
+        case 'browser':
+            auth.service.authType = AuthType.Browser;
+            break;
       }
 
       auth
@@ -132,8 +135,8 @@ class LoginCommand extends Command {
     const options: CommandOption[] = [
       {
         option: '-t, --authType [authType]',
-        description: 'The type of authentication to use. Allowed values certificate|deviceCode|password|identity. Default deviceCode',
-        autocomplete: ['certificate', 'deviceCode', 'password', 'identity']
+        description: 'The type of authentication to use. Allowed values certificate|deviceCode|password|identity|browser. Default deviceCode',
+        autocomplete: ['certificate', 'deviceCode', 'password', 'identity', 'browser']
       },
       {
         option: '-u, --userName [userName]',


### PR DESCRIPTION
I managed to finalize the new authentication method through a browser instance.

You can call it by using `m365 login --authType browser`

This authentication method will try to open a browser instance using the library open. After you successfully authenticate on Azure AD, the necessary authorizationCode operation is executed to retrieve the required tokens.

This approach is working well for all devices requiring conditional access and an interactive authentication.

Before pushing it to production ensure that http://localhost is added to the PnP Azure AD application.
![image](https://user-images.githubusercontent.com/18241305/105574798-42489600-5d67-11eb-8832-49e74064b75e.png)

You can test it using my dedicated Azure AD multi-tenant app using this command: `m365 login --authType browser --appId f98c87e8-8b5e-41c7-9815-c97b10220d32` 