### PR TITLE
Extends 'util accesstoken get' with sharepoint as resource. Closes #2096

### DIFF
--- a/docs/docs/cmd/util/accesstoken/accesstoken-get.md
+++ b/docs/docs/cmd/util/accesstoken/accesstoken-get.md
@@ -22,12 +22,20 @@ m365 util accesstoken get [options]
 
 The `util accesstoken get` command returns an access token for the specified resource. If an access token has been previously retrieved and is still valid, the command will return the cached token. If you want to ensure that the returned access token is valid for as long as possible, you can force the command to retrieve a new access token by using the `--new` option.
 
+If the URL of your SharePoint tenant has been previously retrieved, you can use `sharepoint` as the resource to retrieve access token for SharePoint. To verify if the URL of your SharePoint tenant has been previously retrieved, use the [`spo get`](../../spo/spo-get.md) command. To explicitly set the URL of your SharePoint tenant use the [`spo set`](../../spo/spo-set.md) command.
+
 ## Examples
 
 Get access token for the Microsoft Graph
 
 ```sh
 m365 util accesstoken get --resource https://graph.microsoft.com
+```
+
+Get access token for SharePoint Online using the shorthand identifier
+
+```sh
+m365 util accesstoken get --resource sharepoint
 ```
 
 Get a new access token for SharePoint Online

--- a/src/m365/util/commands/accesstoken/accesstoken-get.ts
+++ b/src/m365/util/commands/accesstoken/accesstoken-get.ts
@@ -25,8 +25,18 @@ class AccessTokenGetCommand extends Command {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+    let resource: string = args.options.resource;
+    if (resource.toLowerCase() === 'sharepoint') {
+      if (auth.service.spoUrl) {
+        resource = auth.service.spoUrl;
+      }
+      else {
+        return cb(`SharePoint URL undefined. Use the 'm365 spo set --url https://contoso.sharepoint.com' command to set the URL`);
+      }
+    }
+
     auth
-      .ensureAccessToken(args.options.resource, logger, this.debug, args.options.new)
+      .ensureAccessToken(resource, logger, this.debug, args.options.new)
       .then((accessToken: string): void => {
         logger.log(accessToken);
         cb();


### PR DESCRIPTION
Extends 'util accesstoken get' with sharepoint as resource. Closes #2096