### PR TITLE
#2140 - Add page title to the set command

### DIFF
--- a/docs/docs/cmd/spo/page/page-set.md
+++ b/docs/docs/cmd/spo/page/page-set.md
@@ -34,6 +34,9 @@ m365 spo page set [options]
 `--description [description]`
 : The description to set for the page
 
+`--title [title]`
+: The title to set for the page
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks

--- a/src/m365/spo/commands/page/page-set.spec.ts
+++ b/src/m365/spo/commands/page/page-set.spec.ts
@@ -363,6 +363,56 @@ describe(commands.PAGE_SET, () => {
     });
   });
 
+  it('updates page title', (done) => {
+    Utils.restore([request.post]);
+
+    const newPageTitle = "updated title";
+    let responseData: any = {};
+    
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields/SetCommentsDisabled(false)`) > -1) {
+        return Promise.resolve();
+      }
+
+      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/checkoutpage`) > -1) {
+        return Promise.resolve({
+          Title: "article",
+          Id: 1,
+          TopicHeader: "TopicHeader",
+          AuthorByline: "AuthorByline",
+          Description: "Description",
+          BannerImageUrl: {
+            Description: '/_layouts/15/images/sitepagethumbnail.png',
+            Url: `https://contoso.sharepoint.com/_layouts/15/images/sitepagethumbnail.png`
+          },
+          CanvasContent1: "{}",
+          LayoutWebpartsContent: "{}"
+        });
+      }
+
+      if ((opts.url as string).indexOf(`/_api/SitePages/Pages(1)/SavePage`) > -1) {
+        responseData = opts.data;
+        return Promise.resolve();
+      }
+      
+      if ((opts.url as string).indexOf(`/_api/SitePages/Pages(1)/SavePageAsDraft`) > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', title: newPageTitle } }, () => {
+      try {
+        assert.strictEqual(responseData.Title, newPageTitle);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('publishes page', (done) => {
     Utils.restore([request.post]);
     

--- a/src/m365/spo/commands/page/page-set.ts
+++ b/src/m365/spo/commands/page/page-set.ts
@@ -26,6 +26,7 @@ interface Options extends GlobalOptions {
   publish: boolean;
   publishMessage?: string;
   description?: string;
+  title?: string;
 }
 
 class SpoPageSetCommand extends SpoCommand {
@@ -45,6 +46,7 @@ class SpoPageSetCommand extends SpoCommand {
     telemetryProps.publish = args.options.publish || false;
     telemetryProps.publishMessage = typeof args.options.publishMessage !== 'undefined';
     telemetryProps.description = typeof args.options.description !== 'undefined';
+    telemetryProps.title = typeof args.options.title !== 'undefined';
     return telemetryProps;
   }
 
@@ -56,7 +58,7 @@ class SpoPageSetCommand extends SpoCommand {
     let bannerImageUrl: string = '';
     let canvasContent1: string = '';
     let layoutWebpartsContent: string = '';
-    let pageTitle: string | null = null;
+    let pageTitle: string = args.options.title || "";
     let pageId: number | null = null;
     let pageDescription: string = args.options.description || "";
     let topicHeader: string = "";
@@ -77,7 +79,7 @@ class SpoPageSetCommand extends SpoCommand {
       })
       .then((res: ClientSidePageProperties): Promise<void> => {
         if (res) {
-          pageTitle = res.Title;
+          pageTitle = pageTitle || res.Title;
           pageId = res.Id;
 
           bannerImageUrl = res.BannerImageUrl;
@@ -358,6 +360,10 @@ class SpoPageSetCommand extends SpoCommand {
       {
         option: '--description [description]',
         description: 'The description to set for the page'
+      },
+      {
+        option: '--title [title]',
+        description: 'The title to set for the page'
       }
     ];
 


### PR DESCRIPTION
Adds the `--title` option support to the `spo page set` command #2140.