### PR TITLE
#2193 - Add CanvasContentJson to the output

### DIFF
--- a/src/m365/spo/commands/page/page-get.spec.ts
+++ b/src/m365/spo/commands/page/page-get.spec.ts
@@ -105,6 +105,7 @@ describe(commands.PAGE_GET, () => {
       try {
         assert(loggerLogSpy.calledWith({
           ...pageListItemMock,
+          CanvasContentJson: controlsMock.CanvasContent1,
           ...sectionMock
         }));
         done();
@@ -132,6 +133,7 @@ describe(commands.PAGE_GET, () => {
       try {
         assert(loggerLogSpy.calledWith({
           ...pageListItemMock,
+          CanvasContentJson: controlsMock.CanvasContent1,
           ...sectionMock
         }));
         done();
@@ -159,6 +161,7 @@ describe(commands.PAGE_GET, () => {
       try {
         assert(loggerLogSpy.calledWith({
           ...pageListItemMock,
+          CanvasContentJson: controlsMock.CanvasContent1,
           ...sectionMock
         }));
         done();

--- a/src/m365/spo/commands/page/page-get.ts
+++ b/src/m365/spo/commands/page/page-get.ts
@@ -83,6 +83,7 @@ class SpoPageGetCommand extends SpoCommand {
       .then((res: { CanvasContent1: string } | void) => {
         if (res && res.CanvasContent1) {
           const canvasData: any[] = JSON.parse(res.CanvasContent1);
+          pageItemData.CanvasContentJson = res.CanvasContent1;
           if (canvasData && canvasData.length > 0) {
             pageItemData.numControls = canvasData.length;
             const sections = [...new Set(canvasData.filter(c => c.position).map(c => c.position.zoneIndex))];


### PR DESCRIPTION
Added `CanvasContent1` JSON data to the output of the `spo page get` command. As we now do the second call to retrieve this data. It is beneficial to also return this data as part of the output (HTML content is already returned). Related to #2193 