### PR TITLE
adds m365 config set --key output. closes #2246

### DIFF
--- a/docs/docs/cmd/cli/config/config-set.md
+++ b/docs/docs/cmd/cli/config/config-set.md
@@ -11,7 +11,7 @@ m365 cli config set [options]
 ## Options
 
 `-k, --key <key>`
-: Config key to specify. Allowed values: `showHelpOnFailure`
+: Config key to specify. Allowed values: `showHelpOnFailure|output`
 
 `-v, --value <value>`
 : Config value to set
@@ -24,6 +24,12 @@ Configure CLI to automatically display help when executing a command failed
 
 ```sh
 m365 cli config set --key showHelpOnFailure --value true
+```
+
+Configure the default output when executing a command. Allowed values `text|json`
+
+```sh
+m365 cli config set --key output --value json
 ```
 
 ## More information

--- a/docs/docs/user-guide/configuring-cli.md
+++ b/docs/docs/user-guide/configuring-cli.md
@@ -6,10 +6,19 @@ To reset settings to their default values, remove them from the configuration fi
 
 ## Configuring settings
 
-You can configure the specific setting using the `cli config set` command. For example, to configure CLI to automatically show help when executing a command failed, execute:
+You can configure the specific setting using the `cli config set` command. 
+
+
+Show help when command execution failed.
 
 ```sh
 m365 cli config set --key showHelpOnFailure --value true
+```
+
+Configure the default output when executing a command.
+
+```sh
+m365 cli config set --key output --value json
 ```
 
 ## Available settings
@@ -19,3 +28,4 @@ Following is the list of configuration settings available in CLI for Microsoft 3
 Setting name|Definition|Default value
 ------------|----------|-------------
 `showHelpOnFailure`|Automatically display help when executing a command failed|`true`
+`output`|Defines the default output when issuing a command|`text|json`

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -814,33 +814,6 @@ describe('Cli', () => {
     assert.strictEqual(actual, '');
   });
 
-  it('formats output as pretty JSON when JSON output configured', (done) => {
-    const o = { lorem: 'ipsum', dolor: 'sit' };
-    sinon.stub((cli as any).config, 'get').callsFake(() => { return 'json' });
-
-    const actual = (Cli as any).formatOutput(o, {});
-    try {
-      assert.strictEqual(actual, JSON.stringify(o, null, 2));
-      done();
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
-  it('formats simple output as text even when the default output is set to JSON', (done) => {
-    const o = false;    
-    sinon.stub((cli as any).config, 'get').callsFake(() => { return 'json' });
-    const actual = (Cli as any).formatOutput(o, { output: 'text' });
-    try {
-      assert.strictEqual(actual, `${o}`);
-      done();
-    }
-    catch (e) {
-      done(e);
-    }
-  });
-
   it('formats output as pretty JSON when JSON output requested', (done) => {
     const o = { lorem: 'ipsum', dolor: 'sit' };
     const actual = (Cli as any).formatOutput(o, { output: 'json' });

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -814,6 +814,33 @@ describe('Cli', () => {
     assert.strictEqual(actual, '');
   });
 
+  it('formats output as pretty JSON when JSON output configured', (done) => {
+    const o = { lorem: 'ipsum', dolor: 'sit' };
+    sinon.stub((cli as any).config, 'get').callsFake(() => { return 'json' });
+
+    const actual = (Cli as any).formatOutput(o, {});
+    try {
+      assert.strictEqual(actual, JSON.stringify(o, null, 2));
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
+  it('formats simple output as text even when the default output is set to JSON', (done) => {
+    const o = false;    
+    sinon.stub((cli as any).config, 'get').callsFake(() => { return 'json' });
+    const actual = (Cli as any).formatOutput(o, { output: 'text' });
+    try {
+      assert.strictEqual(actual, `${o}`);
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
   it('formats output as pretty JSON when JSON output requested', (done) => {
     const o = { lorem: 'ipsum', dolor: 'sit' };
     const actual = (Cli as any).formatOutput(o, { output: 'json' });

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -448,6 +448,11 @@ export class Cli {
       logStatementType = typeof logStatement;
     }
 
+    // overwrite output value with default value if not explicitly specified
+    if (options.output === undefined) {
+      options.output = this.instance.getSettingWithDefaultValue<string|undefined>(settingsNames.output, options.output);
+    }
+
     if (options.output === 'json') {
       return JSON.stringify(logStatement, null, 2);
     }

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -176,6 +176,11 @@ export class Cli {
       return this.closeWithError(validationResult, true);
     }
 
+    // overwrite output value with default value if not explicitly specified
+    if (optionsWithoutShorts.options.output === undefined) {
+      optionsWithoutShorts.options.output = this.getSettingWithDefaultValue<string|undefined>(settingsNames.output, optionsWithoutShorts.options.output);
+    }
+
     return Cli
       .executeCommand(this.commandToExecute.command, optionsWithoutShorts)
       .then(_ => {
@@ -446,11 +451,6 @@ export class Cli {
       // returns an object of different shape than the original message to log
       // #2095
       logStatementType = typeof logStatement;
-    }
-
-    // overwrite output value with default value if not explicitly specified
-    if (options.output === undefined) {
-      options.output = this.instance.getSettingWithDefaultValue<string|undefined>(settingsNames.output, options.output);
     }
 
     if (options.output === 'json') {

--- a/src/m365/cli/commands/config/config-set.spec.ts
+++ b/src/m365/cli/commands/config/config-set.spec.ts
@@ -56,6 +56,48 @@ describe(commands.CONFIG_SET, () => {
     });
   });
 
+  it(`sets ${settingsNames.output} property to 'text'`, (done) => {
+    const output = "text"
+    const config = Cli.getInstance().config;
+    let actualKey: string, actualValue: any;
+    sinon.restore()
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+
+    command.action(logger, { options: { key: settingsNames.output, value: output } }, () => {
+      try {
+        assert.strictEqual(actualKey, settingsNames.output, 'Invalid key');
+        assert.strictEqual(actualValue, output, 'Invalid value');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`sets ${settingsNames.output} property to 'json'`, (done) => {
+    const output = "json"
+    const config = Cli.getInstance().config;
+    let actualKey: string, actualValue: any;
+    sinon.restore()
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+
+    command.action(logger, { options: { key: settingsNames.output, value: output } }, () => {
+      try {
+        assert.strictEqual(actualKey, settingsNames.output, 'Invalid key');
+        assert.strictEqual(actualValue, output, 'Invalid value');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('supports specifying key and value', () => {
     const options = command.options();
     let containsOptionKey = false;
@@ -80,5 +122,10 @@ describe(commands.CONFIG_SET, () => {
   it(`passes validation if service is set to ${settingsNames.showHelpOnFailure} `, () => {
     const actual = command.validate({ options: { key: settingsNames.showHelpOnFailure, value: false } });
     assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if specified output key is invalid ', () => {
+    const actual = command.validate({ options: { key: settingsNames.output, value: 'invalid' } });
+    assert.notStrictEqual(actual, true);
   });
 });

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -36,6 +36,9 @@ class CliConfigSetCommand extends AnonymousCommand {
       case settingsNames.showHelpOnFailure:
         value = args.options.value === "true";
         break;
+      default:
+        value = args.options.value;
+        break;
     }
 
     console.log(Cli.getInstance().config.path);
@@ -47,7 +50,7 @@ class CliConfigSetCommand extends AnonymousCommand {
     const options: CommandOption[] = [
       {
         option: '-k, --key <key>',
-        autocomplete: [settingsNames.showHelpOnFailure]
+        autocomplete: [settingsNames.showHelpOnFailure, settingsNames.output]
       },
       {
         option: '-v, --value <value>'
@@ -59,8 +62,13 @@ class CliConfigSetCommand extends AnonymousCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (args.options.key !== settingsNames.showHelpOnFailure) {
-      return `${args.options.key} is not a valid value for the service option. Allowed values: ${settingsNames.showHelpOnFailure}`;
+    if (args.options.key !== settingsNames.showHelpOnFailure && args.options.key !== settingsNames.output) {
+      return `${args.options.key} is not a valid value for the service option. Allowed values: ${settingsNames.showHelpOnFailure}|${settingsNames.output}`;
+    }
+
+    const allowedOutputs = ["text", "json"]
+    if (args.options.key === settingsNames.output && allowedOutputs.indexOf(args.options.value) === -1) {
+      return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${allowedOutputs.join("|")}`;
     }
 
     return true;

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -1,5 +1,6 @@
 const settingsNames = {
-  showHelpOnFailure: 'showHelpOnFailure'
+  showHelpOnFailure: 'showHelpOnFailure',
+  output: 'output'
 };
 
 export { settingsNames };


### PR DESCRIPTION
Implements #2246 

You can now specify the default output when issuing a new command. This value overwrites the output if not passed explicitly