### PR TITLE
Fixes 'command examples use short options instead of long'. Closes #2319

### DIFF
--- a/docs/docs/cmd/spo/cdn/cdn-get.md
+++ b/docs/docs/cmd/spo/cdn/cdn-get.md
@@ -33,7 +33,7 @@ m365 spo cdn get
 Show if the Private CDN is currently enabled or not
 
 ```sh
-m365 spo cdn get -t Private
+m365 spo cdn get --type Private
 ```
 
 ## More information

--- a/docs/docs/cmd/spo/cdn/cdn-origin-add.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-add.md
@@ -30,7 +30,7 @@ Using the `-t, --type` option you can choose whether you want to manage the sett
 Add _*/CDN_ to the list of origins of the Public CDN
 
 ```sh
-m365 spo cdn origin add -t Public -r */CDN
+m365 spo cdn origin add --type Public --origin */CDN
 ```
 
 ## More information

--- a/docs/docs/cmd/spo/cdn/cdn-origin-list.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-list.md
@@ -33,7 +33,7 @@ m365 spo cdn origin list
 Show the list of origins configured for the Private CDN
 
 ```sh
-m365 spo cdn origin list -t Private
+m365 spo cdn origin list --type Private
 ```
 
 ## More information

--- a/docs/docs/cmd/spo/cdn/cdn-origin-remove.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-remove.md
@@ -33,7 +33,7 @@ Using the `-t, --type` option you can choose whether you want to manage the sett
 Remove _*/CDN_ from the list of origins of the Public CDN
 
 ```sh
-m365 spo cdn origin remove -t Public -r */CDN
+m365 spo cdn origin remove --type Public --origin */CDN
 ```
 
 ## More information

--- a/docs/docs/cmd/spo/cdn/cdn-policy-list.md
+++ b/docs/docs/cmd/spo/cdn/cdn-policy-list.md
@@ -33,7 +33,7 @@ m365 spo cdn policy list
 Show the list of policies configured for the Private CDN
 
 ```sh
-m365 spo cdn policy list -t Private
+m365 spo cdn policy list --type Private
 ```
 
 ## More information

--- a/docs/docs/cmd/spo/cdn/cdn-policy-set.md
+++ b/docs/docs/cmd/spo/cdn/cdn-policy-set.md
@@ -33,7 +33,7 @@ Using the `-t, --type` option you can choose whether you want to manage the sett
 Set the list of extensions supported by the Public CDN
 
 ```sh
-m365 spo cdn policy set -t Public -p IncludeFileExtensions -v CSS,EOT,GIF,ICO,JPEG,JPG,JS,MAP,PNG,SVG,TTF,WOFF,JSON
+m365 spo cdn policy set --type Public --policy IncludeFileExtensions --value CSS,EOT,GIF,ICO,JPEG,JPG,JS,MAP,PNG,SVG,TTF,WOFF,JSON
 ```
 
 ## More information

--- a/docs/docs/cmd/spo/cdn/cdn-set.md
+++ b/docs/docs/cmd/spo/cdn/cdn-set.md
@@ -37,31 +37,31 @@ Using the `--noDefaultOrigins` option you can specify to skip the creation of th
 Enable the Microsoft 365 Public CDN on the current tenant
 
 ```sh
-m365 spo cdn set -t Public -e true
+m365 spo cdn set --type Public --enabled true
 ```
 
 Disable the Microsoft 365 Public CDN on the current tenant
 
 ```sh
-m365 spo cdn set -t Public -e false
+m365 spo cdn set --type Public --enabled false
 ```
 
 Enable the Microsoft 365 Private CDN on the current tenant
 
 ```sh
-m365 spo cdn set -t Private -e true
+m365 spo cdn set --type Private --enabled true
 ```
 
 Enable the Microsoft 365 Private and Public CDN on the current tenant with default origins
 
 ```sh
-m365 spo cdn set -t Both -e true
+m365 spo cdn set --type Both --enabled true
 ```
 
 Enable the Microsoft 365 Private and Public CDN on the current tenant without default origins
 
 ```sh
-m365 spo cdn set -t Both -e true --noDefaultOrigins
+m365 spo cdn set --type Both --enabled true --noDefaultOrigins
 ```
 
 ## More information

--- a/docs/docs/cmd/spo/customaction/customaction-add.md
+++ b/docs/docs/cmd/spo/customaction/customaction-add.md
@@ -71,7 +71,7 @@ m365 spo customaction add [options]
 Running this command from the Windows Command Shell (cmd.exe) or PowerShell for Windows OS XP, 7, 8, 8.1 without bash installed might require additional formatting for command options that have JSON, XML or JavaScript values because the command shell treat quotes differently. For example, this is how ApplicationCustomizer user custom action can be created from the Windows cmd.exe:
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourAppCustomizer" -n "YourName" -l "ClientSideExtension.ApplicationCustomizer" -c b41916e7-e69d-467f-b37f-ff8ecf8f99f2 -p '{\"testMessage\":\"Test message\"}'
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourAppCustomizer" --name "YourName" --location "ClientSideExtension.ApplicationCustomizer" --clientSideComponentId b41916e7-e69d-467f-b37f-ff8ecf8f99f2 --clientSideComponentProperties '{\"testMessage\":\"Test message\"}'
 ```
 
 Note, how the clientSideComponentProperties option (-p) has escaped double quotes `'{\"testMessage\":\"Test message\"}'` compared to execution from bash `'{"testMessage":"Test message"}'`.
@@ -83,49 +83,49 @@ The `--rights` option accepts **case sensitive** values.
 Adds tenant-wide SharePoint Framework Application Customizer extension in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourAppCustomizer" -n "YourName" -l "ClientSideExtension.ApplicationCustomizer" -c b41916e7-e69d-467f-b37f-ff8ecf8f99f2 -p '{"testMessage":"Test message"}'
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourAppCustomizer" --name "YourName" --location "ClientSideExtension.ApplicationCustomizer" --clientSideComponentId b41916e7-e69d-467f-b37f-ff8ecf8f99f2 --clientSideComponentProperties '{"testMessage":"Test message"}'
 ```
 
 Adds tenant-wide SharePoint Framework **modern List View** Command Set extension in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourCommandSet" -n "YourName" -l "ClientSideExtension.ListViewCommandSet" -c db3e6e35-363c-42b9-a254-ca661e437848 -p '{"sampleTextOne":"One item is selected in the list.", "sampleTextTwo":"This command is always visible."}' --registrationId 100 --registrationType List
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourCommandSet" --name "YourName" --location "ClientSideExtension.ListViewCommandSet" --clientSideComponentId db3e6e35-363c-42b9-a254-ca661e437848 --clientSideComponentProperties '{"sampleTextOne":"One item is selected in the list.", "sampleTextTwo":"This command is always visible."}' --registrationId 100 --registrationType List
 ```
 
 Creates url custom action in the SiteActions menu in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourTitle" -n "YourName" -l "Microsoft.SharePoint.StandardMenu" -g "SiteActions" --actionUrl "~site/SitePages/Home.aspx" --sequence 100
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourTitle" --name "YourName" --location "Microsoft.SharePoint.StandardMenu" --group "SiteActions" --actionUrl "~site/SitePages/Home.aspx" --sequence 100
 ```
 
 Creates custom action in **classic** Document Library edit context menu in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourTitle" -n "YourName" -l "EditControlBlock" --actionUrl "javascript:(function(){ return console.log('CLI for Microsoft 365 rocks!'); })();" --registrationId 101 --registrationType List
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourTitle" --name "YourName" --location "EditControlBlock" --actionUrl "javascript:(function(){ return console.log('CLI for Microsoft 365 rocks!'); })();" --registrationId 101 --registrationType List
 ```
 
 Creates ScriptLink custom action with script source in **classic pages** in site collection _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourTitle" -n "YourName" -l "ScriptLink" --scriptSrc "~sitecollection/SiteAssets/YourScript.js" --sequence 101 -s Site
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourTitle" --name "YourName" --location "ScriptLink" --scriptSrc "~sitecollection/SiteAssets/YourScript.js" --sequence 101 --scope Site
 ```
 
 Creates ScriptLink custom action with script block in **classic pages** in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourTitle" -n "YourName" -l "ScriptLink" --scriptBlock "(function(){ return console.log('Hello CLI for Microsoft 365!'); })();" --sequence 102
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourTitle" --name "YourName" --location "ScriptLink" --scriptBlock "(function(){ return console.log('Hello CLI for Microsoft 365!'); })();" --sequence 102
 ```
 
 Creates **classic List View** custom action located in the Ribbon in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourTitle" -n "YourName" -l "CommandUI.Ribbon" --commandUIExtension '<CommandUIExtension><CommandUIDefinitions><CommandUIDefinition Location="Ribbon.List.Share.Controls._children"><Button Id="Ribbon.List.Share.GetItemsCountButton" Alt="Get list items count" Sequence="11" Command="Invoke_GetItemsCountButtonRequest" LabelText="Get Items Count" TemplateAlias="o1" Image32by32="_layouts/15/images/placeholder32x32.png" Image16by16="_layouts/15/images/placeholder16x16.png" /></CommandUIDefinition></CommandUIDefinitions><CommandUIHandlers><CommandUIHandler Command="Invoke_GetItemsCountButtonRequest" CommandAction="javascript: alert(ctx.TotalListItems);" EnabledScript="javascript: function checkEnable() { return (true);} checkEnable();"/></CommandUIHandlers></CommandUIExtension>'
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourTitle" --name "YourName" --location "CommandUI.Ribbon" --commandUIExtension '<CommandUIExtension><CommandUIDefinitions><CommandUIDefinition Location="Ribbon.List.Share.Controls._children"><Button Id="Ribbon.List.Share.GetItemsCountButton" Alt="Get list items count" Sequence="11" Command="Invoke_GetItemsCountButtonRequest" LabelText="Get Items Count" TemplateAlias="o1" Image32by32="_layouts/15/images/placeholder32x32.png" Image16by16="_layouts/15/images/placeholder16x16.png" /></CommandUIDefinition></CommandUIDefinitions><CommandUIHandlers><CommandUIHandler Command="Invoke_GetItemsCountButtonRequest" CommandAction="javascript: alert(ctx.TotalListItems);" EnabledScript="javascript: function checkEnable() { return (true);} checkEnable();"/></CommandUIHandlers></CommandUIExtension>'
 ```
 
 Creates custom action with delegated rights in the SiteActions menu in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction add -u https://contoso.sharepoint.com/sites/test -t "YourTitle" -n "YourName" -l "Microsoft.SharePoint.StandardMenu" -g "SiteActions" --actionUrl "~site/SitePages/Home.aspx" --rights "AddListItems,DeleteListItems,ManageLists"
+m365 spo customaction add --url https://contoso.sharepoint.com/sites/test --title "YourTitle" --name "YourName" --location "Microsoft.SharePoint.StandardMenu" --group "SiteActions" --actionUrl "~site/SitePages/Home.aspx" --rights "AddListItems,DeleteListItems,ManageLists"
 ```
 
 ## More information

--- a/docs/docs/cmd/spo/customaction/customaction-clear.md
+++ b/docs/docs/cmd/spo/customaction/customaction-clear.md
@@ -27,13 +27,13 @@ Clears all user custom actions for both site and site collection _https://contos
 Skips the confirmation prompt message.
 
 ```sh
-m365 spo customaction clear -u https://contoso.sharepoint.com/sites/test --confirm
+m365 spo customaction clear --url https://contoso.sharepoint.com/sites/test --confirm
 ```
 
 Clears all user custom actions for site _https://contoso.sharepoint.com/sites/test_. 
 
 ```sh
-m365 spo customaction clear -u https://contoso.sharepoint.com/sites/test -s Web
+m365 spo customaction clear --url https://contoso.sharepoint.com/sites/test --scope Web
 ```
 
 Clears all user custom actions for site collection _https://contoso.sharepoint.com/sites/test_

--- a/docs/docs/cmd/spo/customaction/customaction-get.md
+++ b/docs/docs/cmd/spo/customaction/customaction-get.md
@@ -26,19 +26,13 @@ m365 spo customaction get [options]
 Return details about the user custom action with ID _058140e3-0e37-44fc-a1d3-79c487d371a3_ located in site or site collection _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction get -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test
-```
-
-Return details about the user custom action with ID _058140e3-0e37-44fc-a1d3-79c487d371a3_ located in site or site collection _https://contoso.sharepoint.com/sites/test_
-
-```sh
 m365 spo customaction get --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url https://contoso.sharepoint.com/sites/test
 ```
 
 Return details about the user custom action with ID _058140e3-0e37-44fc-a1d3-79c487d371a3_ located in site collection _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction get -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test -s Site
+m365 spo customaction get --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url https://contoso.sharepoint.com/sites/test --scope Site
 ```
 
 Return details about the user custom action with ID _058140e3-0e37-44fc-a1d3-79c487d371a3_ located in site _https://contoso.sharepoint.com/sites/test_

--- a/docs/docs/cmd/spo/customaction/customaction-list.md
+++ b/docs/docs/cmd/spo/customaction/customaction-list.md
@@ -27,19 +27,13 @@ When using the text output type (default), the command lists only the values of 
 Return details about all user custom actions located in site or site collection _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction list -u https://contoso.sharepoint.com/sites/test
-```
-
-Return details about all user custom actions located in site or site collection _https://contoso.sharepoint.com/sites/test_
-
-```sh
 m365 spo customaction list --url https://contoso.sharepoint.com/sites/test
 ```
 
 Return details about all user custom actions located in site collection _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction list -u https://contoso.sharepoint.com/sites/test -s Site
+m365 spo customaction list --url https://contoso.sharepoint.com/sites/test --scope Site
 ```
 
 Return details about all user custom actions located in site _https://contoso.sharepoint.com/sites/test_

--- a/docs/docs/cmd/spo/customaction/customaction-remove.md
+++ b/docs/docs/cmd/spo/customaction/customaction-remove.md
@@ -29,7 +29,7 @@ m365 spo customaction remove [options]
 Removes user custom action with ID _058140e3-0e37-44fc-a1d3-79c487d371a3_ located in site or site collection _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction remove -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test
+m365 spo customaction remove --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url https://contoso.sharepoint.com/sites/test
 ```
 
 Removes user custom action with ID _058140e3-0e37-44fc-a1d3-79c487d371a3_ located in site or site collection _https://contoso.sharepoint.com/sites/test_. Skips the confirmation prompt message.
@@ -41,7 +41,7 @@ m365 spo customaction remove --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url htt
 Removes user custom action with ID _058140e3-0e37-44fc-a1d3-79c487d371a3_ located in site collection _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction remove -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test -s Site
+m365 spo customaction remove --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url https://contoso.sharepoint.com/sites/test --scope Site
 ```
 
 Removes user custom action with ID _058140e3-0e37-44fc-a1d3-79c487d371a3_ located in site _https://contoso.sharepoint.com/sites/test_

--- a/docs/docs/cmd/spo/customaction/customaction-set.md
+++ b/docs/docs/cmd/spo/customaction/customaction-set.md
@@ -74,7 +74,7 @@ m365 spo customaction set [options]
 Running this command from the Windows Command Shell (cmd.exe) or PowerShell for Windows OS XP, 7, 8, 8.1 without bash installed might require additional formatting for command options that have JSON, XML or JavaScript values because the command shell treat quotes differently. For example, this is how ApplicationCustomizer user custom action can be created from the Windows cmd.exe:
 
 ```sh
-m365 spo customaction set -u https://contoso.sharepoint.com/sites/test -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -p '{\"testMessage\":\"Test message\"}'
+m365 spo customaction set --url https://contoso.sharepoint.com/sites/test --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --clientSideComponentProperties '{\"testMessage\":\"Test message\"}'
 ```
 
 Note, how the `clientSideComponentProperties` option (-p) has escaped double quotes `'{\"testMessage\":\"Test message\"}'` compared to execution from bash `'{"testMessage":"Test message"}'`.
@@ -88,31 +88,31 @@ Note, specifying the scope option might speed up the execution of the command, b
 Updates tenant-wide SharePoint Framework Application Customizer extension properties in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction set -u https://contoso.sharepoint.com/sites/test -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -p '{"testMessage":"Test message"}'
+m365 spo customaction set --url https://contoso.sharepoint.com/sites/test --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --clientSideComponentProperties '{"testMessage":"Test message"}'
 ```
 
 Updates tenant-wide SharePoint Framework **modern List View** Command Set extension in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction set -u https://contoso.sharepoint.com/sites/test -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -p '{"sampleTextOne":"One item is selected in the list.", "sampleTextTwo":"This command is always visible."}' --sequence 100
+m365 spo customaction set --url https://contoso.sharepoint.com/sites/test --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --clientSideComponentProperties '{"sampleTextOne":"One item is selected in the list.", "sampleTextTwo":"This command is always visible."}' --sequence 100
 ```
 
 Updates url custom action in the SiteActions menu in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction set -u https://contoso.sharepoint.com/sites/test  -u https://contoso.sharepoint.com/sites/test -i 058140e3-0e37-44fc-a1d3-79c487d371a3 --actionUrl "~site/SitePages/Home.aspx"
+m365 spo customaction set --url https://contoso.sharepoint.com/sites/test --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --actionUrl "~site/SitePages/Home.aspx"
 ```
 
 Updates ScriptLink custom action with script source in **classic pages** in site collection _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction set -u https://contoso.sharepoint.com/sites/test -u https://contoso.sharepoint.com/sites/test -i 058140e3-0e37-44fc-a1d3-79c487d371a3 --scriptSrc "~sitecollection/SiteAssets/YourScript.js"
+m365 spo customaction set --url https://contoso.sharepoint.com/sites/test --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --scriptSrc "~sitecollection/SiteAssets/YourScript.js"
 ```
 
 Creates custom action with delegated rights in the SiteActions menu in site _https://contoso.sharepoint.com/sites/test_
 
 ```sh
-m365 spo customaction set -u https://contoso.sharepoint.com/sites/test -i 058140e3-0e37-44fc-a1d3-79c487d371a3 --rights "AddListItems,DeleteListItems,ManageLists"
+m365 spo customaction set --url https://contoso.sharepoint.com/sites/test --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --rights "AddListItems,DeleteListItems,ManageLists"
 ```
 
 ## More information


### PR DESCRIPTION
Fixes 'command examples use short options instead of long'. Closes #2319