### PR TITLE
Adds support for configuring error output. Closes #2325

### DIFF
--- a/docs/docs/_clisettings.md
+++ b/docs/docs/_clisettings.md
@@ -1,0 +1,9 @@
+## Available settings
+
+Following is the list of configuration settings available in CLI for Microsoft 365.
+
+Setting name|Definition|Default value
+------------|----------|-------------
+`errorOutput`|Defines if errors should be written to `stdout` or `stderr`|`stderr`
+`output`|Defines the default output when issuing a command|`text`
+`showHelpOnFailure`|Automatically display help when executing a command failed|`true`

--- a/docs/docs/cmd/cli/config/config-set.md
+++ b/docs/docs/cmd/cli/config/config-set.md
@@ -11,12 +11,14 @@ m365 cli config set [options]
 ## Options
 
 `-k, --key <key>`
-: Config key to specify. Allowed values: `showHelpOnFailure,output`
+: Config key to specify
 
 `-v, --value <value>`
 : Config value to set
 
 --8<-- "docs/cmd/_global.md"
+
+--8<-- "docs/_clisettings.md"
 
 ## Examples
 

--- a/docs/docs/user-guide/configuring-cli.md
+++ b/docs/docs/user-guide/configuring-cli.md
@@ -12,11 +12,4 @@ You can configure the specific setting using the `cli config set` command. For e
 m365 cli config set --key showHelpOnFailure --value true
 ```
 
-## Available settings
-
-Following is the list of configuration settings available in CLI for Microsoft 365.
-
-Setting name|Definition|Default value
-------------|----------|-------------
-`showHelpOnFailure`|Automatically display help when executing a command failed|`true`
-`output`|Defines the default output when issuing a command|`text`
+--8<-- "docs/_clisettings.md"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,8 +12,6 @@ nav:
     - 'Using your own Azure AD identity': 'user-guide/using-own-identity.md'
     - 'Caveats when working with the CLI and certificate login': 'user-guide/cli-certificate-caveats.md'
   - Commands:
-    - config set: 'cmd/cli/config/config-set.md'
-    - consent: 'cmd/cli/cli-consent.md'
     - login: 'cmd/login.md'
     - logout: 'cmd/logout.md'
     - status: 'cmd/status.md'
@@ -81,6 +79,8 @@ nav:
         - completion pwsh update: 'cmd/cli/completion/completion-pwsh-update.md'
         - completion sh setup: 'cmd/cli/completion/completion-sh-setup.md'
         - completion sh update: 'cmd/cli/completion/completion-sh-update.md'
+      - config:
+        - config set: 'cmd/cli/config/config-set.md'
     - File (file):
       - convert:
         - convert pdf: 'cmd/file/convert/convert-pdf.md'

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -1252,11 +1252,23 @@ describe('Cli', () => {
     assert(consoleLogSpy.calledWith());
   });
 
-  it(`logs error to console`, () => {
+  it(`logs error to console stderr`, () => {
     Utils.restore((Cli as any).error);
     const consoleErrorSpy: sinon.SinonSpy = sinon.stub(console, 'error').callsFake(() => { });
     (Cli as any).error('Message');
     assert(consoleErrorSpy.calledWith('Message'));
+  });
+
+  it(`logs error to console stdout when stdout configured as error output`, () => {
+    const config = cli.config;
+    sinon.stub(config, 'get').callsFake(() => 'stdout');
+    Utils.restore((Cli as any).error);
+    const consoleErrorSpy: sinon.SinonSpy = sinon.stub(console, 'error').callsFake(() => { });
+    const consoleLogSpy: sinon.SinonSpy = sinon.stub(console, 'log').callsFake(() => { });
+
+    (Cli as any).error('Message');
+    assert(consoleErrorSpy.notCalled, 'console.error called');
+    assert(consoleLogSpy.calledWith('Message'), 'console.log not called with the right message');
   });
 
   it(`returns stored configuration value when available`, () => {

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -179,15 +179,7 @@ export class Cli {
 
     return Cli
       .executeCommand(this.commandToExecute.command, optionsWithoutShorts)
-      .then(_ => {
-        if (optionsWithoutShorts.options.verbose ||
-          optionsWithoutShorts.options.debug) {
-          const chalk: typeof Chalk = require('chalk');
-          Cli.error(chalk.green('DONE'));
-        }
-
-        process.exit(0);
-      }, err => this.closeWithError(err));
+      .then(_ => process.exit(0), err => this.closeWithError(err));
   }
 
   public static executeCommand(command: Command, args: { options: minimist.ParsedArgs }): Promise<void> {
@@ -211,17 +203,21 @@ export class Cli {
       const parentCommandName: string | undefined = cli.currentCommandName;
       cli.currentCommandName = command.getCommandName();
 
-      command
-        .action(logger, args as any, (err: any): void => {
-          // restore the original command name
-          cli.currentCommandName = parentCommandName;
+      command.action(logger, args as any, (err: any): void => {
+        // restore the original command name
+        cli.currentCommandName = parentCommandName;
 
-          if (err) {
-            return reject(err);
-          }
+        if (err) {
+          return reject(err);
+        }
 
-          resolve();
-        });
+        if (args.options.debug || args.options.verbose) {
+          const chalk: typeof Chalk = require('chalk');
+          logger.logToStderr(chalk.green('DONE'));
+        }
+
+        resolve();
+      });
     });
   }
 
@@ -767,7 +763,13 @@ export class Cli {
   }
 
   private static error(message?: any, ...optionalParams: any[]): void {
-    console.error(message, ...optionalParams);
+    const errorOutput: string = Cli.getInstance().getSettingWithDefaultValue(settingsNames.errorOutput, 'stderr');
+    if (errorOutput === 'stdout') {
+      console.log(message, ...optionalParams);
+    }
+    else {
+      console.error(message, ...optionalParams);
+    }
   }
 
   public static prompt(options: any, cb: (result: any) => void): void {

--- a/src/m365/cli/commands/config/config-set.spec.ts
+++ b/src/m365/cli/commands/config/config-set.spec.ts
@@ -122,13 +122,43 @@ describe(commands.CONFIG_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it(`passes validation if service is set to ${settingsNames.showHelpOnFailure} `, () => {
-    const actual = command.validate({ options: { key: settingsNames.showHelpOnFailure, value: false } });
+  it(`passes validation if setting is set to ${settingsNames.showHelpOnFailure} and value to true`, () => {
+    const actual = command.validate({ options: { key: settingsNames.showHelpOnFailure, value: 'true' } });
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation if specified output key is invalid ', () => {
+  it(`passes validation if setting is set to ${settingsNames.showHelpOnFailure} and value to false`, () => {
+    const actual = command.validate({ options: { key: settingsNames.showHelpOnFailure, value: 'false' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if specified output type is invalid', () => {
     const actual = command.validate({ options: { key: settingsNames.output, value: 'invalid' } });
     assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation for output type text', () => {
+    const actual = command.validate({ options: { key: settingsNames.output, value: 'text' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation for output type json', () => {
+    const actual = command.validate({ options: { key: settingsNames.output, value: 'json' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if specified error output type is invalid', () => {
+    const actual = command.validate({ options: { key: settingsNames.errorOutput, value: 'invalid' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation for error output stdout', () => {
+    const actual = command.validate({ options: { key: settingsNames.errorOutput, value: 'stdout' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation for error output stderr', () => {
+    const actual = command.validate({ options: { key: settingsNames.errorOutput, value: 'stderr' } });
+    assert.strictEqual(actual, true);
   });
 });

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -15,6 +15,8 @@ interface Options extends GlobalOptions {
 }
 
 class CliConfigSetCommand extends AnonymousCommand {
+  private static readonly optionNames: string[] = Object.getOwnPropertyNames(settingsNames);
+
   public get name(): string {
     return commands.CONFIG_SET;
   }
@@ -49,7 +51,7 @@ class CliConfigSetCommand extends AnonymousCommand {
     const options: CommandOption[] = [
       {
         option: '-k, --key <key>',
-        autocomplete: [settingsNames.showHelpOnFailure, settingsNames.output]
+        autocomplete: CliConfigSetCommand.optionNames
       },
       {
         option: '-v, --value <value>'
@@ -61,15 +63,20 @@ class CliConfigSetCommand extends AnonymousCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (args.options.key !== settingsNames.showHelpOnFailure &&
-      args.options.key !== settingsNames.output) {
-      return `${args.options.key} is not a valid setting. Allowed values: ${settingsNames.showHelpOnFailure}, ${settingsNames.output}`;
+    if (CliConfigSetCommand.optionNames.indexOf(args.options.key) < 0) {
+      return `${args.options.key} is not a valid setting. Allowed values: ${CliConfigSetCommand.optionNames.join(', ')}`;
     }
 
     const allowedOutputs = ['text', 'json'];
     if (args.options.key === settingsNames.output &&
       allowedOutputs.indexOf(args.options.value) === -1) {
       return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${allowedOutputs.join(', ')}`;
+    }
+
+    const allowedErrorOutputs = ['stdout', 'stderr'];
+    if (args.options.key === settingsNames.errorOutput &&
+      allowedErrorOutputs.indexOf(args.options.value) === -1) {
+      return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${allowedErrorOutputs.join(', ')}`;
     }
 
     return true;

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -1,4 +1,5 @@
 const settingsNames = {
+  errorOutput: 'errorOutput',
   showHelpOnFailure: 'showHelpOnFailure',
   output: 'output'
 };


### PR DESCRIPTION
Adds support for configuring error output. Closes #2325

Also, I centralized the list of available settings in the docs so that we don't need to maintain them in multiple locations.