### PR TITLE
fix small mistake in the spec for command spo list set

### DIFF
--- a/docs/docs/cmd/spo/list/list-set.md
+++ b/docs/docs/cmd/spo/list/list-set.md
@@ -203,10 +203,10 @@ m365 spo list set [options]
 
 ## Examples
 
-Update the _allowContentTypes_ property of the list with id _3EA5A977-315E-4E25-8B0F-E4F949BF6B8F_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Update the _contentTypesEnabled_ property of the list with id _3EA5A977-315E-4E25-8B0F-E4F949BF6B8F_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
-m365 spo list set --webUrl https://contoso.sharepoint.com/sites/project-x --id 3EA5A977-315E-4E25-8B0F-E4F949BF6B8F --allowContentTypes true
+m365 spo list set --webUrl https://contoso.sharepoint.com/sites/project-x --id 3EA5A977-315E-4E25-8B0F-E4F949BF6B8F --contentTypesEnabled true
 ```
 
 Enable versioning and set the number of major versions to keep on the list with id _3EA5A977-315E-4E25-8B0F-E4F949BF6B8F_ located in site _https://contoso.sharepoint.com/sites/project-x_


### PR DESCRIPTION
### fix of small bug in the spec for command spo list set

#### 🎯 Aim
The aim was to fix small issue in the spec for command `spo list set`. In the example we had a command with `--allowContentTypes` which did not work 
![image](https://user-images.githubusercontent.com/58668583/113941477-73315680-97ff-11eb-9868-e62e8dec82b2.png)
and we should use option `--contentTypesEnabled` if we want to enable CT
![image](https://user-images.githubusercontent.com/58668583/113941507-804e4580-97ff-11eb-975e-b0ea9b97ecc4.png)

#### ✔ What was done
- updated the list-set spec
- run and checked npm run build && npm run test ... all fine 
![image](https://user-images.githubusercontent.com/58668583/113941599-af64b700-97ff-11eb-8425-9ce28f88f335.png)

#### 📸 Result
if we run `m365 help list spo set` we will get the description with correct option in the example
![image](https://user-images.githubusercontent.com/58668583/113941651-cdcab280-97ff-11eb-8d15-ed64b4c26958.png)

### Linked Issue
Closes #2332
