### PR TITLE
command: spo conetenttype add command should return the content type

### DIFF
--- a/src/m365/spo/commands/contenttype/contenttype-get.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-get.ts
@@ -9,7 +9,7 @@ interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
+export interface  Options extends GlobalOptions {
   webUrl: string;
   listTitle?: string;
   id: string;


### PR DESCRIPTION
### spo conetenttype add command should return the content type

#### 🎯 Aim
The aim of this PR is to add a small improvement to spo contenttype add command so that the content type object will be returned as a result of this command. This may be helpful as usually we add content type to site or list to then add columns to it, so usually we would still run the get command after the add one. Also the list add and field add commands return the created object so this behavior seems to be consistent with other commands

#### ✅ What was done
✔ reused spo contenttype get command in spo contenttype add command result

#### What needs to be done 👨‍💻
- [ ] confirm the approach 🤔
- [ ] correct unit test

#### 📸 Result
after we use `spo contenttype add` command as a result we get the added content type output
![image](https://user-images.githubusercontent.com/58668583/115792959-7f0a4480-a3cb-11eb-8188-a14682c2e57b.png)


### Linked Issue
#2333 