### PR TITLE
Extends 'spo site apppermission get'. Closes #2409

### DIFF
--- a/src/m365/spo/commands/site/site-apppermission-get.spec.ts
+++ b/src/m365/spo/commands/site/site-apppermission-get.spec.ts
@@ -144,7 +144,8 @@ describe(commands.SITE_APPPERMISSION_GET, () => {
         assert(loggerLogSpy.calledWith([{
           appDisplayName: 'Selected',
           appId: 'fc1534e7-259d-482a-8688-d6a33d9a0a2c',
-          permissionId: 'aTowaS50fG1zLnNwLmV4dHxmYzE1MzRlNy0yNTlkLTQ4MmEtODY4OC1kNmEzM2Q5YTBhMmNAZWUyYjdjMGMtZDI1My00YjI3LTk0NmItMDYzZGM4OWNlOGMy'
+          permissionId: 'aTowaS50fG1zLnNwLmV4dHxmYzE1MzRlNy0yNTlkLTQ4MmEtODY4OC1kNmEzM2Q5YTBhMmNAZWUyYjdjMGMtZDI1My00YjI3LTk0NmItMDYzZGM4OWNlOGMy',
+          roles: "write"
         }]));
         done();
       }

--- a/src/m365/spo/commands/site/site-apppermission-get.ts
+++ b/src/m365/spo/commands/site/site-apppermission-get.ts
@@ -57,14 +57,15 @@ class SpoSiteAppPermissionGetCommand extends GraphCommand {
       .getSpoSiteId(args)
       .then((siteId: string): Promise<SitePermission> => this.getApplicationPermission(args, siteId))
       .then((permissionObject: SitePermission) => {
-        const transposed: { appDisplayName: string; appId: string; permissionId: string }[] = [];
+        const transposed: { appDisplayName: string; appId: string; permissionId: string, roles: string }[] = [];
 
         permissionObject.grantedToIdentities.forEach((permissionEntity: SitePermissionIdentitySet) => {
           transposed.push(
             {
               appDisplayName: permissionEntity.application.displayName,
               appId: permissionEntity.application.id,
-              permissionId: permissionObject.id
+              permissionId: permissionObject.id,
+              roles: permissionObject.roles.join()
             });
         });
 


### PR DESCRIPTION
Extends 'spo site apppermission get'. Closes #2409
Extends the spo site apppermission get command to show the roles.