### PR TITLE
Extend 'spo list get' to retrieve specific list properties

### DIFF
--- a/docs/docs/cmd/spo/list/list-get.md
+++ b/docs/docs/cmd/spo/list/list-get.md
@@ -19,6 +19,9 @@ m365 spo list get [options]
 `-t, --title [title]`
 : Title of the list to retrieve information for. Specify either `id` or `title` but not both
 
+`-p, --properties [properties]`
+: Comma-separated list of properties to retrieve from the list. Will retrieve all properties possible from default response, if not specified.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples

--- a/src/m365/spo/commands/list/list-get.spec.ts
+++ b/src/m365/spo/commands/list/list-get.spec.ts
@@ -187,6 +187,263 @@ describe(commands.LIST_GET, () => {
     });
   });
 
+  it('retrieves details of list if title and properties option is passed', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.resolve(
+        {
+          "AllowContentTypes": true,
+          "BaseTemplate": 109,
+          "BaseType": 1,
+          "ContentTypesEnabled": false,
+          "CrawlNonDefaultViews": false,
+          "Created": null,
+          "CurrentChangeToken": null,
+          "CustomActionElements": null,
+          "DefaultContentApprovalWorkflowId": "00000000-0000-0000-0000-000000000000",
+          "DefaultItemOpenUseListSetting": false,
+          "Description": "",
+          "Direction": "none",
+          "DocumentTemplateUrl": null,
+          "DraftVersionVisibility": 0,
+          "EnableAttachments": false,
+          "EnableFolderCreation": true,
+          "EnableMinorVersions": false,
+          "EnableModeration": false,
+          "EnableVersioning": false,
+          "EntityTypeName": "Documents",
+          "ExemptFromBlockDownloadOfNonViewableFiles": false,
+          "FileSavePostProcessingEnabled": false,
+          "ForceCheckout": false,
+          "HasExternalDataSource": false,
+          "Hidden": false,
+          "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
+          "ImagePath": null,
+          "ImageUrl": null,
+          "IrmEnabled": false,
+          "IrmExpire": false,
+          "IrmReject": false,
+          "IsApplicationList": false,
+          "IsCatalog": false,
+          "IsPrivate": false,
+          "ItemCount": 69,
+          "LastItemDeletedDate": null,
+          "LastItemModifiedDate": null,
+          "LastItemUserModifiedDate": null,
+          "ListExperienceOptions": 0,
+          "ListItemEntityTypeFullName": null,
+          "MajorVersionLimit": 0,
+          "MajorWithMinorVersionsLimit": 0,
+          "MultipleDataList": false,
+          "NoCrawl": false,
+          "ParentWebPath": null,
+          "ParentWebUrl": null,
+          "ParserDisabled": false,
+          "ServerTemplateCanCreateFolders": true,
+          "TemplateFeatureId": null,
+          "Title": "Documents"
+        }
+      );
+      //}
+      //return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        title: 'Documents',
+        webUrl: 'https://contoso.sharepoint.com',
+        properties:'Title,Id'
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith({
+          AllowContentTypes: true,
+          BaseTemplate: 109,
+          BaseType: 1,
+          ContentTypesEnabled: false,
+          CrawlNonDefaultViews: false,
+          Created: null,
+          CurrentChangeToken: null,
+          CustomActionElements: null,
+          DefaultContentApprovalWorkflowId: '00000000-0000-0000-0000-000000000000',
+          DefaultItemOpenUseListSetting: false,
+          Description: '',
+          Direction: 'none',
+          DocumentTemplateUrl: null,
+          DraftVersionVisibility: 0,
+          EnableAttachments: false,
+          EnableFolderCreation: true,
+          EnableMinorVersions: false,
+          EnableModeration: false,
+          EnableVersioning: false,
+          EntityTypeName: 'Documents',
+          ExemptFromBlockDownloadOfNonViewableFiles: false,
+          FileSavePostProcessingEnabled: false,
+          ForceCheckout: false,
+          HasExternalDataSource: false,
+          Hidden: false,
+          Id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+          ImagePath: null,
+          ImageUrl: null,
+          IrmEnabled: false,
+          IrmExpire: false,
+          IrmReject: false,
+          IsApplicationList: false,
+          IsCatalog: false,
+          IsPrivate: false,
+          ItemCount: 69,
+          LastItemDeletedDate: null,
+          LastItemModifiedDate: null,
+          LastItemUserModifiedDate: null,
+          ListExperienceOptions: 0,
+          ListItemEntityTypeFullName: null,
+          MajorVersionLimit: 0,
+          MajorWithMinorVersionsLimit: 0,
+          MultipleDataList: false,
+          NoCrawl: false,
+          ParentWebPath: null,
+          ParentWebUrl: null,
+          ParserDisabled: false,
+          ServerTemplateCanCreateFolders: true,
+          TemplateFeatureId: null,
+          Title: 'Documents'
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+  it('retrieves details of list if list id and properties option is passed', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.resolve(
+        {
+          "AllowContentTypes": true,
+          "BaseTemplate": 109,
+          "BaseType": 1,
+          "ContentTypesEnabled": false,
+          "CrawlNonDefaultViews": false,
+          "Created": null,
+          "CurrentChangeToken": null,
+          "CustomActionElements": null,
+          "DefaultContentApprovalWorkflowId": "00000000-0000-0000-0000-000000000000",
+          "DefaultItemOpenUseListSetting": false,
+          "Description": "",
+          "Direction": "none",
+          "DocumentTemplateUrl": null,
+          "DraftVersionVisibility": 0,
+          "EnableAttachments": false,
+          "EnableFolderCreation": true,
+          "EnableMinorVersions": false,
+          "EnableModeration": false,
+          "EnableVersioning": false,
+          "EntityTypeName": "Documents",
+          "ExemptFromBlockDownloadOfNonViewableFiles": false,
+          "FileSavePostProcessingEnabled": false,
+          "ForceCheckout": false,
+          "HasExternalDataSource": false,
+          "Hidden": false,
+          "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
+          "ImagePath": null,
+          "ImageUrl": null,
+          "IrmEnabled": false,
+          "IrmExpire": false,
+          "IrmReject": false,
+          "IsApplicationList": false,
+          "IsCatalog": false,
+          "IsPrivate": false,
+          "ItemCount": 69,
+          "LastItemDeletedDate": null,
+          "LastItemModifiedDate": null,
+          "LastItemUserModifiedDate": null,
+          "ListExperienceOptions": 0,
+          "ListItemEntityTypeFullName": null,
+          "MajorVersionLimit": 0,
+          "MajorWithMinorVersionsLimit": 0,
+          "MultipleDataList": false,
+          "NoCrawl": false,
+          "ParentWebPath": null,
+          "ParentWebUrl": null,
+          "ParserDisabled": false,
+          "ServerTemplateCanCreateFolders": true,
+          "TemplateFeatureId": null,
+          "Title": "Documents"
+        }
+      );
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+        webUrl: 'https://contoso.sharepoint.com',
+        properties:'Title,Id'
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith({
+          AllowContentTypes: true,
+          BaseTemplate: 109,
+          BaseType: 1,
+          ContentTypesEnabled: false,
+          CrawlNonDefaultViews: false,
+          Created: null,
+          CurrentChangeToken: null,
+          CustomActionElements: null,
+          DefaultContentApprovalWorkflowId: '00000000-0000-0000-0000-000000000000',
+          DefaultItemOpenUseListSetting: false,
+          Description: '',
+          Direction: 'none',
+          DocumentTemplateUrl: null,
+          DraftVersionVisibility: 0,
+          EnableAttachments: false,
+          EnableFolderCreation: true,
+          EnableMinorVersions: false,
+          EnableModeration: false,
+          EnableVersioning: false,
+          EntityTypeName: 'Documents',
+          ExemptFromBlockDownloadOfNonViewableFiles: false,
+          FileSavePostProcessingEnabled: false,
+          ForceCheckout: false,
+          HasExternalDataSource: false,
+          Hidden: false,
+          Id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+          ImagePath: null,
+          ImageUrl: null,
+          IrmEnabled: false,
+          IrmExpire: false,
+          IrmReject: false,
+          IsApplicationList: false,
+          IsCatalog: false,
+          IsPrivate: false,
+          ItemCount: 69,
+          LastItemDeletedDate: null,
+          LastItemModifiedDate: null,
+          LastItemUserModifiedDate: null,
+          ListExperienceOptions: 0,
+          ListItemEntityTypeFullName: null,
+          MajorVersionLimit: 0,
+          MajorWithMinorVersionsLimit: 0,
+          MultipleDataList: false,
+          NoCrawl: false,
+          ParentWebPath: null,
+          ParentWebUrl: null,
+          ParserDisabled: false,
+          ServerTemplateCanCreateFolders: true,
+          TemplateFeatureId: null,
+          Title: 'Documents'
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('command correctly handles list get reject request', (done) => {
     const err = 'Invalid request';
     sinon.stub(request, 'get').callsFake((opts) => {
@@ -267,6 +524,18 @@ describe(commands.LIST_GET, () => {
     assert(containsTypeOption);
   });
 
+  it('supports specifying properties', () => {
+    const options = command.options();
+    let containsTypeOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--properties') > -1) {
+        containsTypeOption = true;
+      }
+    });
+    assert(containsTypeOption);
+  });
+
+  
   it('fails validation if both id and title options are not passed', () => {
     const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com' } });
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/list/list-get.ts
+++ b/src/m365/spo/commands/list/list-get.ts
@@ -17,6 +17,7 @@ interface Options extends GlobalOptions {
   webUrl: string;
   id?: string;
   title?: string;
+  properties?: string;
 }
 
 class SpoListGetCommand extends SpoCommand {
@@ -32,6 +33,7 @@ class SpoListGetCommand extends SpoCommand {
     const telemetryProps: any = super.getTelemetryProperties(args);
     telemetryProps.id = (!(!args.options.id)).toString();
     telemetryProps.title = (!(!args.options.title)).toString();
+    telemetryProps.properties = (!(!args.options.properties)).toString();
     return telemetryProps;
   }
 
@@ -49,8 +51,10 @@ class SpoListGetCommand extends SpoCommand {
       requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.title as string)}')`;
     }
 
+    const propertiesSelect: string = args.options.properties ? `?$select=${encodeURIComponent(args.options.properties)}` : ``;
+
     const requestOptions: any = {
-      url: requestUrl,
+      url: `${requestUrl}${propertiesSelect}`,
       method: 'GET',
       headers: {
         'accept': 'application/json;odata=nometadata'
@@ -77,6 +81,9 @@ class SpoListGetCommand extends SpoCommand {
       },
       {
         option: '-t, --title [title]'
+      },
+      {
+        option: '-p, --properties [properties]'
       }
     ];
 


### PR DESCRIPTION
> ### Extend 'spo list get' to retrieve specific list properties

Implements #2443  by adding a '-p' '--properties' option to extend the 'spo list get' command. This will provide the ability to request for specific list properties. Added specs and documentation to reflect the change

Usage : 

`m365 spo list get --webUrl "<SiteURL>" --title "<List title>" --properties "Title,Id,HasUniqueRoleAssignments,AllowContentTypes"`
