### PR TITLE
Extends 'spo listitem get' command. Closes #2382

### DIFF
--- a/docs/docs/cmd/spo/listitem/listitem-get.md
+++ b/docs/docs/cmd/spo/listitem/listitem-get.md
@@ -25,6 +25,9 @@ m365 spo listitem get [options]
 `-f, --fields [fields]`
 : Comma-separated list of fields to retrieve. Will retrieve all fields if not specified and json output is requested
 
+`-p, --properties [properties]`
+: Comma-separated list of properties to retrieve from the item.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
@@ -40,4 +43,10 @@ Get an items Title and Created column and with ID _147_ from list with title _De
 
 ```sh
 m365 spo listitem get --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x --fields "Title,Created"
+```
+
+Get an item with ID _147_ from list with title _Demo List_ in site _https://contoso.sharepoint.com/sites/project-x_ with the specified properties
+
+```sh
+m365 spo listitem get --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x --properties "DisplayName,Id,HasUniqueRoleAssignments,ContentType"
 ```

--- a/src/m365/spo/commands/listitem/listitem-get.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-get.spec.ts
@@ -271,6 +271,27 @@ describe(commands.LISTITEM_GET, () => {
     });
   });
 
+  it('returns listItemInstance object when list item is requested with an no output type specified, and a list of fields and properties are not specified', (done) => {
+    sinon.stub(request, 'get').callsFake(getFakesWithProperties);
+
+    const options: any = { 
+      debug: false, 
+      listTitle: 'Demo List', 
+      webUrl: 'https://contoso.sharepoint.com/sites/project-x', 
+      id: expectedId
+    };
+
+    command.action(logger, { options: options } as any, () => {
+      try {
+        assert.strictEqual(actualId, expectedId);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('returns listItemInstance object when list item is requested with an output type of json, and a list of fields specified', (done) => {
     sinon.stub(request, 'get').callsFake(getFakes);
 

--- a/src/m365/spo/commands/listitem/listitem-get.ts
+++ b/src/m365/spo/commands/listitem/listitem-get.ts
@@ -20,6 +20,7 @@ interface Options extends GlobalOptions {
   listTitle?: string;
   id: string;
   fields?: string;
+  properties?: string;
 }
 
 class SpoListItemGetCommand extends SpoCommand {
@@ -39,6 +40,7 @@ class SpoListItemGetCommand extends SpoCommand {
     const telemetryProps: any = super.getTelemetryProperties(args);
     telemetryProps.listId = typeof args.options.listId !== 'undefined';
     telemetryProps.listTitle = typeof args.options.listTitle !== 'undefined';
+    telemetryProps.properties = (!(!args.options.properties)).toString();
     return telemetryProps;
   }
 
@@ -57,8 +59,10 @@ class SpoListItemGetCommand extends SpoCommand {
           ``
       );
 
+    const propertiesSelect: string = args.options.properties ? `,${encodeURIComponent(args.options.properties)}` : ``;
+
     const requestOptions: any = {
-      url: `${listRestUrl}/items(${args.options.id})${fieldSelect}`,
+      url: `${listRestUrl}/items(${args.options.id})${fieldSelect}${propertiesSelect}`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },
@@ -90,6 +94,9 @@ class SpoListItemGetCommand extends SpoCommand {
       },
       {
         option: '-f, --fields [fields]'
+      },
+      {
+        option: '-p, --properties [properties]'
       }
     ];
 

--- a/src/m365/spo/commands/listitem/listitem-get.ts
+++ b/src/m365/spo/commands/listitem/listitem-get.ts
@@ -59,10 +59,14 @@ class SpoListItemGetCommand extends SpoCommand {
           ``
       );
 
-    const propertiesSelect: string = args.options.properties ? `,${encodeURIComponent(args.options.properties)}` : ``;
+    const propertiesSelect: string = args.options.properties ? `${encodeURIComponent(args.options.properties)}` : ``;
+    const selectClause: string = (fieldSelect === "") ? `?$select=${propertiesSelect}` :
+      (
+        (propertiesSelect === "") ? `${fieldSelect}` : `${fieldSelect},${propertiesSelect}`
+      );
 
     const requestOptions: any = {
-      url: `${listRestUrl}/items(${args.options.id})${fieldSelect}${propertiesSelect}`,
+      url: `${listRestUrl}/items(${args.options.id})${selectClause}`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },


### PR DESCRIPTION
Extends 'spo listitem get' command. Closes #2382

Extends 'spo listitem get' command to retrieve properties using option --properties