### PR TITLE
Unable to login when password contains "&"

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -348,7 +348,7 @@ export class Auth {
 
     return (this.clientApplication as Msal.PublicClientApplication).acquireTokenByUsernamePassword({
       username: this.service.userName as string,
-      password: this.service.password as string,
+      password: encodeURIComponent(this.service.password as string),
       scopes: [`${resource}/.default`]
     });
   }


### PR DESCRIPTION

 - Fixes 'm365 login' command. Closes #2466