### PR TITLE
Excludes /assets/ path from loading commands. Closes #2512

### DIFF
--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -280,6 +280,7 @@ export class Cli {
 
     files.forEach(file => {
       if (file.indexOf(`${path.sep}commands${path.sep}`) > -1 &&
+        file.indexOf(`${path.sep}assets${path.sep}`) < 0 &&
         file.endsWith('.js') &&
         !file.endsWith('.spec.js')) {
         try {


### PR DESCRIPTION
Excludes /assets/ path from loading commands. Closes #2512