### PR TITLE
Extend 'spo web get'. Added Groups. Closes #2493

### DIFF
--- a/docs/docs/cmd/spo/web/web-get.md
+++ b/docs/docs/cmd/spo/web/web-get.md
@@ -13,6 +13,9 @@ m365 spo web get [options]
 `-u, --webUrl <webUrl>`
 : URL of the site for which to retrieve the information
 
+`--withGroups`
+: Set if you want to return associated groups (associatedOwnerGroup, associatedMemberGroup and associatedVisitorGroup) along with other properties
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
@@ -21,4 +24,10 @@ Retrieve information about the site _https://contoso.sharepoint.com/subsite_
 
 ```sh
 m365 spo web get --webUrl https://contoso.sharepoint.com/subsite
+```
+
+Retrieve information about the site _https://contoso.sharepoint.com/subsite_ along with associated groups for the web
+
+```sh
+m365 spo web get --webUrl https://contoso.sharepoint.com/subsite --withGroups
 ```

--- a/src/m365/spo/commands/web/WebProperties.ts
+++ b/src/m365/spo/commands/web/WebProperties.ts
@@ -2,6 +2,9 @@ export interface WebProperties {
   AllowRssFeeds: boolean;
   AlternateCssUrl: string;
   AppInstanceId: string;
+  AssociatedMemberGroup: AssociatedGroupProperties;
+  AssociatedOwnerGroup: AssociatedGroupProperties;
+  AssociatedVisitorGroup: AssociatedGroupProperties;
   Configuration: number;
   Created: string;
   CurrentChangeToken: CurrentChangeToken;
@@ -39,4 +42,18 @@ export interface CurrentChangeToken {
 
 export interface ResourcePath {
   DecodedUrl: string;
+}
+export interface AssociatedGroupProperties {
+  Id: number;
+  IsHiddenInUI: boolean;
+  LoginName: string;
+  Title: string;
+  PrincipalType: number;
+  AllowMembersEditMembership: boolean;
+  AllowRequestToJoinLeave: boolean;
+  AutoAcceptRequestToJoinLeave: boolean;
+  Description: string;
+  OnlyAllowMembersViewMembership: boolean;
+  OwnerTitle: string;
+  RequestToJoinLeaveEmailSetting: string;
 }

--- a/src/m365/spo/commands/web/web-get.spec.ts
+++ b/src/m365/spo/commands/web/web-get.spec.ts
@@ -155,6 +155,188 @@ describe(commands.WEB_GET, () => {
     });
   });
 
+  it('retrieves site information - With Associated Groups', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web') > -1) {
+        return Promise.resolve(
+          {
+            "value": [{
+              "AssociatedMemberGroup": {
+                "Id": 5,
+                "IsHiddenInUI": false,
+                "LoginName": "Contoso Members",
+                "Title": "Contoso Members",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": true,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "Contoso Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "AssociatedOwnerGroup": {
+                "Id": 3,
+                "IsHiddenInUI": false,
+                "LoginName": "Contoso Owners",
+                "Title": "Contoso Owners",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": false,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "Contoso Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "AssociatedVisitorGroup": {
+                "Id": 4,
+                "IsHiddenInUI": false,
+                "LoginName": "Contoso Visitors",
+                "Title": "Contoso Visitors",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": false,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "Contoso Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "AllowRssFeeds": false,
+              "AlternateCssUrl": null,
+              "AppInstanceId": "00000000-0000-0000-0000-000000000000",
+              "Configuration": 0,
+              "Created": null,
+              "CurrentChangeToken": null,
+              "CustomMasterUrl": null,
+              "Description": null,
+              "DesignPackageId": null,
+              "DocumentLibraryCalloutOfficeWebAppPreviewersDisabled": false,
+              "EnableMinimalDownload": false,
+              "HorizontalQuickLaunch": false,
+              "Id": "d8d179c7-f459-4f90-b592-14b08e84accb",
+              "IsMultilingual": false,
+              "Language": 1033,
+              "LastItemModifiedDate": null,
+              "LastItemUserModifiedDate": null,
+              "MasterUrl": null,
+              "NoCrawl": false,
+              "OverwriteTranslationsOnChange": false,
+              "ResourcePath": null,
+              "QuickLaunchEnabled": false,
+              "RecycleBinEnabled": false,
+              "ServerRelativeUrl": null,
+              "SiteLogoUrl": null,
+              "SyndicationEnabled": false,
+              "Title": "Subsite",
+              "TreeViewEnabled": false,
+              "UIVersion": 15,
+              "UIVersionConfigurationEnabled": false,
+              "Url": "https://contoso.sharepoint.com/subsite",
+              "WebTemplate": "STS"
+            }]
+          }
+        );
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        output: 'json',
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        withGroups: true
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith({
+          value: [{
+            AssociatedMemberGroup: {
+              Id: 5,
+              IsHiddenInUI: false,
+              LoginName: "Contoso Members",
+              Title: "Contoso Members",
+              PrincipalType: 8,
+              AllowMembersEditMembership: true,
+              AllowRequestToJoinLeave: false,
+              AutoAcceptRequestToJoinLeave: false,
+              Description: null,
+              OnlyAllowMembersViewMembership: false,
+              OwnerTitle: "Contoso Owners",
+              RequestToJoinLeaveEmailSetting: ""
+            },
+            AssociatedOwnerGroup: {
+              Id: 3,
+              IsHiddenInUI: false,
+              LoginName: "Contoso Owners",
+              Title: "Contoso Owners",
+              PrincipalType: 8,
+              AllowMembersEditMembership: false,
+              AllowRequestToJoinLeave: false,
+              AutoAcceptRequestToJoinLeave: false,
+              Description: null,
+              OnlyAllowMembersViewMembership: false,
+              OwnerTitle: "Contoso Owners",
+              RequestToJoinLeaveEmailSetting: ""
+            },
+            AssociatedVisitorGroup: {
+              Id: 4,
+              IsHiddenInUI: false,
+              LoginName: "Contoso Visitors",
+              Title: "Contoso Visitors",
+              PrincipalType: 8,
+              AllowMembersEditMembership: false,
+              AllowRequestToJoinLeave: false,
+              AutoAcceptRequestToJoinLeave: false,
+              Description: null,
+              OnlyAllowMembersViewMembership: false,
+              OwnerTitle: "Contoso Owners",
+              RequestToJoinLeaveEmailSetting: ""
+            },
+            AllowRssFeeds: false,
+            AlternateCssUrl: null,
+            AppInstanceId: "00000000-0000-0000-0000-000000000000",
+            Configuration: 0,
+            Created: null,
+            CurrentChangeToken: null,
+            CustomMasterUrl: null,
+            Description: null,
+            DesignPackageId: null,
+            DocumentLibraryCalloutOfficeWebAppPreviewersDisabled: false,
+            EnableMinimalDownload: false,
+            HorizontalQuickLaunch: false,
+            Id: "d8d179c7-f459-4f90-b592-14b08e84accb",
+            IsMultilingual: false,
+            Language: 1033,
+            LastItemModifiedDate: null,
+            LastItemUserModifiedDate: null,
+            MasterUrl: null,
+            NoCrawl: false,
+            OverwriteTranslationsOnChange: false,
+            ResourcePath: null,
+            QuickLaunchEnabled: false,
+            RecycleBinEnabled: false,
+            ServerRelativeUrl: null,
+            SiteLogoUrl: null,
+            SyndicationEnabled: false,
+            Title: "Subsite",
+            TreeViewEnabled: false,
+            UIVersion: 15,
+            UIVersionConfigurationEnabled: false,
+            Url: "https://contoso.sharepoint.com/subsite",
+            WebTemplate: "STS"
+          }]
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('retrieves all site information with output option text', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/_api/web') > -1) {

--- a/src/m365/spo/commands/web/web-get.ts
+++ b/src/m365/spo/commands/web/web-get.ts
@@ -14,6 +14,7 @@ interface CommandArgs {
 
 export interface Options extends GlobalOptions {
   webUrl: string;
+  withGroups?: boolean;
 }
 
 class SpoWebGetCommand extends SpoCommand {
@@ -25,9 +26,17 @@ class SpoWebGetCommand extends SpoCommand {
     return 'Retrieve information about the specified site';
   }
 
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.withGroups = typeof args.options.withGroups !== 'undefined';
+    return telemetryProps;
+  }
+
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     const requestOptions: any = {
-      url: `${args.options.webUrl}/_api/web/`,
+      url: !args.options.withGroups ?
+        `${args.options.webUrl}/_api/web`
+        : `${args.options.webUrl}/_api/web?$expand=AssociatedMemberGroup,AssociatedOwnerGroup,AssociatedVisitorGroup`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },
@@ -46,6 +55,9 @@ class SpoWebGetCommand extends SpoCommand {
     const options: CommandOption[] = [
       {
         option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '--withGroups [withGroups]'
       }
     ];
 


### PR DESCRIPTION
> ### Extended 'spo web get' which includes AssociatedGroups (Owners, Members, Visitors) in return values
enhances 'spo web get' command for getting `AssociatedGroups` which includes default Owners, Members and Visitors group in the return values. Closes #2493 

> ### Linked Issue

Closes #2493 
