### PR TITLE
fixes yammer messaging. closes #2557

### DIFF
--- a/docs/docs/cmd/yammer/message/message-add.md
+++ b/docs/docs/cmd/yammer/message/message-add.md
@@ -13,17 +13,17 @@ m365 yammer message add [options]
 `-b, --body <body>`
 : The text of the message body
 
+`--groupId [groupId]`
+: Post the message to this group, specified by ID. If this is set then the networkId is inferred from it. You must either specify groupid, repliedToId, or directToUserIds to send the message
+
 `-r, --repliedToId [repliedToId]`
-: The message ID this message is in reply to. If this is set then groupId and networkId are inferred from it
+: The message ID this message is in reply to. If this is set then groupId and networkId are inferred from it. You must either specify groupid, repliedToId, or directToUserIds to send the message
 
 `-d, --directToUserIds [directToUserIds]`
-: Send a private message to one or more users, specified by ID. Alternatively, you can use the Yammer network e-mail addresses instead of the IDs
-
-`--groupId [groupId]`
-: Post the message to this group, specified by ID. If this is set then the networkId is inferred from it. A post without directToUserIds, repliedToId or groupId will default to All Company group
+: Send a private message to one or more users, specified by ID. Alternatively, you can use the Yammer network e-mail addresses instead of the IDs. You must either specify groupid, repliedToId, or directToUserIds to send the message
 
 `--networkId [networkId]`
-: Post a message in the "All Company" feed of this network, if repliedToId, directToUserIds and groupId are all omitted
+: Specify the network to post a message
 
 --8<-- "docs/cmd/_global.md"
 
@@ -33,12 +33,6 @@ m365 yammer message add [options]
     In order to use this command, you need to grant the Azure AD application used by the CLI for Microsoft 365 the permission to the Yammer API. To do this, execute the `cli consent --service yammer` command.
 
 ## Examples
-
-Posts a message to the "All Company" feed
-
-```sh
-m365 yammer message add --body "Hello everyone!"
-```
 
 Replies to a message with the ID 1231231231
 
@@ -70,8 +64,8 @@ Posts a message to the group with the ID 12312312312
 m365 yammer message add --body "Hello everyone!" --groupId 12312312312
 ```
 
-Posts a message to the "All Company" feed of the network 11112312
+Posts a message to the group with the ID 12312312312 in the network 11112312
 
 ```sh
-m365 yammer message add --body "Hello everyone!" --networkId 11112312
+m365 yammer message add --body "Hello everyone!" --groupId 12312312312 --networkId 11112312
 ```

--- a/src/m365/yammer/commands/message/message-add.spec.ts
+++ b/src/m365/yammer/commands/message/message-add.spec.ts
@@ -79,8 +79,28 @@ describe(commands.MESSAGE_ADD, () => {
   });
 
   it('has all fields', () => {
-    const actual = command.validate({ options: { body: "test" } });
+    const actual = command.validate({ options: { body: "test", groupId: 1234123 } });
     assert.strictEqual(actual, true);
+  });
+
+  it('has all fields', () => {
+    const actual = command.validate({ options: { body: "test", repliedToId: 1234122 } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('has all fields', () => {
+    const actual = command.validate({ options: { body: "test", directToUserIds: 1234125 } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('has all fields', () => {
+    const actual = command.validate({ options: { body: "test", groupId: 1234123 } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails if no groupId, directToUserId, or repliedToId is specified', () => {
+    const actual = command.validate({ options: { body: "test" } });
+    assert.notStrictEqual(actual, true);
   });
 
   it('posts a message', function (done) {
@@ -90,7 +110,7 @@ describe(commands.MESSAGE_ADD, () => {
       }
       return Promise.reject('Invalid request');
     });
-    command.action(logger, { options: { body: "send a letter to me", debug: true } } as any, () => {
+    command.action(logger, { options: { body: "send a letter to me", groupId: 13114941440, debug: true } } as any, () => {
       try {
         assert.strictEqual(loggerLogSpy.lastCall.args[0].id, 470839661887488);
         done();
@@ -108,7 +128,7 @@ describe(commands.MESSAGE_ADD, () => {
       }
       return Promise.reject('Invalid request');
     });
-    command.action(logger, { options: { body: "send a letter to me", debug: true, output: "json" } } as any, () => {
+    command.action(logger, { options: { body: "send a letter to me", groupId: 13114941440, debug: true, output: "json" } } as any, () => {
       try {
         assert.strictEqual(loggerLogSpy.lastCall.args[0].id, 470839661887488);
         done();

--- a/src/m365/yammer/commands/message/message-add.ts
+++ b/src/m365/yammer/commands/message/message-add.ts
@@ -47,7 +47,7 @@ class YammerMessageAddCommand extends YammerCommand {
         'content-type': 'application/json;odata=nometadata'
       },
       responseType: 'json',
-      body: {
+      data: {
         body: args.options.body,
         replied_to_id: args.options.repliedToId,
         direct_to_user_ids: args.options.directToUserIds,
@@ -103,6 +103,10 @@ class YammerMessageAddCommand extends YammerCommand {
 
     if (args.options.repliedToId && typeof args.options.repliedToId !== 'number') {
       return `${args.options.repliedToId} is not a number`;
+    }
+
+    if (args.options.groupId === undefined && args.options.directToUserIds === undefined && args.options.repliedToId === undefined) {
+      return "You must either specify the groupId, repliedToId, or directToUserIds option";
     }
 
     return true;


### PR DESCRIPTION
There were two problems:
- you have to specify an additional parameter to the body when using the new Yammer. The company feed is read only and the api can't post a message there anymore
- we passed the "body" parameter to specify a body in the payload. For a reason this is no more valid and we have to use the "data" parameter instead

Just as a side note:
I took the latest version of the CLI. I do not have a 100% coverage on my Win 10 machine and an error in a CLI test
![image](https://user-images.githubusercontent.com/18241305/124343612-30e49f00-dbcd-11eb-8372-e5908a9ba71f.png)
![image](https://user-images.githubusercontent.com/18241305/124343621-3b069d80-dbcd-11eb-8511-946f15a14e3f.png)
![image](https://user-images.githubusercontent.com/18241305/124343632-43f76f00-dbcd-11eb-9c9c-c9ffccdcbcb6.png)
![image](https://user-images.githubusercontent.com/18241305/124343637-55d91200-dbcd-11eb-949c-d29bcf02c691.png)



