### PR TITLE
Adds m365 aad user hibp command. Closes #2476 

### DIFF
--- a/docs/docs/cmd/aad/user/user-hibp.md
+++ b/docs/docs/cmd/aad/user/user-hibp.md
@@ -1,0 +1,48 @@
+# aad user hibp
+
+Allows you to retrieve all accounts that have been pwned with the specified username
+
+## Usage
+
+```sh
+m365 aad user hibp [options]
+```
+
+## Options
+
+`-n, --userName [userName]`
+: The name of the user to retrieve information for.
+
+
+`--apiKey, [apiKey]`
+: Have I been pwned `API Key`. You can buy it from [https://haveibeenpwned.com/API/Key](https://haveibeenpwned.com/API/Key)
+
+
+`--domain, [domain]`
+: Limit the returned breaches only contain results with the domain specified.
+
+
+--8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+If the user with the specified user name doesn't involved in any breach, you will get a `Good news — no pwnage found!` message.
+
+If `API Key` is invalid, you will get a `` error.
+
+## Examples
+
+Check if user with user name _account-exists@hibp-integration-tests.com_ is in a data breach
+
+```sh
+m365 aad user hibp --userName account-exists@hibp-integration-tests.com --apiKey _YOUR-API-KEY_
+```
+Check if user with user name _account-exists@hibp-integration-tests.com_ is in a data breach against the domain specified
+
+```sh
+m365 aad user hibp --userName account-exists@hibp-integration-tests.com --apiKey _YOUR-API-KEY_ --domain adobe.com
+```
+
+## More information
+
+- Have I been pwned API documentation: [https://haveibeenpwned.com/API/v3](https://haveibeenpwned.com/API/v3)

--- a/src/m365/aad/commands.ts
+++ b/src/m365/aad/commands.ts
@@ -46,5 +46,6 @@ export default {
   SITECLASSIFICATION_SET: `${prefix} siteclassification set`,
   SP_GET: `${prefix} sp get`,
   USER_GET: `${prefix} user get`,
-  USER_LIST: `${prefix} user list`
+  USER_LIST: `${prefix} user list`,
+  USER_HIBP: `${prefix} user hibp`
 };

--- a/src/m365/aad/commands/user/user-hibp.spec.ts
+++ b/src/m365/aad/commands/user/user-hibp.spec.ts
@@ -1,0 +1,182 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { Logger } from '../../../../cli';
+import request from '../../../../request';
+import { CommandError } from '../../../../Command';
+import Utils from '../../../../Utils';
+import commands from '../../commands';
+const command = require('./user-hibp');
+
+describe(commands.USER_HIBP, () => {
+
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      request.get
+    ]);
+  });
+
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.USER_HIBP), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if userName and apiKey is not specified', () => {
+    const actual = command.validate({ options: {} });
+    assert.notStrictEqual(actual, true);
+  });
+  
+  it('fails validation if the userName is not a valid UPN', () => {
+    const actual = command.validate({ options: { userName: 'invalid' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if apiKey is not specified', () => {
+    const actual = command.validate({ options: {userName:"account-exists@hibp-integration-tests.com"} });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if userName and apiKey is specified', () => {
+    const actual = command.validate({ options: { userName: "account-exists@hibp-integration-tests.com", apiKey: "2975xc539c304xf797f665x43f8x557x" } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if domain is specified', () => {
+    const actual = command.validate({ options: { userName: "account-exists@hibp-integration-tests.com", apiKey: "2975xc539c304xf797f665x43f8x557x", domain: "domain.com" } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('checks user is pawned using userName', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://haveibeenpwned.com/api/v3/breachedaccount/account-exists@hibp-integration-tests.com`) {
+        return Promise.resolve([{ "Name": "Adobe" }]);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: false, userName: 'account-exists@hibp-integration-tests.com' } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([{ "Name": "Adobe" }]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('checks user is pawned using userName and domain', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://haveibeenpwned.com/api/v3/breachedaccount/account-exists@hibp-integration-tests.com?domain=adobe.com`) {
+        return Promise.resolve([{ "Name": "Adobe" }]);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: false, userName: 'account-exists@hibp-integration-tests.com', domain: "adobe.com" } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([{ "Name": "Adobe" }]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('checks user is pawned using userName (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://haveibeenpwned.com/api/v3/breachedaccount/account-exists@hibp-integration-tests.com`) {
+        return Promise.resolve([{"Name":"Adobe"}]);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: false, userName: 'account-exists@hibp-integration-tests.com' } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([{"Name":"Adobe"}]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles no pwnage found', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.reject({
+        "response": {
+          "status": 404
+        }
+      });
+    });
+
+    command.action(logger, { options: { debug: false, userName: 'account-notexists@hibp-integration-tests.com' } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith("\nGood news — no pwnage found!\n"));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles unauthorized request', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.reject({
+        "statusCode": 401,
+        "message": "Access denied due to improperly formed hibp-api-key."
+      });
+    });
+
+    command.action(logger, { options: { debug: false, userName: 'account-notexists@hibp-integration-tests.com' } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(err.message)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach((o: { option: string; }) => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+});

--- a/src/m365/aad/commands/user/user-hibp.ts
+++ b/src/m365/aad/commands/user/user-hibp.ts
@@ -1,0 +1,100 @@
+import { Logger } from '../../../../cli';
+import {
+  CommandOption
+} from '../../../../Command';
+import Command from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import commands from '../../commands';
+import Utils from '../../../../Utils';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  userName: string;
+  apiKey: string;
+  domain?: string
+}
+
+class HIBPCommand extends Command {
+  public get name(): string {
+    return commands.USER_HIBP;
+  }
+
+  static readonly HIBP_HOST = 'https://haveibeenpwned.com/api/v3';
+
+  public get description(): string {
+    return 'Allows you to retrieve all or accounts from specified domain that have been pwned with the specified username';
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+
+    let url: string = `https://haveibeenpwned.com/api/v3/breachedaccount/${args.options.userName}`;
+    
+    // Filters the result set to only breaches against the domain specified.
+    if (args.options.domain) {
+      url += `?domain=${args.options.domain}`;
+    }
+
+    const requestOptions: any = {
+      url: url,
+      headers: {
+        'accept': 'application/json',
+        'hibp-api-key': args.options.apiKey,
+        'x-anonymous': true
+      },
+      responseType: 'json'
+    };
+
+    request
+      .get(requestOptions)
+      .then((res: any): void => {
+        logger.log(res);
+        cb();
+      }, (rawRes: any): void => {
+        if (rawRes.response !== undefined && rawRes.response.status === 404) {
+          logger.log("\nGood news — no pwnage found!\n");
+          cb();
+        } 
+        else {
+          this.handleRejectedPromise(rawRes, logger, cb);
+        }
+      });
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-n, --userName [userName]'
+      },
+      {
+        option: '--apiKey, [apiKey]'
+      },
+      {
+        option: '--domain, [domain]'
+      }
+    ];
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    if (!args.options.userName) {
+      return 'Specify userName';
+    }
+
+    if (!Utils.isValidUserPrincipalName(args.options.userName)) {
+      return 'Specify valid userName';
+    }
+
+    if (!args.options.apiKey) {
+      return 'Specify apiKey';
+    }
+
+    return true;
+  }
+}
+
+module.exports = new HIBPCommand();


### PR DESCRIPTION
New Command: `aad user hibp command`  that allows you to retrieve all accounts that have been pwned with the specified username.