### PR TITLE
Docs: rename 'PowerShell Core'. Closes #2620

### DIFF
--- a/docs/docs/sample-scripts/aad/analyze-user-profile-photos.md
+++ b/docs/docs/sample-scripts/aad/analyze-user-profile-photos.md
@@ -13,7 +13,7 @@ Prerequisites
 !!! note
     If you don't already have an [Azure Cognitive Services instance and key](https://azure.microsoft.com/try/cognitive-services/), create a cognitive service instance and get API key from there.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $resultDir = "Output"
 $azureVisionApiInstance = "azure-vision-api-instance-name"
 $azureVisionApiKey = "azure-vision-api-key"

--- a/docs/docs/sample-scripts/aad/delete-m365-groups-and-sharepoint-sites.md
+++ b/docs/docs/sample-scripts/aad/delete-m365-groups-and-sharepoint-sites.md
@@ -4,7 +4,7 @@ Author: [Patrick Lamber](https://www.nubo.eu/Delete-All-SPO-Sites-And-M365-Group
 
 Another example how you can delete all Microsoft 365 Groups and SharePoint Online sites in your development environment.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 ### Warning. Use with caution. This script deletes all M365 Groups and SPO Sites in your tenant
 $devAccount = "<putyourupnhereforsecuritycheck>"
 ### Deletes the resources from the recyclebin. The CLI does not support this feature yet

--- a/docs/docs/sample-scripts/aad/delete-m365-groups.md
+++ b/docs/docs/sample-scripts/aad/delete-m365-groups.md
@@ -4,7 +4,7 @@ Author: [Laura Kokkarinen](https://laurakokkarinen.com/does-it-spark-joy-powersh
 
 There are so many different ways to create Microsoft 365 groups. Teams, Planner, SharePoint team sites, etc. — you can accumulate a lot of them very fast. Use this script below to delete the ones you no longer need.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $sparksjoy = "All Company", "TEMPLATE Project", "We have cats in this team! Join!"
 $groups = m365 aad o365group list -o json | ConvertFrom-Json
 $groups = $groups | where {-not ($sparksjoy -contains $_.displayName)}

--- a/docs/docs/sample-scripts/aad/flag-groups-with-user-names.md
+++ b/docs/docs/sample-scripts/aad/flag-groups-with-user-names.md
@@ -8,7 +8,7 @@ This sample script scans the Microsoft 365 groups that may contain user’s firs
 
 Note: The filter condition can be changed as per your requirement.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $groupsToFlag = @()
 
 $users = m365 aad user list --properties 'displayName,givenName,surname' -o json | ConvertFrom-Json

--- a/docs/docs/sample-scripts/aad/manage-group-users.md
+++ b/docs/docs/sample-scripts/aad/manage-group-users.md
@@ -6,7 +6,7 @@ Companies pursue to hasten profits growth or enter new marketplace through Merge
 
 Note: Refactor the code as per your requirement.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $taskItems = import-csv "sample-input-file.csv" –header mailNickname, userEmail, role, action
 $groups = m365 aad o365group list -o json | ConvertFrom-Json
 

--- a/docs/docs/sample-scripts/aad/replace-membership-of-selected-groups.md
+++ b/docs/docs/sample-scripts/aad/replace-membership-of-selected-groups.md
@@ -4,7 +4,7 @@ Inspired by: [Alan Eardley](https://blog.eardley.org.uk/2021/04/managing-teams-m
 
 This script can be used to replace the membership of a user for a selected list of Groups. It might be useful when a person changes role in an organization or is about to leave it.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $fileInput = "<PUTYOURPATHHERE.csv>"
 $oldUser = "upnOfOldUser"
 $newUser = "upnOfNewUser"

--- a/docs/docs/sample-scripts/aad/replace-owner-with-a-different-one.md
+++ b/docs/docs/sample-scripts/aad/replace-owner-with-a-different-one.md
@@ -4,7 +4,7 @@ Inspired by: [Alan Eardley](https://blog.eardley.org.uk/2021/04/managing-teams-m
 
 Find all the Microsoft 365 Groups that a user is an Owner of and replace them with someone else useful for when an employee leaves and ownership needs to be updated.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 # This script replaces an owner with a different person in all Microsoft 365 Groups
 $oldUser = "oldUserUpn"
 $newUser = "newUserUpn"

--- a/docs/docs/sample-scripts/flow/cancel-all-running-flow-runs.md
+++ b/docs/docs/sample-scripts/flow/cancel-all-running-flow-runs.md
@@ -8,7 +8,7 @@ Microsoft 365 CLI cmdlets will help you to cancel all the running flow runs.
 
 This script will cancel all running flow runs of a Power Automate flow created in an environment. Pass the Flow environment id and the flow guid as parameter while running the script.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $flowEnvironment = $args[0]
 $flowGUID = $args[1]
 $flowRuns = m365 flow run list --environment $flowEnvironment --flow $flowGUID --output json | ConvertFrom-Json

--- a/docs/docs/sample-scripts/flow/export-all-flows-in-environment.md
+++ b/docs/docs/sample-scripts/flow/export-all-flows-in-environment.md
@@ -8,7 +8,7 @@ By combining the CLI for Microsoft 365 and PowerShell we can make this task easy
 
 This script will get all flows in your default environment and export them as both a ZIP file for importing back into Power Automate and as a JSON file for importing into Azure as an Azure Logic App.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 Write-Output "Getting environment info..."
 $environment = m365 flow environment list --query '[?contains(displayName,`default`)] .name'
 

--- a/docs/docs/sample-scripts/flow/export-flow-logicapp.md
+++ b/docs/docs/sample-scripts/flow/export-flow-logicapp.md
@@ -11,7 +11,7 @@ By combining the CLI for Microsoft 365 and PowerShell we can make this task easy
 This script will export the Power Automate flow *Your sample test flow*, make sure to pass the correct name in the script, and your flow will be exported right away.
 !!!
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 Write-Output "Getting environment info..."
 $environmentId = $(m365 flow environment list --query "[?displayName == '(default)']" -o json | ConvertFrom-Json).Name
 $flowId = $(m365 flow list --environment $environmentId --query "[?displayName == 'Your sample test flow']" -o json | ConvertFrom-Json)[0].Name

--- a/docs/docs/sample-scripts/flow/inventory-flows-by-author.md
+++ b/docs/docs/sample-scripts/flow/inventory-flows-by-author.md
@@ -6,7 +6,7 @@ The [Power Automate Admin Center](https://admin.flow.microsoft.com) provides a l
 
 The `bash` version of this script uses an external file to process owner mapping. This is provided in the jq tab and should be saved to the same folder as the bash script and named `merge.jq`.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 #!/usr/local/bin/pwsh -File
 
 $DIR = Split-Path $script:MyInvocation.MyCommand.Path

--- a/docs/docs/sample-scripts/flow/resubmit-all-failed-flow-runs.md
+++ b/docs/docs/sample-scripts/flow/resubmit-all-failed-flow-runs.md
@@ -8,7 +8,7 @@ Microsoft 365 CLI cmdlets to the rescue, it will help you resubmit the flow runs
 
 This script will resubmit all failed flow runs of a Power Automate flow created in an environment. Pass the Flow environment id and the flow guid as parameter while running the script.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $flowEnvironment = $args[0]
 $flowGUID = $args[1]
 $flowRuns = m365 flow run list --environment $flowEnvironment --flow $flowGUID --output json | ConvertFrom-Json

--- a/docs/docs/sample-scripts/flow/search-flows-for-connection.md
+++ b/docs/docs/sample-scripts/flow/search-flows-for-connection.md
@@ -4,7 +4,7 @@ Author: [Albert-Jan Schot](https://www.cloudappie.nl/search-flows-connections/)
 
 Search all flows as, an administrator, for a specific search string and report results. This sample allows you to get a report of all flows that are connected to a specific site or list. The `$searchString` can be any value but results are the best when using a GUID or site collection URL.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 Write-Output "Retrieving all environments"
 
 $environments = m365 flow environment list -o json | ConvertFrom-Json

--- a/docs/docs/sample-scripts/graph/call-graph.md
+++ b/docs/docs/sample-scripts/graph/call-graph.md
@@ -4,7 +4,7 @@ Author: [Garry Trinder](https://github.com/garrytrinder)
 
 Obtain a new access token for the Microsoft Graph and use it an HTTP request.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $token = m365 util accesstoken get --resource https://graph.microsoft.com --new
 $me = Invoke-RestMethod -Uri https://graph.microsoft.com/v1.0/me -Headers @{"Authorization"="Bearer $token"}
 $me

--- a/docs/docs/sample-scripts/spo/add-app-catalog.md
+++ b/docs/docs/sample-scripts/spo/add-app-catalog.md
@@ -4,7 +4,7 @@ Author: [David Ramalho](https://sharepoint-tricks.com/tenant-app-catalog-vs-site
 
 When you just want to deploy certain SharePoint solution to a specific site, it's required to create an app catalog for that site. The below script will create it for the site. In the article referenced above you can check where you can use App catalog for the site instead of global app catalog.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $site = "https://contoso.sharepoint.com/sites/site"
 m365 login
 m365 spo site appcatalog add --url $site

--- a/docs/docs/sample-scripts/spo/add-custom-clientside-webpart-to-modern-page.md
+++ b/docs/docs/sample-scripts/spo/add-custom-clientside-webpart-to-modern-page.md
@@ -4,7 +4,7 @@ Author: [Yannick Plenevaux](https://ypcode.wordpress.com)
 
 You've built an amazing new web part and now you want to programmatically add it to a modern page. This sample helps you add your web part to the page with your custom properties that might be dynamic according to your script.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $site = "https://contoso.sharepoint.com/sites/site1"
 $pageName = "AModernPage.aspx"
 $webPartId = "af660fc1-c09b-4c15-b093-2b74b047286b"

--- a/docs/docs/sample-scripts/spo/add-multiple-folders-in-libraries-using-csv-file.md
+++ b/docs/docs/sample-scripts/spo/add-multiple-folders-in-libraries-using-csv-file.md
@@ -15,7 +15,7 @@ Below is an example of the format needed for your .csv file:
 !!! important
     Make sure your target libraries contained in the file do exist in SharePoint Online.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 <#
 .SYNOPSIS
     Create multiple folders in different libraries.
@@ -64,7 +64,7 @@ Below is an example of the format needed for your .csv file:
 !!! important
     Make sure your target libraries & sites contained in the file do exist in SharePoint Online.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 <#
 .SYNOPSIS
     Create multiple folders in different libraries and in different sites.

--- a/docs/docs/sample-scripts/spo/add-multiple-lists-in-multiple-sites.md
+++ b/docs/docs/sample-scripts/spo/add-multiple-lists-in-multiple-sites.md
@@ -2,7 +2,7 @@
 
 Author: [Sudharsan Kesavanarayanan](https://twitter.com/sudharsank)
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 <#
 .SYNOPSIS
     Create multiple lists in multiple sites.

--- a/docs/docs/sample-scripts/spo/add-site-collection-admin-using-csv-file.md
+++ b/docs/docs/sample-scripts/spo/add-site-collection-admin-using-csv-file.md
@@ -13,7 +13,7 @@
 
 To get all the Site Collections in your tenant and export to a .csv file, you can run the following:
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $allSites = m365 spo site classic list --query "[?Template!='SRCHCEN#0']" -o json | ConvertFrom-Json
 $results = @()
 
@@ -29,7 +29,7 @@ $results | Export-Csv -Path "<YOUR-CSV-FILE-PATH>"
 
 The script above has a query to ignore the _Search_ site collection by filtering with the template code. If for example you wish to only get the sites that have been created with Private Channels, you could amend your query as follows:
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $privateChannelSites = m365 spo site classic list --query "[?Template=='TEAMCHANNEL#0']" -o json | ConvertFrom-Json
 ```
 
@@ -40,7 +40,7 @@ Once you've got the .csv file from the script above, filter it to your needs to 
 !!! note
     The script will add the user as a "site admin" on classic and non group-connected sites, or a an "additional admin" in group-connected sites (and not as a group Member).
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $csvSites = Import-Csv -Path "<YOUR-CSV-FILE-PATH>"
 $UserToAdd = "john.smith@contoso.com"  ## Change to your user
 $siteCount = $csvSites.Count

--- a/docs/docs/sample-scripts/spo/copy-files-to-another-library.md
+++ b/docs/docs/sample-scripts/spo/copy-files-to-another-library.md
@@ -6,7 +6,7 @@ This script shows how you can use the CLI to:
 - when copyKeepingSameFolderStructure is true - copy all files and folders from source library to a different library in different SharePoint site keeping the same folder and subfolder structure
 - when copyKeepingSameFolderStructure is false - copy all files from all folders and subfolders from source library to a different library to a root folder in different SharePoint
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 Write-host 'Copy files to another SharePoint Library in another site'
 
 function Copy-FilesFromFolderToLibrary(

--- a/docs/docs/sample-scripts/spo/delete-non-group-connected-modern-sites.md
+++ b/docs/docs/sample-scripts/spo/delete-non-group-connected-modern-sites.md
@@ -4,7 +4,7 @@ Author: [Laura Kokkarinen](https://laurakokkarinen.com/does-it-spark-joy-powersh
 
 When you delete Microsoft 365 groups, the modern group-connected team sites get deleted with them. The script below handles the remaining modern sites: communication sites and groupless team sites.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $sparksjoy = "Cat Lovers United", "Extranet", "Hub"
 $sites = m365 spo site classic list -o json |ConvertFrom-Json
 $sites = $sites | where {  $_.template -eq "SITEPAGEPUBLISHING#0" -or $_.template -eq "STS#3" -and -not ($sparksjoy -contains $_.Title)}

--- a/docs/docs/sample-scripts/spo/disable-tenant-wide-extension.md
+++ b/docs/docs/sample-scripts/spo/disable-tenant-wide-extension.md
@@ -6,7 +6,7 @@ Tenant Wide Extensions list from the App Catalog helps to manage the activation 
 
 Note: TenantWideExtensionDisabled column denotes the extension is enabled or disabled.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $extensionName = Read-Host "Enter the Extension Name"
 $listName = "Tenant Wide Extensions"
 

--- a/docs/docs/sample-scripts/spo/empty-tenant-recyclebin.md
+++ b/docs/docs/sample-scripts/spo/empty-tenant-recyclebin.md
@@ -4,7 +4,7 @@ Author: [Laura Kokkarinen](https://laurakokkarinen.com/does-it-spark-joy-powersh
 
 Your deleted modern SharePoint sites are not going to disappear from the UI before they have been removed from the tenant recycle bin. You can either wait for three months, delete them manually via the SharePoint admin center, or run the CLI for Microsoft 365 script below.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $deletedSites = m365 spo tenant recyclebinitem list -o json | ConvertFrom-Json
 $deletedSites | Format-Table Url
 

--- a/docs/docs/sample-scripts/spo/ensure-siteassets-library.md
+++ b/docs/docs/sample-scripts/spo/ensure-siteassets-library.md
@@ -12,7 +12,7 @@ Reference: ['ensure' commands #1427](https://github.com/pnp/cli-microsoft365/dis
   - calls the _api/web/Lists/EnsureSiteAssetsLibrary REST endpoint to create the Site Assets library
 - returns the existing or created SPList as a JSON object
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 function EnsureSiteAssetsLibrary {
   param (
     [Parameter(Mandatory)][string]$siteUrl

--- a/docs/docs/sample-scripts/spo/export-configs-tenant-wide-extensions.md
+++ b/docs/docs/sample-scripts/spo/export-configs-tenant-wide-extensions.md
@@ -4,7 +4,7 @@ Author: [Joseph Velliah](https://sprider.blog/export-configs-tenant-wide-extensi
 
 The SharePoint Admin Center provides various governance features, but there is no way to easily export Configurations of Tenant Wide Extensions from the SharePoint admin center for governance activities. This script retrieves Tenant Wide Extension configurations from the App Catalog and exports the same in a comma-separated values (CSV) file.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $resultDir = "Output"
 $listName = "Tenant Wide Extensions"
 $fields = $fields = "Title, Modified, Created, AuthorId, EditorId, TenantWideExtensionComponentId, TenantWideExtensionComponentProperties, TenantWideExtensionListTemplate, TenantWideExtensionWebTemplate, TenantWideExtensionSequence, TenantWideExtensionHostProperties, TenantWideExtensionLocation, TenantWideExtensionDisabled"

--- a/docs/docs/sample-scripts/spo/grant-api-permissions-aad.md
+++ b/docs/docs/sample-scripts/spo/grant-api-permissions-aad.md
@@ -25,7 +25,7 @@ So what if you could bypass all these steps for both Graph and owned API?
 !!! warning
     These permissions will be granted on the whole tenant and could be used by any script running in your tenant. More info [here](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-aadhttpclient#considerations).
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 m365 login # Don't execute that command if you're already logged in
 
 # Granting Microsoft Graph permissions

--- a/docs/docs/sample-scripts/spo/hide-list-from-site-contents.md
+++ b/docs/docs/sample-scripts/spo/hide-list-from-site-contents.md
@@ -4,7 +4,7 @@ Author: [David Ramalho](https://sharepoint-tricks.com/hide-sharepoint-list-from-
 
 If you need to hide the SharePoint list from the UI this simple PowerShell script will hide a specific list from the site contents. This will prevent users from easily accessing the list while, for example, you are still setting it up.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $listName = "listName"
 $site = "https://contoso.sharepoint.com/"
 

--- a/docs/docs/sample-scripts/spo/insert-sp-library-pictures-into-word.md
+++ b/docs/docs/sample-scripts/spo/insert-sp-library-pictures-into-word.md
@@ -17,7 +17,7 @@ Prerequisites:
 - Folder to download the images
 - Blank Word document to add the images
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 Write-Host "Execution started"
 
 $imagesDownloadFolderPath = "C:\Users\username\Downloads\Temp\images"

--- a/docs/docs/sample-scripts/spo/list-all-application-customizers.md
+++ b/docs/docs/sample-scripts/spo/list-all-application-customizers.md
@@ -4,7 +4,7 @@ Author: [Rabia Williams](https://twitter.com/williamsrabia)
 
 List all the application customizers in a tenant. Scope is default `All`. Here we are using the [custom action list](https://pnp.github.io/cli-microsoft365/cmd/spo/customaction/customaction-list/) command to list out all the Application Customizers in all the sites in the tenant.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $sites = m365 spo search --queryText "contentclass:STS_site -SPSiteURL:personal" --selectProperties "Path,Title" --allResults --output json | ConvertFrom-Json
 foreach ($site in $sites) {                                                      
   write-host $site.Title                      

--- a/docs/docs/sample-scripts/spo/list-all-list-folders-itemcount.md
+++ b/docs/docs/sample-scripts/spo/list-all-list-folders-itemcount.md
@@ -4,7 +4,7 @@ Author: [Albert-Jan Schot](https://www.cloudappie.nl/lists-file-count-cli-micros
 
 List all Lists, the folders and sub folders in a given site, and output the item count. Each folder is processed recursively. By default only non hidden document libraries are processed. As specified with the filter `$false -eq $list.Hidden -and $list.BaseTemplate -eq "101"`. The output is a CSV that contains the itemcount for each list and folder found in the specified site collection.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $siteUrl = "<PUTYOURURLHERE>"
 $fileExportPath = "<PUTYOURPATHHERE.csv>"
 

--- a/docs/docs/sample-scripts/spo/list-failed-sitedesigns.md
+++ b/docs/docs/sample-scripts/spo/list-failed-sitedesigns.md
@@ -4,7 +4,7 @@ Author: [Albert-Jan Schot](https://www.cloudappie.nl/failed-sitedesigns-clim365/
 
 The following script iterates through all site collections and lists all site design runs with errors. By filtering on `OutcomeCode == '1'` it will return all sites and runs with explicit errors. By filtering on `OutcomeCode != '0'` you can also return any result that is not marked as successful.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $allSPOSites = m365 spo site classic list -o json | ConvertFrom-Json
 $siteCount = $allSPOSites.Count
 Write-Output "Processing $siteCount sites..."

--- a/docs/docs/sample-scripts/spo/list-site-app-catalogs.md
+++ b/docs/docs/sample-scripts/spo/list-site-app-catalogs.md
@@ -6,7 +6,7 @@ A sample that shows how to find all installed site collection application catalo
 
 Note, because the sample uses the SharePoint search API to identify the site collection application catalogs, a newly created one might not be indexed right away. The sample output would not list the newly created app catalog until the search crawler indexes it; this usually does not take longer than a few minutes.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $appCatalogs = m365 spo search --query "contentclass:STS_List_336" --selectProperties SPSiteURL --allResults --output json | ConvertFrom-Json
 
 $appCatalogs | ForEach-Object { Write-Host $_.SPSiteURL }

--- a/docs/docs/sample-scripts/spo/list-site-collection-lists.md
+++ b/docs/docs/sample-scripts/spo/list-site-collection-lists.md
@@ -4,7 +4,7 @@ Author: [Albert-Jan Schot](https://www.cloudappie.nl/migration-report-climicroso
 
 This script helps you to list and export all site collection and their lists SharePoint Online sites, ideal for getting insights into the size of your environment.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $fileExportPath = "<PUTYOURPATHHERE.csv>"
 
 $m365Status = m365 status

--- a/docs/docs/sample-scripts/spo/list-site-collection-owners.md
+++ b/docs/docs/sample-scripts/spo/list-site-collection-owners.md
@@ -4,7 +4,7 @@ Author: [Patrick Lamber](https://www.nubo.eu/Retrieve-All-Site-Collection-Owners
 
 This script helps you to list and export all site collection owners in your SharePoint Online sites.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $fileExportPath = "<PUTYOURPATHHERE.csv>"
 
 $m365Status = m365 status

--- a/docs/docs/sample-scripts/spo/list-site-externalusers.md
+++ b/docs/docs/sample-scripts/spo/list-site-externalusers.md
@@ -4,7 +4,7 @@ Author: [Albert-Jan Schot](https://www.cloudappie.nl/migration-report-external-u
 
 This script helps you to list all external users in all SharePoint Online sites. It provides insights in who the users are, and if available who they where invited by.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $fileExportPath = "<PUTYOURPATHHERE.csv>"
 
 $m365Status = m365 status

--- a/docs/docs/sample-scripts/spo/list-tenant-wide-extensions.md
+++ b/docs/docs/sample-scripts/spo/list-tenant-wide-extensions.md
@@ -4,7 +4,7 @@ Author: [Shantha Kumar T](https://www.ktskumar.com/2020/04/manage-tenant-wide-ex
 
 The following script lists all tenant-wide extensions deployed in the tenant. The sample returns the Id, Title, Extension Location and Extension Disabled status of each extension.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $listName = "Tenant Wide Extensions"
 $fields = "Id, Title, TenantWideExtensionDisabled, TenantWideExtensionLocation"
 

--- a/docs/docs/sample-scripts/spo/monitor-site-collection-storage-usage.md
+++ b/docs/docs/sample-scripts/spo/monitor-site-collection-storage-usage.md
@@ -2,7 +2,7 @@
 
 Inspired by [Salaudeen Rajack](https://www.sharepointdiary.com/2020/08/sharepoint-online-monitor-site-storage-usage-with-powershell.html)
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 <#
 .SYNOPSIS
     Monitor Site Collections storage usage and send an email.

--- a/docs/docs/sample-scripts/spo/remove-custom-themes.md
+++ b/docs/docs/sample-scripts/spo/remove-custom-themes.md
@@ -4,7 +4,7 @@ Author: [Laura Kokkarinen](https://laurakokkarinen.com/does-it-spark-joy-powersh
 
 Have you been creating a lot of beautiful themes lately and testing them in your dev tenant, but don’t want to keep them anymore? If yes, then this PowerShell script is for you.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $sparksjoy = "Cat Lovers United", "Multicolored theme"
 $themes = m365 spo theme list -o json | ConvertFrom-Json
 $themes = $themes | where {-not ($sparksjoy -contains $_.name)}

--- a/docs/docs/sample-scripts/spo/remove-orphaned-redirect-sites.md
+++ b/docs/docs/sample-scripts/spo/remove-orphaned-redirect-sites.md
@@ -4,7 +4,7 @@ Author: [Albert-Jan Schot](https://www.cloudappie.nl/remove-orphaned-redirectsit
 
 Changing the URL of a site results in a new site type: a Redirect Site. However this redirect site does not get removed if you delete the newly renamed site. This could result in orphaned redirect site collections that redirect to nothing. This script provides you with an overview of all orphaned redirect sites and allows you to quickly delete them.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $sites = m365 spo site classic list --t "REDIRECTSITE#0" --output json | ConvertFrom-Json
 
 $sites | ForEach-Object {

--- a/docs/docs/sample-scripts/spo/remove-site-designs.md
+++ b/docs/docs/sample-scripts/spo/remove-site-designs.md
@@ -4,7 +4,7 @@ Author: [Laura Kokkarinen](https://laurakokkarinen.com/does-it-spark-joy-powersh
 
 Site designs and especially site scripts can be something that ends up just hanging around in your tenant for a long time even though you no longer need them for anything. Use the scripts below to get rid of them. You might also find some site scripts that are not linked to any site design and hence never get executed!
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $sparksjoy = "Cat Lovers United", "Multicolored theme"
 $sitedesigns = m365 spo sitedesign list -o json | ConvertFrom-Json
 $sitedesigns = $sitedesigns | where {-not ($sparksjoy -contains $_.Title)}

--- a/docs/docs/sample-scripts/spo/remove-site-scripts.md
+++ b/docs/docs/sample-scripts/spo/remove-site-scripts.md
@@ -4,7 +4,7 @@ Author: [Laura Kokkarinen](https://laurakokkarinen.com/does-it-spark-joy-powersh
 
 Site designs and especially site scripts can be something that ends up just hanging around in your tenant for a long time even though you no longer need them for anything. Use the scripts below to get rid of them. You might also find some site scripts that are not linked to any site design and hence never get executed!
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $sparksjoy = "Project Site", "Issues List"
 $siteScripts = m365 spo sitescript list -o json | ConvertFrom-Json
 $siteScripts = $siteScripts | where {  -not ($sparksjoy -contains $_.Title)}

--- a/docs/docs/sample-scripts/spo/replace-site-collection-admin.md
+++ b/docs/docs/sample-scripts/spo/replace-site-collection-admin.md
@@ -5,7 +5,7 @@ Inspired By: [Salaudeen Rajack](https://www.sharepointdiary.com/2015/08/sharepoi
 
 The script removes a user from a site collection and adds a new one as site collection admin.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $userToAdd = "<upnOfUserToAdd>"
 $userToRemove = "<upnOfUserToRemove>"
 $webUrl = "<spoUrl>"

--- a/docs/docs/sample-scripts/spo/setup-example-site.md
+++ b/docs/docs/sample-scripts/spo/setup-example-site.md
@@ -11,7 +11,7 @@ This script is a good starting point for a setup script to create site with some
 - modifies the all items view of the document library,
 - modifies the site navigation links
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 Write-host 'setup script example'
 
 Write-host 'ensure logged in'

--- a/docs/docs/sample-scripts/spo/sync-splib-into-az-storage-container.md
+++ b/docs/docs/sample-scripts/spo/sync-splib-into-az-storage-container.md
@@ -13,7 +13,7 @@ Prerequisites:
 - Azure Storage Container
 - Azure Storage Account Key with required permission to upload documents
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $spolHostName = "https://tenant-name.sharepoint.com"
 $spolSiteRelativeUrl = "/sites/site-name"
 $spolDocLibTitle = "document-library-title"

--- a/docs/docs/sample-scripts/spo/upload-local-files-and-folder.md
+++ b/docs/docs/sample-scripts/spo/upload-local-files-and-folder.md
@@ -4,7 +4,7 @@ Author: [Patrick Lamber](https://github.com/plamber), [Adam](https://github.com/
 
 This script shows how you can use the CLI to upload files located on a local folder to a SharePoint Online library or subfolder. This is a simple script that could be used for simple data migration scenarios. The given example uploads to the given site to Shared Documents library all files and sub folders of ./import local folder
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 Write-host 'upload files and folders from directory example'
 
 function Import-FilesAndFolders(

--- a/docs/docs/sample-scripts/teams/add-bulk-users-teams.md
+++ b/docs/docs/sample-scripts/teams/add-bulk-users-teams.md
@@ -2,7 +2,7 @@
 
 Inspired by: [Rakesh Pandey](https://www.flexmind.co/blog/how-to-add-bulk-users-from-csv-file-to-ms-teams-using-powershell/)
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 <#
 .SYNOPSIS
     Add users to a Microsoft 365 group linked to Teams.

--- a/docs/docs/sample-scripts/teams/create-team-and-add-members-and-owners.md
+++ b/docs/docs/sample-scripts/teams/create-team-and-add-members-and-owners.md
@@ -4,7 +4,7 @@ Inspired by: [Rakesh Pandey](https://www.flexmind.co/blog/how-to-add-bulk-users-
 
 This sample script shows you how to create a Team and add members and owners using a CSV.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 # This script provisions a Group with owners and members and Teamifies it
 # The owners and members can be specified using a CSV file following this format
 ## upn,type

--- a/docs/docs/sample-scripts/teams/create-team-from-group.md
+++ b/docs/docs/sample-scripts/teams/create-team-from-group.md
@@ -4,7 +4,7 @@ Inspired by: [Patrick Lamber](https://www.nubo.eu/Provision-A-Team-With-CLI-For-
 
 A sample script which creates a Microsoft 365 Group, associates a logo to it and some members. Afterward, it teamyfies the Group and creates two public channels.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 # this examples searches the users in a directory by displayname
 $memberDisplayName = "A"
 # Group settings

--- a/docs/docs/sample-scripts/teams/deploy-teams-app.md
+++ b/docs/docs/sample-scripts/teams/deploy-teams-app.md
@@ -4,7 +4,7 @@ Author: [Garry Trinder](https://github.com/garrytrinder)
 
 Installs or updates a Microsoft Teams app from an Azure DevOps pipeline. Deploys the app if it hasn't been deployed yet or updates the existing package if it's been previously deployed.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 m365 login -t password -u $(username) -p $(password)
 
 $apps = m365 teams app list -o json | ConvertFrom-Json

--- a/docs/docs/sample-scripts/teams/export-teams-conversations.md
+++ b/docs/docs/sample-scripts/teams/export-teams-conversations.md
@@ -16,7 +16,7 @@ This script uses CLI for Microsoft 365 to export the conversations from Microsof
 !!! attention
     Commands `m365 teams message list` and `m365 teams message reply list` are based on an API that is currently in preview and is subject to change once the API reached general availability.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 function  Get-Teams {
   $teams = m365 teams team list -o json | ConvertFrom-Json -AsHashtable
   return $teams

--- a/docs/docs/sample-scripts/teams/govern-orphan-teams.md
+++ b/docs/docs/sample-scripts/teams/govern-orphan-teams.md
@@ -4,7 +4,7 @@ Author: [Matti Paukkonen](https://mattipaukkonen.com/2019/10/09/govern-orphaned-
 
 Every team needs an owner, at least one. Common best practice is that you should have at least two users in owner role. Teams is not allowing the last owner to leave the team, but there might occasions when last owner is removed, example when people are leaving the organization and account gets deleted. This script finds those teams that no longer have an owner.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $availableTeams = m365 teams team list -o json | ConvertFrom-Json
 $teams = @()
 foreach ($team in $availableTeams) {

--- a/docs/docs/sample-scripts/teams/install-personal-app.md
+++ b/docs/docs/sample-scripts/teams/install-personal-app.md
@@ -4,7 +4,7 @@ Author: [Sébastien Levert](https://github.com/sebastienlevert)
 
 Installs or updates a Microsoft Teams app from a provided zipped manifest and then, based on the parameters, add it to the current users and / or to a set of users.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 <#
   .SYNOPSIS
     Installs an app to Microsoft Teams and potentially to a set of users

--- a/docs/docs/sample-scripts/teams/list-all-tabs-teams.md
+++ b/docs/docs/sample-scripts/teams/list-all-tabs-teams.md
@@ -4,7 +4,7 @@ Inspired by: [Patrick Lamber](https://www.nubo.eu/List-all-tabs-in-Microsoft-Tea
 
 List all tabs in Microsoft Teams teams in the tenant and exports the results in a CSV.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $fileExportPath = "<PUTYOURPATHHERE.csv>"
 $m365Status = m365 status
 if ($m365Status -eq "Logged Out") {

--- a/docs/docs/sample-scripts/teams/list-teams-app-usage.md
+++ b/docs/docs/sample-scripts/teams/list-teams-app-usage.md
@@ -4,7 +4,7 @@ Inspired by: [Thomy Goelles](https://thomy.tech/list-teams-app-usage/)
 
 A sample script which iterates through all the teams in your tenant and lists all apps in each team. This script will be handy if you want to generate a report of available apps in Teams across your tenant.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $availableTeams = m365 teams team list -o json | ConvertFrom-Json
 
 if ($availableTeams.count -gt 15) {

--- a/docs/docs/sample-scripts/teams/list-teams-owners-and-members.md
+++ b/docs/docs/sample-scripts/teams/list-teams-owners-and-members.md
@@ -4,7 +4,7 @@ Author: [Patrick Lamber](https://www.nubo.eu/List-All-Microsoft-Teams-Owners-And
 
 This script allows you to list all Teams team's owners and members and export them into a CSV file. This script is inspired by [Robin Clarke](https://dailysysadmin.com/KB/Article/3607/microsoft-teams-powershell-commands-to-list-all-members-and-owners/).
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $fileExportPath = "<PUTYOURPATHHERE.csv>"
 # process teams that you have joined only
 $joined = $false

--- a/docs/docs/sample-scripts/teams/remove-personal-app.md
+++ b/docs/docs/sample-scripts/teams/remove-personal-app.md
@@ -4,7 +4,7 @@ Author: [Sébastien Levert](https://github.com/sebastienlevert)
 
 Uninstalls an app from the specified users and / or unpublish it from the Microsoft Teams app catalog based on the App Id available in the `manifest.json` of the Teams app.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 <#
   .SYNOPSIS
     Removes an app from the personal scope of a set of users

--- a/docs/docs/sample-scripts/teams/remove-wikitab-teams.md
+++ b/docs/docs/sample-scripts/teams/remove-wikitab-teams.md
@@ -4,7 +4,7 @@ Inspired by: [Garry Trinder](https://gist.github.com/garrytrinder/4df2aeaf9dd66c
 
 Removes the wiki tab of a Microsoft Teams Team's channel.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 $groupMailNickname = "Architecture"
 $channelName = "General"
 

--- a/docs/docs/sample-scripts/tenant/tenant-monitor-notify-healthstatus.md
+++ b/docs/docs/sample-scripts/tenant/tenant-monitor-notify-healthstatus.md
@@ -20,7 +20,7 @@ All the pre-requisites would be completed by the script. Script checks whether S
 
 If you want to schedule the script directly, you can go ahead without the need of any other configurations.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 #Ensure that you are logged in to the site mentioned in the webURL as a user who has Edit Permission
 $webURL = "https://contoso.sharepoint.com/sites/contososite"
 $listName = "M365HealthStatus"

--- a/docs/docs/sample-scripts/todo/cleanup-completed-todos.md
+++ b/docs/docs/sample-scripts/todo/cleanup-completed-todos.md
@@ -6,7 +6,7 @@ Microsoft To Do is my task management tool of choice, I use it for tracking ever
 
 This script iterates across all of the task lists and removes the tasks that have been marked as complete.
 
-```powershell tab="PowerShell Core"
+```powershell tab="PowerShell"
 Write-Output "Getting Microsoft To Do task lists ..."
 $lists = m365 todo list list -o json | ConvertFrom-Json
 

--- a/docs/docs/user-guide/using-own-identity.md
+++ b/docs/docs/user-guide/using-own-identity.md
@@ -148,4 +148,4 @@ Open a new PowerShell session and execute `$env:CLIMICROSOFT365_AADAPPID` and `$
 
 If you are on Linux or MacOS, depending on your terminal, add the  `export` lines to `.bashrc` or `.zshrc` file in your home directory.
 
-If you are using PowerShell Core, it is worth noting that environment variables set in `bash` or `zsh` will persist to the `pwsh` session and the same applies to Windows.
+If you are using PowerShell, it is worth noting that environment variables set in `bash` or `zsh` will persist to the `pwsh` session and the same applies to Windows.


### PR DESCRIPTION
Rename all `PowerShell Core`-references to `PowerShell`. Closes #2620 
