### PR TITLE
2171 - Extend login to support auth using client secret

### DIFF
--- a/docs/docs/cmd/login.md
+++ b/docs/docs/cmd/login.md
@@ -11,7 +11,7 @@ m365 login [options]
 ## Options
 
 `-t, --authType [authType]`
-: The type of authentication to use. Allowed values `certificate,deviceCode,password,identity,browser`. Default `deviceCode`
+: The type of authentication to use. Allowed values `certificate,deviceCode,password,identity,browser,secret`. Default `deviceCode`
 
 `-u, --userName [userName]`
 : Name of the user to authenticate. Required when `authType` is set to `password`
@@ -27,6 +27,9 @@ m365 login [options]
 
 `--thumbprint [thumbprint]`
 : Certificate thumbprint. If not specified, and `authType` is set to `certificate`, it will be automatically calculated based on the specified certificate
+
+`-s, --secret [secret]`
+: Client Secret of the Azure AD application to use for authentication. Required when `authType` is set to `secret`.
 
 `--appId [appId]`
 : App ID of the Azure AD application to use for authentication. If not specified, use the app specified in the `CLIMICROSOFT365_AADAPPID` environment variable. If the environment variable is not defined, use the multitenant PnP Management Shell app
@@ -48,7 +51,7 @@ When logging in to Microsoft 365 using the user name and password, next to the a
 
 When logging in to Microsoft 365 using a certificate, the CLI for Microsoft 365 will store the contents of the certificate so that it can automatically re-authenticate if necessary. The contents of the certificate are removed by re-authenticating using the device code or by calling the [logout](logout.md) command.  
 
-To log in to Microsoft 365 using a certificate, you will typically [create a custom Azure AD application](../user-guide/using-own-identity.md). To use this application with the CLI for Microsoft 365, you will set the `CLIMICROSOFT365_AADAPPID` environment variable to the application's ID and the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Azure AD tenant, where you created the Azure AD application. Also, please make sure to read about [the caveats when using the certificate login option](../user-guide/cli-certificate-caveats.md).
+To log in to Microsoft 365 using a certificate or secret, you will typically [create a custom Azure AD application](../user-guide/using-own-identity.md). To use this application with the CLI for Microsoft 365, you will set the `CLIMICROSOFT365_AADAPPID` environment variable to the application's ID and the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Azure AD tenant, where you created the Azure AD application. Also, please make sure to read about [the caveats when using the certificate login option](../user-guide/cli-certificate-caveats.md).
 
 Managed identity in Azure Cloud Shell is the identity of the user. It is neither system- nor user-assigned and it can't be configured. To log in to Microsoft 365 using managed identity in Azure Cloud Shell, set `authType` to `identity` and don't specify the `userName` option.
 
@@ -149,4 +152,10 @@ Log in to Microsoft 365 using the interactive browser authentication. Uses the i
 
 ```sh
 m365 login --authType browser
+```
+
+Log in to Microsoft 365 using a client secret.
+
+```sh
+m365 login --authType secret --secret topSeCr3t@007
 ```

--- a/docs/docs/user-guide/connecting-office-365.md
+++ b/docs/docs/user-guide/connecting-office-365.md
@@ -98,6 +98,31 @@ openssl pkcs12 -in protected.pfx -out privateKeyWithPassphrase.pem -nodes
 
 At this point the `privateKeyWithPassphrase.pem` file can be used to log in the CLI for Microsoft 365 following the instructions above for logging in using a PEM certificate.
 
+#### Log in using a secret
+
+CLI for Microsoft 365 also supports login using a secret. To use this authentication method, set the `CLIMICROSOFT365_AADAPPID` environment variable to the ID of the Azure AD application that you want to use to authenticate the CLI for Microsoft 365 and the `CLIMICROSOFT365_TENANT` environment variable to the ID of your Azure AD directory. When calling the login command, set the `authType` option to `secret` and specify the client secret value. 
+
+To log in to Microsoft 365 using a secret, execute:
+
+```sh
+m365 login --authType secret --secret '<secret-value>'
+```
+
+Logging in to Microsoft 365 using a secret is convenient for automation scenarios where you cannot authenticate interactively but also don't want to use credentials.
+
+Because there is no user context when logging in using a secret, you will typically create a new Azure AD application, specific to your organization and grant it the required permissions.
+
+!!! attention
+    You should keep in mind, that because the CLI for Microsoft 365 will be accessing these APIs with app-only context, you need to grant the correct application permissions rather than delegated permissions that would be used in other authentication methods.
+
+Logging in using a secret gives the CLI for Microsoft 365 app-only access to Microsoft 365 services. Not all operations support app-only access so it is possible, that some CLI commands will fail when executed while logged in to Microsoft 365 using a secret.
+
+!!! attention
+    Currently, SharePoint does not support authentication using Azure AD App ID and Secret. Microsoft 365 CLI commands that call the SharePoint APIs will fail while logged in to Microsoft 365 using a Secret.
+
+!!! attention
+    When logging in to Microsoft 365 using a secret, CLI for Microsoft 365 will persist not only the retrieved access token but also the secret. This is necessary for the CLI to be able to retrieve a new access token in case of the previously retrieved access token expired or has been invalidated.
+
 #### Log in using a browser authentication
 
 Yet another way to log in to Microsoft 365 in the CLI for Microsoft 365 is by using a an interactive browser authentication. To use this authentication method, call the login command with the `authType` option set to `browser`:

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -33,6 +33,7 @@ export class Service {
   authType: AuthType = AuthType.DeviceCode;
   userName?: string;
   password?: string;
+  secret?: string;
   certificateType: CertificateType = CertificateType.Unknown;
   certificate?: string;
   thumbprint?: string;
@@ -71,7 +72,8 @@ export enum AuthType {
   Password,
   Certificate,
   Identity,
-  Browser
+  Browser,
+  Secret
 }
 
 export enum CertificateType {
@@ -171,6 +173,9 @@ export class Auth {
         case AuthType.Browser:
           getTokenPromise = this.ensureAccessTokenWithBrowser.bind(this);
           break;
+        case AuthType.Secret:
+          getTokenPromise = this.ensureAccessTokenWithSecret.bind(this);
+          break;
       }
     }
 
@@ -214,26 +219,35 @@ export class Auth {
       case AuthType.Browser:
         return this.getPublicClient(logger, debug);
       case AuthType.Certificate:
-        return this.getConfidentialClient(logger, debug, this.service.thumbprint as string, this.service.password);
+        return this.getConfidentialClient(logger, debug, this.service.thumbprint as string, this.service.password, undefined);
       case AuthType.Identity:
         // msal-node doesn't support managed identity so we need to do it manually
         return undefined;
+      case AuthType.Secret:
+        return this.getConfidentialClient(logger, debug, undefined, undefined, this.service.secret);
     }
   }
 
-  private getAuthClientConfiguration(logger: Logger, debug: boolean, certificateThumbprint?: string, certificatePrivateKey?: string): Msal.Configuration {
+  private getAuthClientConfiguration(logger: Logger, debug: boolean, certificateThumbprint?: string, certificatePrivateKey?: string, clientSecret?: string): Msal.Configuration {
     const msal: typeof Msal = require('@azure/msal-node');
     const { LogLevel } = msal;
     const cert = !certificateThumbprint ? undefined : {
       thumbprint: certificateThumbprint,
       privateKey: certificatePrivateKey as string
     };
+
+    const authConfig = cert ? {
+      clientId: this.service.appId,
+      authority: `https://login.microsoftonline.com/${this.service.tenant}`,
+      clientCertificate: cert
+    } : {
+      clientId: this.service.appId,
+      authority: `https://login.microsoftonline.com/${this.service.tenant}`,
+      clientSecret: clientSecret
+    };
+
     return {
-      auth: {
-        clientId: this.service.appId,
-        authority: `https://login.microsoftonline.com/${this.service.tenant}`,
-        clientCertificate: cert
-      },
+      auth: authConfig,
       cache: {
         cachePlugin: msalCachePlugin
       },
@@ -267,11 +281,11 @@ export class Auth {
     return new PublicClientApplication(this.getAuthClientConfiguration(logger, debug));
   }
 
-  private getConfidentialClient(logger: Logger, debug: boolean, certificateThumbprint: string, certificatePrivateKey?: string) {
+  private getConfidentialClient(logger: Logger, debug: boolean, certificateThumbprint?: string, certificatePrivateKey?: string, clientSecret?: string) {
     const msal: typeof Msal = require('@azure/msal-node');
     const { ConfidentialClientApplication } = msal;
 
-    return new ConfidentialClientApplication(this.getAuthClientConfiguration(logger, debug, certificateThumbprint, certificatePrivateKey));
+    return new ConfidentialClientApplication(this.getAuthClientConfiguration(logger, debug, certificateThumbprint, certificatePrivateKey, clientSecret));
   }
 
   private retrieveAuthCodeWithBrowser(resource: string, logger: Logger, debug: boolean): Promise<InteractiveAuthorizationCodeResponse> {
@@ -565,6 +579,13 @@ export class Auth {
         }
       }
     }
+  }
+
+  private async ensureAccessTokenWithSecret(resource: string, logger: Logger, debug: boolean): Promise<AccessToken | null> {
+    this.clientApplication = this.getConfidentialClient(logger, debug, undefined, undefined, this.service.secret);
+    return (this.clientApplication as Msal.ConfidentialClientApplication).acquireTokenByClientCredential({
+      scopes: [`${resource}/.default`]
+    });
   }
 
   private calculateThumbprint(certificate: NodeForge.pki.Certificate): string {

--- a/src/m365/commands/login.spec.ts
+++ b/src/m365/commands/login.spec.ts
@@ -182,6 +182,22 @@ describe(commands.LOGIN, () => {
     });
   });
 
+  
+  it('logs in to Microsoft 365 using client secret authType "secret" set', (done) => {
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve(''));
+    command.action(logger, { options: { debug: false, authType: 'secret', secret: 'unBrEakaBle@123' } }, () => {
+      try {
+        assert.strictEqual(auth.service.authType, AuthType.Secret, 'Incorrect authType set');
+        assert.strictEqual(auth.service.secret, 'unBrEakaBle@123', 'Incorrect secret set');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
   it('supports specifying authType', () => {
     const options = command.options();
     let containsOption = false;
@@ -369,4 +385,10 @@ describe(commands.LOGIN, () => {
       }
     });
   });
+
+  it('fails validation if authType is set to secret and secret option is not specified', () => {
+    const actual = command.validate({ options: { authType: 'secret' } });
+    assert.notStrictEqual(actual, true);
+  });
+
 });

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -21,6 +21,7 @@ interface Options extends GlobalOptions {
   thumbprint?: string;
   appId?: string;
   tenant?: string;
+  secret?: string;
 }
 
 class LoginCommand extends Command {
@@ -72,6 +73,10 @@ class LoginCommand extends Command {
           break;        
         case 'browser':
           auth.service.authType = AuthType.Browser;
+          break;
+        case 'secret':
+          auth.service.authType = AuthType.Secret;
+          auth.service.secret = args.options.secret;
           break;
       }
 
@@ -143,6 +148,9 @@ class LoginCommand extends Command {
       },
       {
         option: '--tenant [tenant]'
+      },
+      {
+        option: '--secret [secret]'
       }
     ];
 
@@ -174,6 +182,12 @@ class LoginCommand extends Command {
         if (!fs.existsSync(args.options.certificateFile)) {
           return `File '${args.options.certificateFile}' does not exist`;
         }
+      }
+    }
+
+    if (args.options.authType === 'secret') {
+      if (!args.options.secret) {
+        return 'Required option secret missing';
       }
     }
 


### PR DESCRIPTION
> ### Extend login to support auth using client secret

- Adds **--authType** `secret ` to `m365 login` command. Closes #2171  

Creating this as a Draft for initial review. This PR extends the existing methods in the `Auth` service used for `Certificate` authentication. Separate methods can also be implemented to clearly differentiate methods for `cert`  and `secret` authentication, possibly requiring updates to the existing code and tests.