### PR TITLE
2591  - Update base SPO Command to show an error when AuthType is secret

### DIFF
--- a/src/m365/base/SpoCommand.spec.ts
+++ b/src/m365/base/SpoCommand.spec.ts
@@ -786,4 +786,20 @@ describe('SpoCommand', () => {
         done('Options resolved while error expected');
       }, _ => done());
   });
+
+  it('Shows an error when CLI is connected with authType "Secret"',(done) => {
+
+    sinon.stub(auth.service, 'authType').value(5);
+
+    const mock = new MockCommand();
+    mock.action(logger, { options: {} }, (err?:any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("SharePoint does not support authentication using AAD Client ID and 'Secret' at the moment. Please use an alternate login type to connect to CLI for Microsoft 365 to work with SharePoint commands.")));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
 });

--- a/src/m365/base/SpoCommand.ts
+++ b/src/m365/base/SpoCommand.ts
@@ -1,6 +1,6 @@
-import auth from '../../Auth';
+import auth, { AuthType } from '../../Auth';
 import { Logger } from '../../cli';
-import Command from '../../Command';
+import Command, { CommandArgs, CommandError } from '../../Command';
 import config from '../../config';
 import request from '../../request';
 import { SpoOperation } from '../spo/commands/site/SpoOperation';
@@ -405,5 +405,21 @@ export default abstract class SpoCommand extends Command {
     }
 
     return `${baseUrl}/${relativeUrl}`;
+  }
+
+  public action(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+
+    auth
+      .restoreAuth()
+      .then((): void => {
+        if (auth.service.connected && AuthType[auth.service.authType] === AuthType[AuthType.Secret]) {
+          cb(new CommandError(`SharePoint does not support authentication using AAD Client ID and 'Secret' at the moment. Please use an alternate login type to connect to CLI for Microsoft 365 to work with SharePoint commands.`));
+          return;
+        }
+
+        super.action(logger,args,cb);
+      }, (error: any): void => {
+        cb(new CommandError(error));
+      });
   }
 }


### PR DESCRIPTION
> ### #2591  - Update base SPO Command to show an error when AuthType is secret
>
> - The implementation verifies the authType in SpoCommand and calls the base `action` if authType is not `secret` - to keep the existing implementation unchanged. If the authType is secret, an error is displayed.