### PR TITLE
Fixes 'aad siteclassification get' command. Closes #2676

### DIFF
--- a/docs/docs/cmd/aad/siteclassification/siteclassification-get.md
+++ b/docs/docs/cmd/aad/siteclassification/siteclassification-get.md
@@ -12,11 +12,6 @@ m365 aad siteclassification get [options]
 
 --8<-- "docs/cmd/_global.md"
 
-## Remarks
-
-!!! attention
-    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
-
 ## Examples
 
 Get information about the Microsoft 365 Tenant site classification

--- a/src/m365/aad/commands/siteclassification/siteclassification-get.spec.ts
+++ b/src/m365/aad/commands/siteclassification/siteclassification-get.spec.ts
@@ -16,7 +16,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
   });
 
@@ -60,7 +60,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
 
   it('handles Microsoft 365 Tenant siteclassification is not enabled', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
           ]
@@ -83,7 +83,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
 
   it('handles Microsoft 365 Tenant siteclassification missing DirectorySettingTemplate', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -166,7 +166,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
 
   it('retrieves information about the Microsoft 365 Tenant siteclassification (single siteclassification)', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -253,7 +253,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
 
   it('retrieves information about the Microsoft 365 Tenant siteclassification (multi siteclassification)', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -340,7 +340,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
 
   it('Handles Microsoft 365 Tenant siteclassification DirectorySettings Key does not exist', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {

--- a/src/m365/aad/commands/siteclassification/siteclassification-get.ts
+++ b/src/m365/aad/commands/siteclassification/siteclassification-get.ts
@@ -24,7 +24,7 @@ class AadSiteClassificationGetCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
     const requestOptions: any = {
-      url: `${this.resource}/beta/settings`,
+      url: `${this.resource}/v1.0/groupSettings`,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },
@@ -66,7 +66,7 @@ class AadSiteClassificationGetCommand extends GraphCommand {
         });
 
         siteClassificationsSettings.UsageGuidelinesUrl = "";
-        if (guidanceUrl !==null && guidanceUrl.length > 0) {
+        if (guidanceUrl !== null && guidanceUrl.length > 0) {
           siteClassificationsSettings.UsageGuidelinesUrl = guidanceUrl[0].value;
         }
 


### PR DESCRIPTION
Fixes `aad siteclassification get` command. Closes #2676
Make use of `v1.0/groupSettings` endpoint.