### PR TITLE
Fixes 'aad siteclassification disable' command. Closes #2674

### DIFF
--- a/docs/docs/cmd/aad/siteclassification/siteclassification-disable.md
+++ b/docs/docs/cmd/aad/siteclassification/siteclassification-disable.md
@@ -15,11 +15,6 @@ m365 aad siteclassification disable [options]
 
 --8<-- "docs/cmd/_global.md"
 
-## Remarks
-
-!!! attention
-    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
-
 ## Examples
 
 Disable site classification

--- a/src/m365/aad/commands/siteclassification/siteclassification-disable.spec.ts
+++ b/src/m365/aad/commands/siteclassification/siteclassification-disable.spec.ts
@@ -96,7 +96,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
 
   it('handles Microsoft 365 Tenant siteclassification is not enabled', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
           ]
@@ -120,7 +120,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
 
   it('handles Microsoft 365 Tenant siteclassification missing DirectorySettingTemplate', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -203,7 +203,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
 
   it('handles Microsoft 365 Tenant siteclassification missing UnifiedGroupSetting ID', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -286,7 +286,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
 
   it('handles Microsoft 365 Tenant siteclassification empty UnifiedGroupSetting ID', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -370,7 +370,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
   it('handles disabling site classification without prompting', (done) => {
     let deleteRequestIssued = false;
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -440,7 +440,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
     });
 
     sinon.stub(request, 'delete').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings/d20c475c-6f96-449a-aee8-08146be187d3`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings/d20c475c-6f96-449a-aee8-08146be187d3`) {
         deleteRequestIssued = true;
 
         return Promise.resolve({
@@ -468,7 +468,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
   it('handles disabling site classification without prompting (debug)', (done) => {
     let deleteRequestIssued = false;
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -538,7 +538,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
     });
 
     sinon.stub(request, 'delete').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings/d20c475c-6f96-449a-aee8-08146be187d3`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings/d20c475c-6f96-449a-aee8-08146be187d3`) {
         deleteRequestIssued = true;
 
         return Promise.resolve({
@@ -583,7 +583,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
     let deleteRequestIssued = false;
 
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings`) {
         return Promise.resolve({
           value: [
             {
@@ -653,7 +653,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
     });
 
     sinon.stub(request, 'delete').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/settings/d20c475c-6f96-449a-aee8-08146be187d3`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groupSettings/d20c475c-6f96-449a-aee8-08146be187d3`) {
         deleteRequestIssued = true;
 
         return Promise.resolve({

--- a/src/m365/aad/commands/siteclassification/siteclassification-disable.ts
+++ b/src/m365/aad/commands/siteclassification/siteclassification-disable.ts
@@ -35,7 +35,7 @@ class AadSiteClassificationDisableCommand extends GraphCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
     const disableSiteClassification: () => void = (): void => {
       const requestOptions: any = {
-        url: `${this.resource}/beta/settings`,
+        url: `${this.resource}/v1.0/groupSettings`,
         headers: {
           accept: 'application/json;odata.metadata=none'
         },
@@ -63,7 +63,7 @@ class AadSiteClassificationDisableCommand extends GraphCommand {
           }
 
           const requestOptions: any = {
-            url: `${this.resource}/beta/settings/` + unifiedGroupSetting[0].id,
+            url: `${this.resource}/v1.0/groupSettings/` + unifiedGroupSetting[0].id,
             headers: {
               accept: 'application/json;odata.metadata=none',
               'content-type': 'application/json'


### PR DESCRIPTION
Fixes `aad siteclassification disable` command. Closes #2674 
Make use of `v1.0/groupSettings` endpoint.
