### PR TITLE
Fixes 'aad oauth2grant remove' command. Closes #2713

### DIFF
--- a/src/m365/aad/commands/oauth2grant/oauth2grant-remove.spec.ts
+++ b/src/m365/aad/commands/oauth2grant/oauth2grant-remove.spec.ts
@@ -17,7 +17,7 @@ describe(commands.OAUTH2GRANT_REMOVE, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
   });
 
@@ -62,7 +62,7 @@ describe(commands.OAUTH2GRANT_REMOVE, () => {
 
   it('removes OAuth2 permission grant (debug)', (done) => {
     sinon.stub(request, 'delete').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/myorganization/oauth2PermissionGrants/YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek?api-version=1.6`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/oauth2PermissionGrants/YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek`) > -1) {
         return Promise.resolve();
       }
 
@@ -82,7 +82,7 @@ describe(commands.OAUTH2GRANT_REMOVE, () => {
 
   it('removes OAuth2 permission grant', (done) => {
     sinon.stub(request, 'delete').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/myorganization/oauth2PermissionGrants/YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek?api-version=1.6`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/oauth2PermissionGrants/YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek`) > -1) {
         return Promise.resolve();
       }
 

--- a/src/m365/aad/commands/oauth2grant/oauth2grant-remove.ts
+++ b/src/m365/aad/commands/oauth2grant/oauth2grant-remove.ts
@@ -1,10 +1,8 @@
 import { Logger } from '../../../../cli';
-import {
-  CommandOption
-} from '../../../../Command';
+import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import AadCommand from '../../../base/AadCommand';
+import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
 interface CommandArgs {
@@ -15,7 +13,7 @@ interface Options extends GlobalOptions {
   grantId: string;
 }
 
-class AadOAuth2GrantRemoveCommand extends AadCommand {
+class AadOAuth2GrantRemoveCommand extends GraphCommand {
   public get name(): string {
     return commands.OAUTH2GRANT_REMOVE;
   }
@@ -30,7 +28,10 @@ class AadOAuth2GrantRemoveCommand extends AadCommand {
     }
 
     const requestOptions: any = {
-      url: `${this.resource}/myorganization/oauth2PermissionGrants/${encodeURIComponent(args.options.grantId)}?api-version=1.6`,
+      url: `${this.resource}/v1.0/oauth2PermissionGrants/${encodeURIComponent(args.options.grantId)}`,
+      headers: {
+        'accept': 'application/json;odata.metadata=none'
+      },
       responseType: 'json'
     };
 


### PR DESCRIPTION
Fixes `aad oauth2grant remove` command. Closes #2713
Updated to use the Microsoft Graph v1.0 endpoint.