### PR TITLE
Fixes 'aad oauth2grant set' command. Closes #2711

### DIFF
--- a/docs/docs/cmd/aad/oauth2grant/oauth2grant-set.md
+++ b/docs/docs/cmd/aad/oauth2grant/oauth2grant-set.md
@@ -22,7 +22,7 @@ m365 aad oauth2grant set [options]
 
 Before you can update service principal's OAuth2 permissions, you need to get the `objectId` of the permissions grant to update. You can retrieve it using the [aad oauth2grant list](./oauth2grant-list.md) command.
 
-If the `objectId` listed when using the [aad oauth2grant list](./oauth2grant-list.md) command has a minus sign ('-') prefix, you may receive an error indicating `--grantId` is missing.  To resolve this issue simply escape the leading '-'.  
+If the `objectId` listed when using the [aad oauth2grant list](./oauth2grant-list.md) command has a minus sign ('-') prefix, you may receive an error indicating `--grantId` is missing. To resolve this issue simply escape the leading '-'.  
 
 ```sh
 m365 aad oauth2grant set --grantId \\-Zc1JRY8REeLxmXz5KtixAYU3Q6noCBPlhwGiX7pxmU

--- a/src/m365/aad/commands/oauth2grant/oauth2grant-set.spec.ts
+++ b/src/m365/aad/commands/oauth2grant/oauth2grant-set.spec.ts
@@ -62,7 +62,7 @@ describe(commands.OAUTH2GRANT_SET, () => {
 
   it('updates OAuth2 permission grant (debug)', (done) => {
     sinon.stub(request, 'patch').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/myorganization/oauth2PermissionGrants/YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek?api-version=1.6`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/oauth2PermissionGrants/YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek`) > -1) {
         if (opts.headers &&
           opts.headers['content-type'] &&
           opts.headers['content-type'].indexOf('application/json') === 0 &&
@@ -87,7 +87,7 @@ describe(commands.OAUTH2GRANT_SET, () => {
 
   it('updates OAuth2 permission grant', (done) => {
     sinon.stub(request, 'patch').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/myorganization/oauth2PermissionGrants/YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek?api-version=1.6`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/oauth2PermissionGrants/YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek`) > -1) {
         if (opts.headers &&
           opts.headers['content-type'] &&
           opts.headers['content-type'].indexOf('application/json') === 0 &&

--- a/src/m365/aad/commands/oauth2grant/oauth2grant-set.ts
+++ b/src/m365/aad/commands/oauth2grant/oauth2grant-set.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import AadCommand from '../../../base/AadCommand';
+import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
 interface CommandArgs {
@@ -16,7 +16,7 @@ interface Options extends GlobalOptions {
   scope: string;
 }
 
-class AadOAuth2GrantSetCommand extends AadCommand {
+class AadOAuth2GrantSetCommand extends GraphCommand {
   public get name(): string {
     return commands.OAUTH2GRANT_SET;
   }
@@ -31,7 +31,7 @@ class AadOAuth2GrantSetCommand extends AadCommand {
     }
 
     const requestOptions: any = {
-      url: `${this.resource}/myorganization/oauth2PermissionGrants/${encodeURIComponent(args.options.grantId)}?api-version=1.6`,
+      url: `${this.resource}/v1.0/oauth2PermissionGrants/${encodeURIComponent(args.options.grantId)}`,
       headers: {
         'content-type': 'application/json'
       },


### PR DESCRIPTION
Fixes 'aad oauth2grant set' command. Closes #2711
Updated to use the Microsoft Graph v1.0 endpoint.