### PR TITLE
Fixes 'teams report pstncalls' command. Closes #2679

### DIFF
--- a/docs/docs/cmd/teams/report/report-pstncalls.md
+++ b/docs/docs/cmd/teams/report/report-pstncalls.md
@@ -24,9 +24,6 @@ This command only works with app-only permissions. You will need to create your 
 
 The difference between `fromDateTime` and `toDateTime` cannot exceed a period of 90 days
 
-!!! attention
-    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
-
 ## Examples
 
 Get details about PSTN calls made between 2020-10-31 and today
@@ -46,3 +43,7 @@ Get details about PSTN calls made between 2020-10-31 and 2020-12-31 and exports 
 ```sh
 m365 teams report pstncalls --fromDateTime 2020-10-31 --toDateTime 2020-12-31 --output json > "pstncalls.json"
 ```
+
+## More information
+
+- List PSTN calls: [https://docs.microsoft.com/en-us/graph/api/callrecords-callrecord-getpstncalls?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/callrecords-callrecord-getpstncalls?view=graph-rest-1.0)

--- a/src/m365/teams/commands/report/report-pstncalls.spec.ts
+++ b/src/m365/teams/commands/report/report-pstncalls.spec.ts
@@ -14,7 +14,7 @@ describe(commands.REPORT_PSTNCALLS, () => {
   let logger: Logger;
 
   const jsonOutput = {
-    "@odata.context": "https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.callRecords.pstnCallLogRow)",
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.callRecords.pstnCallLogRow)",
     "@odata.count": 1000,
     "value": [{
       "id": "9c4984c7-6c3c-427d-a30c-bd0b2eacee90",
@@ -39,7 +39,7 @@ describe(commands.REPORT_PSTNCALLS, () => {
       "licenseCapability": "MCOPSTNU",
       "inventoryType": "Subscriber"
     }],
-    "@odata.nextLink": "https://graph.microsoft.com/beta/communications/callRecords/getPstnCalls(from=2019-11-01,to=2019-12-01)?$skip=1000"
+    "@odata.nextLink": "https://graph.microsoft.com/v1.0/communications/callRecords/getPstnCalls(from=2019-11-01,to=2019-12-01)?$skip=1000"
   };
 
   before(() => {
@@ -144,7 +144,7 @@ describe(commands.REPORT_PSTNCALLS, () => {
 
   it('gets pstncalls in teams', (done) => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)`) {
         return Promise.resolve(jsonOutput);
       }
 
@@ -153,7 +153,7 @@ describe(commands.REPORT_PSTNCALLS, () => {
 
     command.action(logger, { options: { debug: false, fromDateTime: '2019-11-01', toDateTime: '2019-12-01' } }, () => {
       try {
-        assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/beta/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)");
+        assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)");
         assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
         done();
       }
@@ -169,7 +169,7 @@ describe(commands.REPORT_PSTNCALLS, () => {
     const toDateTime: string = encodeURIComponent(now.toISOString());
 
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=${toDateTime})`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=${toDateTime})`) {
         return Promise.resolve(jsonOutput);
       }
 
@@ -178,7 +178,7 @@ describe(commands.REPORT_PSTNCALLS, () => {
 
     command.action(logger, { options: { debug: false, fromDateTime: '2019-11-01' } }, () => {
       try {
-        assert.strictEqual(requestStub.lastCall.args[0].url, `https://graph.microsoft.com/beta/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=${toDateTime})`);
+        assert.strictEqual(requestStub.lastCall.args[0].url, `https://graph.microsoft.com/v1.0/communications/callRecords/getPstnCalls(fromDateTime=2019-11-01,toDateTime=${toDateTime})`);
         assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
         done();
       }

--- a/src/m365/teams/commands/report/report-pstncalls.ts
+++ b/src/m365/teams/commands/report/report-pstncalls.ts
@@ -39,7 +39,7 @@ class TeamsReportPstncallsCommand extends GraphCommand {
     const toDateTimeParameter: string = encodeURIComponent(args.options.toDateTime ? args.options.toDateTime : new Date().toISOString());
 
     const requestOptions: any = {
-      url: `${this.resource}/beta/communications/callRecords/getPstnCalls(fromDateTime=${encodeURIComponent(args.options.fromDateTime)},toDateTime=${toDateTimeParameter})`,
+      url: `${this.resource}/v1.0/communications/callRecords/getPstnCalls(fromDateTime=${encodeURIComponent(args.options.fromDateTime)},toDateTime=${toDateTimeParameter})`,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },


### PR DESCRIPTION
Fixes `teams report pstncalls` command. Closes #2679
Updated to use the Microsoft Graph v1.0 endpoint.