### PR TITLE
Update 'aad o365group add' to make execution faulty for invalid values

### DIFF
--- a/docs/docs/cmd/aad/o365group/o365group-add.md
+++ b/docs/docs/cmd/aad/o365group/o365group-add.md
@@ -20,10 +20,10 @@ m365 aad o365group add [options]
 : Name to use in the group e-mail (part before the `@`)
 
 `--owners [owners]`
-: Comma-separated list of Microsoft 365 Group owners
+: Comma-separated list of valid Microsoft 365 Group owners
 
 `--members [members]`
-: Comma-separated list of Microsoft 365 Group members
+: Comma-separated list of valid Microsoft 365 Group members
 
 `--isPrivate [isPrivate]`
 : Set to `true` if the Microsoft 365 Group should be private and to `false` if it should be public (default)
@@ -36,6 +36,7 @@ m365 aad o365group add [options]
 ## Remarks
 
 When specifying the path to the logo image you can use both relative and absolute paths. Note, that ~ in the path, will not be resolved and will most likely result in an error.
+The Owners and Members should be valid Microsoft 365 Users. If an invalid user is provided in the comma-separated list, the command operation will fail.
 
 ## Examples
 

--- a/docs/docs/cmd/aad/o365group/o365group-add.md
+++ b/docs/docs/cmd/aad/o365group/o365group-add.md
@@ -20,10 +20,10 @@ m365 aad o365group add [options]
 : Name to use in the group e-mail (part before the `@`)
 
 `--owners [owners]`
-: Comma-separated list of valid Microsoft 365 Group owners
+: Comma-separated list of Microsoft 365 Group owners
 
 `--members [members]`
-: Comma-separated list of valid Microsoft 365 Group members
+: Comma-separated list of Microsoft 365 Group members
 
 `--isPrivate [isPrivate]`
 : Set to `true` if the Microsoft 365 Group should be private and to `false` if it should be public (default)
@@ -36,7 +36,7 @@ m365 aad o365group add [options]
 ## Remarks
 
 When specifying the path to the logo image you can use both relative and absolute paths. Note, that ~ in the path, will not be resolved and will most likely result in an error.
-The Owners and Members should be valid Microsoft 365 Users. If an invalid user is provided in the comma-separated list, the command operation will fail.
+If an invalid user is provided in the comma-separated list or Owners or Members, the command operation will fail and the Micrsoft 365 Group will not be created.
 
 ## Examples
 

--- a/src/m365/aad/commands/o365group/o365group-add.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-add.spec.ts
@@ -1033,7 +1033,7 @@ describe(commands.O365GROUP_ADD, () => {
 
     command.action(logger, { options: { debug: false, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', owners: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, (err?: any) => {
       try {
-        assert.strictEqual(err.message, "Cannot proceed with group creation. The following Owners provided are invalid : user2@contoso.onmicrosoft.com");
+        assert.strictEqual(err.message, "Cannot proceed with group creation. The following users provided are invalid : user2@contoso.onmicrosoft.com");
         done();
       }
       catch (e) {
@@ -1066,7 +1066,7 @@ describe(commands.O365GROUP_ADD, () => {
 
     command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', owners: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, (err?: any) => {
       try {
-        assert.strictEqual(err.message, "Cannot proceed with group creation. The following Owners provided are invalid : user2@contoso.onmicrosoft.com");
+        assert.strictEqual(err.message, "Cannot proceed with group creation. The following users provided are invalid : user2@contoso.onmicrosoft.com");
         done();
       }
       catch (e) {
@@ -1099,7 +1099,7 @@ describe(commands.O365GROUP_ADD, () => {
 
     command.action(logger, { options: { debug: false, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', members: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, (err?: any) => {
       try {
-        assert.strictEqual(err.message, "Cannot proceed with group creation. The following Members provided are invalid : user2@contoso.onmicrosoft.com");
+        assert.strictEqual(err.message, "Cannot proceed with group creation. The following users provided are invalid : user2@contoso.onmicrosoft.com");
         done();
       }
       catch (e) {
@@ -1132,7 +1132,7 @@ describe(commands.O365GROUP_ADD, () => {
 
     command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', members: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, (err?: any) => {
       try {
-        assert.strictEqual(err.message, "Cannot proceed with group creation. The following Members provided are invalid : user2@contoso.onmicrosoft.com");
+        assert.strictEqual(err.message, "Cannot proceed with group creation. The following users provided are invalid : user2@contoso.onmicrosoft.com");
         done();
       }
       catch (e) {

--- a/src/m365/aad/commands/o365group/o365group-add.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-add.spec.ts
@@ -695,7 +695,7 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -793,7 +793,7 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -804,7 +804,7 @@ describe(commands.O365GROUP_ADD, () => {
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -875,7 +875,7 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -973,7 +973,7 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -984,7 +984,7 @@ describe(commands.O365GROUP_ADD, () => {
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -1011,7 +1011,7 @@ describe(commands.O365GROUP_ADD, () => {
 
   it('fails when an invalid user is specified as owner', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -1022,7 +1022,7 @@ describe(commands.O365GROUP_ADD, () => {
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: []
         });
@@ -1044,7 +1044,7 @@ describe(commands.O365GROUP_ADD, () => {
 
   it('fails when an invalid user is specified as owner (debug)', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -1055,7 +1055,7 @@ describe(commands.O365GROUP_ADD, () => {
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: []
         });
@@ -1077,7 +1077,7 @@ describe(commands.O365GROUP_ADD, () => {
 
   it('fails when an invalid user is specified as member', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -1088,7 +1088,7 @@ describe(commands.O365GROUP_ADD, () => {
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: []
         });
@@ -1110,7 +1110,7 @@ describe(commands.O365GROUP_ADD, () => {
 
   it('fails when an invalid user is specified as member (debug)', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
@@ -1121,7 +1121,7 @@ describe(commands.O365GROUP_ADD, () => {
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: []
         });

--- a/src/m365/aad/commands/o365group/o365group-add.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-add.spec.ts
@@ -695,11 +695,12 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user@contoso.onmicrosoft.com'&$select=id`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
-              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a'
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a',
+              userPrincipalName: 'user@contoso.onmicrosoft.com'
             }
           ]
         });
@@ -792,21 +793,23 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
-              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a'
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a',
+              userPrincipalName: 'user1@contoso.onmicrosoft.com'
             }
           ]
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
-              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8b'
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8b',
+              userPrincipalName: 'user2@contoso.onmicrosoft.com'
             }
           ]
         });
@@ -815,7 +818,7 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', owners: 'user1@contoso.onmicrosoft.com,user@contoso.onmicrosoft.com' } }, () => {
+    command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', owners: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, () => {
       try {
         assert(groupCreated);
         done();
@@ -872,11 +875,12 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user@contoso.onmicrosoft.com'&$select=id`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
-              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a'
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a',
+              userPrincipalName: 'user@contoso.onmicrosoft.com'
             }
           ]
         });
@@ -969,21 +973,23 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
-              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a'
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a',
+              userPrincipalName: 'user1@contoso.onmicrosoft.com'
             }
           ]
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
           value: [
             {
-              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8b'
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8b',
+              userPrincipalName: 'user2@contoso.onmicrosoft.com'
             }
           ]
         });
@@ -992,9 +998,141 @@ describe(commands.O365GROUP_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', members: 'user1@contoso.onmicrosoft.com,user@contoso.onmicrosoft.com' } }, () => {
+    command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', members: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, () => {
       try {
         assert(groupCreated);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails when an invalid user is specified as owner', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+        return Promise.resolve({
+          value: [
+            {
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a',
+              userPrincipalName: 'user1@contoso.onmicrosoft.com'
+            }
+          ]
+        });
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+        return Promise.resolve({
+          value: []
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: false, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', owners: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, "Cannot proceed with group creation. The following Owners provided are invalid : user2@contoso.onmicrosoft.com");
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails when an invalid user is specified as owner (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+        return Promise.resolve({
+          value: [
+            {
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a',
+              userPrincipalName: 'user1@contoso.onmicrosoft.com'
+            }
+          ]
+        });
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+        return Promise.resolve({
+          value: []
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', owners: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, "Cannot proceed with group creation. The following Owners provided are invalid : user2@contoso.onmicrosoft.com");
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails when an invalid user is specified as member', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+        return Promise.resolve({
+          value: [
+            {
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a',
+              userPrincipalName: 'user1@contoso.onmicrosoft.com'
+            }
+          ]
+        });
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+        return Promise.resolve({
+          value: []
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: false, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', members: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, "Cannot proceed with group creation. The following Members provided are invalid : user2@contoso.onmicrosoft.com");
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails when an invalid user is specified as member (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user1@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+        return Promise.resolve({
+          value: [
+            {
+              id: '949b16c1-a032-453e-a8ae-89a52bfc1d8a',
+              userPrincipalName: 'user1@contoso.onmicrosoft.com'
+            }
+          ]
+        });
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user2@contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
+        return Promise.resolve({
+          value: []
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', members: 'user1@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com' } }, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, "Cannot proceed with group creation. The following Members provided are invalid : user2@contoso.onmicrosoft.com");
         done();
       }
       catch (e) {


### PR DESCRIPTION
> ### #2654 Update 'aad o365group add' to make execution faulty for invalid values
>
> - Updates 'aad o365group add' command to validate whether the `--owners` and `--members` supplied are valid users
> - The existing approach fetch user info through the MS Graph API using multiple filters with `OR` is now replaced by individual call for each user. This is because the GET operation fails for large number of OR conditions with the below message

**_Error: Too many child clauses specified in search filter expression containing 
'OR' operators: 18. Max allowed: 15._**



Closes #2654 