### PR TITLE
Fixes 'teams report directroutingcalls' command. Closes #2680

### DIFF
--- a/docs/docs/cmd/teams/report/report-directroutingcalls.md
+++ b/docs/docs/cmd/teams/report/report-directroutingcalls.md
@@ -24,9 +24,6 @@ This command only works with app-only permissions. You will need to create your 
 
 The difference between `fromDateTime` and `toDateTime` cannot exceed a period of 90 days
 
-!!! attention
-    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
-
 ## Examples
 
 Get details about direct routing calls made between 2020-10-31 and today

--- a/src/m365/teams/commands/report/report-directroutingcalls.spec.ts
+++ b/src/m365/teams/commands/report/report-directroutingcalls.spec.ts
@@ -14,7 +14,7 @@ describe(commands.REPORT_DIRECTROUTINGCALLS, () => {
   let logger: Logger;
 
   const jsonOutput = {
-    "@odata.context": "https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.callRecords.directRoutingLogRow)",
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.callRecords.directRoutingLogRow)",
     "@odata.count": 1000,
     "value": [{
       "id": "9e8bba57-dc14-533a-a7dd-f0da6575eed1",
@@ -39,7 +39,7 @@ describe(commands.REPORT_DIRECTROUTINGCALLS, () => {
       "trunkFullyQualifiedDomainName": "tll-audiocodes01.adatum.biz",
       "mediaBypassEnabled": false
     }],
-    "@odata.nextLink": "https://graph.microsoft.com/beta/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)?$skip=1000"
+    "@odata.nextLink": "https://graph.microsoft.com/v1.0/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)?$skip=1000"
   };
 
   before(() => {
@@ -144,7 +144,7 @@ describe(commands.REPORT_DIRECTROUTINGCALLS, () => {
 
   it('gets directroutingcalls in teams', (done) => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)`) {
         return Promise.resolve(jsonOutput);
       }
 
@@ -153,7 +153,7 @@ describe(commands.REPORT_DIRECTROUTINGCALLS, () => {
 
     command.action(logger, { options: { debug: false, fromDateTime: '2019-11-01', toDateTime: '2019-12-01' } }, () => {
       try {
-        assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/beta/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)");
+        assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=2019-12-01)");
         assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
         done();
       }
@@ -169,7 +169,7 @@ describe(commands.REPORT_DIRECTROUTINGCALLS, () => {
     const toDateTime: string = encodeURIComponent(now.toISOString());
 
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=${toDateTime})`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=${toDateTime})`) {
         return Promise.resolve(jsonOutput);
       }
 
@@ -178,7 +178,7 @@ describe(commands.REPORT_DIRECTROUTINGCALLS, () => {
 
     command.action(logger, { options: { debug: false, fromDateTime: '2019-11-01' } }, () => {
       try {
-        assert.strictEqual(requestStub.lastCall.args[0].url, `https://graph.microsoft.com/beta/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=${toDateTime})`);
+        assert.strictEqual(requestStub.lastCall.args[0].url, `https://graph.microsoft.com/v1.0/communications/callRecords/getDirectRoutingCalls(fromDateTime=2019-11-01,toDateTime=${toDateTime})`);
         assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
         done();
       }

--- a/src/m365/teams/commands/report/report-directroutingcalls.ts
+++ b/src/m365/teams/commands/report/report-directroutingcalls.ts
@@ -40,7 +40,7 @@ class TeamsReportDirectroutingcallsCommand extends GraphCommand {
     const toDateTimeParameter: string = encodeURIComponent(args.options.toDateTime ? args.options.toDateTime : new Date().toISOString());
 
     const requestOptions: any = {
-      url: `${this.resource}/beta/communications/callRecords/getDirectRoutingCalls(fromDateTime=${encodeURIComponent(args.options.fromDateTime)},toDateTime=${toDateTimeParameter})`,
+      url: `${this.resource}/v1.0/communications/callRecords/getDirectRoutingCalls(fromDateTime=${encodeURIComponent(args.options.fromDateTime)},toDateTime=${toDateTimeParameter})`,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },


### PR DESCRIPTION
Fixes `teams report directroutingcalls` command. Closes #2680
Updated to use the Microsoft Graph v1.0 endpoint.