### PR TITLE
Extend 'spo list get' command with '--withPermissions' option. Closes #2796

### DIFF
--- a/docs/docs/cmd/spo/list/list-get.md
+++ b/docs/docs/cmd/spo/list/list-get.md
@@ -22,6 +22,9 @@ m365 spo list get [options]
 `-p, --properties [properties]`
 : Comma-separated list of properties to retrieve from the list. Will retrieve all properties possible from default response, if not specified.
 
+`--withPermissions`
+: Set if you want to return associated roles and permissions (associatedOwnerGroup, associatedMemberGroup and associatedVisitorGroup) of the list.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
@@ -42,6 +45,12 @@ Get information about a list returning the specified list properties
 
 ```sh
 m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --properties "Title,Id,HasUniqueRoleAssignments,AllowContentTypes"
+```
+
+Get information about a list along with the roles and permissions
+
+```sh
+m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --withPermissions
 ```
 
 ## More information

--- a/src/m365/spo/commands/list/list-get.spec.ts
+++ b/src/m365/spo/commands/list/list-get.spec.ts
@@ -60,7 +60,6 @@ describe(commands.LIST_GET, () => {
 
   it('retrieves and prints all details of list if title option is passed', (done) => {
     sinon.stub(request, 'get').callsFake(() => {
-      //if ((opts.url as string).indexOf('/_api/web/lists/GetByTitle(') > -1) {
       return Promise.resolve(
         {
           "AllowContentTypes": true,
@@ -115,8 +114,6 @@ describe(commands.LIST_GET, () => {
           "Title": "Documents"
         }
       );
-      //}
-      //return Promise.reject('Invalid request');
     });
 
     command.action(logger, {
@@ -191,60 +188,10 @@ describe(commands.LIST_GET, () => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.resolve(
         {
-          "AllowContentTypes": true,
-          "BaseTemplate": 109,
-          "BaseType": 1,
-          "ContentTypesEnabled": false,
-          "CrawlNonDefaultViews": false,
-          "Created": null,
-          "CurrentChangeToken": null,
-          "CustomActionElements": null,
-          "DefaultContentApprovalWorkflowId": "00000000-0000-0000-0000-000000000000",
-          "DefaultItemOpenUseListSetting": false,
-          "Description": "",
-          "Direction": "none",
-          "DocumentTemplateUrl": null,
-          "DraftVersionVisibility": 0,
-          "EnableAttachments": false,
-          "EnableFolderCreation": true,
-          "EnableMinorVersions": false,
-          "EnableModeration": false,
-          "EnableVersioning": false,
-          "EntityTypeName": "Documents",
-          "ExemptFromBlockDownloadOfNonViewableFiles": false,
-          "FileSavePostProcessingEnabled": false,
-          "ForceCheckout": false,
-          "HasExternalDataSource": false,
-          "Hidden": false,
           "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
-          "ImagePath": null,
-          "ImageUrl": null,
-          "IrmEnabled": false,
-          "IrmExpire": false,
-          "IrmReject": false,
-          "IsApplicationList": false,
-          "IsCatalog": false,
-          "IsPrivate": false,
-          "ItemCount": 69,
-          "LastItemDeletedDate": null,
-          "LastItemModifiedDate": null,
-          "LastItemUserModifiedDate": null,
-          "ListExperienceOptions": 0,
-          "ListItemEntityTypeFullName": null,
-          "MajorVersionLimit": 0,
-          "MajorWithMinorVersionsLimit": 0,
-          "MultipleDataList": false,
-          "NoCrawl": false,
-          "ParentWebPath": null,
-          "ParentWebUrl": null,
-          "ParserDisabled": false,
-          "ServerTemplateCanCreateFolders": true,
-          "TemplateFeatureId": null,
           "Title": "Documents"
         }
       );
-      //}
-      //return Promise.reject('Invalid request');
     });
 
     command.action(logger, {
@@ -257,55 +204,7 @@ describe(commands.LIST_GET, () => {
     }, () => {
       try {
         assert(loggerLogSpy.calledWith({
-          AllowContentTypes: true,
-          BaseTemplate: 109,
-          BaseType: 1,
-          ContentTypesEnabled: false,
-          CrawlNonDefaultViews: false,
-          Created: null,
-          CurrentChangeToken: null,
-          CustomActionElements: null,
-          DefaultContentApprovalWorkflowId: '00000000-0000-0000-0000-000000000000',
-          DefaultItemOpenUseListSetting: false,
-          Description: '',
-          Direction: 'none',
-          DocumentTemplateUrl: null,
-          DraftVersionVisibility: 0,
-          EnableAttachments: false,
-          EnableFolderCreation: true,
-          EnableMinorVersions: false,
-          EnableModeration: false,
-          EnableVersioning: false,
-          EntityTypeName: 'Documents',
-          ExemptFromBlockDownloadOfNonViewableFiles: false,
-          FileSavePostProcessingEnabled: false,
-          ForceCheckout: false,
-          HasExternalDataSource: false,
-          Hidden: false,
           Id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
-          ImagePath: null,
-          ImageUrl: null,
-          IrmEnabled: false,
-          IrmExpire: false,
-          IrmReject: false,
-          IsApplicationList: false,
-          IsCatalog: false,
-          IsPrivate: false,
-          ItemCount: 69,
-          LastItemDeletedDate: null,
-          LastItemModifiedDate: null,
-          LastItemUserModifiedDate: null,
-          ListExperienceOptions: 0,
-          ListItemEntityTypeFullName: null,
-          MajorVersionLimit: 0,
-          MajorWithMinorVersionsLimit: 0,
-          MultipleDataList: false,
-          NoCrawl: false,
-          ParentWebPath: null,
-          ParentWebUrl: null,
-          ParserDisabled: false,
-          ServerTemplateCanCreateFolders: true,
-          TemplateFeatureId: null,
           Title: 'Documents'
         }));
         done();
@@ -321,6 +220,167 @@ describe(commands.LIST_GET, () => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.resolve(
         {
+          "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
+          "Title": "Documents"
+        }
+      );
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+        webUrl: 'https://contoso.sharepoint.com',
+        properties:'Title,Id'
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith({
+          Id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+          Title: 'Documents'
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('retrieves details of list if list id and withPermissions option is passed', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.resolve(
+        {
+          "RoleAssignments": [
+            {
+              "Member": {
+                "Id": 3,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Owners",
+                "Title": "MySite Owners",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": false,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "2147483647",
+                    "Low": "4294967295"
+                  },
+                  "Description": "Has full control.",
+                  "Hidden": false,
+                  "Id": 1073741829,
+                  "Name": "Full Control",
+                  "Order": 1,
+                  "RoleTypeKind": 5
+                }
+              ],
+              "PrincipalId": 3
+            },
+            {
+              "Member": {
+                "Id": 4,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Visitors",
+                "Title": "MySite Visitors",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": false,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "176",
+                    "Low": "138612833"
+                  },
+                  "Description": "Can view pages and list items and download documents.",
+                  "Hidden": false,
+                  "Id": 1073741826,
+                  "Name": "Read",
+                  "Order": 128,
+                  "RoleTypeKind": 2
+                }
+              ],
+              "PrincipalId": 4
+            },
+            {
+              "Member": {
+                "Id": 5,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Members",
+                "Title": "MySite Members",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": true,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "432",
+                    "Low": "1011030767"
+                  },
+                  "Description": "Can add, edit and delete lists; can view, add, update and delete list items and documents.",
+                  "Hidden": false,
+                  "Id": 1073741830,
+                  "Name": "Edit",
+                  "Order": 48,
+                  "RoleTypeKind": 6
+                }
+              ],
+              "PrincipalId": 5
+            },
+            {
+              "Member": {
+                "Id": 12,
+                "IsHiddenInUI": false,
+                "LoginName": "i:0#.f|membership|user@contoso.onmicrosoft.com",
+                "Title": "User",
+                "PrincipalType": 1,
+                "Email": "user@contoso.onmicrosoft.com",
+                "Expiration": "",
+                "IsEmailAuthenticationGuestUser": false,
+                "IsShareByEmailGuestUser": false,
+                "IsSiteAdmin": false,
+                "UserId": {
+                  "NameId": "10032000f65ded70",
+                  "NameIdIssuer": "urn:federation:microsoftonline"
+                },
+                "UserPrincipalName": "user@contoso.onmicrosoft.com"
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "176",
+                    "Low": "138612833"
+                  },
+                  "Description": "Can view pages and list items and download documents.",
+                  "Hidden": false,
+                  "Id": 1073741826,
+                  "Name": "Read",
+                  "Order": 128,
+                  "RoleTypeKind": 2
+                }
+              ],
+              "PrincipalId": 12
+            }
+          ],
+          "HasUniqueRoleAssignments": true,
           "AllowContentTypes": true,
           "BaseTemplate": 109,
           "BaseType": 1,
@@ -377,10 +437,10 @@ describe(commands.LIST_GET, () => {
 
     command.action(logger, {
       options: {
-        debug: true,
+        debug: false,
         id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
         webUrl: 'https://contoso.sharepoint.com',
-        properties:'Title,Id'
+        withPermissions: true
       }
     }, () => {
       try {
@@ -409,6 +469,7 @@ describe(commands.LIST_GET, () => {
           FileSavePostProcessingEnabled: false,
           ForceCheckout: false,
           HasExternalDataSource: false,
+          HasUniqueRoleAssignments: true,
           Hidden: false,
           Id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
           ImagePath: null,
@@ -432,8 +493,722 @@ describe(commands.LIST_GET, () => {
           ParentWebPath: null,
           ParentWebUrl: null,
           ParserDisabled: false,
+          RoleAssignments: [
+            {
+              Member: {
+                Id: 3,
+                IsHiddenInUI: false,
+                LoginName: "MySite Owners",
+                Title: "MySite Owners",
+                PrincipalType: 8,
+                AllowMembersEditMembership: false,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "2147483647",
+                    Low: "4294967295"
+                  },
+                  Description: "Has full control.",
+                  Hidden: false,
+                  Id: 1073741829,
+                  Name: "Full Control",
+                  Order: 1,
+                  RoleTypeKind: 5
+                }
+              ],
+              PrincipalId: 3
+            },
+            {
+              Member: {
+                Id: 4,
+                IsHiddenInUI: false,
+                LoginName: "MySite Visitors",
+                Title: "MySite Visitors",
+                PrincipalType: 8,
+                AllowMembersEditMembership: false,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "176",
+                    Low: "138612833"
+                  },
+                  Description: "Can view pages and list items and download documents.",
+                  Hidden: false,
+                  Id: 1073741826,
+                  Name: "Read",
+                  Order: 128,
+                  RoleTypeKind: 2
+                }
+              ],
+              PrincipalId: 4
+            },
+            {
+              Member: {
+                Id: 5,
+                IsHiddenInUI: false,
+                LoginName: "MySite Members",
+                Title: "MySite Members",
+                PrincipalType: 8,
+                AllowMembersEditMembership: true,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "432",
+                    Low: "1011030767"
+                  },
+                  Description: "Can add, edit and delete lists; can view, add, update and delete list items and documents.",
+                  Hidden: false,
+                  Id: 1073741830,
+                  Name: "Edit",
+                  Order: 48,
+                  RoleTypeKind: 6
+                }
+              ],
+              PrincipalId: 5
+            },
+            {
+              Member: {
+                Id: 12,
+                IsHiddenInUI: false,
+                LoginName: "i:0#.f|membership|user@contoso.onmicrosoft.com",
+                Title: "User",
+                PrincipalType: 1,
+                Email: "user@contoso.onmicrosoft.com",
+                Expiration: "",
+                IsEmailAuthenticationGuestUser: false,
+                IsShareByEmailGuestUser: false,
+                IsSiteAdmin: false,
+                UserId: {
+                  NameId: "10032000f65ded70",
+                  NameIdIssuer: "urn:federation:microsoftonline"
+                },
+                UserPrincipalName: "user@contoso.onmicrosoft.com"
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "176",
+                    Low: "138612833"
+                  },
+                  Description: "Can view pages and list items and download documents.",
+                  Hidden: false,
+                  Id: 1073741826,
+                  Name: "Read",
+                  Order: 128,
+                  RoleTypeKind: 2
+                }
+              ],
+              PrincipalId: 12
+            }
+          ],
           ServerTemplateCanCreateFolders: true,
           TemplateFeatureId: null,
+          Title: 'Documents'
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+  it('retrieves details of list if list id, properties and withPermissions option is passed', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.resolve(
+        {
+          "RoleAssignments": [
+            {
+              "Member": {
+                "Id": 3,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Owners",
+                "Title": "MySite Owners",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": false,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "2147483647",
+                    "Low": "4294967295"
+                  },
+                  "Description": "Has full control.",
+                  "Hidden": false,
+                  "Id": 1073741829,
+                  "Name": "Full Control",
+                  "Order": 1,
+                  "RoleTypeKind": 5
+                }
+              ],
+              "PrincipalId": 3
+            },
+            {
+              "Member": {
+                "Id": 4,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Visitors",
+                "Title": "MySite Visitors",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": false,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "176",
+                    "Low": "138612833"
+                  },
+                  "Description": "Can view pages and list items and download documents.",
+                  "Hidden": false,
+                  "Id": 1073741826,
+                  "Name": "Read",
+                  "Order": 128,
+                  "RoleTypeKind": 2
+                }
+              ],
+              "PrincipalId": 4
+            },
+            {
+              "Member": {
+                "Id": 5,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Members",
+                "Title": "MySite Members",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": true,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "432",
+                    "Low": "1011030767"
+                  },
+                  "Description": "Can add, edit and delete lists; can view, add, update and delete list items and documents.",
+                  "Hidden": false,
+                  "Id": 1073741830,
+                  "Name": "Edit",
+                  "Order": 48,
+                  "RoleTypeKind": 6
+                }
+              ],
+              "PrincipalId": 5
+            },
+            {
+              "Member": {
+                "Id": 12,
+                "IsHiddenInUI": false,
+                "LoginName": "i:0#.f|membership|user@contoso.onmicrosoft.com",
+                "Title": "User",
+                "PrincipalType": 1,
+                "Email": "user@contoso.onmicrosoft.com",
+                "Expiration": "",
+                "IsEmailAuthenticationGuestUser": false,
+                "IsShareByEmailGuestUser": false,
+                "IsSiteAdmin": false,
+                "UserId": {
+                  "NameId": "10032000f65ded70",
+                  "NameIdIssuer": "urn:federation:microsoftonline"
+                },
+                "UserPrincipalName": "user@contoso.onmicrosoft.com"
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "176",
+                    "Low": "138612833"
+                  },
+                  "Description": "Can view pages and list items and download documents.",
+                  "Hidden": false,
+                  "Id": 1073741826,
+                  "Name": "Read",
+                  "Order": 128,
+                  "RoleTypeKind": 2
+                }
+              ],
+              "PrincipalId": 12
+            }
+          ],
+          "HasUniqueRoleAssignments": true,
+          "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
+          "Title": "Documents"
+        }
+      );
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+        webUrl: 'https://contoso.sharepoint.com',
+        properties:'Title,Id',
+        withPermissions: true
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith({
+          HasUniqueRoleAssignments: true,
+          Id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+          RoleAssignments: [
+            {
+              Member: {
+                Id: 3,
+                IsHiddenInUI: false,
+                LoginName: "MySite Owners",
+                Title: "MySite Owners",
+                PrincipalType: 8,
+                AllowMembersEditMembership: false,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "2147483647",
+                    Low: "4294967295"
+                  },
+                  Description: "Has full control.",
+                  Hidden: false,
+                  Id: 1073741829,
+                  Name: "Full Control",
+                  Order: 1,
+                  RoleTypeKind: 5
+                }
+              ],
+              PrincipalId: 3
+            },
+            {
+              Member: {
+                Id: 4,
+                IsHiddenInUI: false,
+                LoginName: "MySite Visitors",
+                Title: "MySite Visitors",
+                PrincipalType: 8,
+                AllowMembersEditMembership: false,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "176",
+                    Low: "138612833"
+                  },
+                  Description: "Can view pages and list items and download documents.",
+                  Hidden: false,
+                  Id: 1073741826,
+                  Name: "Read",
+                  Order: 128,
+                  RoleTypeKind: 2
+                }
+              ],
+              PrincipalId: 4
+            },
+            {
+              Member: {
+                Id: 5,
+                IsHiddenInUI: false,
+                LoginName: "MySite Members",
+                Title: "MySite Members",
+                PrincipalType: 8,
+                AllowMembersEditMembership: true,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "432",
+                    Low: "1011030767"
+                  },
+                  Description: "Can add, edit and delete lists; can view, add, update and delete list items and documents.",
+                  Hidden: false,
+                  Id: 1073741830,
+                  Name: "Edit",
+                  Order: 48,
+                  RoleTypeKind: 6
+                }
+              ],
+              PrincipalId: 5
+            },
+            {
+              Member: {
+                Id: 12,
+                IsHiddenInUI: false,
+                LoginName: "i:0#.f|membership|user@contoso.onmicrosoft.com",
+                Title: "User",
+                PrincipalType: 1,
+                Email: "user@contoso.onmicrosoft.com",
+                Expiration: "",
+                IsEmailAuthenticationGuestUser: false,
+                IsShareByEmailGuestUser: false,
+                IsSiteAdmin: false,
+                UserId: {
+                  NameId: "10032000f65ded70",
+                  NameIdIssuer: "urn:federation:microsoftonline"
+                },
+                UserPrincipalName: "user@contoso.onmicrosoft.com"
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "176",
+                    Low: "138612833"
+                  },
+                  Description: "Can view pages and list items and download documents.",
+                  Hidden: false,
+                  Id: 1073741826,
+                  Name: "Read",
+                  Order: 128,
+                  RoleTypeKind: 2
+                }
+              ],
+              PrincipalId: 12
+            }
+          ],
+          Title: 'Documents'
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('retrieves details of list if list title, properties and withPermissions option is passed', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.resolve(
+        {
+          "RoleAssignments": [
+            {
+              "Member": {
+                "Id": 3,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Owners",
+                "Title": "MySite Owners",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": false,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "2147483647",
+                    "Low": "4294967295"
+                  },
+                  "Description": "Has full control.",
+                  "Hidden": false,
+                  "Id": 1073741829,
+                  "Name": "Full Control",
+                  "Order": 1,
+                  "RoleTypeKind": 5
+                }
+              ],
+              "PrincipalId": 3
+            },
+            {
+              "Member": {
+                "Id": 4,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Visitors",
+                "Title": "MySite Visitors",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": false,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "176",
+                    "Low": "138612833"
+                  },
+                  "Description": "Can view pages and list items and download documents.",
+                  "Hidden": false,
+                  "Id": 1073741826,
+                  "Name": "Read",
+                  "Order": 128,
+                  "RoleTypeKind": 2
+                }
+              ],
+              "PrincipalId": 4
+            },
+            {
+              "Member": {
+                "Id": 5,
+                "IsHiddenInUI": false,
+                "LoginName": "MySite Members",
+                "Title": "MySite Members",
+                "PrincipalType": 8,
+                "AllowMembersEditMembership": true,
+                "AllowRequestToJoinLeave": false,
+                "AutoAcceptRequestToJoinLeave": false,
+                "Description": null,
+                "OnlyAllowMembersViewMembership": false,
+                "OwnerTitle": "MySite Owners",
+                "RequestToJoinLeaveEmailSetting": ""
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "432",
+                    "Low": "1011030767"
+                  },
+                  "Description": "Can add, edit and delete lists; can view, add, update and delete list items and documents.",
+                  "Hidden": false,
+                  "Id": 1073741830,
+                  "Name": "Edit",
+                  "Order": 48,
+                  "RoleTypeKind": 6
+                }
+              ],
+              "PrincipalId": 5
+            },
+            {
+              "Member": {
+                "Id": 12,
+                "IsHiddenInUI": false,
+                "LoginName": "i:0#.f|membership|user@contoso.onmicrosoft.com",
+                "Title": "User",
+                "PrincipalType": 1,
+                "Email": "user@contoso.onmicrosoft.com",
+                "Expiration": "",
+                "IsEmailAuthenticationGuestUser": false,
+                "IsShareByEmailGuestUser": false,
+                "IsSiteAdmin": false,
+                "UserId": {
+                  "NameId": "10032000f65ded70",
+                  "NameIdIssuer": "urn:federation:microsoftonline"
+                },
+                "UserPrincipalName": "user@contoso.onmicrosoft.com"
+              },
+              "RoleDefinitionBindings": [
+                {
+                  "BasePermissions": {
+                    "High": "176",
+                    "Low": "138612833"
+                  },
+                  "Description": "Can view pages and list items and download documents.",
+                  "Hidden": false,
+                  "Id": 1073741826,
+                  "Name": "Read",
+                  "Order": 128,
+                  "RoleTypeKind": 2
+                }
+              ],
+              "PrincipalId": 12
+            }
+          ],
+          "HasUniqueRoleAssignments": true,
+          "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
+          "Title": "Documents"
+        }
+      );
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        title: 'Documents',
+        webUrl: 'https://contoso.sharepoint.com',
+        properties:'Title,Id',
+        withPermissions: true
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith({
+          HasUniqueRoleAssignments: true,
+          Id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+          RoleAssignments: [
+            {
+              Member: {
+                Id: 3,
+                IsHiddenInUI: false,
+                LoginName: "MySite Owners",
+                Title: "MySite Owners",
+                PrincipalType: 8,
+                AllowMembersEditMembership: false,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "2147483647",
+                    Low: "4294967295"
+                  },
+                  Description: "Has full control.",
+                  Hidden: false,
+                  Id: 1073741829,
+                  Name: "Full Control",
+                  Order: 1,
+                  RoleTypeKind: 5
+                }
+              ],
+              PrincipalId: 3
+            },
+            {
+              Member: {
+                Id: 4,
+                IsHiddenInUI: false,
+                LoginName: "MySite Visitors",
+                Title: "MySite Visitors",
+                PrincipalType: 8,
+                AllowMembersEditMembership: false,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "176",
+                    Low: "138612833"
+                  },
+                  Description: "Can view pages and list items and download documents.",
+                  Hidden: false,
+                  Id: 1073741826,
+                  Name: "Read",
+                  Order: 128,
+                  RoleTypeKind: 2
+                }
+              ],
+              PrincipalId: 4
+            },
+            {
+              Member: {
+                Id: 5,
+                IsHiddenInUI: false,
+                LoginName: "MySite Members",
+                Title: "MySite Members",
+                PrincipalType: 8,
+                AllowMembersEditMembership: true,
+                AllowRequestToJoinLeave: false,
+                AutoAcceptRequestToJoinLeave: false,
+                Description: null,
+                OnlyAllowMembersViewMembership: false,
+                OwnerTitle: "MySite Owners",
+                RequestToJoinLeaveEmailSetting: ""
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "432",
+                    Low: "1011030767"
+                  },
+                  Description: "Can add, edit and delete lists; can view, add, update and delete list items and documents.",
+                  Hidden: false,
+                  Id: 1073741830,
+                  Name: "Edit",
+                  Order: 48,
+                  RoleTypeKind: 6
+                }
+              ],
+              PrincipalId: 5
+            },
+            {
+              Member: {
+                Id: 12,
+                IsHiddenInUI: false,
+                LoginName: "i:0#.f|membership|user@contoso.onmicrosoft.com",
+                Title: "User",
+                PrincipalType: 1,
+                Email: "user@contoso.onmicrosoft.com",
+                Expiration: "",
+                IsEmailAuthenticationGuestUser: false,
+                IsShareByEmailGuestUser: false,
+                IsSiteAdmin: false,
+                UserId: {
+                  NameId: "10032000f65ded70",
+                  NameIdIssuer: "urn:federation:microsoftonline"
+                },
+                UserPrincipalName: "user@contoso.onmicrosoft.com"
+              },
+              RoleDefinitionBindings: [
+                {
+                  BasePermissions: {
+                    High: "176",
+                    Low: "138612833"
+                  },
+                  Description: "Can view pages and list items and download documents.",
+                  Hidden: false,
+                  Id: 1073741826,
+                  Name: "Read",
+                  Order: 128,
+                  RoleTypeKind: 2
+                }
+              ],
+              PrincipalId: 12
+            }
+          ],
           Title: 'Documents'
         }));
         done();

--- a/src/m365/spo/commands/list/list-get.ts
+++ b/src/m365/spo/commands/list/list-get.ts
@@ -18,6 +18,7 @@ interface Options extends GlobalOptions {
   id?: string;
   title?: string;
   properties?: string;
+  withPermissions?: boolean;
 }
 
 class SpoListGetCommand extends SpoCommand {
@@ -34,6 +35,7 @@ class SpoListGetCommand extends SpoCommand {
     telemetryProps.id = (!(!args.options.id)).toString();
     telemetryProps.title = (!(!args.options.title)).toString();
     telemetryProps.properties = (!(!args.options.properties)).toString();
+    telemetryProps.withPermissions = typeof args.options.withPermissions !== 'undefined';
     return telemetryProps;
   }
 
@@ -53,8 +55,10 @@ class SpoListGetCommand extends SpoCommand {
 
     const propertiesSelect: string = args.options.properties ? `?$select=${encodeURIComponent(args.options.properties)}` : ``;
 
+    const permissionsExpand: string = args.options.withPermissions ? `${args.options.properties ? '&' : '?'}$expand=HasUniqueRoleAssignments,RoleAssignments/Member,RoleAssignments/RoleDefinitionBindings` : ``;
+
     const requestOptions: any = {
-      url: requestUrl + propertiesSelect,
+      url: requestUrl + propertiesSelect + permissionsExpand,
       method: 'GET',
       headers: {
         'accept': 'application/json;odata=nometadata'
@@ -84,6 +88,9 @@ class SpoListGetCommand extends SpoCommand {
       },
       {
         option: '-p, --properties [properties]'
+      },
+      {
+        option: '--withPermissions'
       }
     ];
 


### PR DESCRIPTION
- Extends 'spo list get' command with roles and permissions. Closes #2796

`m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --withPermissions`