### PR TITLE
Adds more options to spo page add/set --layoutType. Solves #2821

### DIFF
--- a/docs/docs/cmd/spo/page/page-add.md
+++ b/docs/docs/cmd/spo/page/page-add.md
@@ -20,7 +20,7 @@ m365 spo page add [options]
 : Title of the page to create. If not specified, will use the page name as its title
 
 `-l, --layoutType [layoutType]`
-: Layout of the page. Allowed values `Article,Home`. Default `Article`
+: Layout of the page. Allowed values `Article,HomeSingleWebPartAppPage,RepostPage,HeaderlessSearchResults,Spaces,Topic`. Default `Article`
 
 `-p, --promoteAs [promoteAs]`
 : Create the page for a specific purpose. Allowed values `HomePage,NewsPage`

--- a/docs/docs/cmd/spo/page/page-set.md
+++ b/docs/docs/cmd/spo/page/page-set.md
@@ -17,7 +17,7 @@ m365 spo page set [options]
 : URL of the site where the page to update is located
 
 `-l, --layoutType [layoutType]`
-: Layout of the page. Allowed values `Article,Home`
+: Layout of the page. Allowed values `Article,Home,SingleWebPartAppPage,RepostPage,HeaderlessSearchResults,Spaces,Topic`
 
 `-p, --promoteAs [promoteAs]`
 : Update the page purpose. Allowed values `HomePage,NewsPage`

--- a/src/m365/spo/commands/page/page-add.spec.ts
+++ b/src/m365/spo/commands/page/page-add.spec.ts
@@ -1295,6 +1295,31 @@ describe(commands.PAGE_ADD, () => {
     assert.strictEqual(actual, true);
   });
 
+  it('passes validation if layout type is SingleWebPartAppPage', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'SingleWebPartAppPage' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if layout type is RepostPage', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'RepostPage' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if layout type is HeaderlessSearchResults', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'HeaderlessSearchResults' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if layout type is Spaces', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'Spaces' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if layout type is Topic', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'Topic' } });
+    assert.strictEqual(actual, true);
+  });
+
   it('fails validation if promote type is invalid', () => {
     const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', promoteAs: 'invalid' } });
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/page/page-add.ts
+++ b/src/m365/spo/commands/page/page-add.ts
@@ -334,7 +334,7 @@ class SpoPageAddCommand extends SpoCommand {
       },
       {
         option: '-l, --layoutType [layoutType]',
-        autocomplete: ['Article', 'Home']
+        autocomplete: ['Article', 'Home', 'SingleWebPartAppPage', 'RepostPage', 'HeaderlessSearchResults', 'Spaces', 'Topic']
       },
       {
         option: '-p, --promoteAs [promoteAs]',
@@ -366,8 +366,13 @@ class SpoPageAddCommand extends SpoCommand {
 
     if (args.options.layoutType &&
       args.options.layoutType !== 'Article' &&
-      args.options.layoutType !== 'Home') {
-      return `${args.options.layoutType} is not a valid option for layoutType. Allowed values Article|Home`;
+      args.options.layoutType !== 'Home' &&
+      args.options.layoutType !== 'SingleWebPartAppPage' &&
+      args.options.layoutType !== 'RepostPage' &&
+      args.options.layoutType !== 'HeaderlessSearchResults' &&
+      args.options.layoutType !== 'Spaces' &&
+      args.options.layoutType !== 'Topic') {
+      return `${args.options.layoutType} is not a valid option for layoutType. Allowed values Article|Home|SingleWebPartAppPage|RepostPage|HeaderlessSearchResults|Spaces|Topic`;
     }
 
     if (args.options.promoteAs &&
@@ -381,7 +386,7 @@ class SpoPageAddCommand extends SpoCommand {
       return 'You can only promote home pages as site home page';
     }
 
-    if (args.options.promoteAs === 'NewsPage' && args.options.layoutType === 'Home') {
+    if (args.options.promoteAs === 'NewsPage' && args.options.layoutType  && args.options.layoutType !== 'Article') {
       return 'You can only promote article pages as news article';
     }
 

--- a/src/m365/spo/commands/page/page-set.spec.ts
+++ b/src/m365/spo/commands/page/page-set.spec.ts
@@ -661,6 +661,31 @@ describe(commands.PAGE_SET, () => {
     assert.strictEqual(actual, true);
   });
 
+  it('passes validation if layout type is SingleWebPartAppPage', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'SingleWebPartAppPage' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if layout type is RepostPage', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'RepostPage' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if layout type is HeaderlessSearchResults', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'HeaderlessSearchResults' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if layout type is Spaces', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'Spaces' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if layout type is Topic', () => {
+    const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'Topic' } });
+    assert.strictEqual(actual, true);
+  });
+
   it('fails validation if promote type is invalid', () => {
     const actual = command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', promoteAs: 'invalid' } });
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/page/page-set.ts
+++ b/src/m365/spo/commands/page/page-set.ts
@@ -333,7 +333,7 @@ class SpoPageSetCommand extends SpoCommand {
       },
       {
         option: '-l, --layoutType [layoutType]',
-        autocomplete: ['Article', 'Home']
+        autocomplete: ['Article', 'Home', 'SingleWebPartAppPage', 'RepostPage', 'HeaderlessSearchResults', 'Spaces', 'Topic']
       },
       {
         option: '-p, --promoteAs [promoteAs]',
@@ -369,8 +369,13 @@ class SpoPageSetCommand extends SpoCommand {
 
     if (args.options.layoutType &&
       args.options.layoutType !== 'Article' &&
-      args.options.layoutType !== 'Home') {
-      return `${args.options.layoutType} is not a valid option for layoutType. Allowed values Article|Home`;
+      args.options.layoutType !== 'Home' &&
+      args.options.layoutType !== 'SingleWebPartAppPage' &&
+      args.options.layoutType !== 'RepostPage' &&
+      args.options.layoutType !== 'HeaderlessSearchResults' &&
+      args.options.layoutType !== 'Spaces' &&
+      args.options.layoutType !== 'Topic') {
+      return `${args.options.layoutType} is not a valid option for layoutType. Allowed values Article|Home|SingleWebPartAppPage|RepostPage|HeaderlessSearchResults|Spaces|Topic`;
     }
 
     if (args.options.promoteAs &&
@@ -384,7 +389,7 @@ class SpoPageSetCommand extends SpoCommand {
       return 'You can only promote home pages as site home page';
     }
 
-    if (args.options.promoteAs === 'NewsPage' && args.options.layoutType === 'Home') {
+    if (args.options.promoteAs === 'NewsPage' && args.options.layoutType && args.options.layoutType !== 'Article') {
       return 'You can only promote article pages as news article';
     }
 


### PR DESCRIPTION
> ### Adds more options to spo page add/set --layoutType. Solves #2821
>
> - Extends 'spo page add' and 'spo page set' commands with support for more layoutTypes in addition to Article and Home
> - Layout types added: SingleWebPartAppPage, RepostPage, HeaderlessSearchResults, Spaces, Topic. 
> - Closes #2821

> ### Linked Issue
> Closes #2821 

