### PR TITLE
implements csv output mode. closes #2836

### DIFF
--- a/docs/docs/cmd/_global.md
+++ b/docs/docs/cmd/_global.md
@@ -5,7 +5,7 @@
 : JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 
 `-o, --output [output]`
-: Output type. `json,text`. Default `text`
+: Output type. `json,text,csv`. Default `json`
 
 `--verbose`
 : Runs command with verbose logging

--- a/docs/docs/cmd/spfx/project/project-externalize.md
+++ b/docs/docs/cmd/spfx/project/project-externalize.md
@@ -20,7 +20,7 @@ m365 spfx project externalize [options]
 : JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 
 `-o, --output [output]`
-: Output type. `json,text,md`. Default `text`
+: Output type. `json,text,csv,md`. Default `json`
 
 `--verbose`
 : Runs command with verbose logging
@@ -29,12 +29,12 @@ m365 spfx project externalize [options]
 : Runs command with debug logging
 
 !!! important
-    Run this command in the folder where the project for which you want to externalize dependencies is located. This command doesn't change your project files.
+Run this command in the folder where the project for which you want to externalize dependencies is located. This command doesn't change your project files.
 
 ## Remarks
 
 !!! attention
-    This command is in preview and could change once it's officially released. If you see any room for improvement, we'd love to hear from you at [https://github.com/pnp/cli-microsoft365/issues](https://github.com/pnp/cli-microsoft365/issues).
+This command is in preview and could change once it's officially released. If you see any room for improvement, we'd love to hear from you at [https://github.com/pnp/cli-microsoft365/issues](https://github.com/pnp/cli-microsoft365/issues).
 
 The `spfx project externalize` command helps you externalize your SharePoint Framework project dependencies using the [unpkg CDN](https://unpkg.com/).
 

--- a/docs/docs/cmd/spfx/project/project-rename.md
+++ b/docs/docs/cmd/spfx/project/project-rename.md
@@ -23,7 +23,7 @@ m365 spfx project rename [options]
 : JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 
 `-o, --output [output]`
-: Output type. `json,text,md`. Default `text`
+: Output type. `json,text,csv,md`. Default `json`
 
 `--verbose`
 : Runs command with verbose logging
@@ -32,7 +32,7 @@ m365 spfx project rename [options]
 : Runs command with debug logging
 
 !!! important
-    Run this command in the folder where the project that you want to rename is located.
+Run this command in the folder where the project that you want to rename is located.
 
 ## Remarks
 

--- a/docs/docs/cmd/spfx/spfx-doctor.md
+++ b/docs/docs/cmd/spfx/spfx-doctor.md
@@ -20,7 +20,7 @@ m365 spfx doctor [options]
 : JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 
 `-o, --output [output]`
-: Output type. `json,text,md`. Default `text`
+: Output type. `json,text,csv,md`. Default `json`
 
 `--verbose`
 : Runs command with verbose logging
@@ -29,7 +29,7 @@ m365 spfx doctor [options]
 : Runs command with debug logging
 
 !!! important
-    Checks ran by this command are based on what is officially supported by Microsoft. It's possible that using different package managers or packages versions will work just fine.
+Checks ran by this command are based on what is officially supported by Microsoft. It's possible that using different package managers or packages versions will work just fine.
 
 ## Remarks
 

--- a/docs/docs/user-guide/cli-output-mode.md
+++ b/docs/docs/user-guide/cli-output-mode.md
@@ -1,10 +1,10 @@
 # CLI for Microsoft 365 output mode
 
-CLI for Microsoft 365 commands can present their output either as plain-text or as JSON. Following is information on these two output modes along with information when to use which.
+CLI for Microsoft 365 commands can present their output either as plain-text, JSON, or as CSV. Following is information on these two output modes along with information when to use which.
 
 ## Choose the command output mode
 
-All commands in CLI for Microsoft 365 can present their output as plain-text or as JSON. By default, all commands use the JSON output mode, but by setting the `--output`, or `-o` for short, option to `text`, you can change the output mode for that command to text.
+All commands in CLI for Microsoft 365 can present their output as plain-text, JSON, or as CSV. By default, all commands use the JSON output mode, but by setting the `--output`, or `-o` for short, option to `text`, you can change the output mode for that command to text. By setting the output option to `csv`, you can change the output mode for that command to csv.
 
 ## JSON output mode
 
@@ -86,7 +86,7 @@ $ m365 spo app list -o json
 ```
 
 !!! tip
-    Some `list` commands return different output in text and JSON mode. For readability, in the text mode they only include a few properties, so that the output can be formatted as a table and will fit on the screen. In JSON mode however, they will include all available properties so that it's possible to process the full set of information about the particular object. For more details, refer to the help of the particular command.
+Some `list` commands return different output in text and JSON mode. For readability, in the text mode they only include a few properties, so that the output can be formatted as a table and will fit on the screen. In JSON mode however, they will include all available properties so that it's possible to process the full set of information about the particular object. For more details, refer to the help of the particular command.
 
 ### Verbose and debug output in JSON mode
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,6 +17,7 @@
         "applicationinsights": "^2.1.9",
         "axios": "^0.24.0",
         "chalk": "^4.1.2",
+        "csv-stringify": "^6.0.4",
         "easy-table": "^1.2.0",
         "inquirer": "^8.2.0",
         "jmespath": "^0.15.0",
@@ -1848,6 +1849,11 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.0.4.tgz",
+      "integrity": "sha512-Z3EbRQWwkOV3Qc2fQnJmfjrxRgAwH9AncnNK2jmtTvBvFjj/hESZUGm42YvTh9kMw2OOGPHQn5Yt0EbqoRtUVQ=="
     },
     "node_modules/d3-format": {
       "version": "1.4.5",
@@ -7675,6 +7681,11 @@
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         }
       }
+    },
+    "csv-stringify": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.0.4.tgz",
+      "integrity": "sha512-Z3EbRQWwkOV3Qc2fQnJmfjrxRgAwH9AncnNK2jmtTvBvFjj/hESZUGm42YvTh9kMw2OOGPHQn5Yt0EbqoRtUVQ=="
     },
     "d3-format": {
       "version": "1.4.5",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "applicationinsights": "^2.1.9",
     "axios": "^0.24.0",
     "chalk": "^4.1.2",
+    "csv-stringify": "^6.0.4",
     "easy-table": "^1.2.0",
     "inquirer": "^8.2.0",
     "jmespath": "^0.15.0",

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -848,6 +848,45 @@ describe('Cli', () => {
     }
   });
 
+  it('formats object with array as csv', (done) => {
+    const input = 
+    [{
+      "header1": "value1item1",
+      "header2": "value2item1"
+    },
+    {
+      "header1": "value1item2",
+      "header2": "value2item2"
+    }
+    ];
+    const expected = "header1,header2\nvalue1item1,value2item1\nvalue1item2,value2item2\n";
+    const actual = (Cli as any).formatOutput(input, { output: 'csv' });
+    try {
+      assert.strictEqual(actual, expected);
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
+  it('formats a simple object as csv', (done) => {
+    const input = 
+    {
+      "header1": "value1item1",
+      "header2": "value2item1"
+    };
+    const expected = "header1,header2\nvalue1item1,value2item1\n";
+    const actual = (Cli as any).formatOutput(input, { output: 'csv' });
+    try {
+      assert.strictEqual(actual, expected);
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
   it('formats simple output as text', (done) => {
     const o = false;
     const actual = (Cli as any).formatOutput(o, { output: 'text' });

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -491,11 +491,11 @@ export class Cli {
       return logStatement.join(os.EOL);
     }
 
-    // if output type has been set to 'text', process the retrieved
+    // if output type has been set to 'text' or 'csv', process the retrieved
     // data so that returned objects contain only default properties specified
     // on the current command. If there is no current command or the
     // command doesn't specify default properties, return original data
-    if (options.output === 'text') {
+    if (options.output === 'text' || options.ouptut === 'csv') {
       const cli: Cli = Cli.getInstance();
       const currentCommand: CommandInfo | undefined = cli.commandToExecute;
 
@@ -517,6 +517,23 @@ export class Cli {
             Utils.filterObject(s, currentCommand.defaultProperties as string[]));
         }
       }
+    }
+
+    if (options.output === 'csv') {
+      const { stringify } = require('csv-stringify/sync');
+
+      /* 
+        https://csv.js.org/stringify/options/
+        header: Display the column names on the first line if the columns option is provided or discovered.
+        escape: Single character used for escaping; only apply to characters matching the quote and the escape options default to ".
+        quote: The quote characters surrounding a field, defaults to the " (double quotation marks), an empty quote value will preserve the original field, whether it contains quotation marks or not.
+        quoted: Boolean, default to false, quote all the non-empty fields even if not required.
+        quotedEmpty: Quote empty strings and overrides quoted_string on empty strings when defined; default is false.
+      */
+
+      return stringify(logStatement, {
+        header: true
+      });
     }
 
     // display object as a list of key-value pairs


### PR DESCRIPTION
Hi,
in this version, I am implementing a simple way to output CSV using a third-party library ['csv-stringify'](https://csv.js.org/stringify/#:~:text=Run%20npm%20install%20csv%20to%20install%20the%20full,JavaScript%20features%20and%20run%20natively%20in%20Node%207.6%2B.).

By default, the CSV output has a header and the default settings specified [here](https://csv.js.org/stringify/options/). I had a discussion with @waldekmastykarz  about allowing users to configure the CSV output using our configuration file. I would suggest doing this as a separate issue once this feature is integrated.

On top of this, I added the new output mode in our documentation. I noticed that we still mentioned that the default output mode is text. I corrected also that part.

Cheers

