### PR TITLE
Adds `teams chat message list` command. Closes #2860 

### DIFF
--- a/docs/docs/cmd/teams/chat/chat-message-list.md
+++ b/docs/docs/cmd/teams/chat/chat-message-list.md
@@ -1,0 +1,25 @@
+# teams chat message list
+
+Lists all messages from a Microsoft Teams chat conversation.
+
+## Usage
+
+```sh
+m365 teams chat message list [options]
+```
+
+## Options
+
+`-i, --chatId <chatId>`
+: The ID of the chat conversation
+
+--8<-- "docs/cmd/_global.md"
+
+
+## Examples
+
+List the messages from a Microsoft Teams chat conversation
+
+```sh
+m365 teams chat message list --chatId 19:2da4c29f6d7041eca70b638b43d45437@thread.v2
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -515,6 +515,8 @@ nav:
         - channel list: 'cmd/teams/channel/channel-list.md'
         - channel remove: 'cmd/teams/channel/channel-remove.md'
         - channel set: 'cmd/teams/channel/channel-set.md'
+      - chat:        
+        - chat message list: 'cmd/teams/chat/chat-message-list.md'
       - conversationmember:
         - conversationmember add: 'cmd/teams/conversationmember/conversationmember-add.md'
         - conversationmember list: 'cmd/teams/conversationmember/conversationmember-list.md'

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -58,6 +58,12 @@ export default class Utils {
     return guidRegEx.test(guid);
   }
 
+  public static isValidTeamsChatId(guid: string): boolean {
+    const guidRegEx: RegExp = new RegExp(/^19:[0-9a-zA-Z-_]+(@thread\.v2|@unq\.gbl\.spaces)$/i);
+
+    return guidRegEx.test(guid);
+  }
+
   public static isValidUserPrincipalName(upn: string): boolean {
     const upnRegEx = new RegExp(/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/i);
 

--- a/src/m365/teams/commands.ts
+++ b/src/m365/teams/commands.ts
@@ -12,6 +12,7 @@ export default {
   CHANNEL_LIST: `${prefix} channel list`,
   CHANNEL_REMOVE: `${prefix} channel remove`,
   CHANNEL_SET: `${prefix} channel set`,
+  CHAT_MESSAGE_LIST: `${prefix} chat message list`,
   CONVERSATIONMEMBER_ADD: `${prefix} conversationmember add`,
   CONVERSATIONMEMBER_LIST: `${prefix} conversationmember list`,
   FUNSETTINGS_LIST: `${prefix} funsettings list`,

--- a/src/m365/teams/commands/chat/chat-message-list.spec.ts
+++ b/src/m365/teams/commands/chat/chat-message-list.spec.ts
@@ -59,7 +59,7 @@ describe(commands.CHAT_MESSAGE_LIST, () => {
   });
 
   it('defines correct properties for the default output', () => {
-    assert.deepStrictEqual(command.defaultProperties(), ['id', 'summary', 'body']);
+    assert.deepStrictEqual(command.defaultProperties(), ['id', 'shortBody']);
   });
 
   it('fails validation if chatId is not specified', () => {
@@ -381,6 +381,142 @@ describe(commands.CHAT_MESSAGE_LIST, () => {
       }
     });
   });
+
+
+  it('lists chat messages, with truncated shortbody property in text mode', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages`) {
+        return Promise.resolve({
+          value: [ { "id": "1616964509832", "replyToId": null, "etag": "1616964509832", "messageType": "message", "createdDateTime": "2021-03-28T20:48:29.832Z", "lastModifiedDateTime": "2021-03-28T20:48:29.832Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "text", "content": "Hello world" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615971548136", "replyToId": null, "etag": "1615971548136", "messageType": "message", "createdDateTime": "2021-03-17T08:59:08.136Z", "lastModifiedDateTime": "2021-03-17T08:59:08.136Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "html", "content": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615943825123", "replyToId": null, "etag": "1615943825123", "messageType": "unknownFutureValue", "createdDateTime": "2021-03-1706:47:05.123Z", "lastModifiedDateTime": "2021-03-1706:47:05.123Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "from": null, "body": { "contentType": "html", "content": "<systemEventMessage/>" }, "attachments": [], "mentions": [], "reactions": [], "eventDetail": { "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail", "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "chatDisplayName": "Graph Members", "initiator": { "application": null, "device": null, "user": { "id": "1fb8890f-423e-4154-8fbf-db6809bc8756", "displayName": null, "userIdentityType": "aadUser" } } } } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        output: "text",
+        chatId: "19:2da4c29f6d7041eca70b638b43d45437@thread.v2"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "id": "1616964509832",
+            "replyToId": null,
+            "etag": "1616964509832",
+            "messageType": "message",
+            "createdDateTime": "2021-03-28T20:48:29.832Z",
+            "lastModifiedDateTime": "2021-03-28T20:48:29.832Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "eventDetail": null,
+            "from": {
+              "application": null,
+              "device": null,
+              "user": {
+                "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+                "displayName": "Robin Kline",
+                "userIdentityType": "aadUser"
+              }
+            },
+            "body": "Hello world",
+            "shortBody": "Hello world",
+            "attachments": [],
+            "mentions": [],
+            "reactions": []
+          },
+          {
+            "id": "1615971548136",
+            "replyToId": null,
+            "etag": "1615971548136",
+            "messageType": "message",
+            "createdDateTime": "2021-03-17T08:59:08.136Z",
+            "lastModifiedDateTime": "2021-03-17T08:59:08.136Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "eventDetail": null,
+            "from": {
+              "application": null,
+              "device": null,
+              "user": {
+                "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+                "displayName": "Robin Kline",
+                "userIdentityType": "aadUser"
+              }
+            },
+            "body": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>",
+            "shortBody": "<div><div><div><span><img height=\"63\" src=\"https:/...",
+            "attachments": [],
+            "mentions": [],
+            "reactions": []
+          },
+          {
+            "id": "1615943825123",
+            "replyToId": null,
+            "etag": "1615943825123",
+            "messageType": "unknownFutureValue",
+            "createdDateTime": "2021-03-1706:47:05.123Z",
+            "lastModifiedDateTime": "2021-03-1706:47:05.123Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "from": null,
+            "body": "<systemEventMessage/>",
+            "shortBody": "<systemEventMessage/>",
+            "attachments": [],
+            "mentions": [],
+            "reactions": [],
+            "eventDetail": {
+              "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail",
+              "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+              "chatDisplayName": "Graph Members",
+              "initiator": {
+                "application": null,
+                "device": null,
+                "user": {
+                  "id": "1fb8890f-423e-4154-8fbf-db6809bc8756",
+                  "displayName": null,
+                  "userIdentityType": "aadUser"
+                }
+              }
+            }
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
 
   it('outputs all data in json output mode', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {

--- a/src/m365/teams/commands/chat/chat-message-list.spec.ts
+++ b/src/m365/teams/commands/chat/chat-message-list.spec.ts
@@ -1,0 +1,434 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import commands from '../../commands';
+const command: Command = require('./chat-message-list');
+
+describe(commands.CHAT_MESSAGE_LIST, () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      request.get
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.CHAT_MESSAGE_LIST), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['id', 'summary', 'body']);
+  });
+
+  it('fails validation if chatId is not specified', () => {
+    const actual = command.validate({
+      options: {
+        debug: false
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the chatId is not valid', () => {
+    const actual = command.validate({
+      options: {
+        chatId: "2da4c29f6d7041"
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  
+  it('fails validatation for an incorrect chatId missing leading 19:.', (done) => {
+    const actual = command.validate({
+      options: {
+        chatId: '2da4c29f6d7041eca70b638b43d45437@thread.v2'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation for an incorrect chatId missing trailing @thread.v2 or @unq.gbl.spaces', (done) => {
+    const actual = command.validate({
+      options: {
+        chatId: '19:2da4c29f6d7041eca70b638b43d45437'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('validates for a correct input', () => {
+    const actual = command.validate({
+      options: {
+        chatId: "19:2da4c29f6d7041eca70b638b43d45437@thread.v2"
+      }
+    });
+    assert.strictEqual(actual, true);
+  });
+
+  it('lists chat messages (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages`) {
+        return Promise.resolve({
+          "value": [ { "id": "1616964509832", "replyToId": null, "etag": "1616964509832", "messageType": "message", "createdDateTime": "2021-03-28T20:48:29.832Z", "lastModifiedDateTime": "2021-03-28T20:48:29.832Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "text", "content": "Hello world" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615971548136", "replyToId": null, "etag": "1615971548136", "messageType": "message", "createdDateTime": "2021-03-17T08:59:08.136Z", "lastModifiedDateTime": "2021-03-17T08:59:08.136Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "html", "content": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615943825123", "replyToId": null, "etag": "1615943825123", "messageType": "unknownFutureValue", "createdDateTime": "2021-03-1706:47:05.123Z", "lastModifiedDateTime": "2021-03-1706:47:05.123Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "from": null, "body": { "contentType": "html", "content": "<systemEventMessage/>" }, "attachments": [], "mentions": [], "reactions": [], "eventDetail": { "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail", "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "chatDisplayName": "Graph Members", "initiator": { "application": null, "device": null, "user": { "id": "1fb8890f-423e-4154-8fbf-db6809bc8756", "displayName": null, "userIdentityType": "aadUser" } } } } ]
+        });
+      }
+      
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        chatId: "19:2da4c29f6d7041eca70b638b43d45437@thread.v2"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "id": "1616964509832",
+            "replyToId": null,
+            "etag": "1616964509832",
+            "messageType": "message",
+            "createdDateTime": "2021-03-28T20:48:29.832Z",
+            "lastModifiedDateTime": "2021-03-28T20:48:29.832Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "eventDetail": null,
+            "from": {
+              "application": null,
+              "device": null,
+              "user": {
+                "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+                "displayName": "Robin Kline",
+                "userIdentityType": "aadUser"
+              }
+            },
+            "body": "Hello world",
+            "attachments": [],
+            "mentions": [],
+            "reactions": []
+          },
+          {
+            "id": "1615971548136",
+            "replyToId": null,
+            "etag": "1615971548136",
+            "messageType": "message",
+            "createdDateTime": "2021-03-17T08:59:08.136Z",
+            "lastModifiedDateTime": "2021-03-17T08:59:08.136Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "eventDetail": null,
+            "from": {
+              "application": null,
+              "device": null,
+              "user": {
+                "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+                "displayName": "Robin Kline",
+                "userIdentityType": "aadUser"
+              }
+            },
+            "body": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>",
+            "attachments": [],
+            "mentions": [],
+            "reactions": []
+          },
+          {
+            "id": "1615943825123",
+            "replyToId": null,
+            "etag": "1615943825123",
+            "messageType": "unknownFutureValue",
+            "createdDateTime": "2021-03-1706:47:05.123Z",
+            "lastModifiedDateTime": "2021-03-1706:47:05.123Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "from": null,
+            "body": "<systemEventMessage/>",
+            "attachments": [],
+            "mentions": [],
+            "reactions": [],
+            "eventDetail": {
+              "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail",
+              "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+              "chatDisplayName": "Graph Members",
+              "initiator": {
+                "application": null,
+                "device": null,
+                "user": {
+                  "id": "1fb8890f-423e-4154-8fbf-db6809bc8756",
+                  "displayName": null,
+                  "userIdentityType": "aadUser"
+                }
+              }
+            }
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('lists chat messages', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages`) {
+        return Promise.resolve({
+          value: [ { "id": "1616964509832", "replyToId": null, "etag": "1616964509832", "messageType": "message", "createdDateTime": "2021-03-28T20:48:29.832Z", "lastModifiedDateTime": "2021-03-28T20:48:29.832Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "text", "content": "Hello world" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615971548136", "replyToId": null, "etag": "1615971548136", "messageType": "message", "createdDateTime": "2021-03-17T08:59:08.136Z", "lastModifiedDateTime": "2021-03-17T08:59:08.136Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "html", "content": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615943825123", "replyToId": null, "etag": "1615943825123", "messageType": "unknownFutureValue", "createdDateTime": "2021-03-1706:47:05.123Z", "lastModifiedDateTime": "2021-03-1706:47:05.123Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "from": null, "body": { "contentType": "html", "content": "<systemEventMessage/>" }, "attachments": [], "mentions": [], "reactions": [], "eventDetail": { "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail", "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "chatDisplayName": "Graph Members", "initiator": { "application": null, "device": null, "user": { "id": "1fb8890f-423e-4154-8fbf-db6809bc8756", "displayName": null, "userIdentityType": "aadUser" } } } } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        chatId: "19:2da4c29f6d7041eca70b638b43d45437@thread.v2"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "id": "1616964509832",
+            "replyToId": null,
+            "etag": "1616964509832",
+            "messageType": "message",
+            "createdDateTime": "2021-03-28T20:48:29.832Z",
+            "lastModifiedDateTime": "2021-03-28T20:48:29.832Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "eventDetail": null,
+            "from": {
+              "application": null,
+              "device": null,
+              "user": {
+                "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+                "displayName": "Robin Kline",
+                "userIdentityType": "aadUser"
+              }
+            },
+            "body": "Hello world",
+            "attachments": [],
+            "mentions": [],
+            "reactions": []
+          },
+          {
+            "id": "1615971548136",
+            "replyToId": null,
+            "etag": "1615971548136",
+            "messageType": "message",
+            "createdDateTime": "2021-03-17T08:59:08.136Z",
+            "lastModifiedDateTime": "2021-03-17T08:59:08.136Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "eventDetail": null,
+            "from": {
+              "application": null,
+              "device": null,
+              "user": {
+                "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+                "displayName": "Robin Kline",
+                "userIdentityType": "aadUser"
+              }
+            },
+            "body": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>",
+            "attachments": [],
+            "mentions": [],
+            "reactions": []
+          },
+          {
+            "id": "1615943825123",
+            "replyToId": null,
+            "etag": "1615943825123",
+            "messageType": "unknownFutureValue",
+            "createdDateTime": "2021-03-1706:47:05.123Z",
+            "lastModifiedDateTime": "2021-03-1706:47:05.123Z",
+            "lastEditedDateTime": null,
+            "deletedDateTime": null,
+            "subject": null,
+            "summary": null,
+            "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+            "importance": "normal",
+            "locale": "en-us",
+            "webUrl": null,
+            "channelIdentity": null,
+            "policyViolation": null,
+            "from": null,
+            "body": "<systemEventMessage/>",
+            "attachments": [],
+            "mentions": [],
+            "reactions": [],
+            "eventDetail": {
+              "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail",
+              "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2",
+              "chatDisplayName": "Graph Members",
+              "initiator": {
+                "application": null,
+                "device": null,
+                "user": {
+                  "id": "1fb8890f-423e-4154-8fbf-db6809bc8756",
+                  "displayName": null,
+                  "userIdentityType": "aadUser"
+                }
+              }
+            }
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('outputs all data in json output mode', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages`) {
+        return Promise.resolve({
+          value: [ { "id": "1616964509832", "replyToId": null, "etag": "1616964509832", "messageType": "message", "createdDateTime": "2021-03-28T20:48:29.832Z", "lastModifiedDateTime": "2021-03-28T20:48:29.832Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "text", "content": "Hello world" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615971548136", "replyToId": null, "etag": "1615971548136", "messageType": "message", "createdDateTime": "2021-03-17T08:59:08.136Z", "lastModifiedDateTime": "2021-03-17T08:59:08.136Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "html", "content": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615943825123", "replyToId": null, "etag": "1615943825123", "messageType": "unknownFutureValue", "createdDateTime": "2021-03-1706:47:05.123Z", "lastModifiedDateTime": "2021-03-1706:47:05.123Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "from": null, "body": { "contentType": "html", "content": "<systemEventMessage/>" }, "attachments": [], "mentions": [], "reactions": [], "eventDetail": { "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail", "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "chatDisplayName": "Graph Members", "initiator": { "application": null, "device": null, "user": { "id": "1fb8890f-423e-4154-8fbf-db6809bc8756", "displayName": null, "userIdentityType": "aadUser" } } } } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        output: 'json',
+        chatId: "19:2da4c29f6d7041eca70b638b43d45437@thread.v2"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([ { "id": "1616964509832", "replyToId": null, "etag": "1616964509832", "messageType": "message", "createdDateTime": "2021-03-28T20:48:29.832Z", "lastModifiedDateTime": "2021-03-28T20:48:29.832Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "text", "content": "Hello world" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615971548136", "replyToId": null, "etag": "1615971548136", "messageType": "message", "createdDateTime": "2021-03-17T08:59:08.136Z", "lastModifiedDateTime": "2021-03-17T08:59:08.136Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "eventDetail": null, "from": { "application": null, "device": null, "user": { "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2", "displayName": "Robin Kline", "userIdentityType": "aadUser" } }, "body": { "contentType": "html", "content": "<div><div><div><span><img height=\"63\" src=\"https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1615971548136/hostedContents/aWQ9eF8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNix0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kOS1lNTRmNjM1NWYxYmJkNGQ3ZTNmNGJhZmU4NTI5MTBmNi92aWV3cy9pbWdv/$value\" width=\"67\" style=\"vertical-align:bottom; width:67px; height:63px\"></span></div></div></div>" }, "attachments": [], "mentions": [], "reactions": [] }, { "id": "1615943825123", "replyToId": null, "etag": "1615943825123", "messageType": "unknownFutureValue", "createdDateTime": "2021-03-1706:47:05.123Z", "lastModifiedDateTime": "2021-03-1706:47:05.123Z", "lastEditedDateTime": null, "deletedDateTime": null, "subject": null, "summary": null, "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "importance": "normal", "locale": "en-us", "webUrl": null, "channelIdentity": null, "policyViolation": null, "from": null, "body": { "contentType": "html", "content": "<systemEventMessage/>" }, "attachments": [], "mentions": [], "reactions": [], "eventDetail": { "@odata.type": "#microsoft.graph.chatRenamedEventMessageDetail", "chatId": "19:2da4c29f6d7041eca70b638b43d45437@thread.v2", "chatDisplayName": "Graph Members", "initiator": { "application": null, "device": null, "user": { "id": "1fb8890f-423e-4154-8fbf-db6809bc8756", "displayName": null, "userIdentityType": "aadUser" } } } } ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles error when listing messages', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.reject('An error has occurred');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        chatId: "19:2da4c29f6d7041eca70b638b43d45437@thread.v2"
+      }
+    } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/m365/teams/commands/chat/chat-message-list.ts
+++ b/src/m365/teams/commands/chat/chat-message-list.ts
@@ -1,0 +1,69 @@
+import { Logger } from '../../../../cli';
+import {
+  CommandOption
+} from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import Utils from '../../../../Utils';
+import { GraphItemsListCommand } from '../../../base/GraphItemsListCommand';
+import commands from '../../commands';
+import { Message } from '../../Message';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  chatId: string;
+}
+
+class TeamsChatMessageListCommand extends GraphItemsListCommand<Message> {
+  public get name(): string {
+    return commands.CHAT_MESSAGE_LIST;
+  }
+
+  public get description(): string {
+    return 'Lists all messages from a chat';
+  }
+
+  public defaultProperties(): string[] | undefined {
+    return ['id', 'summary', 'body'];
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    const endpoint: string = `${this.resource}/v1.0/chats/${args.options.chatId}/messages`;
+
+    this
+      .getAllItems(endpoint, logger, true)
+      .then((): void => {
+        if (args.options.output !== 'json') {
+          this.items.forEach(i => {
+            i.body = i.body.content as any;
+          });
+        }
+
+        logger.log(this.items);
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --chatId <chatId>'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    if (!Utils.isValidTeamsChatId(args.options.chatId)) {
+      return `${args.options.chatId} is not a valid Teams ChatId`;
+    }
+
+    return true;
+  }
+}
+
+module.exports = new TeamsChatMessageListCommand();

--- a/src/m365/teams/commands/chat/chat-message-list.ts
+++ b/src/m365/teams/commands/chat/chat-message-list.ts
@@ -6,7 +6,7 @@ import GlobalOptions from '../../../../GlobalOptions';
 import Utils from '../../../../Utils';
 import { GraphItemsListCommand } from '../../../base/GraphItemsListCommand';
 import commands from '../../commands';
-import { Message } from '../../Message';
+import { ItemBody } from '@microsoft/microsoft-graph-types';
 
 interface CommandArgs {
   options: Options;
@@ -16,7 +16,7 @@ interface Options extends GlobalOptions {
   chatId: string;
 }
 
-class TeamsChatMessageListCommand extends GraphItemsListCommand<Message> {
+class TeamsChatMessageListCommand extends GraphItemsListCommand<any> {
   public get name(): string {
     return commands.CHAT_MESSAGE_LIST;
   }
@@ -26,7 +26,7 @@ class TeamsChatMessageListCommand extends GraphItemsListCommand<Message> {
   }
 
   public defaultProperties(): string[] | undefined {
-    return ['id', 'summary', 'body'];
+    return ['id', 'shortBody'];
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
@@ -37,7 +37,27 @@ class TeamsChatMessageListCommand extends GraphItemsListCommand<Message> {
       .then((): void => {
         if (args.options.output !== 'json') {
           this.items.forEach(i => {
-            i.body = i.body.content as any;
+            i.body = (i.body as ItemBody).content;
+          });
+        }
+
+        if (args.options.output === 'text') {
+          this.items.forEach(i => {
+            let shortBody;
+            const bodyToProcess = i.body;
+
+            if (bodyToProcess) {
+              let maxLength = 50;
+              let addedDots = "...";
+              if (bodyToProcess.length < maxLength) {
+                maxLength = bodyToProcess.length;
+                addedDots = "";
+              }
+
+              shortBody = bodyToProcess.replace(/\n/g, ' ').substring(0, maxLength) + addedDots;
+            }
+
+            i.shortBody = shortBody;
           });
         }
 


### PR DESCRIPTION
# Added teams chat message list command
The new `teams chat message list` can be used to list all the messages in a chat conversation of the current user. The `chatId` or `conversationId` is necessary to execute this command. This chatId has two possible setups, depending on the chatType (oneOneOne VS group or meeting). The chatId is verified if it is in the correct format before executing the command.

This pull request Closes #2860.

This is my first contribution, I hope it's all good. Any feedback is warmly welcomed.

