### PR TITLE
Adds `teams chat list` command. Closes #2893

### DIFF
--- a/docs/docs/cmd/teams/chat/chat-list.md
+++ b/docs/docs/cmd/teams/chat/chat-list.md
@@ -1,0 +1,22 @@
+# teams chat list
+
+Lists all Microsoft Teams chat conversations for the current user.
+
+## Usage
+
+```sh
+m365 teams chat list [options]
+```
+
+## Options
+
+--8<-- "docs/cmd/_global.md"
+
+
+## Examples
+
+List the messages from a Microsoft Teams chat conversation
+
+```sh
+m365 teams chat list
+```

--- a/docs/docs/cmd/teams/chat/chat-list.md
+++ b/docs/docs/cmd/teams/chat/chat-list.md
@@ -10,13 +10,22 @@ m365 teams chat list [options]
 
 ## Options
 
+`-t, --type [chatType]`
+: The chat type to optionally filter chat conversations by type. The value can be `oneOnOne`, `group` or `meeting`.
+
 --8<-- "docs/cmd/_global.md"
 
 
 ## Examples
 
-List the messages from a Microsoft Teams chat conversation
+List all the Microsoft Teams chat conversations of the current user.
 
 ```sh
 m365 teams chat list
+```
+
+List only the one on one Microsoft Teams chat conversations.
+
+```sh
+m365 teams chat list --type oneOnOne
 ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -515,6 +515,8 @@ nav:
         - channel list: 'cmd/teams/channel/channel-list.md'
         - channel remove: 'cmd/teams/channel/channel-remove.md'
         - channel set: 'cmd/teams/channel/channel-set.md'
+      - chat:
+        - chat list: 'cmd/teams/chat/chat-list.md'
       - conversationmember:
         - conversationmember add: 'cmd/teams/conversationmember/conversationmember-add.md'
         - conversationmember list: 'cmd/teams/conversationmember/conversationmember-list.md'

--- a/src/m365/teams/commands.ts
+++ b/src/m365/teams/commands.ts
@@ -12,6 +12,7 @@ export default {
   CHANNEL_LIST: `${prefix} channel list`,
   CHANNEL_REMOVE: `${prefix} channel remove`,
   CHANNEL_SET: `${prefix} channel set`,
+  CHAT_LIST: `${prefix} chat list`,
   CONVERSATIONMEMBER_ADD: `${prefix} conversationmember add`,
   CONVERSATIONMEMBER_LIST: `${prefix} conversationmember list`,
   FUNSETTINGS_LIST: `${prefix} funsettings list`,

--- a/src/m365/teams/commands/chat/chat-list.spec.ts
+++ b/src/m365/teams/commands/chat/chat-list.spec.ts
@@ -1,0 +1,221 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import commands from '../../commands';
+const command: Command = require('./chat-list');
+
+describe(commands.CHAT_LIST, () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      request.get
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.CHAT_LIST), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['id', 'topic', 'chatType']);
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('lists chat conversations (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats`) {
+        return Promise.resolve({
+          "value": [ { "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2", "topic": "Meeting chat sample", "createdDateTime": "2020-12-08T23:53:05.801Z", "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z", "chatType": "meeting" }, { "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2", "topic": "Group chat sample", "createdDateTime": "2020-12-03T19:41:07.054Z", "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z", "chatType": "group" }, { "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces", "topic": null, "createdDateTime": "2020-12-04T23:10:28.51Z", "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z", "chatType": "oneOnOne" } ]
+        });
+      }
+      
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2",
+            "topic": "Meeting chat sample",
+            "createdDateTime": "2020-12-08T23:53:05.801Z",
+            "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z",
+            "chatType": "meeting"
+          },
+          {
+            "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2",
+            "topic": "Group chat sample",
+            "createdDateTime": "2020-12-03T19:41:07.054Z",
+            "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z",
+            "chatType": "group"
+          },
+          {
+            "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces",
+            "topic": null,
+            "createdDateTime": "2020-12-04T23:10:28.51Z",
+            "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z",
+            "chatType": "oneOnOne"
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('lists chat conversations', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats`) {
+        return Promise.resolve({
+          "value": [ { "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2", "topic": "Meeting chat sample", "createdDateTime": "2020-12-08T23:53:05.801Z", "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z", "chatType": "meeting" }, { "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2", "topic": "Group chat sample", "createdDateTime": "2020-12-03T19:41:07.054Z", "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z", "chatType": "group" }, { "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces", "topic": null, "createdDateTime": "2020-12-04T23:10:28.51Z", "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z", "chatType": "oneOnOne" } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2",
+            "topic": "Meeting chat sample",
+            "createdDateTime": "2020-12-08T23:53:05.801Z",
+            "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z",
+            "chatType": "meeting"
+          },
+          {
+            "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2",
+            "topic": "Group chat sample",
+            "createdDateTime": "2020-12-03T19:41:07.054Z",
+            "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z",
+            "chatType": "group"
+          },
+          {
+            "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces",
+            "topic": null,
+            "createdDateTime": "2020-12-04T23:10:28.51Z",
+            "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z",
+            "chatType": "oneOnOne"
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('outputs all data in json output mode', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats`) {
+        return Promise.resolve({
+          "value": [ { "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2", "topic": "Meeting chat sample", "createdDateTime": "2020-12-08T23:53:05.801Z", "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z", "chatType": "meeting" }, { "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2", "topic": "Group chat sample", "createdDateTime": "2020-12-03T19:41:07.054Z", "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z", "chatType": "group" }, { "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces", "topic": null, "createdDateTime": "2020-12-04T23:10:28.51Z", "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z", "chatType": "oneOnOne" } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        output: 'json'
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([ { "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2", "topic": "Meeting chat sample", "createdDateTime": "2020-12-08T23:53:05.801Z", "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z", "chatType": "meeting" }, { "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2", "topic": "Group chat sample", "createdDateTime": "2020-12-03T19:41:07.054Z", "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z", "chatType": "group" }, { "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces", "topic": null, "createdDateTime": "2020-12-04T23:10:28.51Z", "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z", "chatType": "oneOnOne" } ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles error when listing messages', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.reject('An error has occurred');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false
+      }
+    } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/m365/teams/commands/chat/chat-list.spec.ts
+++ b/src/m365/teams/commands/chat/chat-list.spec.ts
@@ -73,7 +73,52 @@ describe(commands.CHAT_LIST, () => {
     assert(containsOption);
   });
 
-  it('lists chat conversations (debug)', (done) => {
+  it('fails validation for an incorrect chatType.', (done) => {
+    const actual = command.validate({
+      options: {
+        type: 'oneOn'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('validates for a correct input without chat type', () => {
+    const actual = command.validate({
+      options: {        
+      }
+    });
+    assert.strictEqual(actual, true);
+  });
+  
+  it('validates for a correct input for oneOnOne chat conversations', () => {
+    const actual = command.validate({
+      options: {
+        type: "oneOnOne"
+      }
+    });
+    assert.strictEqual(actual, true);
+  });
+  
+  it('validates for a correct input for group chat conversations', () => {
+    const actual = command.validate({
+      options: {
+        type: "group"
+      }
+    });
+    assert.strictEqual(actual, true);
+  });
+  
+  it('validates for a correct input for meeting chat conversations', () => {
+    const actual = command.validate({
+      options: {
+        type: "meeting"
+      }
+    });
+    assert.strictEqual(actual, true);
+  });
+
+  it('lists all chat conversations (debug)', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/chats`) {
         return Promise.resolve({
@@ -122,7 +167,7 @@ describe(commands.CHAT_LIST, () => {
     });
   });
 
-  it('lists chat conversations', (done) => {
+  it('lists all chat conversations', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/chats`) {
         return Promise.resolve({
@@ -170,6 +215,115 @@ describe(commands.CHAT_LIST, () => {
       }
     });
   });
+  
+  it('lists oneOnOne chat conversations', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats?$filter=chatType eq 'oneOnOne'`) {
+        return Promise.resolve({
+          "value": [ { "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces", "topic": null, "createdDateTime": "2020-12-04T23:10:28.51Z", "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z", "chatType": "oneOnOne" } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        type: "oneOnOne"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([          
+          {
+            "id": "19:d74fc2ed-cb0e-4288-a219-b5c71abaf2aa_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces",
+            "topic": null,
+            "createdDateTime": "2020-12-04T23:10:28.51Z",
+            "lastUpdatedDateTime": "2020-12-04T23:10:36.925Z",
+            "chatType": "oneOnOne"
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('lists group chat conversations', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats?$filter=chatType eq 'group'`) {
+        return Promise.resolve({
+          "value": [ { "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2", "topic": "Group chat sample", "createdDateTime": "2020-12-03T19:41:07.054Z", "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z", "chatType": "group" } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        type: "group"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "id": "19:561082c0f3f847a58069deb8eb300807@thread.v2",
+            "topic": "Group chat sample",
+            "createdDateTime": "2020-12-03T19:41:07.054Z",
+            "lastUpdatedDateTime": "2020-12-08T23:53:11.012Z",
+            "chatType": "group"
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+  
+  it('lists meeting chat conversations', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats?$filter=chatType eq 'meeting'`) {
+        return Promise.resolve({
+          "value": [ { "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2", "topic": "Meeting chat sample", "createdDateTime": "2020-12-08T23:53:05.801Z", "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z", "chatType": "meeting" } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        type: "meeting"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "id": "19:meeting_MjdhNjM4YzUtYzExZi00OTFkLTkzZTAtNTVlNmZmMDhkNGU2@thread.v2",
+            "topic": "Meeting chat sample",
+            "createdDateTime": "2020-12-08T23:53:05.801Z",
+            "lastUpdatedDateTime": "2020-12-08T23:58:32.511Z",
+            "chatType": "meeting"
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
 
   it('outputs all data in json output mode', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {

--- a/src/m365/teams/commands/chat/chat-list.spec.ts
+++ b/src/m365/teams/commands/chat/chat-list.spec.ts
@@ -199,7 +199,7 @@ describe(commands.CHAT_LIST, () => {
     });
   });
 
-  it('correctly handles error when listing messages', (done) => {
+  it('correctly handles error when listing chat conversations', (done) => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject('An error has occurred');
     });

--- a/src/m365/teams/commands/chat/chat-list.ts
+++ b/src/m365/teams/commands/chat/chat-list.ts
@@ -5,7 +5,6 @@ import {
 import GlobalOptions from '../../../../GlobalOptions';
 import { GraphItemsListCommand } from '../../../base/GraphItemsListCommand';
 import commands from '../../commands';
-import { Message } from '../../Message';
 
 interface CommandArgs {
   options: Options;
@@ -15,7 +14,7 @@ interface Options extends GlobalOptions {
   chatId: string;
 }
 
-class TeamsChatListCommand extends GraphItemsListCommand<Message> {
+class TeamsChatListCommand extends GraphItemsListCommand<any> {
   public get name(): string {
     return commands.CHAT_LIST;
   }

--- a/src/m365/teams/commands/chat/chat-list.ts
+++ b/src/m365/teams/commands/chat/chat-list.ts
@@ -1,0 +1,49 @@
+import { Logger } from '../../../../cli';
+import {
+  CommandOption
+} from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import { GraphItemsListCommand } from '../../../base/GraphItemsListCommand';
+import commands from '../../commands';
+import { Message } from '../../Message';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  chatId: string;
+}
+
+class TeamsChatListCommand extends GraphItemsListCommand<Message> {
+  public get name(): string {
+    return commands.CHAT_LIST;
+  }
+
+  public get description(): string {
+    return 'Lists all chat conversations';
+  }
+
+  public defaultProperties(): string[] | undefined {
+    return ['id', 'topic', 'chatType'];
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    const endpoint: string = `${this.resource}/v1.0/chats`;
+
+    this
+      .getAllItems(endpoint, logger, true)
+      .then((): void => {
+        logger.log(this.items);
+        
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public options(): CommandOption[] {    
+    const parentOptions: CommandOption[] = super.options();
+    return parentOptions;
+  }
+}
+
+module.exports = new TeamsChatListCommand();


### PR DESCRIPTION
# Added teams chat list command

The new teams chat list command can be used to list all the chat conversations of the current user. There are no specific options necessary to execute this command. The command returns the basic list of chat conversations *without* the members expanded of the [MS example](https://docs.microsoft.com/en-us/graph/api/chat-list?view=graph-rest-1.0&tabs=http#example-2-list-all-chats-along-with-the-members-of-each-chat). 

This pull request Closes #2893.

I've been a bit fast on this, as the issue is still in state 'New'. I'm OK to wait for more discussion if nececssary. But I had time on my hands, so I thought: let's just do it.

## Azure AD permissions
The Azure AD permissions of the PnP App need to be updated, just like issue #2860, adding `Chat.BasicRead`, `Chat.Read` or `Chat.ReadWrite` would all be okay. `Chat.BasicRead` is not enough for issue 2860 though.