### PR TITLE
Fixes 'teams message get' command. Closes #2678

### DIFF
--- a/docs/docs/cmd/teams/message/message-get.md
+++ b/docs/docs/cmd/teams/message/message-get.md
@@ -23,9 +23,6 @@ m365 teams message get [options]
 
 ## Remarks
 
-!!! attention
-    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
-
 You can only retrieve a message from a Microsoft Teams team if you are a member of that team.
 
 ## Examples

--- a/src/m365/teams/commands/message/message-get.spec.ts
+++ b/src/m365/teams/commands/message/message-get.spec.ts
@@ -137,7 +137,7 @@ describe(commands.MESSAGE_GET, () => {
 
   it('retrieves the specified message (debug)', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/teams/5f5d7b71-1161-44d8-bcc1-3da710eb4171/channels/19:88f7e66a8dfe42be92db19505ae912a8@thread.skype/messages/1540911392778`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/5f5d7b71-1161-44d8-bcc1-3da710eb4171/channels/19:88f7e66a8dfe42be92db19505ae912a8@thread.skype/messages/1540911392778`) {
         return Promise.resolve({
           attachments: [],
           body: { "contentType": "text", "content": "Konnichiwa" },
@@ -200,7 +200,7 @@ describe(commands.MESSAGE_GET, () => {
 
   it('retrieves the specified message', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/teams/5f5d7b71-1161-44d8-bcc1-3da710eb4171/channels/19:88f7e66a8dfe42be92db19505ae912a8@thread.skype/messages/1540911392778`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/5f5d7b71-1161-44d8-bcc1-3da710eb4171/channels/19:88f7e66a8dfe42be92db19505ae912a8@thread.skype/messages/1540911392778`) {
         return Promise.resolve({
           attachments: [],
           body: { "contentType": "text", "content": "Konnichiwa" },

--- a/src/m365/teams/commands/message/message-get.ts
+++ b/src/m365/teams/commands/message/message-get.ts
@@ -29,7 +29,7 @@ class TeamsMessageGetCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     const requestOptions: any = {
-      url: `${this.resource}/beta/teams/${args.options.teamId}/channels/${args.options.channelId}/messages/${args.options.messageId}`,
+      url: `${this.resource}/v1.0/teams/${args.options.teamId}/channels/${args.options.channelId}/messages/${args.options.messageId}`,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },


### PR DESCRIPTION
Fixes `teams message get` command. Closes #2678
Use the v1.0/teams endpoint.