### PR TITLE
Adds teams chat member list command. Closes #2896

### DIFF
--- a/docs/docs/cmd/teams/chat/chat-member-list.md
+++ b/docs/docs/cmd/teams/chat/chat-member-list.md
@@ -1,0 +1,25 @@
+# teams chat member list
+
+Lists all members from a Microsoft Teams chat conversation.
+
+## Usage
+
+```sh
+m365 teams chat member list [options]
+```
+
+## Options
+
+`-i, --chatId <chatId>`
+: The ID of the chat conversation
+
+--8<-- "docs/cmd/_global.md"
+
+
+## Examples
+
+List the members from a Microsoft Teams chat conversation
+
+```sh
+m365 teams chat member list --chatId 19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -515,6 +515,8 @@ nav:
         - channel list: 'cmd/teams/channel/channel-list.md'
         - channel remove: 'cmd/teams/channel/channel-remove.md'
         - channel set: 'cmd/teams/channel/channel-set.md'
+      - chat:
+        - chat member list: 'cmd/teams/chat/chat-member-list.md'
       - conversationmember:
         - conversationmember add: 'cmd/teams/conversationmember/conversationmember-add.md'
         - conversationmember list: 'cmd/teams/conversationmember/conversationmember-list.md'

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -58,6 +58,12 @@ export default class Utils {
     return guidRegEx.test(guid);
   }
 
+  public static isValidTeamsChatId(guid: string): boolean {
+    const guidRegEx: RegExp = new RegExp(/^19:[0-9a-zA-Z-_]+(@thread\.v2|@unq\.gbl\.spaces)$/i);
+
+    return guidRegEx.test(guid);
+  }
+
   public static isValidUserPrincipalName(upn: string): boolean {
     const upnRegEx = new RegExp(/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/i);
 

--- a/src/m365/teams/commands.ts
+++ b/src/m365/teams/commands.ts
@@ -12,6 +12,7 @@ export default {
   CHANNEL_LIST: `${prefix} channel list`,
   CHANNEL_REMOVE: `${prefix} channel remove`,
   CHANNEL_SET: `${prefix} channel set`,
+  CHAT_MEMBER_LIST: `${prefix} chat member list`,
   CONVERSATIONMEMBER_ADD: `${prefix} conversationmember add`,
   CONVERSATIONMEMBER_LIST: `${prefix} conversationmember list`,
   FUNSETTINGS_LIST: `${prefix} funsettings list`,

--- a/src/m365/teams/commands/chat/chat-member-list.spec.ts
+++ b/src/m365/teams/commands/chat/chat-member-list.spec.ts
@@ -1,0 +1,304 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import commands from '../../commands';
+const command: Command = require('./chat-member-list');
+
+describe(commands.CHAT_MEMBER_LIST, () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      request.get
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.CHAT_MEMBER_LIST), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['userId', 'displayName', 'tenantId']);
+  });
+
+  it('fails validation if chatId is not specified', () => {
+    const actual = command.validate({
+      options: {
+        debug: false
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the chatId is not valid', () => {
+    const actual = command.validate({
+      options: {
+        chatId: "8b081ef6"
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  
+  it('fails validatation for an incorrect chatId missing leading 19:.', (done) => {
+    const actual = command.validate({
+      options: {
+        chatId: '8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation for an incorrect chatId missing trailing @thread.v2 or @unq.gbl.spaces', (done) => {
+    const actual = command.validate({
+      options: {
+        chatId: '19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('validates for a correct input', () => {
+    const actual = command.validate({
+      options: {
+        chatId: "19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces"
+      }
+    });
+    assert.strictEqual(actual, true);
+  });
+
+  it('lists chat members (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats/19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces/members`) {
+        return Promise.resolve({
+          "value":[ { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"8b081ef6-4792-4def-b2c9-c363a1bf41d5", "roles":[ "owner" ], "displayName":"John Doe", "userId":"8b081ef6-4792-4def-b2c9-c363a1bf41d5", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z" }, { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"2de87aaf-844d-4def-9dee-2c317f0be1b3", "roles":[ "owner" ], "displayName":"Bart Hogan", "userId":"2de87aaf-844d-4def-9dee-2c317f0be1b3", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"0001-01-01T00:00:00Z" }, { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"07ad17ad-ada5-4f1f-a650-7a963886a8a7", "roles":[ "owner" ], "displayName":"Minna Pham", "userId":"07ad17ad-ada5-4f1f-a650-7a963886a8a7", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z" } ]
+        });
+      }
+      
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        chatId: "19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "@odata.type":"#microsoft.graph.aadUserConversationMember",
+            "id":"8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+            "roles":[
+              "owner"
+            ],
+            "displayName":"John Doe",
+            "userId":"8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+            "email":null,
+            "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb",
+            "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z"
+          },
+          {
+            "@odata.type":"#microsoft.graph.aadUserConversationMember",
+            "id":"2de87aaf-844d-4def-9dee-2c317f0be1b3",
+            "roles":[
+              "owner"
+            ],
+            "displayName":"Bart Hogan",
+            "userId":"2de87aaf-844d-4def-9dee-2c317f0be1b3",
+            "email":null,
+            "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb",
+            "visibleHistoryStartDateTime":"0001-01-01T00:00:00Z"
+          },
+          {
+            "@odata.type":"#microsoft.graph.aadUserConversationMember",
+            "id":"07ad17ad-ada5-4f1f-a650-7a963886a8a7",
+            "roles":[
+              "owner"
+            ],
+            "displayName":"Minna Pham",
+            "userId":"07ad17ad-ada5-4f1f-a650-7a963886a8a7",
+            "email":null,
+            "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb",
+            "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z"
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('lists chat members', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats/19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces/members`) {
+        return Promise.resolve({
+          "value":[ { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"8b081ef6-4792-4def-b2c9-c363a1bf41d5", "roles":[ "owner" ], "displayName":"John Doe", "userId":"8b081ef6-4792-4def-b2c9-c363a1bf41d5", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z" }, { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"2de87aaf-844d-4def-9dee-2c317f0be1b3", "roles":[ "owner" ], "displayName":"Bart Hogan", "userId":"2de87aaf-844d-4def-9dee-2c317f0be1b3", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"0001-01-01T00:00:00Z" }, { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"07ad17ad-ada5-4f1f-a650-7a963886a8a7", "roles":[ "owner" ], "displayName":"Minna Pham", "userId":"07ad17ad-ada5-4f1f-a650-7a963886a8a7", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z" } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        chatId: "19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "@odata.type":"#microsoft.graph.aadUserConversationMember",
+            "id":"8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+            "roles":[
+              "owner"
+            ],
+            "displayName":"John Doe",
+            "userId":"8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+            "email":null,
+            "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb",
+            "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z"
+          },
+          {
+            "@odata.type":"#microsoft.graph.aadUserConversationMember",
+            "id":"2de87aaf-844d-4def-9dee-2c317f0be1b3",
+            "roles":[
+              "owner"
+            ],
+            "displayName":"Bart Hogan",
+            "userId":"2de87aaf-844d-4def-9dee-2c317f0be1b3",
+            "email":null,
+            "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb",
+            "visibleHistoryStartDateTime":"0001-01-01T00:00:00Z"
+          },
+          {
+            "@odata.type":"#microsoft.graph.aadUserConversationMember",
+            "id":"07ad17ad-ada5-4f1f-a650-7a963886a8a7",
+            "roles":[
+              "owner"
+            ],
+            "displayName":"Minna Pham",
+            "userId":"07ad17ad-ada5-4f1f-a650-7a963886a8a7",
+            "email":null,
+            "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb",
+            "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z"
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('outputs all data in json output mode', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/chats/19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces/members`) {
+        return Promise.resolve({
+          "value":[ { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"8b081ef6-4792-4def-b2c9-c363a1bf41d5", "roles":[ "owner" ], "displayName":"John Doe", "userId":"8b081ef6-4792-4def-b2c9-c363a1bf41d5", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z" }, { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"2de87aaf-844d-4def-9dee-2c317f0be1b3", "roles":[ "owner" ], "displayName":"Bart Hogan", "userId":"2de87aaf-844d-4def-9dee-2c317f0be1b3", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"0001-01-01T00:00:00Z" }, { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"07ad17ad-ada5-4f1f-a650-7a963886a8a7", "roles":[ "owner" ], "displayName":"Minna Pham", "userId":"07ad17ad-ada5-4f1f-a650-7a963886a8a7", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z" } ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        output: 'json',
+        chatId: "19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([ { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"8b081ef6-4792-4def-b2c9-c363a1bf41d5", "roles":[ "owner" ], "displayName":"John Doe", "userId":"8b081ef6-4792-4def-b2c9-c363a1bf41d5", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z" }, { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"2de87aaf-844d-4def-9dee-2c317f0be1b3", "roles":[ "owner" ], "displayName":"Bart Hogan", "userId":"2de87aaf-844d-4def-9dee-2c317f0be1b3", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"0001-01-01T00:00:00Z" }, { "@odata.type":"#microsoft.graph.aadUserConversationMember", "id":"07ad17ad-ada5-4f1f-a650-7a963886a8a7", "roles":[ "owner" ], "displayName":"Minna Pham", "userId":"07ad17ad-ada5-4f1f-a650-7a963886a8a7", "email":null, "tenantId":"6e5147da-6a35-4275-b3f3-fc069456b6eb", "visibleHistoryStartDateTime":"2019-04-18T23:51:43.255Z" } ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles error when listing members', (done) => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.reject('An error has occurred');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        chatId: "19:8b081ef6-4792-4def-b2c9-c363a1bf41d5_5031bb31-22c0-4f6f-9f73-91d34ab2b32d@unq.gbl.spaces"
+      }
+    } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/m365/teams/commands/chat/chat-member-list.spec.ts
+++ b/src/m365/teams/commands/chat/chat-member-list.spec.ts
@@ -59,7 +59,7 @@ describe(commands.CHAT_MEMBER_LIST, () => {
   });
 
   it('defines correct properties for the default output', () => {
-    assert.deepStrictEqual(command.defaultProperties(), ['userId', 'displayName', 'tenantId']);
+    assert.deepStrictEqual(command.defaultProperties(), ['userId', 'displayName', 'email']);
   });
 
   it('fails validation if chatId is not specified', () => {

--- a/src/m365/teams/commands/chat/chat-member-list.ts
+++ b/src/m365/teams/commands/chat/chat-member-list.ts
@@ -25,7 +25,7 @@ class TeamsChatMemberListCommand extends GraphItemsListCommand<any> {
   }
 
   public defaultProperties(): string[] | undefined {
-    return ['userId', 'displayName', 'tenantId'];
+    return ['userId', 'displayName', 'email'];
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
@@ -34,7 +34,6 @@ class TeamsChatMemberListCommand extends GraphItemsListCommand<any> {
     this
       .getAllItems(endpoint, logger, true)
       .then((): void => {
-        
         logger.log(this.items);
         cb();
       }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));

--- a/src/m365/teams/commands/chat/chat-member-list.ts
+++ b/src/m365/teams/commands/chat/chat-member-list.ts
@@ -1,0 +1,63 @@
+import { Logger } from '../../../../cli';
+import {
+  CommandOption
+} from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import Utils from '../../../../Utils';
+import { GraphItemsListCommand } from '../../../base/GraphItemsListCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  chatId: string;
+}
+
+class TeamsChatMemberListCommand extends GraphItemsListCommand<any> {
+  public get name(): string {
+    return commands.CHAT_MEMBER_LIST;
+  }
+
+  public get description(): string {
+    return 'Lists all members from a chat';
+  }
+
+  public defaultProperties(): string[] | undefined {
+    return ['userId', 'displayName', 'tenantId'];
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    const endpoint: string = `${this.resource}/v1.0/chats/${args.options.chatId}/members`;
+
+    this
+      .getAllItems(endpoint, logger, true)
+      .then((): void => {
+        
+        logger.log(this.items);
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --chatId <chatId>'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    if (!Utils.isValidTeamsChatId(args.options.chatId)) {
+      return `${args.options.chatId} is not a valid Teams ChatId`;
+    }
+
+    return true;
+  }
+}
+
+module.exports = new TeamsChatMemberListCommand();


### PR DESCRIPTION
# Added teams chat member list command

The new teams chat member list command can be used to list all the members of a specific chat conversations of the current user. You need a chatId / conversationId option to execute this command. The command returns the basic list of chat members. 

This pull request Closes #2896.

## Azure AD permissions
The Azure AD permissions of the PnP App need to be updated, just like issue #2860 and #2893, adding `ChatMember.Read`, `ChatMember.ReadWrite`, `Chat.ReadBasic`, `Chat.Read` or `Chat.ReadWrite` would all be okay. `Chat.ReadBasic` is not enough for issue 2860 though.
I propose we add `Chat.Read` to encompass all three new commands in one permission.


> Note: I added a shared util function to validate the chatId in this pull request. I also added the same function in issue #2860. As I'm basing both branches on main, this will probably cause a merge conflict after merging 2860 before this one.