### PR TITLE
2901 - Configure csv output settings with m365 cli config set command

### DIFF
--- a/docs/docs/_clisettings.md
+++ b/docs/docs/_clisettings.md
@@ -8,3 +8,8 @@ Setting name|Definition|Default value
 `output`|Defines the default output when issuing a command|`json`
 `printErrorsAsPlainText`|When output mode is set to `json`, print error messages as plain-text rather than JSON|`true`
 `showHelpOnFailure`|Automatically display help when executing a command failed|`true`
+`csvHeader`|Display the column names on the first line|`true`
+`csvEscape`|Single character used for escaping; only apply to characters matching the quote and the escape options|`"`
+`csvQuote`|The quote characters surrounding a field. An empty quote value will preserve the original field, whether it contains quotation marks or not.|` `
+`csvQuoted`|Quote all the non-empty fields even if not required|`false`
+`csvQuotedEmpty`|Quote empty strings and overrides quoted_string on empty strings when defined	|`false`

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -13,6 +13,7 @@ import AnonymousCommand from '../m365/base/AnonymousCommand';
 import Utils from '../Utils';
 import { Logger } from './Logger';
 import Table = require('easy-table');
+import { settingsNames } from '../settingsNames';
 const packageJSON = require('../../package.json');
 
 class MockCommand extends AnonymousCommand {
@@ -207,7 +208,8 @@ describe('Cli', () => {
       (Cli as any).formatOutput,
       process.exit,
       markshell.toRawContent,
-      appInsights.trackEvent
+      appInsights.trackEvent,
+      cli.getSettingWithDefaultValue
     ]);
   });
 
@@ -863,6 +865,108 @@ describe('Cli', () => {
       "header2": "value2item1"
     };
     const expected = "header1,header2\nvalue1item1,value2item1\n";
+    const actual = (Cli as any).formatOutput(input, { output: 'csv' });
+    try {
+      assert.strictEqual(actual, expected);
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
+  it('does not produce headers when csvHeader config is set to false ', (done) => {
+    const input = 
+    {
+      "header1": "value1item1",
+      "header2": "value2item1"
+    };
+    sinon.stub(Cli.getInstance(),'getSettingWithDefaultValue').callsFake((settingName,defaultValue) =>{
+      if(settingName === settingsNames.csvHeader){
+        return false;
+      }
+      return defaultValue;
+    });
+
+    const expected = "value1item1,value2item1\n";
+    const actual = (Cli as any).formatOutput(input, { output: 'csv' });
+    try {
+      assert.strictEqual(actual, expected);
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
+  it('quotes all non-empty fields even if not required when csvQuoted config is set to true', (done) => {
+    const input = 
+    {
+      "header1": "value1item1",
+      "header2": "value2item1"
+    };
+    sinon.stub(Cli.getInstance(),'getSettingWithDefaultValue').callsFake((settingName,defaultValue) =>{
+      if(settingName === settingsNames.csvQuoted){
+        return true;
+      }
+      return defaultValue;
+    });
+
+    const expected = "\"header1\",\"header2\"\n\"value1item1\",\"value2item1\"\n";
+    const actual = (Cli as any).formatOutput(input, { output: 'csv' });
+    try {
+      assert.strictEqual(actual, expected);
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
+  it('quotes all empty fields if csvQuotedEmpty config is set to true', (done) => {
+    const input = 
+    {
+      "header1": "value1item1",
+      "header2": ""
+    };
+    sinon.stub(Cli.getInstance(),'getSettingWithDefaultValue').callsFake((settingName,defaultValue) =>{
+      if(settingName === settingsNames.csvQuotedEmpty){
+        return true;
+      }
+      return defaultValue;
+    });
+
+    const expected = "header1,header2\nvalue1item1,\"\"\n";
+    const actual = (Cli as any).formatOutput(input, { output: 'csv' });
+    try {
+      assert.strictEqual(actual, expected);
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
+  });
+
+  it('quotes all fields with character set in csvQuote config', (done) => {
+    const input = 
+    {
+      "header1": "value1item1",
+      "header2": "value2item1"
+    };
+    sinon.stub(Cli.getInstance(),'getSettingWithDefaultValue').callsFake((settingName,defaultValue) =>{
+      if(settingName === settingsNames.csvQuoted){
+        return true;
+      }
+      return defaultValue;
+    });
+    sinon.stub(Cli.getInstance().config,'get').callsFake((settingName) =>{
+      if(settingName === settingsNames.csvQuote){
+        return "_";
+      }
+      return null;
+    });
+
+    const expected = "_header1_,_header2_\n_value1item1_,_value2item1_\n";
     const actual = (Cli as any).formatOutput(input, { output: 'csv' });
     try {
       assert.strictEqual(actual, expected);

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -528,17 +528,13 @@ export class Cli {
     if (options.output === 'csv') {
       const { stringify } = require('csv-stringify/sync');
 
-      /* 
-        https://csv.js.org/stringify/options/
-        header: Display the column names on the first line if the columns option is provided or discovered.
-        escape: Single character used for escaping; only apply to characters matching the quote and the escape options default to ".
-        quote: The quote characters surrounding a field, defaults to the " (double quotation marks), an empty quote value will preserve the original field, whether it contains quotation marks or not.
-        quoted: Boolean, default to false, quote all the non-empty fields even if not required.
-        quotedEmpty: Quote empty strings and overrides quoted_string on empty strings when defined; default is false.
-      */
-
+      // https://csv.js.org/stringify/options/
       return stringify(logStatement, {
-        header: true
+        header:Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.csvHeader, true),
+        escape:Cli.getInstance().getSettingWithDefaultValue(settingsNames.csvEscape, "\""),
+        quote:Cli.getInstance().config.get(settingsNames.csvQuote),
+        quoted:Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.csvQuoted, false),
+        quotedEmpty:Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.csvQuotedEmpty, false)
       });
     }
 

--- a/src/m365/cli/commands/config/config-set.spec.ts
+++ b/src/m365/cli/commands/config/config-set.spec.ts
@@ -30,6 +30,10 @@ describe(commands.CONFIG_SET, () => {
     Utils.restore(Cli.getInstance().config.set);
   });
 
+  afterEach(() =>{
+    Utils.restore(Cli.getInstance().config.set);
+  });
+
   it('has correct name', () => {
     assert.strictEqual(command.name.startsWith(commands.CONFIG_SET), true);
   });
@@ -101,6 +105,86 @@ describe(commands.CONFIG_SET, () => {
     });
   });
 
+  it(`sets ${settingsNames.output} property to 'csv'`, (done) => {
+    const output = "csv";
+    const config = Cli.getInstance().config;
+    let actualKey: string, actualValue: any;
+    sinon.restore();
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+
+    command.action(logger, { options: { key: settingsNames.output, value: output } }, () => {
+      try {
+        assert.strictEqual(actualKey, settingsNames.output, 'Invalid key');
+        assert.strictEqual(actualValue, output, 'Invalid value');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`sets ${settingsNames.csvHeader} property`, (done) => {
+    const config = Cli.getInstance().config;
+    let actualKey: string, actualValue: any;
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+    command.action(logger, { options: { key: settingsNames.csvHeader, value: false } }, () => {
+      try {
+        assert.strictEqual(actualKey, settingsNames.csvHeader, 'Invalid key');
+        assert.strictEqual(actualValue, false, 'Invalid value');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`sets ${settingsNames.csvQuoted} property`, (done) => {
+    const config = Cli.getInstance().config;
+    let actualKey: string, actualValue: any;
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+    command.action(logger, { options: { key: settingsNames.csvQuoted, value: false } }, () => {
+      try {
+        assert.strictEqual(actualKey, settingsNames.csvQuoted, 'Invalid key');
+        assert.strictEqual(actualValue, false, 'Invalid value');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`sets ${settingsNames.csvQuotedEmpty} property`, (done) => {
+    const config = Cli.getInstance().config;
+    let actualKey: string, actualValue: any;
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+    command.action(logger, { options: { key: settingsNames.csvQuotedEmpty, value: false } }, () => {
+      try {
+        assert.strictEqual(actualKey, settingsNames.csvQuotedEmpty, 'Invalid key');
+        assert.strictEqual(actualValue, false, 'Invalid value');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
   it('supports specifying key and value', () => {
     const options = command.options();
     let containsOptionKey = false;
@@ -144,6 +228,11 @@ describe(commands.CONFIG_SET, () => {
 
   it('passes validation for output type json', () => {
     const actual = command.validate({ options: { key: settingsNames.output, value: 'json' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation for output type csv', () => {
+    const actual = command.validate({ options: { key: settingsNames.output, value: 'csv' } });
     assert.strictEqual(actual, true);
   });
 

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -37,6 +37,9 @@ class CliConfigSetCommand extends AnonymousCommand {
     switch (args.options.key) {
       case settingsNames.showHelpOnFailure:
       case settingsNames.printErrorsAsPlainText:
+      case settingsNames.csvHeader:
+      case settingsNames.csvQuoted:
+      case settingsNames.csvQuotedEmpty:
         value = args.options.value === 'true';
         break;
       default:
@@ -68,7 +71,7 @@ class CliConfigSetCommand extends AnonymousCommand {
       return `${args.options.key} is not a valid setting. Allowed values: ${CliConfigSetCommand.optionNames.join(', ')}`;
     }
 
-    const allowedOutputs = ['text', 'json'];
+    const allowedOutputs = ['text', 'json', 'csv'];
     if (args.options.key === settingsNames.output &&
       allowedOutputs.indexOf(args.options.value) === -1) {
       return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${allowedOutputs.join(', ')}`;

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -2,7 +2,12 @@ const settingsNames = {
   errorOutput: 'errorOutput',
   output: 'output',
   printErrorsAsPlainText: 'printErrorsAsPlainText',
-  showHelpOnFailure: 'showHelpOnFailure'
+  showHelpOnFailure: 'showHelpOnFailure',
+  csvHeader:'csvHeader',
+  csvEscape:'csvEscape',
+  csvQuote:'csvQuote',
+  csvQuoted:'csvQuoted',
+  csvQuotedEmpty:'csvQuotedEmpty'
 };
 
 export { settingsNames };


### PR DESCRIPTION
> ### 2901 - Configure csv output settings with m365 cli config set command
> - Adds the capability to configure CSV output settings in m365 cli config. Closes #2901 
> - Fixes the issue of being unable to configure 'csv' output mode in the m365 cli config.

