### PR TITLE
Adds `m365 tenant serviceannouncement message get` command. Closes #2952

### DIFF
--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-message-get.md
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-message-get.md
@@ -1,0 +1,28 @@
+# tenant serviceannouncement message get
+
+Retrieves a specified service update message for the tenant
+
+## Usage
+
+```sh
+m365 tenant serviceannouncement message get [options]
+```
+
+## Options
+
+`-i, --id <id>`
+: The ID of the service update message.
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Get service update message with ID MC001337
+
+```sh
+m365 tenant serviceannouncement message get --id MC001337
+```
+
+## More information
+
+- Microsoft Graph REST API reference: [https://docs.microsoft.com/en-us/graph/api/serviceupdatemessage-get](https://docs.microsoft.com/en-us/graph/api/serviceupdatemessage-get)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -127,6 +127,8 @@ nav:
         - service list: 'cmd/tenant/service/service-list.md'
         - service message list: 'cmd/tenant/service/service-message-list.md'
         - service report historicalservicestatus: 'cmd/tenant/service/service-report-historicalservicestatus.md'
+      - serviceannouncement:
+        - serviceannouncement message get: 'cmd/tenant/serviceannouncement/serviceannouncement-message-get.md'
       - status:
         - status list: 'cmd/tenant/status/status-list.md'
     - Microsoft Graph (graph):

--- a/src/m365/tenant/commands.ts
+++ b/src/m365/tenant/commands.ts
@@ -12,5 +12,6 @@ export default {
   SERVICE_LIST: `${prefix} service list`,
   SERVICE_MESSAGE_LIST: `${prefix} service message list`,
   SERVICE_REPORT_HISTORICALSERVICESTATUS: `${prefix} service report historicalservicestatus`,
+  SERVICEANNOUNCEMENT_MESSAGE_GET: `${prefix} serviceannouncement message get`,
   STATUS_LIST: `${prefix} status list`
 }; 

--- a/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-get.spec.ts
+++ b/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-get.spec.ts
@@ -1,0 +1,223 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command from '../../../../Command';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import commands from "../../commands";
+const command: Command = require('./serviceannouncement-message-get');
+
+describe (commands.SERVICEANNOUNCEMENT_MESSAGE_GET, () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  const testId = 'MC001337';
+  const testIncorrectId = '123456';
+
+  const resResourceNotExist = {
+    "error": {
+      "code": "UnknownError",
+      "message": "{\"code\":\"forbidden\",\"message\":\"{\\u0022error\\u0022:\\u0022Resource doesn\\\\u0027t exist for the tenant. ActivityId: b2307a39-e878-458b-bc90-03bc578531d6. Learn more: https://docs.microsoft.com/en-us/graph/api/resources/service-communications-api-overview?view=graph-rest-beta\\\\u0026preserve-view=true.\\u0022}\"}",
+      "innerError": {
+        "date": "2022-01-22T15:01:15",
+        "request-id": "b2307a39-e878-458b-bc90-03bc578531d6",
+        "client-request-id": "b2307a39-e878-458b-bc90-03bc578531d6"
+      }
+    }
+  };
+
+  const resMessage = {
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#admin/serviceAnnouncement/messages/$entity",
+    "startDateTime": "2021-02-01T19:23:04Z",
+    "endDateTime": "2022-01-31T08:00:00Z",
+    "lastModifiedDateTime": "2021-02-01T19:24:37.837Z",
+    "title": "Service reminder: Skype for Business Online retires in 6 months",
+    "id": "MC001337",
+    "category": "planForChange",
+    "severity": "normal",
+    "tags": [
+      "User impact",
+      "Admin impact"
+    ],
+    "isMajorChange": false,
+    "actionRequiredByDateTime": "2021-07-31T07:00:00Z",
+    "services": [
+      "Skype for Business"
+    ],
+    "expiryDateTime": null,
+    "hasAttachments": false,
+    "viewPoint": null,
+    "details": [
+      {
+        "name": "BlogLink",
+        "value": "https://techcommunity.microsoft.com/t5/microsoft-teams-blog/skype-for-business-online-will-retire-in-12-months-plan-for-a/ba-p/1554531"
+      },
+      {
+        "name": "ExternalLink",
+        "value": "https://docs.microsoft.com/microsoftteams/skype-for-business-online-retirement"
+      }
+    ],
+    "body": {
+      "contentType": "html",
+      "content": "<p>Originally announced in MC219641 (July '20), as Microsoft Teams has become the core communications client for Microsoft 365, this is a reminder the Skype for Business Online service will <a href=\"https://techcommunity.microsoft.com/t5/microsoft-teams-blog/skype-for-business-online-will-retire-in-12-months-plan-for-a/ba-p/1554531\" target=\"_blank\">retire July 31, 2021</a>. At that point, access to the service will end.</p><p>Please click Additional Information to learn more.</p>"
+    }
+  };
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      request.get
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.SERVICEANNOUNCEMENT_MESSAGE_GET), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if incorrect message ID is provided', (done) => {
+    const actual = command.validate({
+      options: {
+        id: testIncorrectId
+      }
+    });
+    assert.strictEqual(actual, `${testIncorrectId} is not a valid message ID`);
+    done();
+  });
+
+  it('passes validation if correct message ID is provided', (done) => {
+    const actual = command.validate({
+      options: {
+        id: testId
+      }
+    });
+    assert(actual);
+    done();
+  });
+
+  it('correctly retrieves service update message', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/messages/${testId}`) {
+        return Promise.resolve(resMessage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        id: testId
+      }
+    }, () => {
+      try {
+        assert.strictEqual(loggerLogSpy.calledWith(resMessage), true);
+        assert.strictEqual(loggerLogSpy.lastCall.args[0].id, testId);
+        assert.strictEqual(loggerLogSpy.callCount, 1);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly retrieves service update message (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/messages/${testId}`) {
+        return Promise.resolve(resMessage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        id: testId
+      }
+    }, () => {
+      try {
+        assert.strictEqual(loggerLogSpy.calledWith(resMessage), true);
+        assert.strictEqual(loggerLogSpy.lastCall.args[0].id, testId);
+        assert.strictEqual(loggerLogSpy.callCount, 1);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails when the message does not exist for the tenant', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/messages/${testIncorrectId}`) {
+        return Promise.reject(resResourceNotExist);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        id: testIncorrectId
+      }
+    }, (err?: any) => {
+      try {
+        assert((JSON.parse(JSON.parse(err.message).message).error as string).indexOf(`Resource doesn't exist for the tenant.`) > -1);
+        done();
+      }
+      catch (e){
+        done(e);
+      }
+    }
+    );
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    
+    assert(containsOption);
+  });
+});

--- a/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-get.spec.ts
+++ b/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-get.spec.ts
@@ -111,6 +111,10 @@ describe (commands.SERVICEANNOUNCEMENT_MESSAGE_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['startDateTime', 'endDateTime', 'lastModifiedDateTime', 'title', 'id', 'category', 'severity', 'tags', 'isMajorChange', 'actionRequiredByDateTime', 'services', 'expiryDateTime', 'hasAttachments', 'viewPoint' ]);
+  });
+
   it('fails validation if incorrect message ID is provided', (done) => {
     const actual = command.validate({
       options: {
@@ -207,6 +211,32 @@ describe (commands.SERVICEANNOUNCEMENT_MESSAGE_GET, () => {
       }
     }
     );
+  });
+
+  it('lists all properties for output json', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/serviceAnnouncement/messages/${testId}`) {
+        return Promise.resolve(resMessage);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+
+    command.action(logger, { 
+      options: 
+      {
+        id: testId,
+        output: 'json'
+      } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith(resMessage));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
   });
 
   it('supports debug mode', () => {

--- a/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-get.ts
+++ b/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-get.ts
@@ -24,10 +24,8 @@ class TenantServiceAnnouncementMessageGetCommand extends GraphCommand {
     return 'Retrieves a specified service update message for the tenant';
   }
 
-  public getTelemetryProperties(args: CommandArgs): any {
-    const telemetryProps: any = super.getTelemetryProperties(args);
-    telemetryProps.id = (!(!args.options.appId)).toString();
-    return telemetryProps;
+  public defaultProperties(): string[] | undefined {
+    return ['startDateTime', 'endDateTime', 'lastModifiedDateTime', 'title', 'id', 'category', 'severity', 'tags', 'isMajorChange', 'actionRequiredByDateTime', 'services', 'expiryDateTime', 'hasAttachments', 'viewPoint' ];
   }
 
   public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {

--- a/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-get.ts
+++ b/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-get.ts
@@ -1,0 +1,78 @@
+import { Logger } from '../../../../cli';
+import GraphCommand from '../../../base/GraphCommand';
+import {
+  CommandOption
+} from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+export interface Options extends GlobalOptions {
+  id: string;
+}
+
+class TenantServiceAnnouncementMessageGetCommand extends GraphCommand {
+  public get name(): string {
+    return commands.SERVICEANNOUNCEMENT_MESSAGE_GET;
+  }
+
+  public get description(): string {
+    return 'Retrieves a specified service update message for the tenant';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.id = (!(!args.options.appId)).toString();
+    return telemetryProps;
+  }
+
+  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
+    if (this.verbose) {
+      logger.logToStderr(`Retrieving service update message ${args.id}`);
+    }
+
+    const requestOptions: any = {
+      url: `${this.resource}/v1.0/admin/serviceAnnouncement/messages/${args.options.id}`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    request
+      .get<{ value: [{ id: string }] }>(requestOptions)
+      .then((res: any): void => {
+        logger.log(res);
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --id [id]'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  private isValidId(id: string): boolean {
+    return (/MC\d{6}/).test(id);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    if (!this.isValidId(args.options.id)) {
+      return `${args.options.id} is not a valid message ID`;
+    }
+
+    return true;
+  }
+}
+
+module.exports = new TenantServiceAnnouncementMessageGetCommand();


### PR DESCRIPTION
# Adds `m365 tenant serviceannouncement message get` command. Closes #2952

New command as a part of `serviceannouncement` category.

# AD permissions

If `ServiceMessage.Read.All` permissions are already added after merging #2959 #2958 or #2970, no additional permission is needed.

# Specification

The command is implemented with updated specification. It uses `--id` instead `--messageId`.

# Documentation

Not all commands have links to respective Graph endpoints, but I decided to include a link at the bottom of the doc file.

I also thought about adding one more example, using `-i` instead of `--id`, but I checked a few commands and there were no such example included.

# `commands.ts`

I wasn't sure whether `SERVICEANNOUNCEMENT` should go after or before `SERVICE`. Correct me if I'm wrong, but lexicographical order puts `SERVICE` first (checked on Notepad++ as I didn't have any better idea 😎).