### PR TITLE
Fixes 'teams channel get' command. Closes #3009

### DIFF
--- a/docs/docs/cmd/teams/channel/channel-get.md
+++ b/docs/docs/cmd/teams/channel/channel-get.md
@@ -16,7 +16,7 @@ m365 teams channel get [options]
 `--teamName [teamName]`
 : The display name of the team to which the channel belongs to. Specify either teamId or teamName but not both
 
-`-c, --channelId <channelId>`
+`-c, --channelId [channelId]`
 : The ID of the channel for which to retrieve more information. Specify either channelId or channelName but not both
 
 `--channelName [channelName]`


### PR DESCRIPTION
Fixes `teams channel get` command. Closes #3009
Set `channelid` as optional parameter.