### PR TITLE
Add `--save` option to `aad app get` command. Closes #2939

### DIFF
--- a/docs/docs/cmd/aad/app/app-get.md
+++ b/docs/docs/cmd/aad/app/app-get.md
@@ -19,13 +19,18 @@ m365 aad app get [options]
 `--name [name]`
 : Name of the Azure AD application registration to get. Specify either `appId`, `objectId` or `name`
 
+`--save`
+: Use to store the information about the created app in a local file
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
-For best performance use the `objectId` option to reference the Azure AD application registration to update. If you use `appId` or `name`, this command will first need to find the corresponding object ID for that application.
+For best performance use the `objectId` option to reference the Azure AD application registration to get. If you use `appId` or `name`, this command will first need to find the corresponding object ID for that application.
 
 If the command finds multiple Azure AD application registrations with the specified app name, it will prompt you to disambiguate which app it should use, listing the discovered object IDs.
+
+If you want to store the information about the Azure AD app registration, use the `--save` option. This is useful when you build solutions connected to Microsoft 365 and want to easily manage app registrations used with your solution. When you use the `--save` option, after you get the app registration, the command will write its ID and name to the `.m365rc.json` file in the current directory. If the file already exists, it will add the information about the App registration to it if it's not already present, allowing you to track multiple apps. If the file doesn't exist, the command will create it.
 
 ## Examples
 
@@ -45,4 +50,10 @@ Get the Azure AD application registration by its name
 
 ```sh
 m365 aad app get --name "My app"
+```
+
+Get the Azure AD application registration by its name. Store information about the retrieved app registration in the _.m365rc.json_ file in the current directory.
+
+```sh
+m365 aad app get --name "My app" --save
 ```

--- a/src/m365/aad/commands/app/app-get.spec.ts
+++ b/src/m365/aad/commands/app/app-get.spec.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
+import * as fs from 'fs';
 import { Logger } from '../../../../cli';
 import Command from '../../../../Command';
 import request from '../../../../request';
@@ -38,7 +39,10 @@ describe(commands.APP_GET, () => {
 
   afterEach(() => {
     Utils.restore([
-      request.get
+      request.get,
+      fs.existsSync,
+      fs.readFileSync,
+      fs.writeFileSync
     ]);
   });
 
@@ -221,7 +225,7 @@ describe(commands.APP_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('should get an Azure AD app registration by its app (client) ID', (done) => {
+  it(`should get an Azure AD app registration by its app (client) ID. Doesn't save the app info if not requested`, (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
         return Promise.resolve({
@@ -249,6 +253,7 @@ describe(commands.APP_GET, () => {
 
       return Promise.reject('Invalid request');
     });
+    const fsWriteFileSyncSpy = sinon.spy(fs, 'writeFileSync');
 
     command.action(logger, {
       options: {
@@ -260,6 +265,7 @@ describe(commands.APP_GET, () => {
         assert.strictEqual(call.args[0].id, '340a4aa3-1af6-43ac-87d8-189819003952');
         assert.strictEqual(call.args[0].appId, '9b1b1e42-794b-4c71-93ac-5ed92488b67f');
         assert.strictEqual(call.args[0].displayName, 'My App');
+        assert(fsWriteFileSyncSpy.notCalled);
         done();
       }
       catch (e) {
@@ -268,7 +274,7 @@ describe(commands.APP_GET, () => {
     });
   });
 
-  it('should get an Azure AD app registration by its name', (done) => {
+  it(`should get an Azure AD app registration by its name. Doesn't save the app info if not requested`, (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=displayName eq 'My%20App'&$select=id`) {
         return Promise.resolve({
@@ -296,6 +302,7 @@ describe(commands.APP_GET, () => {
 
       return Promise.reject('Invalid request');
     });
+    const fsWriteFileSyncSpy = sinon.spy(fs, 'writeFileSync');
 
     command.action(logger, {
       options: {
@@ -307,6 +314,7 @@ describe(commands.APP_GET, () => {
         assert.strictEqual(call.args[0].id, '340a4aa3-1af6-43ac-87d8-189819003952');
         assert.strictEqual(call.args[0].appId, '9b1b1e42-794b-4c71-93ac-5ed92488b67f');
         assert.strictEqual(call.args[0].displayName, 'My App');
+        assert(fsWriteFileSyncSpy.notCalled);
         done();
       }
       catch (e) {
@@ -315,7 +323,7 @@ describe(commands.APP_GET, () => {
     });
   });
 
-  it('should get an Azure AD app registration by its object ID', (done) => {
+  it(`should get an Azure AD app registration by its object ID. Doesn't save the app info if not requested`, (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/340a4aa3-1af6-43ac-87d8-189819003952`) {
         return Promise.resolve({
@@ -328,6 +336,7 @@ describe(commands.APP_GET, () => {
       }
       return Promise.reject('Invalid request');
     });
+    const fsWriteFileSyncSpy = sinon.spy(fs, 'writeFileSync');
 
     command.action(logger, {
       options: {
@@ -339,6 +348,429 @@ describe(commands.APP_GET, () => {
         assert.strictEqual(call.args[0].id, '340a4aa3-1af6-43ac-87d8-189819003952');
         assert.strictEqual(call.args[0].appId, '9b1b1e42-794b-4c71-93ac-5ed92488b67f');
         assert.strictEqual(call.args[0].displayName, 'My App');
+        assert(fsWriteFileSyncSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+  
+  it(`should get an Azure AD app registration by its app (client) ID. Creates the file it doesn't exist`, (done) => {
+    let fileContents: string | undefined;
+    let filePath: string | undefined;
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
+        return Promise.resolve({
+          value: [
+            {
+              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+              "createdDateTime": "2019-10-29T17:46:55Z",
+              "displayName": "My App",
+              "description": null
+            }
+          ]
+        });
+      }
+
+      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
+        return Promise.resolve({
+          "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+          "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+          "createdDateTime": "2019-10-29T17:46:55Z",
+          "displayName": "My App",
+          "description": null
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => false);
+    sinon.stub(fs, 'writeFileSync').callsFake((_, contents) => {
+      filePath = _.toString();
+      fileContents = contents as string;
+    });
+
+    command.action(logger, {
+      options: {
+        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+        save: true
+      }
+    }, () => {
+      try {
+        const call: sinon.SinonSpyCall = loggerLogSpy.lastCall;
+        assert.strictEqual(call.args[0].id, '340a4aa3-1af6-43ac-87d8-189819003952');
+        assert.strictEqual(call.args[0].appId, '9b1b1e42-794b-4c71-93ac-5ed92488b67f');
+        assert.strictEqual(call.args[0].displayName, 'My App');
+        assert.strictEqual(filePath, '.m365rc.json');
+        assert.strictEqual(fileContents, JSON.stringify({
+          apps: [{
+            appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+            name: 'My App'
+          }]
+        }, null, 2));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`should get an Azure AD app registration by its app (client) ID. Writes to the existing empty file`, (done) => {
+    let fileContents: string | undefined;
+    let filePath: string | undefined;
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
+        return Promise.resolve({
+          value: [
+            {
+              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+              "createdDateTime": "2019-10-29T17:46:55Z",
+              "displayName": "My App",
+              "description": null
+            }
+          ]
+        });
+      }
+
+      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
+        return Promise.resolve({
+          "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+          "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+          "createdDateTime": "2019-10-29T17:46:55Z",
+          "displayName": "My App",
+          "description": null
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    sinon.stub(fs, 'readFileSync').callsFake(_ => '');
+    sinon.stub(fs, 'writeFileSync').callsFake((_, contents) => {
+      filePath = _.toString();
+      fileContents = contents as string;
+    });
+
+    command.action(logger, {
+      options: {
+        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+        save: true
+      }
+    }, () => {
+      try {
+        const call: sinon.SinonSpyCall = loggerLogSpy.lastCall;
+        assert.strictEqual(call.args[0].id, '340a4aa3-1af6-43ac-87d8-189819003952');
+        assert.strictEqual(call.args[0].appId, '9b1b1e42-794b-4c71-93ac-5ed92488b67f');
+        assert.strictEqual(call.args[0].displayName, 'My App');
+        assert.strictEqual(filePath, '.m365rc.json');
+        assert.strictEqual(fileContents, JSON.stringify({
+          apps: [{
+            appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+            name: 'My App'
+          }]
+        }, null, 2));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`should get an Azure AD app registration by its app (client) ID. Adds to the existing file contents`, (done) => {
+    let fileContents: string | undefined;
+    let filePath: string | undefined;
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
+        return Promise.resolve({
+          value: [
+            {
+              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+              "createdDateTime": "2019-10-29T17:46:55Z",
+              "displayName": "My App",
+              "description": null
+            }
+          ]
+        });
+      }
+
+      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
+        return Promise.resolve({
+          "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+          "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+          "createdDateTime": "2019-10-29T17:46:55Z",
+          "displayName": "My App",
+          "description": null
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    sinon.stub(fs, 'readFileSync').callsFake(_ => JSON.stringify({
+      "apps": [
+        {
+          "appId": "74ad36da-3704-4e67-ba08-8c8e833f3c52",
+          "name": "M365 app"
+        }
+      ]
+    }));
+    sinon.stub(fs, 'writeFileSync').callsFake((_, contents) => {
+      filePath = _.toString();
+      fileContents = contents as string;
+    });
+
+    command.action(logger, {
+      options: {
+        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+        save: true
+      }
+    }, () => {
+      try {
+        const call: sinon.SinonSpyCall = loggerLogSpy.lastCall;
+        assert.strictEqual(call.args[0].id, '340a4aa3-1af6-43ac-87d8-189819003952');
+        assert.strictEqual(call.args[0].appId, '9b1b1e42-794b-4c71-93ac-5ed92488b67f');
+        assert.strictEqual(call.args[0].displayName, 'My App');
+        assert.strictEqual(filePath, '.m365rc.json');
+        assert.strictEqual(fileContents, JSON.stringify({
+          apps: [
+            {
+              "appId": "74ad36da-3704-4e67-ba08-8c8e833f3c52",
+              "name": "M365 app"
+            },
+            {
+              appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+              name: 'My App'
+            }]
+        }, null, 2));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`should get an Azure AD app registration by its app (client) ID. Adds to the existing file contents (Debug)`, (done) => {
+    let fileContents: string | undefined;
+    let filePath: string | undefined;
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
+        return Promise.resolve({
+          value: [
+            {
+              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+              "createdDateTime": "2019-10-29T17:46:55Z",
+              "displayName": "My App",
+              "description": null
+            }
+          ]
+        });
+      }
+
+      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
+        return Promise.resolve({
+          "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+          "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+          "createdDateTime": "2019-10-29T17:46:55Z",
+          "displayName": "My App",
+          "description": null
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    sinon.stub(fs, 'readFileSync').callsFake(_ => JSON.stringify({
+      "apps": [
+        {
+          "appId": "74ad36da-3704-4e67-ba08-8c8e833f3c52",
+          "name": "M365 app"
+        }
+      ]
+    }));
+    sinon.stub(fs, 'writeFileSync').callsFake((_, contents) => {
+      filePath = _.toString();
+      fileContents = contents as string;
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+        save: true
+      }
+    }, () => {
+      try {
+        const call: sinon.SinonSpyCall = loggerLogSpy.lastCall;
+        assert.strictEqual(call.args[0].id, '340a4aa3-1af6-43ac-87d8-189819003952');
+        assert.strictEqual(call.args[0].appId, '9b1b1e42-794b-4c71-93ac-5ed92488b67f');
+        assert.strictEqual(call.args[0].displayName, 'My App');
+        assert.strictEqual(filePath, '.m365rc.json');
+        assert.strictEqual(fileContents, JSON.stringify({
+          apps: [
+            {
+              "appId": "74ad36da-3704-4e67-ba08-8c8e833f3c52",
+              "name": "M365 app"
+            },
+            {
+              appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+              name: 'My App'
+            }]
+        }, null, 2));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`doesn't save app info in the .m365rc.json file when there was error reading file contents`, (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
+        return Promise.resolve({
+          value: [
+            {
+              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+              "createdDateTime": "2019-10-29T17:46:55Z",
+              "displayName": "My App",
+              "description": null
+            }
+          ]
+        });
+      }
+
+      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
+        return Promise.resolve({
+          "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+          "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+          "createdDateTime": "2019-10-29T17:46:55Z",
+          "displayName": "My App",
+          "description": null
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    sinon.stub(fs, 'readFileSync').callsFake(_ => { throw new Error('An error has occurred'); });    
+    const fsWriteFileSyncSpy = sinon.spy(fs, 'writeFileSync');
+
+    command.action(logger, {
+      options: {
+        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+        save: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
+        assert(fsWriteFileSyncSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`doesn't save app info in the .m365rc.json file when file has invalid JSON`, (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
+        return Promise.resolve({
+          value: [
+            {
+              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+              "createdDateTime": "2019-10-29T17:46:55Z",
+              "displayName": "My App",
+              "description": null
+            }
+          ]
+        });
+      }
+
+      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
+        return Promise.resolve({
+          "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+          "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+          "createdDateTime": "2019-10-29T17:46:55Z",
+          "displayName": "My App",
+          "description": null
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    sinon.stub(fs, 'readFileSync').callsFake(_ => '{');
+    const fsWriteFileSyncSpy = sinon.spy(fs, 'writeFileSync');
+
+    command.action(logger, {
+      options: {
+        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+        save: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
+        assert(fsWriteFileSyncSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it(`doesn't fail execution when error occurred while saving app info`, (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
+        return Promise.resolve({
+          value: [
+            {
+              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+              "createdDateTime": "2019-10-29T17:46:55Z",
+              "displayName": "My App",
+              "description": null
+            }
+          ]
+        });
+      }
+
+      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
+        return Promise.resolve({
+          "id": "340a4aa3-1af6-43ac-87d8-189819003952",
+          "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+          "createdDateTime": "2019-10-29T17:46:55Z",
+          "displayName": "My App",
+          "description": null
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => false);
+    sinon.stub(fs, 'writeFileSync').callsFake(_ => { throw new Error('Error occurred while saving app info'); });
+
+
+    command.action(logger, {
+      options: {
+        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
+        save: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
         done();
       }
       catch (e) {

--- a/src/m365/aad/commands/app/app-get.ts
+++ b/src/m365/aad/commands/app/app-get.ts
@@ -9,14 +9,10 @@ import GraphCommand from '../../../base/GraphCommand';
 import { M365RcJson } from '../../../base/M365RcJson';
 import commands from '../../commands';
 import * as fs from 'fs';
+import { Application } from '@microsoft/microsoft-graph-types';
 
 interface CommandArgs {
   options: Options;
-}
-
-interface AppInfo {
-  appId: string;
-  displayName: string;  
 }
 
 export interface Options extends GlobalOptions {
@@ -89,7 +85,7 @@ class AadAppGetCommand extends GraphCommand {
       });
   }
 
-  private getAppInfo(appObjectId: string): Promise<AppInfo> {
+  private getAppInfo(appObjectId: string): Promise<Application> {
     const requestOptions: any = {
       url: `${this.resource}/v1.0/myorganization/applications/${appObjectId}`,
       headers: {
@@ -98,10 +94,10 @@ class AadAppGetCommand extends GraphCommand {
       responseType: 'json'
     };
 
-    return request.get<AppInfo>(requestOptions);
+    return request.get<Application>(requestOptions);
   }
 
-  private saveAppInfo(args: CommandArgs, appInfo: AppInfo, logger: Logger): Promise<AppInfo> {
+  private saveAppInfo(args: CommandArgs, appInfo: Application, logger: Logger): Promise<Application> {
     if (!args.options.save) {
       return Promise.resolve(appInfo);
     }
@@ -134,10 +130,10 @@ class AadAppGetCommand extends GraphCommand {
       m365rc.apps = [];
     }
 
-    if (m365rc.apps.every(a => a.appId !== appInfo.appId)) {
+    if (!m365rc.apps.some(a => a.appId === appInfo.appId)) {
       m365rc.apps.push({
-        appId: appInfo.appId,
-        name: appInfo.displayName
+        appId: appInfo.appId as string,
+        name: appInfo.displayName as string
       });
 
       try {


### PR DESCRIPTION
This pull request adds a `--save` option to the `aad app get` command.

When used, it will cause the command to write the information about the retrieved existing app to the .m365rc.json file in the working directory. It will check if the file exists and create it if it doesn't. It will only add the information if the app is not already referenced in the json file.

Closes #2939



