### PR TITLE
Extends 'teams app update' command. Closes #3026

### DIFF
--- a/docs/docs/cmd/teams/app/app-update.md
+++ b/docs/docs/cmd/teams/app/app-update.md
@@ -10,8 +10,11 @@ m365 teams app update [options]
 
 ## Options
 
-`-i, --id <id>`
-: ID of the app to update
+`-i, --id [id]`
+: ID of the app to update. Specify either id or name but not both
+
+`-n, --name [name]`
+: The display name of the app to update. Specify either id or name but not both
 
 `-p, --filePath <filePath>`
 : Absolute or relative path to the Teams manifest zip file to update in the app catalog
@@ -28,4 +31,10 @@ Update the Teams app with ID _83cece1e-938d-44a1-8b86-918cf6151957_ from file _t
 
 ```sh
 m365 teams app update --id 83cece1e-938d-44a1-8b86-918cf6151957 --filePath ./teams-manifest.zip
+```
+
+Update the Teams app with name _Test app_ from file _teams-manifest.zip_
+
+```sh
+m365 teams app update --name "Test app" --filePath ./teams-manifest.zip
 ```

--- a/src/m365/teams/commands/app/app-update.spec.ts
+++ b/src/m365/teams/commands/app/app-update.spec.ts
@@ -16,7 +16,7 @@ describe(commands.APP_UPDATE, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
   });
 
@@ -38,6 +38,7 @@ describe(commands.APP_UPDATE, () => {
 
   afterEach(() => {
     Utils.restore([
+      request.get,
       request.put,
       fs.readFileSync,
       fs.existsSync
@@ -58,6 +59,28 @@ describe(commands.APP_UPDATE, () => {
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if both id and name options are passed', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'e3e29acb-8c79-412b-b746-e6c39ff4cd22',
+        name: 'Test app',
+        filePath: 'teamsapp.zip'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation if both id and name options are not passed', (done) => {
+    const actual = command.validate({
+      options: {
+        filePath: 'teamsapp.zip'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
   });
 
   it('fails validation if the id is not a valid GUID.', (done) => {
@@ -115,7 +138,32 @@ describe(commands.APP_UPDATE, () => {
     done();
   });
 
-  it('update Teams app in the tenant app catalog', (done) => {
+  it('fails to get Teams app when app does not exists', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/v1.0/appCatalogs/teamsApps?$filter=displayName eq '`) > -1) {
+        return Promise.resolve({ value: [] });
+      }
+      return Promise.reject('The specified Teams app does not exist');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        name: 'Test app',
+        filePath: 'teamsapp.zip'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified Teams app does not exist`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('update Teams app in the tenant app catalog by id', (done) => {
     let updateTeamsAppCalled = false;
     sinon.stub(request, 'put').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/e3e29acb-8c79-412b-b746-e6c39ff4cd22`) {
@@ -139,8 +187,9 @@ describe(commands.APP_UPDATE, () => {
     });
   });
 
-  it('update Teams app in the tenant app catalog (debug)', (done) => {
+  it('update Teams app in the tenant app catalog by id (debug)', (done) => {
     let updateTeamsAppCalled = false;
+
     sinon.stub(request, 'put').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/e3e29acb-8c79-412b-b746-e6c39ff4cd22`) {
         updateTeamsAppCalled = true;
@@ -153,6 +202,51 @@ describe(commands.APP_UPDATE, () => {
     sinon.stub(fs, 'readFileSync').callsFake(() => '123');
 
     command.action(logger, { options: { debug: true, filePath: 'teamsapp.zip', id: `e3e29acb-8c79-412b-b746-e6c39ff4cd22` } }, () => {
+      try {
+        assert(updateTeamsAppCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('update Teams app in the tenant app catalog by name (debug)', (done) => {
+    let updateTeamsAppCalled = false;
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/v1.0/appCatalogs/teamsApps?$filter=displayName eq '`) > -1) {
+        return Promise.resolve({
+          "value": [
+            {
+              "id": "e3e29acb-8c79-412b-b746-e6c39ff4cd22",
+              "displayName": "Test app"
+            }
+          ]
+        });
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(request, 'put').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/e3e29acb-8c79-412b-b746-e6c39ff4cd22`) {
+        updateTeamsAppCalled = true;
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(fs, 'readFileSync').callsFake(() => '123');
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        filePath: 'teamsapp.zip',
+        name: 'Test app'
+      }
+    }, () => {
       try {
         assert(updateTeamsAppCalled);
         done();

--- a/src/m365/teams/commands/app/app-update.ts
+++ b/src/m365/teams/commands/app/app-update.ts
@@ -13,7 +13,8 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  id: string;
+  id?: string;
+  name?: string;
   filePath: string;
 }
 
@@ -27,30 +28,63 @@ class TeamsAppUpdateCommand extends GraphCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    const { id: appId, filePath } = args.options;
+    const { filePath } = args.options;
 
-    const fullPath: string = path.resolve(filePath);
-    if (this.verbose) {
-      logger.logToStderr(`Updating app with id '${appId}' and file '${fullPath}' in the app catalog...`);
+    this
+      .getAppId(args)
+      .then((appId: string): Promise<any> => {
+        const fullPath: string = path.resolve(filePath);
+        if (this.verbose) {
+          logger.logToStderr(`Updating app with id '${appId}' and file '${fullPath}' in the app catalog...`);
+        }
+
+        const requestOptions: any = {
+          url: `${this.resource}/v1.0/appCatalogs/teamsApps/${appId}`,
+          headers: {
+            "content-type": "application/zip"
+          },
+          data: fs.readFileSync(fullPath)
+        };
+
+        return request
+          .put(requestOptions);
+      })
+      .then(_ => cb(), (res: any): void => this.handleRejectedODataJsonPromise(res, logger, cb));
+  }
+
+  private getAppId(args: CommandArgs): Promise<string> {
+    if (args.options.id) {
+      return Promise.resolve(args.options.id);
     }
 
     const requestOptions: any = {
-      url: `${this.resource}/v1.0/appCatalogs/teamsApps/${appId}`,
+      url: `${this.resource}/v1.0/appCatalogs/teamsApps?$filter=displayName eq '${encodeURIComponent(args.options.name as string)}'`,
       headers: {
-        "content-type": "application/zip"
+        accept: 'application/json;odata.metadata=none'
       },
-      data: fs.readFileSync(fullPath)
+      responseType: 'json'
     };
 
-    request
-      .put(requestOptions)
-      .then(_ => cb(), (res: any): void => this.handleRejectedODataJsonPromise(res, logger, cb));
+    return request
+      .get<{ value: { id: string; }[] }>(requestOptions)
+      .then(response => {
+        const app: { id: string; } | undefined = response.value[0];
+
+        if (!app) {
+          return Promise.reject(`The specified Teams app does not exist`);
+        }
+
+        return Promise.resolve(app.id);
+      });
   }
 
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       {
-        option: '-i, --id <id>'
+        option: '-i, --id [id]'
+      },
+      {
+        option: '-n, --name [name]'
       },
       {
         option: '-p, --filePath <filePath>'
@@ -62,7 +96,15 @@ class TeamsAppUpdateCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (!Utils.isValidGuid(args.options.id)) {
+    if (!args.options.id && !args.options.name) {
+      return 'Specify either id or name';
+    }
+
+    if (args.options.id && args.options.name) {
+      return 'Specify either id or name but not both';
+    }
+
+    if (args.options.id && !Utils.isValidGuid(args.options.id)) {
       return `${args.options.id} is not a valid GUID`;
     }
 


### PR DESCRIPTION
Extends `teams app update` command. Closes #3026
Included support for updating the app using its name.