### PR TITLE
Extends 'aad o365group add' command. Closes #3080

### DIFF
--- a/docs/docs/cmd/aad/o365group/o365group-add.md
+++ b/docs/docs/cmd/aad/o365group/o365group-add.md
@@ -28,6 +28,18 @@ m365 aad o365group add [options]
 `--isPrivate [isPrivate]`
 : Set to `true` if the Microsoft 365 Group should be private and to `false` if it should be public (default)
 
+`--allowMembersToPost [allowMembersToPost]`
+: Set if only group members should be able to post conversations to the group
+
+`--hideGroupInOutlook [hideGroupInOutlook]`
+: Set to hide the group in Outlook experiences
+
+`--subscribeNewGroupMembers [subscribeNewGroupMembers]`
+: Set to subscribe all new group members to receive group conversation emails when new messages are posted in the group
+
+`--welcomeEmailDisabled [welcomeEmailDisabled]`
+: Set to not send welcome emails to new group members
+
 `-l, --logoPath [logoPath]`
 : Local path to the image file to use as group logo
 
@@ -43,29 +55,40 @@ If an invalid user is provided in the comma-separated list or Owners or Members,
 Create a public Microsoft 365 Group
 
 ```sh
-m365 aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance
 ```
 
 Create a private Microsoft 365 Group
 
 ```sh
-m365 aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --isPrivate true
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --isPrivate true
 ```
 
 Create a public Microsoft 365 Group and set specified users as its owners
 
 ```sh
-m365 aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --owners "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --owners "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 ```
 
 Create a public Microsoft 365 Group and set specified users as its members
 
 ```sh
-m365 aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --members "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --members "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
+```
+
+Create a public Microsoft 365 Group and set its resourceBehaviorOptions
+
+```sh
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --allowMembersToPost --hideGroupInOutlook --subscribeNewGroupMembers --welcomeEmailDisabled
 ```
 
 Create a public Microsoft 365 Group and set its logo
 
 ```sh
-m365 aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --logoPath images/logo.png
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --logoPath images/logo.png
 ```
+
+## More information
+
+- Create group: [https://docs.microsoft.com/en-us/graph/api/group-post-groups](https://docs.microsoft.com/en-us/graph/api/group-post-groups)
+- Set Microsoft 365 group behaviors and provisioning options: [https://docs.microsoft.com/en-us/graph/group-set-options](https://docs.microsoft.com/en-us/graph/group-set-options)

--- a/docs/docs/cmd/aad/o365group/o365group-add.md
+++ b/docs/docs/cmd/aad/o365group/o365group-add.md
@@ -1,6 +1,6 @@
 # aad o365group add
 
-Creates Microsoft 365 Group
+Creates a Microsoft 365 Group
 
 ## Usage
 
@@ -76,10 +76,28 @@ Create a public Microsoft 365 Group and set specified users as its members
 m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --members "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 ```
 
-Create a public Microsoft 365 Group and set its resourceBehaviorOptions
+Create a public Microsoft 365 Group and allows only group members to be able to post conversations to the group.
 
 ```sh
-m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --allowMembersToPost --hideGroupInOutlook --subscribeNewGroupMembers --welcomeEmailDisabled
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --allowMembersToPost
+```
+
+Create a public Microsoft 365 Group and hides it from the Outlook experiences (web and client).
+
+```sh
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --hideGroupInOutlook
+```
+
+Create a public Microsoft 365 Group and subscribe all new group members to receive group conversation emails when new messages are posted in the group.
+
+```sh
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --subscribeNewGroupMembers
+```
+
+Create a public Microsoft 365 Group and set to not send welcome emails to new group members.
+
+```sh
+m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --welcomeEmailDisabled
 ```
 
 Create a public Microsoft 365 Group and set its logo
@@ -87,8 +105,3 @@ Create a public Microsoft 365 Group and set its logo
 ```sh
 m365 aad o365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --logoPath images/logo.png
 ```
-
-## More information
-
-- Create group: [https://docs.microsoft.com/en-us/graph/api/group-post-groups](https://docs.microsoft.com/en-us/graph/api/group-post-groups)
-- Set Microsoft 365 group behaviors and provisioning options: [https://docs.microsoft.com/en-us/graph/group-set-options](https://docs.microsoft.com/en-us/graph/group-set-options)

--- a/src/m365/aad/commands/o365group/o365group-add.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-add.spec.ts
@@ -75,6 +75,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -96,6 +97,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -125,6 +127,7 @@ describe(commands.O365GROUP_ADD, () => {
           preferredDataLocation: null,
           proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
           renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: "Public"
         }));
@@ -147,6 +150,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -168,6 +172,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -197,6 +202,7 @@ describe(commands.O365GROUP_ADD, () => {
           preferredDataLocation: null,
           proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
           renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: "Public"
         }));
@@ -219,6 +225,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Private'
         })) {
@@ -240,6 +247,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Private"
           });
@@ -269,6 +277,7 @@ describe(commands.O365GROUP_ADD, () => {
           preferredDataLocation: null,
           proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
           renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: "Private"
         }));
@@ -280,7 +289,7 @@ describe(commands.O365GROUP_ADD, () => {
     });
   });
 
-  it('creates Microsoft 365 Group with a png logo', (done) => {
+  it('creates Microsoft 365 Group with resourceBehaviorOptions (debug)', (done) => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/groups') {
         if (JSON.stringify(opts.data) === JSON.stringify({
@@ -291,6 +300,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: ["allowMembersToPost", "hideGroupInOutlook", "subscribeNewGroupMembers", "welcomeEmailDisabled"],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -312,6 +322,82 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: ["allowMembersToPost", "hideGroupInOutlook", "subscribeNewGroupMembers", "welcomeEmailDisabled"],
+            securityEnabled: false,
+            visibility: "Public"
+          });
+        }
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', allowMembersToPost: true, hideGroupInOutlook: true, subscribeNewGroupMembers: true, welcomeEmailDisabled: true } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith({
+          id: "f3db5c2b-068f-480d-985b-ec78b9fa0e76",
+          deletedDateTime: null,
+          classification: null,
+          createdDateTime: "2018-02-24T18:38:53Z",
+          description: "My awesome group",
+          displayName: "My group",
+          groupTypes: ["Unified"],
+          mail: "my_group@contoso.onmicrosoft.com",
+          mailEnabled: true,
+          mailNickname: "my_group",
+          onPremisesLastSyncDateTime: null,
+          onPremisesProvisioningErrors: [],
+          onPremisesSecurityIdentifier: null,
+          onPremisesSyncEnabled: null,
+          preferredDataLocation: null,
+          proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
+          renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: ["allowMembersToPost", "hideGroupInOutlook", "subscribeNewGroupMembers", "welcomeEmailDisabled"],
+          securityEnabled: false,
+          visibility: "Public"
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('creates Microsoft 365 Group with a png logo', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/groups') {
+        if (JSON.stringify(opts.data) === JSON.stringify({
+          description: 'My awesome group',
+          displayName: 'My group',
+          groupTypes: [
+            "Unified"
+          ],
+          mailEnabled: true,
+          mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
+          securityEnabled: false,
+          visibility: 'Public'
+        })) {
+          return Promise.resolve({
+            id: "f3db5c2b-068f-480d-985b-ec78b9fa0e76",
+            deletedDateTime: null,
+            classification: null,
+            createdDateTime: "2018-02-24T18:38:53Z",
+            description: "My awesome group",
+            displayName: "My group",
+            groupTypes: ["Unified"],
+            mail: "my_group@contoso.onmicrosoft.com",
+            mailEnabled: true,
+            mailNickname: "my_group",
+            onPremisesLastSyncDateTime: null,
+            onPremisesProvisioningErrors: [],
+            onPremisesSecurityIdentifier: null,
+            onPremisesSyncEnabled: null,
+            preferredDataLocation: null,
+            proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
+            renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -350,6 +436,7 @@ describe(commands.O365GROUP_ADD, () => {
           preferredDataLocation: null,
           proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
           renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: "Public"
         }));
@@ -372,6 +459,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -393,6 +481,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -431,6 +520,7 @@ describe(commands.O365GROUP_ADD, () => {
           preferredDataLocation: null,
           proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
           renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: "Public"
         }));
@@ -453,6 +543,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -474,6 +565,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -512,6 +604,7 @@ describe(commands.O365GROUP_ADD, () => {
           preferredDataLocation: null,
           proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
           renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: "Public"
         }));
@@ -534,6 +627,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -555,6 +649,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -565,7 +660,7 @@ describe(commands.O365GROUP_ADD, () => {
     });
     sinon.stub(request, 'put').callsFake((opts) => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/groups/f3db5c2b-068f-480d-985b-ec78b9fa0e76/photo/$value') {
-        return Promise.reject('An error has occurred');
+        return Promise.reject('Invalid request');
       }
 
       return Promise.reject('Invalid request');
@@ -577,7 +672,7 @@ describe(commands.O365GROUP_ADD, () => {
 
     command.action(logger, { options: { debug: false, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', logoPath: 'logo.png' } } as any, (err?: any) => {
       try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Invalid request')));
         done();
       }
       catch (e) {
@@ -597,6 +692,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -618,6 +714,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -628,7 +725,7 @@ describe(commands.O365GROUP_ADD, () => {
     });
     sinon.stub(request, 'put').callsFake((opts) => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/groups/f3db5c2b-068f-480d-985b-ec78b9fa0e76/photo/$value') {
-        return Promise.reject('An error has occurred');
+        return Promise.reject('Invalid request');
       }
 
       return Promise.reject('Invalid request');
@@ -640,7 +737,7 @@ describe(commands.O365GROUP_ADD, () => {
 
     command.action(logger, { options: { debug: true, displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', logoPath: 'logo.png' } } as any, (err?: any) => {
       try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Invalid request')));
         done();
       }
       catch (e) {
@@ -660,6 +757,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -681,6 +779,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -729,6 +828,7 @@ describe(commands.O365GROUP_ADD, () => {
           preferredDataLocation: null,
           proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
           renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: "Public"
         }));
@@ -752,6 +852,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -774,6 +875,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -840,6 +942,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -861,6 +964,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -909,6 +1013,7 @@ describe(commands.O365GROUP_ADD, () => {
           preferredDataLocation: null,
           proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
           renewedDateTime: "2018-02-24T18:38:53Z",
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: "Public"
         }));
@@ -932,6 +1037,7 @@ describe(commands.O365GROUP_ADD, () => {
           ],
           mailEnabled: true,
           mailNickname: 'my_group',
+          resourceBehaviorOptions: [],
           securityEnabled: false,
           visibility: 'Public'
         })) {
@@ -954,6 +1060,7 @@ describe(commands.O365GROUP_ADD, () => {
             preferredDataLocation: null,
             proxyAddresses: ["SMTP:my_group@contoso.onmicrosoft.com"],
             renewedDateTime: "2018-02-24T18:38:53Z",
+            resourceBehaviorOptions: [],
             securityEnabled: false,
             visibility: "Public"
           });
@@ -1148,7 +1255,7 @@ describe(commands.O365GROUP_ADD, () => {
           'odata.error': {
             code: '-1, InvalidOperationException',
             message: {
-              value: 'An error has occurred'
+              value: 'Invalid request'
             }
           }
         }
@@ -1157,7 +1264,7 @@ describe(commands.O365GROUP_ADD, () => {
 
     command.action(logger, { options: { debug: false, clientId: '6a7b1395-d313-4682-8ed4-65a6265a6320', resourceId: '6a7b1395-d313-4682-8ed4-65a6265a6320', scope: 'user_impersonation' } } as any, (err?: any) => {
       try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Invalid request')));
         done();
       }
       catch (e) {

--- a/src/m365/aad/commands/o365group/o365group-add.ts
+++ b/src/m365/aad/commands/o365group/o365group-add.ts
@@ -23,6 +23,10 @@ interface Options extends GlobalOptions {
   members?: string;
   isPrivate?: string;
   logoPath?: string;
+  allowMembersToPost: boolean;
+  hideGroupInOutlook: boolean;
+  subscribeNewGroupMembers: boolean;
+  welcomeEmailDisabled: boolean;
 }
 
 class AadO365GroupAddCommand extends GraphCommand {
@@ -40,9 +44,26 @@ class AadO365GroupAddCommand extends GraphCommand {
     let group: Group;
     let ownerIds: string[] = [];
     let memberIds: string[] = [];
+    const resourceBehaviorOptionsCollection: string[] = [];
 
     if (this.verbose) {
       logger.logToStderr(`Creating Microsoft 365 Group...`);
+    }
+
+    if (args.options.allowMembersToPost) {
+      resourceBehaviorOptionsCollection.push("allowMembersToPost");
+    }
+
+    if (args.options.hideGroupInOutlook) {
+      resourceBehaviorOptionsCollection.push("hideGroupInOutlook");
+    }
+
+    if (args.options.subscribeNewGroupMembers) {
+      resourceBehaviorOptionsCollection.push("subscribeNewGroupMembers");
+    }
+
+    if (args.options.welcomeEmailDisabled) {
+      resourceBehaviorOptionsCollection.push("welcomeEmailDisabled");
     }
 
     const requestOptions: any = {
@@ -59,6 +80,7 @@ class AadO365GroupAddCommand extends GraphCommand {
         ],
         mailEnabled: true,
         mailNickname: args.options.mailNickname,
+        resourceBehaviorOptions: resourceBehaviorOptionsCollection,
         securityEnabled: false,
         visibility: args.options.isPrivate === 'true' ? 'Private' : 'Public'
       }
@@ -232,6 +254,18 @@ class AadO365GroupAddCommand extends GraphCommand {
       },
       {
         option: '--isPrivate [isPrivate]'
+      },
+      {
+        option: '--allowMembersToPost [allowMembersToPost]'
+      },
+      {
+        option: '--hideGroupInOutlook [hideGroupInOutlook]'
+      },
+      {
+        option: '--subscribeNewGroupMembers [subscribeNewGroupMembers]'
+      },
+      {
+        option: '--welcomeEmailDisabled [welcomeEmailDisabled]'
       },
       {
         option: '-l, --logoPath [logoPath]'

--- a/src/m365/aad/commands/o365group/o365group-add.ts
+++ b/src/m365/aad/commands/o365group/o365group-add.ts
@@ -23,10 +23,10 @@ interface Options extends GlobalOptions {
   members?: string;
   isPrivate?: string;
   logoPath?: string;
-  allowMembersToPost: boolean;
-  hideGroupInOutlook: boolean;
-  subscribeNewGroupMembers: boolean;
-  welcomeEmailDisabled: boolean;
+  allowMembersToPost?: boolean;
+  hideGroupInOutlook?: boolean;
+  subscribeNewGroupMembers?: boolean;
+  welcomeEmailDisabled?: boolean;
 }
 
 class AadO365GroupAddCommand extends GraphCommand {
@@ -37,7 +37,19 @@ class AadO365GroupAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Creates Microsoft 365 Group';
+    return 'Creates a Microsoft 365 Group';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.displayName = typeof args.options.displayName !== 'undefined';
+    telemetryProps.mailNickname = typeof args.options.mailNickname !== 'undefined';
+    telemetryProps.isPrivate = (!(!args.options.isPrivate)).toString();
+    telemetryProps.allowMembersToPost = (!(!args.options.allowMembersToPost)).toString();
+    telemetryProps.hideGroupInOutlook = (!(!args.options.hideGroupInOutlook)).toString();
+    telemetryProps.subscribeNewGroupMembers = (!(!args.options.subscribeNewGroupMembers)).toString();
+    telemetryProps.welcomeEmailDisabled = (!(!args.options.welcomeEmailDisabled)).toString();
+    return telemetryProps;
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {


### PR DESCRIPTION
Extends `aad o365group add` command. Closes #3080
Set `resourceBehaviorOptions` at creation time of an Microsoft 365 Group.