### PR TITLE
Refactoring `teams chat message send`, closes #3106, #3107, #3123

### DIFF
--- a/src/m365/teams/commands/chat/chat-message-send.spec.ts
+++ b/src/m365/teams/commands/chat/chat-message-send.spec.ts
@@ -434,7 +434,7 @@ describe(commands.CHAT_MESSAGE_SEND, () => {
       try {
         assert.strictEqual(
           JSON.stringify(err),
-          JSON.stringify(new CommandError(`Multiple chat conversations with this topic found. Please disambiguate:${os.EOL}${[
+          JSON.stringify(new CommandError(`Multiple chat conversations with this name found. Please disambiguate:${os.EOL}${[
             `- 19:309128478c1743b19bebd08efc390efb@thread.v2 - ${new Date("2021-09-14T07:44:11.5Z").toLocaleString()} - AlexW@M365x214355.onmicrosoft.com, MeganB@M365x214355.onmicrosoft.com, NateG@M365x214355.onmicrosoft.com`,
             `- 19:650081f4700a4414ac15cd7993129f80@thread.v2 - ${new Date("2020-06-26T08:27:55.154Z").toLocaleString()} - MeganB@M365x214355.onmicrosoft.com, AlexW@M365x214355.onmicrosoft.com, NateG@M365x214355.onmicrosoft.com`
           ].join(os.EOL)}`)));
@@ -456,7 +456,7 @@ describe(commands.CHAT_MESSAGE_SEND, () => {
       try {
         assert.strictEqual(
           JSON.stringify(err),
-          JSON.stringify(new CommandError(`Multiple chat conversations with this topic found. Please disambiguate:${os.EOL}${[
+          JSON.stringify(new CommandError(`Multiple chat conversations with this name found. Please disambiguate:${os.EOL}${[
             `- 19:35bd5bc75e604da8a64e6cba7cfcf175@thread.v2 - Megan Bowen_Alex Wilber_Sundar Ganesan_ArchivedChat - ${new Date("2021-12-22T13:13:11.023Z").toLocaleString()}`,
             `- 19:5fb8d18dd38b40a4ae0209888adf5c38@thread.v2 - CC Call v3 - ${new Date("2021-10-18T16:56:30.205Z").toLocaleString()}`
           ].join(os.EOL)}`)));                              

--- a/src/m365/teams/commands/chat/chat-message-send.ts
+++ b/src/m365/teams/commands/chat/chat-message-send.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { accessToken, ODataResponse, validation } from '../../../../utils';
+import { accessToken, odata, validation } from '../../../../utils';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -32,18 +32,21 @@ class TeamsChatMessageSendCommand extends GraphCommand {
     return 'Send a message to an existing or new chat conversation.';
   }
 
-  public async commandAction(logger: Logger, args: CommandArgs, cb: () => void): Promise<void> {
-    try {
-      const chatId = args.options.chatId
-        || args.options.userEmails && await this.ensureChatIdByUserEmails(args.options.userEmails)
-        || args.options.chatName && await this.getChatIdByName(args.options.chatName);
+  public getTelemetryProperties(args: any): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.chatId = typeof args.options.chatId !== 'undefined';
+    telemetryProps.userEmails = typeof args.options.userEmails !== 'undefined';
+    telemetryProps.chatName = typeof args.options.chatName !== 'undefined';
+    return telemetryProps;
+  }
 
-      await this.sendChatMessage(chatId as string, args.options);
-      cb();
-    }
-    catch (error) {
-      this.handleRejectedODataJsonPromise(error, logger, cb);
-    }
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {    
+    this
+      .getChatId(logger, args)
+      .then(chatId => this.sendChatMessage(chatId as string, args))
+      .then(_ => {
+        cb();
+      }, (err: any) => this.handleRejectedODataJsonPromise(err, logger, cb));   
   }
 
   public options(): CommandOption[] {
@@ -89,7 +92,7 @@ class TeamsChatMessageSendCommand extends GraphCommand {
     }
 
     if (args.options.userEmails) {
-      const userEmails = args.options.userEmails.toLowerCase().replace(/\s/g, '').split(',').filter(e => e && e !== '');
+      const userEmails = this.convertCommaSeparatedListToArray(args.options.userEmails);
       if (!userEmails || userEmails.length === 0 || userEmails.some(e => !validation.isValidUserPrincipalName(e))) {
         return `${args.options.userEmails} contains one or more invalid email addresses.`;
       }
@@ -98,30 +101,39 @@ class TeamsChatMessageSendCommand extends GraphCommand {
     return true;
   }
 
-  private async ensureChatIdByUserEmails(userEmailsOption: string): Promise<string> {
-    const userEmails = userEmailsOption.toLowerCase().replace(/\s/g, '').split(',').filter(e => e && e !== '');
-    const currentUserEmail = accessToken.getUserNameFromAccessToken(Auth.service.accessTokens[this.resource].accessToken).toLowerCase();
-    const existingChats = await this.findExistingGroupChatsByMembers([currentUserEmail, ...userEmails]);
+  private async getChatId(logger: Logger, args: CommandArgs): Promise<string> {
+    if (args.options.chatId) {
+      return args.options.chatId;
+    }    
 
-    if (existingChats && existingChats.length > 0) {
-      if (existingChats.length > 1) {
-        const disambiguationText = existingChats.map(c => {
-          return `- ${c.id}${c.topic && ' - '}${c.topic} - ${c.createdDateTime && new Date(c.createdDateTime).toLocaleString()}`;
-        }).join(os.EOL);
-
-        throw new Error(`Multiple chat conversations with this topic found. Please disambiguate:${os.EOL}${disambiguationText}`);
-      }
-      else {
-        return existingChats[0].id as string;
-      }
-    }
-
-    const chat = await this.createConversation([currentUserEmail, ...userEmails]);
-    return chat.id as string;
+    return args.options.userEmails 
+      ? this.ensureChatIdByUserEmails(args.options.userEmails, logger)
+      : this.getChatIdByName(args.options.chatName as string, logger);
   }
 
-  private async getChatIdByName(chatName: string): Promise<string> {
-    const existingChats = await this.findExistingGroupChatsByTopic(chatName);
+  private async ensureChatIdByUserEmails(userEmailsOption: string, logger: Logger): Promise<string> {
+    const userEmails = this.convertCommaSeparatedListToArray(userEmailsOption);
+    const currentUserEmail = accessToken.getUserNameFromAccessToken(Auth.service.accessTokens[this.resource].accessToken).toLowerCase();
+    const existingChats = await this.findExistingGroupChatsByMembers([currentUserEmail, ...userEmails], logger);
+    
+    if (!existingChats || existingChats.length === 0) {
+      const chat = await this.createConversation([currentUserEmail, ...userEmails]);
+      return chat.id as string;
+    }
+
+    if (existingChats.length === 1) {
+      return existingChats[0].id as string;
+    }
+
+    const disambiguationText = existingChats.map(c => {
+      return `- ${c.id}${c.topic && ' - '}${c.topic} - ${c.createdDateTime && new Date(c.createdDateTime).toLocaleString()}`;
+    }).join(os.EOL);
+
+    throw new Error(`Multiple chat conversations with this name found. Please disambiguate:${os.EOL}${disambiguationText}`);
+  }
+
+  private async getChatIdByName(chatName: string, logger: Logger): Promise<string> {
+    const existingChats = await this.findExistingGroupChatsByName(chatName, logger);
 
     if (!existingChats || existingChats.length === 0) {
       throw new Error('No chat conversation was found with this name.');
@@ -136,7 +148,7 @@ class TeamsChatMessageSendCommand extends GraphCommand {
       return `- ${c.id} - ${c.createdDateTime && new Date(c.createdDateTime).toLocaleString()} - ${memberstring}`;
     }).join(os.EOL);
 
-    throw new Error(`Multiple chat conversations with this topic found. Please disambiguate:${os.EOL}${disambiguationText}`);
+    throw new Error(`Multiple chat conversations with this name found. Please disambiguate:${os.EOL}${disambiguationText}`);
   }
 
   // This Microsoft Graph API request throws an intermittent 404 exception, saying that it cannot find the principal.
@@ -178,7 +190,7 @@ class TeamsChatMessageSendCommand extends GraphCommand {
     }
   }
 
-  private async sendChatMessage(chatId: string, options: Options): Promise<void> {
+  private async sendChatMessage(chatId: string, args: CommandArgs): Promise<void> {
     const requestOptions: AxiosRequestConfig = {
       url: `${this.resource}/v1.0/chats/${chatId}/messages`,
       headers: {
@@ -188,7 +200,7 @@ class TeamsChatMessageSendCommand extends GraphCommand {
       responseType: 'json',
       data: {
         body: {
-          content: options.message
+          content: args.options.message
         }
       }
     };
@@ -196,11 +208,11 @@ class TeamsChatMessageSendCommand extends GraphCommand {
     await request.post(requestOptions);
   }
 
-  private async findExistingGroupChatsByMembers(expectedMemberEmails: string[]): Promise<Chat[]> {
+  private async findExistingGroupChatsByMembers(expectedMemberEmails: string[], logger: Logger): Promise<Chat[]> {
     const endpoint = `${this.resource}/v1.0/chats?$filter=chatType eq 'group'&$expand=members&$select=id,topic,createdDateTime,members`;
     const foundChats: Chat[] = [];
 
-    const chats = await this.getAllChats(endpoint, []);
+    const chats = await odata.getAllItems<Chat>(endpoint, logger);
 
     for (const chat of chats) {
       const chatMembers = chat.members as ConversationMember[];
@@ -216,31 +228,13 @@ class TeamsChatMessageSendCommand extends GraphCommand {
     return foundChats;
   }
 
-  private async findExistingGroupChatsByTopic(topic: string): Promise<Chat[]> {
-    const endpoint = `${this.resource}/v1.0/chats?$filter=topic eq '${encodeURIComponent(topic)}'&$expand=members&$select=id,topic,createdDateTime,chatType`;
-    const chats = await this.getAllChats(endpoint, []);
-    return chats;
+  private async findExistingGroupChatsByName(name: string, logger: Logger): Promise<Chat[]> {
+    const endpoint = `${this.resource}/v1.0/chats?$filter=topic eq '${encodeURIComponent(name)}'&$expand=members&$select=id,topic,createdDateTime,chatType`;
+    return odata.getAllItems<Chat>(endpoint, logger);
   }
 
-  private async getAllChats(url: string, items: Chat[]): Promise<Chat[]> {
-    const requestOptions: AxiosRequestConfig = {
-      url: url,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
-
-    const res = await request.get<ODataResponse<Chat>>(requestOptions);
-
-    items = items.concat(res.value);
-
-    if (res['@odata.nextLink']) {
-      return await this.getAllChats(res['@odata.nextLink'] as string, items);
-    }
-    else {
-      return items;
-    }
+  private convertCommaSeparatedListToArray(userEmailsString: string): string[] {
+    return userEmailsString.toLowerCase().replace(/\s/g, '').split(',').filter(e => e && e !== '');
   }
 }
 


### PR DESCRIPTION
Closes #3106, Closes #3107, Closes #3123

This pull request refactors the following points in the `teams chat message send` command:
- CommandAction return `void` instead of `Promise<void>`
- Use `odata.getAllItems` util function
- Add telemetry properties for optional parameters
- Rename all instances of 'topic' to 'name' for consistency.
- Update ensureChatIdByUserEmails function for readability and consistency
- Refactor string to array conversion into a function