### PR TITLE
Add options to `spo tenant settings set` to enable the new B2B integration. Closes #3110

### DIFF
--- a/docs/docs/cmd/spo/tenant/tenant-settings-set.md
+++ b/docs/docs/cmd/spo/tenant/tenant-settings-set.md
@@ -258,6 +258,12 @@ m365 spo tenant settings set [options]
 `--DisableCustomAppAuthentication [DisableCustomAppAuthentication]`
 : Configure if ACS-based app-only auth should be disabled or not. Allowed values `true,false`
 
+`--EnableAzureADB2BIntegration [EnableAzureADB2BIntegration]`
+: Enables the preview for OneDrive and SharePoint integration with Azure AD B2B. Allowed values `true,false`. Azure AD one-time passcode needs to be enabled for this integration to work. For more information see [http://aka.ms/spo-b2b-integration](http://aka.ms/spo-b2b-integration).
+
+`--SyncAadB2BManagementPolicy [SyncAadB2BManagementPolicy]`
+: Syncs Azure B2B Management Policies. Allowed values `true,false`. For more information, see [SharePoint and OneDrive integration with Azure AD B2B](https://docs.microsoft.com/en-us/sharepoint/sharepoint-azureb2b-integration-preview).
+
 !!! important
     To use this command you have to have permissions to access the tenant admin site.
 
@@ -273,4 +279,17 @@ Sets multiple tenant global settings at once
 
 ```sh
 m365 spo tenant settings set --UserVoiceForFeedbackEnabled true --HideSyncButtonOnODB true --AllowedDomainListForSyncClient c9b1909e-901a-0000-2cdb-e91c3f46320a,c9b1909e-901a-0000-2cdb-e91c3f463201
+```
+
+Enable Azure AD B2B integration for SharePoint and OneDrive and sync the Azure AD B2B management policies
+
+```sh
+m365 spo tenant settings set --EnableAzureADB2BIntegration true
+m365 spo tenant settings set --SyncAadB2BManagementPolicy true
+```
+
+Disable Azure AD B2B integration for SharePoint and OneDrive
+
+```sh
+m365 spo tenant settings set --EnableAzureADB2BIntegration false
 ```

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -71,7 +71,7 @@ export default abstract class Command {
     }
   }
 
-  protected showWarning(logger: Logger, warning: string): void {
+  protected warn(logger: Logger, warning: string): void {
     const chalk: typeof Chalk = require('chalk');
     logger.logToStderr(chalk.yellow(warning));
   }

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -71,6 +71,11 @@ export default abstract class Command {
     }
   }
 
+  protected showWarning(logger: Logger, warning: string): void {
+    const chalk: typeof Chalk = require('chalk');
+    logger.logToStderr(chalk.yellow(warning));
+  }
+
   protected getUsedCommandName(): string {
     const cli: Cli = Cli.getInstance();
     const commandName: string = this.getCommandName();

--- a/src/m365/spo/commands/tenant/tenant-settings-set.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-settings-set.spec.ts
@@ -14,6 +14,7 @@ describe(commands.TENANT_SETTINGS_SET, () => {
   let log: any[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let loggerStderrLogSpy: sinon.SinonSpy;
 
   const defaultRequestsSuccessStub = (): sinon.SinonStub => {
     return sinon.stub(request, 'post').callsFake((opts) => {
@@ -57,6 +58,7 @@ describe(commands.TENANT_SETTINGS_SET, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
+    loggerStderrLogSpy = sinon.spy(logger, 'logToStderr');
   });
 
   afterEach(() => {
@@ -388,5 +390,23 @@ describe(commands.TENANT_SETTINGS_SET, () => {
     };
     const actual = command.validate({ options: options });
     assert.strictEqual(actual, true);
+  });
+  
+  it('shows warning when option EnableAzureADB2BIntegration is used with value true', (done) => {
+    defaultRequestsSuccessStub();
+
+    command.action(logger, {
+      options: {
+        EnableAzureADB2BIntegration: 'true'
+      }
+    }, () => {
+      try {
+        assert.strictEqual(loggerStderrLogSpy.calledOnceWith("WARNING: Make sure to also enable the Azure AD one-time passcode authentication preview. If it is not enabled then SharePoint will not use Azure AD B2B even if EnableAzureADB2BIntegration is set to true. Learn more at http://aka.ms/spo-b2b-integration."), true);        
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
   });
 });

--- a/src/m365/spo/commands/tenant/tenant-settings-set.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-settings-set.spec.ts
@@ -8,6 +8,7 @@ import config from '../../../../config';
 import request from '../../../../request';
 import { sinonUtil, spo } from '../../../../utils';
 import commands from '../../commands';
+import * as chalk from 'chalk';
 const command: Command = require('./tenant-settings-set');
 
 describe(commands.TENANT_SETTINGS_SET, () => {
@@ -401,7 +402,7 @@ describe(commands.TENANT_SETTINGS_SET, () => {
       }
     }, () => {
       try {
-        assert.strictEqual(loggerStderrLogSpy.calledOnceWith("WARNING: Make sure to also enable the Azure AD one-time passcode authentication preview. If it is not enabled then SharePoint will not use Azure AD B2B even if EnableAzureADB2BIntegration is set to true. Learn more at http://aka.ms/spo-b2b-integration."), true);        
+        assert.strictEqual(loggerStderrLogSpy.calledWith(chalk.yellow("WARNING: Make sure to also enable the Azure AD one-time passcode authentication preview. If it is not enabled then SharePoint will not use Azure AD B2B even if EnableAzureADB2BIntegration is set to true. Learn more at http://aka.ms/spo-b2b-integration.")), true);        
         done();
       }
       catch (e) {

--- a/src/m365/spo/commands/tenant/tenant-settings-set.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-settings-set.spec.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
 import { Logger } from '../../../../cli';
-import Command, { CommandError } from '../../../../Command';
+import Command, { CommandError, CommandTypes } from '../../../../Command';
 import config from '../../../../config';
 import request from '../../../../request';
 import { sinonUtil, spo } from '../../../../utils';
@@ -85,6 +85,11 @@ describe(commands.TENANT_SETTINGS_SET, () => {
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
+  });
+
+  it('configures command types', () => {
+    assert.notStrictEqual(typeof command.types(), 'undefined', 'command types undefined');
+    assert.notStrictEqual((command.types() as CommandTypes).string, 'undefined', 'command string types undefined');
   });
 
   it('supports debug mode', () => {
@@ -398,7 +403,7 @@ describe(commands.TENANT_SETTINGS_SET, () => {
 
     command.action(logger, {
       options: {
-        EnableAzureADB2BIntegration: 'true'
+        EnableAzureADB2BIntegration: true
       }
     }, () => {
       try {

--- a/src/m365/spo/commands/tenant/tenant-settings-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-settings-set.ts
@@ -97,6 +97,8 @@ export interface Options extends GlobalOptions {
   AllowedDomainListForSyncClient: string[];
   DisabledWebPartIds: string[];
   DisableCustomAppAuthentication: boolean;
+  EnableAzureADB2BIntegration: boolean;
+  SyncAadB2BManagementPolicy: boolean;
 }
 
 class SpoTenantSettingsSetCommand extends SpoCommand {
@@ -192,6 +194,8 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
     telemetryProps.DisabledWebPartIds = (!(!args.options.DisabledWebPartIds)).toString();
     telemetryProps.AllowedDomainListForSyncClient = (!(!args.options.AllowedDomainListForSyncClient)).toString();
     telemetryProps.DisableCustomAppAuthentication = (!(!args.options.DisableCustomAppAuthentication)).toString();
+    telemetryProps.EnableAzureADB2BIntegration = (!(!args.options.EnableAzureADB2BIntegration)).toString();
+    telemetryProps.SyncAadB2BManagementPolicy = (!(!args.options.SyncAadB2BManagementPolicy)).toString();
     return telemetryProps;
   }
 
@@ -279,6 +283,10 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
         if (response.ErrorInfo) {
           cb(new CommandError(response.ErrorInfo.ErrorMessage));
           return;
+        }
+
+        if (args.options.EnableAzureADB2BIntegration === 'true') {
+          this.showWarning(logger, 'WARNING: Make sure to also enable the Azure AD one-time passcode authentication preview. If it is not enabled then SharePoint will not use Azure AD B2B even if EnableAzureADB2BIntegration is set to true. Learn more at http://aka.ms/spo-b2b-integration.');
         }
 
         cb();
@@ -595,6 +603,14 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
       },
       {
         option: '--DisableCustomAppAuthentication [DisableCustomAppAuthentication]',
+        autocomplete: ['true', 'false']
+      },
+      {
+        option: '--EnableAzureADB2BIntegration [EnableAzureADB2BIntegration]',
+        autocomplete: ['true', 'false']
+      },
+      {
+        option: '--SyncAadB2BManagementPolicy [SyncAadB2BManagementPolicy]',
         autocomplete: ['true', 'false']
       }
     ];

--- a/src/m365/spo/commands/tenant/tenant-settings-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-settings-set.ts
@@ -1,6 +1,6 @@
 import { Logger } from '../../../../cli';
 import {
-  CommandError, CommandOption
+  CommandError, CommandOption, CommandTypes
 } from '../../../../Command';
 import config from '../../../../config';
 import GlobalOptions from '../../../../GlobalOptions';
@@ -97,8 +97,8 @@ export interface Options extends GlobalOptions {
   AllowedDomainListForSyncClient: string[];
   DisabledWebPartIds: string[];
   DisableCustomAppAuthentication: boolean;
-  EnableAzureADB2BIntegration: string;
-  SyncAadB2BManagementPolicy: string;
+  EnableAzureADB2BIntegration: boolean;
+  SyncAadB2BManagementPolicy: boolean;
 }
 
 class SpoTenantSettingsSetCommand extends SpoCommand {
@@ -108,6 +108,15 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
 
   public get description(): string {
     return 'Sets tenant global settings';
+  }
+  
+  public types(): CommandTypes {
+    return {
+      boolean: [
+        'EnableAzureADB2BIntegration',
+        'SyncAadB2BManagementPolicy'
+      ]
+    };
   }
 
   public getTelemetryProperties(args: CommandArgs): any {
@@ -285,7 +294,7 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
           return;
         }
 
-        if (args.options.EnableAzureADB2BIntegration === 'true') {
+        if (args.options.EnableAzureADB2BIntegration === true) {
           this.warn(logger, 'WARNING: Make sure to also enable the Azure AD one-time passcode authentication preview. If it is not enabled then SharePoint will not use Azure AD B2B even if EnableAzureADB2BIntegration is set to true. Learn more at http://aka.ms/spo-b2b-integration.');
         }
 

--- a/src/m365/spo/commands/tenant/tenant-settings-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-settings-set.ts
@@ -97,8 +97,8 @@ export interface Options extends GlobalOptions {
   AllowedDomainListForSyncClient: string[];
   DisabledWebPartIds: string[];
   DisableCustomAppAuthentication: boolean;
-  EnableAzureADB2BIntegration: boolean;
-  SyncAadB2BManagementPolicy: boolean;
+  EnableAzureADB2BIntegration: string;
+  SyncAadB2BManagementPolicy: string;
 }
 
 class SpoTenantSettingsSetCommand extends SpoCommand {
@@ -194,8 +194,8 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
     telemetryProps.DisabledWebPartIds = (!(!args.options.DisabledWebPartIds)).toString();
     telemetryProps.AllowedDomainListForSyncClient = (!(!args.options.AllowedDomainListForSyncClient)).toString();
     telemetryProps.DisableCustomAppAuthentication = (!(!args.options.DisableCustomAppAuthentication)).toString();
-    telemetryProps.EnableAzureADB2BIntegration = (!(!args.options.EnableAzureADB2BIntegration)).toString();
-    telemetryProps.SyncAadB2BManagementPolicy = (!(!args.options.SyncAadB2BManagementPolicy)).toString();
+    telemetryProps.EnableAzureADB2BIntegration = typeof args.options.EnableAzureADB2BIntegration !== 'undefined';
+    telemetryProps.SyncAadB2BManagementPolicy = typeof args.options.SyncAadB2BManagementPolicy !== 'undefined';
     return telemetryProps;
   }
 
@@ -214,7 +214,7 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
   private getSpecialCharactersState(): string[] { return ['NoPreference', 'Allowed', 'Disallowed']; }
   private getSPOLimitedAccessFileType(): string[] { return ['OfficeOnlineFilesOnly', 'WebPreviewableFiles', 'OtherFiles']; }
 
-  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
+  public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
     let formDigestValue = '';
     let spoAdminUrl: string = '';
     let tenantId: string = '';
@@ -286,7 +286,7 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
         }
 
         if (args.options.EnableAzureADB2BIntegration === 'true') {
-          this.showWarning(logger, 'WARNING: Make sure to also enable the Azure AD one-time passcode authentication preview. If it is not enabled then SharePoint will not use Azure AD B2B even if EnableAzureADB2BIntegration is set to true. Learn more at http://aka.ms/spo-b2b-integration.');
+          this.warn(logger, 'WARNING: Make sure to also enable the Azure AD one-time passcode authentication preview. If it is not enabled then SharePoint will not use Azure AD B2B even if EnableAzureADB2BIntegration is set to true. Learn more at http://aka.ms/spo-b2b-integration.');
         }
 
         cb();


### PR DESCRIPTION
Closes #3110

Adds the options `EnableAzureADB2BIntegration` and `SyncAadB2BManagementPolicy`.

More info: https://docs.microsoft.com/en-us/sharepoint/sharepoint-azureb2b-integration





