### PR TITLE
Fixes 'Authenticate with and call the Microsoft Graph' sample

### DIFF
--- a/docs/docs/sample-scripts/graph/call-graph.md
+++ b/docs/docs/sample-scripts/graph/call-graph.md
@@ -7,7 +7,7 @@ Obtain a new access token for the Microsoft Graph and use it an HTTP request.
 === "PowerShell"
 
     ```powershell
-    $token = m365 util accesstoken get --resource https://graph.microsoft.com --new
+    $token = m365 util accesstoken get --resource https://graph.microsoft.com --new --output text
     $me = Invoke-RestMethod -Uri https://graph.microsoft.com/v1.0/me -Headers @{"Authorization"="Bearer $token"}
     $me
     ```
@@ -19,7 +19,7 @@ Obtain a new access token for the Microsoft Graph and use it an HTTP request.
 
     # requires jq: https://stedolan.github.io/jq/
 
-    token=`m365 util accesstoken get --resource https://graph.microsoft.com --new`
+    token=`m365 util accesstoken get --resource https://graph.microsoft.com --new --output text`
     me=`curl https://graph.microsoft.com/v1.0/me -H "Authorization: Bearer $token"`
     echo $me | jq
     ```


### PR DESCRIPTION
Following the default output change to JSON, the sample no longer works as the JSON response adds quotes around the access token in the response which when used in the HTTP request throws an error.

By adding the `--output text` option, the enclosing quotes are stripped out and the HTTP request can be executed successfully.