### PR TITLE
Added the capability to provide 'optionSets' in commands.

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -161,6 +161,10 @@ export default abstract class Command {
     ];
   }
 
+  public optionSets(): string[][] | undefined {
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public validate(args: any): boolean | string {
     return true;

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -47,6 +47,33 @@ class MockCommand extends AnonymousCommand {
   }
 }
 
+class MockCommandWithOptionSets extends AnonymousCommand {
+  public get name(): string {
+    return 'cli mock optionsets';
+  }
+  public get description(): string {
+    return 'Mock command with option sets';
+  }
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '--opt1 [name]'
+      },
+      {
+        option: '--opt2 [name]'
+      }
+    ];
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+  public optionSets(): string[][] | undefined {
+    return [["opt1", "opt2"], []];
+  }
+  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
+    cb();
+  }
+}
+
 class MockCommandWithAlias extends AnonymousCommand {
   public get name(): string {
     return 'cli mock alias';
@@ -145,6 +172,7 @@ describe('Cli', () => {
   let markshellStub: sinon.SinonStub;
   let mockCommandActionSpy: sinon.SinonSpy;
   let mockCommand: Command;
+  let mockCommandWithOptionSets: Command;
   let mockCommandWithAlias: Command;
   let mockCommandWithValidation: Command;
 
@@ -160,6 +188,7 @@ describe('Cli', () => {
     mockCommand = new MockCommand();
     mockCommandWithAlias = new MockCommandWithAlias();
     mockCommandWithValidation = new MockCommandWithValidation();
+    mockCommandWithOptionSets = new MockCommandWithOptionSets();
     mockCommandActionSpy = sinon.spy(mockCommand, 'action');
 
     return new Promise((resolve) => {
@@ -173,6 +202,7 @@ describe('Cli', () => {
   beforeEach(() => {
     cli = Cli.getInstance();
     (cli as any).loadCommand(mockCommand);
+    (cli as any).loadCommand(mockCommandWithOptionSets);
     (cli as any).loadCommand(mockCommandWithAlias);
     (cli as any).loadCommand(mockCommandWithValidation);
   });
@@ -428,6 +458,34 @@ describe('Cli', () => {
       .then(_ => done('Promise fulfilled while error expected'), _ => {
         try {
           assert(cliErrorStub.calledWith(chalk.red(`Error: Required option parameterX not specified`)));
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+  });
+
+  it(`shows error when optionSets validation fails - at least one option is specified`, (done) => {
+    cli
+      .execute(rootFolder, ['cli', 'mock', 'optionsets'])
+      .then(_ => done('Promise fulfilled while error expected'), _ => {
+        try {
+          assert(cliErrorStub.calledWith(chalk.red('Error: Specify either opt1,opt2.')));
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      });
+  });
+
+  it(`shows error when optionSets validation fails - multiple options are specified`, (done) => {
+    cli
+      .execute(rootFolder, ['cli', 'mock', 'optionsets', '--opt1', 'testvalue', '--opt2', 'testvalue'])
+      .then(_ => done('Promise fulfilled while error expected'), _ => {
+        try {
+          assert(cliErrorStub.calledWith(chalk.red('Error: Specify either opt1,opt2 but not multiple.')));
           done();
         }
         catch (e) {
@@ -784,7 +842,7 @@ describe('Cli', () => {
       .then(_ => {
         try {
           // 12 commands from the folder + 3 mocks
-          assert.strictEqual(cli.commands.length, 12 + 3);
+          assert.strictEqual(cli.commands.length, 12 + 4);
           done();
         }
         catch (e) {
@@ -1377,7 +1435,7 @@ describe('Cli', () => {
     (cli as any).printAvailableCommands();
 
     try {
-      assert(cliLogStub.calledWith('  cli *  4 commands'));
+      assert(cliLogStub.calledWith('  cli *  5 commands'));
       done();
     }
     catch (e) {
@@ -1397,7 +1455,7 @@ describe('Cli', () => {
     (cli as any).printAvailableCommands();
 
     try {
-      assert(cliLogStub.calledWith('  cli mock *   2 commands'));
+      assert(cliLogStub.calledWith('  cli mock *   3 commands'));
       done();
     }
     catch (e) {
@@ -1417,7 +1475,7 @@ describe('Cli', () => {
     (cli as any).printAvailableCommands();
 
     try {
-      assert(cliLogStub.calledWith('  cli *  4 commands'));
+      assert(cliLogStub.calledWith('  cli *  5 commands'));
       done();
     }
     catch (e) {

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -161,7 +161,7 @@ export class Cli {
         if (!shouldPrompt) {
           return this.closeWithError(`Required option ${this.commandToExecute.options[i].name} not specified`, this.optionsFromArgs, true);
         }
-        
+
         if (i === 0) {
           Cli.log('Provide values for the following parameters:');
         }
@@ -202,6 +202,23 @@ export class Cli {
     if (optionsWithoutShorts.options.output === undefined) {
       optionsWithoutShorts.options.output = this.getSettingWithDefaultValue<string | undefined>(settingsNames.output, undefined);
     }
+
+    // Validate the Option sets provided in the command
+    const optionsSets: string[][] | undefined = this.commandToExecute.command.optionSets();
+    const argsOptions: string[] = Object.keys(this.optionsFromArgs.options);
+    const cmdArgs = this.optionsFromArgs;
+    optionsSets?.forEach((optionSet) => {
+      if (optionSet.length > 0) {
+        const commonOptions = argsOptions.filter(opt => optionSet.includes(opt));
+        if (commonOptions.length === 0) {
+          return this.closeWithError(`Specify either ${optionSet.map(opt => opt).join(',')}.`, cmdArgs, false);
+        }
+        if (commonOptions.length > 1) {
+          return this.closeWithError(`Specify either ${optionSet.map(opt => opt).join(',')} but not multiple.`, cmdArgs, false);
+        }
+      }
+    });
+
 
     const validationResult: boolean | string = this.commandToExecute.command.validate(optionsWithoutShorts);
     if (typeof validationResult === 'string') {


### PR DESCRIPTION
> ### #2998 extend command definition with option set
>
> - Extends command definition with 'optionSets'. Closes #2998 
> - Example usage : To provide 'optionSets' for `aad app get` command where any one and atleast one option from 'appId', 'objectId', 'name' must be provided, the command definition can be extended by adding the below


```
public optionSets(): string[][] | undefined {
    return [['appId', 'objectId', 'name']];
  }
```