### PR TITLE
Add new setting autoOpenLinksInBrowser and implement it in login, reconsent. Closes #3118

### DIFF
--- a/docs/docs/_clisettings.md
+++ b/docs/docs/_clisettings.md
@@ -4,7 +4,8 @@ Following is the list of configuration settings available in CLI for Microsoft 3
 
 Setting name|Definition|Default value
 ------------|----------|-------------
-`autoOpenBrowserOnLogin`|Automatically open the browser to the Azure AD login page after running `m365 login` command in device code mode|`false`
+`autoOpenBrowserOnLogin`|Automatically open the browser to the Azure AD login page after running `m365 login` command in device code mode. This setting will be replaced by `autoOpenLinksInBrowser` in the next major release.|`false`
+`autoOpenLinksInBrowser`|Automatically open the browser for all commands which return a url and expect the user to copy paste this to the browser. For example when logging in, using `m365 login` in device code mode. This setting will replace `autoOpenBrowserOnLogin` in the next major release.|`false`
 `copyDeviceCodeToClipboard`|Automatically copy the device code to the clipboard when running `m365 login` command in device code mode|`false`
 `csvEscape`|Single character used for escaping; only apply to characters matching the quote and the escape options|`"`
 `csvHeader`|Display the column names on the first line|`true`

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -432,7 +432,20 @@ describe('Auth', () => {
     });
   });
 
-  it('opens the browser with the login', () => {
+  it('opens the browser with the login (using autoOpenBrowserOnLogin)', () => {
+    (auth as any).processDeviceCodeCallback(response, logger, false);
+    assert(openStub.called);
+  });
+
+  it('opens the browser with the login (using autoOpenLinksInBrowser)', () => {
+    getSettingWithDefaultValueStub.restore();
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(((settingName, defaultValue) => {
+      if (settingName === "autoOpenBrowserOnLogin") { return false; }
+      else if (settingName === "autoOpenLinksInBrowser") { return true; }
+      else {
+        return defaultValue;
+      }
+    }));
     (auth as any).processDeviceCodeCallback(response, logger, false);
     assert(openStub.called);
   });

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -361,7 +361,8 @@ export class Auth {
 
     logger.log(response.message);
 
-    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenBrowserOnLogin, false)) {
+    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenBrowserOnLogin, false)
+      || Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false)) {
       // _open is never set before hitting this line, but this check
       // is implemented so that we can support lazy loading
       // but also stub it for testing

--- a/src/m365/cli/commands/cli-reconsent.spec.ts
+++ b/src/m365/cli/commands/cli-reconsent.spec.ts
@@ -1,15 +1,20 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as open from 'open';
 import appInsights from '../../../appInsights';
-import { Logger } from '../../../cli';
-import Command from '../../../Command';
+import { Cli, Logger } from '../../../cli';
+import Command, { CommandError } from '../../../Command';
 import { sinonUtil } from '../../../utils';
 import commands from '../commands';
 const command: Command = require('./cli-reconsent');
 
-describe(commands.COMPLETION_SH_SETUP, () => {
+describe(commands.RECONSENT, () => {
   let log: string[];
   let logger: Logger;
+  let cli: Cli;
+  let getSettingWithDefaultValueStub: sinon.SinonStub;
+  let openStub: sinon.SinonStub;
+  let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
     sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
@@ -17,6 +22,7 @@ describe(commands.COMPLETION_SH_SETUP, () => {
 
   beforeEach(() => {
     log = [];
+    cli = Cli.getInstance();
     logger = {
       log: (msg: string) => {
         log.push(msg);
@@ -28,6 +34,16 @@ describe(commands.COMPLETION_SH_SETUP, () => {
         log.push(msg);
       }
     };
+    loggerLogSpy = sinon.spy(logger, 'log');
+    (command as any)._open = open;
+    openStub = sinon.stub(command as any, '_open').callsFake(() => Promise.resolve(null));  
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((() => false));   
+  });
+
+  afterEach(() => {
+    loggerLogSpy.restore();
+    openStub.restore();    
+    getSettingWithDefaultValueStub.restore();
   });
 
   after(() => {
@@ -44,10 +60,56 @@ describe(commands.COMPLETION_SH_SETUP, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('generates file with commands info', (done) => {
-    command.action(logger, { options: { debug: false } }, () => {
+  it('shows message with url (not using autoOpenLinksInBrowser)', (done) => {   
+    command.action(logger, { options: { debug: false } }, (err) => {
+      try {   
+        assert(loggerLogSpy.calledWith(`To re-consent the PnP Microsoft 365 Management Shell Azure AD application navigate in your web browser to https://login.microsoftonline.com/common/oauth2/authorize?client_id=31359c7f-bd7e-475c-86db-fdb8c937548e&response_type=code&prompt=admin_consent`));
+        assert.strictEqual(err, undefined);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('shows message with url (using autoOpenLinksInBrowser)', (done) => {
+    getSettingWithDefaultValueStub.restore();
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((() => true));
+
+    command.action(logger, {
+      options: {
+        debug: false
+      }
+    }, (err?: any) => {
       try {
-        assert(log[0].indexOf('/oauth2/authorize?client_id') > -1);
+        assert(loggerLogSpy.calledWith(`Opening the following page in your browser: https://login.microsoftonline.com/common/oauth2/authorize?client_id=31359c7f-bd7e-475c-86db-fdb8c937548e&response_type=code&prompt=admin_consent`));
+        assert.strictEqual(err, undefined);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('throws error when open in browser fails', (done) => {
+    openStub.restore();
+    openStub = sinon.stub(command as any, '_open').callsFake(() => Promise.reject("An error occurred"));
+    getSettingWithDefaultValueStub.restore();
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((() => true));
+
+    command.action(logger, {
+      options: {
+        debug: false
+      }
+    }, (err?: any) => {
+      try {        
+        assert(loggerLogSpy.calledWith(`Opening the following page in your browser: https://login.microsoftonline.com/common/oauth2/authorize?client_id=31359c7f-bd7e-475c-86db-fdb8c937548e&response_type=code&prompt=admin_consent`));
+        assert.strictEqual(
+          JSON.stringify(err),
+          JSON.stringify(new CommandError("An error occurred"))
+        );
         done();
       }
       catch (e) {

--- a/src/m365/cli/commands/cli-reconsent.ts
+++ b/src/m365/cli/commands/cli-reconsent.ts
@@ -1,6 +1,8 @@
-import { Logger } from '../../../cli';
+import { Cli, Logger } from '../../../cli';
+import type * as open from 'open';
 import config from '../../../config';
 import GlobalOptions from '../../../GlobalOptions';
+import { settingsNames } from '../../../settingsNames';
 import AnonymousCommand from '../../base/AnonymousCommand';
 import commands from '../commands';
 
@@ -9,6 +11,8 @@ interface CommandArgs {
 }
 
 class CliReconsentCommand extends AnonymousCommand {
+  private _open: typeof open | undefined;
+
   public get name(): string {
     return commands.RECONSENT;
   }
@@ -18,8 +22,28 @@ class CliReconsentCommand extends AnonymousCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
-    logger.log(`To re-consent the PnP Microsoft 365 Management Shell Azure AD application navigate in your web browser to https://login.microsoftonline.com/${config.tenant}/oauth2/authorize?client_id=${config.cliAadAppId}&response_type=code&prompt=admin_consent`);
-    cb();
+    const url = `https://login.microsoftonline.com/${config.tenant}/oauth2/authorize?client_id=${config.cliAadAppId}&response_type=code&prompt=admin_consent`;
+
+    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) === false) {
+      logger.log(`To re-consent the PnP Microsoft 365 Management Shell Azure AD application navigate in your web browser to ${url}`);
+      return cb();
+    } 
+
+    logger.log(`Opening the following page in your browser: ${url}`);
+
+    // _open is never set before hitting this line, but this check
+    // is implemented so that we can support lazy loading
+    // but also stub it for testing
+    /* c8 ignore next 3 */
+    if (!this._open) {
+      this._open = require('open');
+    }
+    
+    (this._open as typeof open)(url).then(() => {
+      cb();
+    }, (error) => {
+      this.handleRejectedODataJsonPromise(error, logger, cb);
+    });      
   }
 }
 

--- a/src/m365/cli/commands/config/config-set.spec.ts
+++ b/src/m365/cli/commands/config/config-set.spec.ts
@@ -76,6 +76,25 @@ describe(commands.CONFIG_SET, () => {
     });
   });
 
+  it(`sets ${settingsNames.autoOpenLinksInBrowser} property`, (done) => {
+    const config = Cli.getInstance().config;
+    let actualKey: string, actualValue: any;
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+    command.action(logger, { options: { key: settingsNames.autoOpenLinksInBrowser, value: false } }, () => {
+      try {
+        assert.strictEqual(actualKey, settingsNames.autoOpenLinksInBrowser, 'Invalid key');
+        assert.strictEqual(actualValue, false, 'Invalid value');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it(`sets ${settingsNames.output} property to 'text'`, (done) => {
     const output = "text";
     const config = Cli.getInstance().config;

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -36,6 +36,7 @@ class CliConfigSetCommand extends AnonymousCommand {
 
     switch (args.options.key) {
       case settingsNames.autoOpenBrowserOnLogin:
+      case settingsNames.autoOpenLinksInBrowser:
       case settingsNames.copyDeviceCodeToClipboard:
       case settingsNames.csvHeader:
       case settingsNames.csvQuoted:

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -1,5 +1,6 @@
 const settingsNames = {
   autoOpenBrowserOnLogin: 'autoOpenBrowserOnLogin',
+  autoOpenLinksInBrowser: 'autoOpenLinksInBrowser',
   copyDeviceCodeToClipboard: 'copyDeviceCodeToClipboard',
   csvEscape: 'csvEscape',
   csvHeader: 'csvHeader',


### PR DESCRIPTION
Closes #3118

Adds new configurable setting `autoOpenLinksInBrowser` with default value `false`.
This setting will be used for commands that return a url and expect users to copy and paste that url into the browser.

Implemented the setting in the `login` and `reconsent` commands.

