### PR TITLE
Extends `spfx project upgrade` with guidance for SPFx fast serve. Closes #3154

### DIFF
--- a/src/m365/spfx/commands/project/project-upgrade.spec.ts
+++ b/src/m365/spfx/commands/project/project-upgrade.spec.ts
@@ -2147,7 +2147,7 @@ describe(commands.PROJECT_UPGRADE, () => {
 
     command.action(logger, { options: { toVersion: '1.9.1', output: 'json' } } as any, () => {
       const findings: FindingToReport[] = log[0];
-      assert.strictEqual(findings.length, 23);
+      assert.strictEqual(findings.length, 24);
     });
   });
   //#endregion
@@ -2333,7 +2333,7 @@ describe(commands.PROJECT_UPGRADE, () => {
 
     command.action(logger, { options: { toVersion: '1.12.0', output: 'json' } } as any, () => {
       const findings: FindingToReport[] = log[0];
-      assert.strictEqual(findings.length, 33);
+      assert.strictEqual(findings.length, 34);
     });
   });
   //#endregion
@@ -2445,7 +2445,7 @@ describe(commands.PROJECT_UPGRADE, () => {
 
     command.action(logger, { options: { toVersion: '1.13.0', output: 'json' } } as any, () => {
       const findings: FindingToReport[] = log[0];
-      assert.strictEqual(findings.length, 28);
+      assert.strictEqual(findings.length, 29);
     });
   });
   //#endregion
@@ -2557,7 +2557,7 @@ describe(commands.PROJECT_UPGRADE, () => {
 
     command.action(logger, { options: { toVersion: '1.14.0', output: 'json' } } as any, () => {
       const findings: FindingToReport[] = log[0];
-      assert.strictEqual(findings.length, 23);
+      assert.strictEqual(findings.length, 24);
     });
   });
   //#endregion

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN002019_DEVDEP_spfx_fast_serve_helpers.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN002019_DEVDEP_spfx_fast_serve_helpers.ts
@@ -1,4 +1,3 @@
-import { Project } from "../../model";
 import { DependencyRule } from "./DependencyRule";
 
 export class FN002019_DEVDEP_spfx_fast_serve_helpers extends DependencyRule {
@@ -8,11 +7,5 @@ export class FN002019_DEVDEP_spfx_fast_serve_helpers extends DependencyRule {
 
   get id(): string {
     return 'FN002019';
-  }
-
-  customCondition(project: Project): boolean {
-    return typeof project.packageJson !== 'undefined' &&
-    typeof project.packageJson.devDependencies !== 'undefined' &&
-    typeof project.packageJson.devDependencies['spfx-fast-serve-helpers'] !== 'undefined';
   }
 }

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN002019_DEVDEP_spfx_fast_serve_helpers.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN002019_DEVDEP_spfx_fast_serve_helpers.ts
@@ -11,8 +11,8 @@ export class FN002019_DEVDEP_spfx_fast_serve_helpers extends DependencyRule {
   }
 
   customCondition(project: Project): boolean {
-    return (typeof project.packageJson !== 'undefined' &&
+    return typeof project.packageJson !== 'undefined' &&
     typeof project.packageJson.devDependencies !== 'undefined' &&
-    typeof project.packageJson.devDependencies['spfx-fast-serve-helpers'] !== 'undefined');
+    typeof project.packageJson.devDependencies['spfx-fast-serve-helpers'] !== 'undefined';
   }
 }

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN002019_DEVDEP_spfx_fast_serve_helpers.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN002019_DEVDEP_spfx_fast_serve_helpers.ts
@@ -1,0 +1,18 @@
+import { Project } from "../../model";
+import { DependencyRule } from "./DependencyRule";
+
+export class FN002019_DEVDEP_spfx_fast_serve_helpers extends DependencyRule {
+  constructor(packageVersion: string) {
+    super('spfx-fast-serve-helpers', packageVersion, true, true);
+  }
+
+  get id(): string {
+    return 'FN002019';
+  }
+
+  customCondition(project: Project): boolean {
+    return (typeof project.packageJson !== 'undefined' &&
+    typeof project.packageJson.devDependencies !== 'undefined' &&
+    typeof project.packageJson.devDependencies['spfx-fast-serve-helpers'] !== 'undefined');
+  }
+}

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.12.0.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.12.0.ts
@@ -32,6 +32,7 @@ import { FN002014_DEVDEP_types_es6_promise } from "./rules/FN002014_DEVDEP_types
 import { FN002015_DEVDEP_types_react } from "./rules/FN002015_DEVDEP_types_react";
 import { FN002016_DEVDEP_types_react_dom } from "./rules/FN002016_DEVDEP_types_react_dom";
 import { FN002017_DEVDEP_microsoft_rush_stack_compiler_3_7 } from "./rules/FN002017_DEVDEP_microsoft_rush_stack_compiler_3_7";
+import { FN002019_DEVDEP_spfx_fast_serve_helpers } from "./rules/FN002019_DEVDEP_spfx_fast_serve_helpers";
 import { FN010001_YORC_version } from "./rules/FN010001_YORC_version";
 import { FN012013_TSC_exclude } from "./rules/FN012013_TSC_exclude";
 import { FN012017_TSC_extends } from "./rules/FN012017_TSC_extends";
@@ -76,6 +77,7 @@ module.exports = [
   new FN002014_DEVDEP_types_es6_promise('', false),
   new FN002015_DEVDEP_types_react('16.9.36'),
   new FN002016_DEVDEP_types_react_dom('16.9.8'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.12.0'),
   new FN010001_YORC_version('1.12.0'),
   new FN012013_TSC_exclude([], false),
   new FN012017_TSC_extends('./node_modules/@microsoft/rush-stack-compiler-3.7/includes/tsconfig-web.json'),

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.12.0.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.12.0.ts
@@ -77,7 +77,7 @@ module.exports = [
   new FN002014_DEVDEP_types_es6_promise('', false),
   new FN002015_DEVDEP_types_react('16.9.36'),
   new FN002016_DEVDEP_types_react_dom('16.9.8'),
-  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.12.0'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('1.12.0'),
   new FN010001_YORC_version('1.12.0'),
   new FN012013_TSC_exclude([], false),
   new FN012017_TSC_extends('./node_modules/@microsoft/rush-stack-compiler-3.7/includes/tsconfig-web.json'),

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.13.0.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.13.0.ts
@@ -27,6 +27,7 @@ import { FN002009_DEVDEP_microsoft_sp_tslint_rules } from "./rules/FN002009_DEVD
 import { FN002015_DEVDEP_types_react } from "./rules/FN002015_DEVDEP_types_react";
 import { FN002017_DEVDEP_microsoft_rush_stack_compiler_3_7 } from "./rules/FN002017_DEVDEP_microsoft_rush_stack_compiler_3_7";
 import { FN002018_DEVDEP_microsoft_rush_stack_compiler_3_9 } from "./rules/FN002018_DEVDEP_microsoft_rush_stack_compiler_3_9";
+import { FN002019_DEVDEP_spfx_fast_serve_helpers } from "./rules/FN002019_DEVDEP_spfx_fast_serve_helpers";
 import { FN006004_CFG_PS_developer } from "./rules/FN006004_CFG_PS_developer";
 import { FN007002_CFG_S_initialPage } from "./rules/FN007002_CFG_S_initialPage";
 import { FN007003_CFG_S_api } from "./rules/FN007003_CFG_S_api";
@@ -67,6 +68,7 @@ module.exports = [
   new FN002015_DEVDEP_types_react('16.9.51'),
   new FN002017_DEVDEP_microsoft_rush_stack_compiler_3_7('', false),
   new FN002018_DEVDEP_microsoft_rush_stack_compiler_3_9('0.4.47'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.4.0'),
   new FN006004_CFG_PS_developer('1.13.0'),
   new FN007002_CFG_S_initialPage('https://enter-your-SharePoint-site/_layouts/workbench.aspx'),
   new FN007003_CFG_S_api(),

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.13.0.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.13.0.ts
@@ -68,7 +68,7 @@ module.exports = [
   new FN002015_DEVDEP_types_react('16.9.51'),
   new FN002017_DEVDEP_microsoft_rush_stack_compiler_3_7('', false),
   new FN002018_DEVDEP_microsoft_rush_stack_compiler_3_9('0.4.47'),
-  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.4.0'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('1.13.0'),
   new FN006004_CFG_PS_developer('1.13.0'),
   new FN007002_CFG_S_initialPage('https://enter-your-SharePoint-site/_layouts/workbench.aspx'),
   new FN007003_CFG_S_api(),

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.14.0.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.14.0.ts
@@ -20,6 +20,7 @@ import { FN001032_DEP_microsoft_sp_page_context } from "./rules/FN001032_DEP_mic
 import { FN002001_DEVDEP_microsoft_sp_build_web } from "./rules/FN002001_DEVDEP_microsoft_sp_build_web";
 import { FN002002_DEVDEP_microsoft_sp_module_interfaces } from "./rules/FN002002_DEVDEP_microsoft_sp_module_interfaces";
 import { FN002009_DEVDEP_microsoft_sp_tslint_rules } from "./rules/FN002009_DEVDEP_microsoft_sp_tslint_rules";
+import { FN002019_DEVDEP_spfx_fast_serve_helpers } from "./rules/FN002019_DEVDEP_spfx_fast_serve_helpers";
 import { FN006004_CFG_PS_developer } from "./rules/FN006004_CFG_PS_developer";
 import { FN006005_CFG_PS_metadata } from "./rules/FN006005_CFG_PS_metadata";
 import { FN006006_CFG_PS_features } from "./rules/FN006006_CFG_PS_features";
@@ -49,6 +50,7 @@ module.exports = [
   new FN002001_DEVDEP_microsoft_sp_build_web('1.14.0'),
   new FN002002_DEVDEP_microsoft_sp_module_interfaces('1.14.0'),
   new FN002009_DEVDEP_microsoft_sp_tslint_rules('1.14.0'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.14.0'),
   new FN006004_CFG_PS_developer('1.14.0'),
   new FN006005_CFG_PS_metadata(),
   new FN006006_CFG_PS_features(),

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.14.0.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.14.0.ts
@@ -50,7 +50,7 @@ module.exports = [
   new FN002001_DEVDEP_microsoft_sp_build_web('1.14.0'),
   new FN002002_DEVDEP_microsoft_sp_module_interfaces('1.14.0'),
   new FN002009_DEVDEP_microsoft_sp_tslint_rules('1.14.0'),
-  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.14.0'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('1.14.0'),
   new FN006004_CFG_PS_developer('1.14.0'),
   new FN006005_CFG_PS_metadata(),
   new FN006006_CFG_PS_features(),

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.4.1.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.4.1.ts
@@ -38,6 +38,6 @@ module.exports = [
   new FN002001_DEVDEP_microsoft_sp_build_web('1.4.1'),
   new FN002002_DEVDEP_microsoft_sp_module_interfaces('1.4.1'),
   new FN002003_DEVDEP_microsoft_sp_webpart_workbench('1.4.1'),
-  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.4.0'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('1.4.0'),
   new FN010001_YORC_version('1.4.1')
 ]; 

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.4.1.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.4.1.ts
@@ -1,3 +1,4 @@
+import { FN002019_DEVDEP_spfx_fast_serve_helpers } from './rules/FN002019_DEVDEP_spfx_fast_serve_helpers';
 import { FN001001_DEP_microsoft_sp_core_library } from "./rules/FN001001_DEP_microsoft_sp_core_library";
 import { FN001002_DEP_microsoft_sp_lodash_subset } from "./rules/FN001002_DEP_microsoft_sp_lodash_subset";
 import { FN001003_DEP_microsoft_sp_office_ui_fabric_core } from "./rules/FN001003_DEP_microsoft_sp_office_ui_fabric_core";
@@ -37,5 +38,6 @@ module.exports = [
   new FN002001_DEVDEP_microsoft_sp_build_web('1.4.1'),
   new FN002002_DEVDEP_microsoft_sp_module_interfaces('1.4.1'),
   new FN002003_DEVDEP_microsoft_sp_webpart_workbench('1.4.1'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.4.0'),
   new FN010001_YORC_version('1.4.1')
 ]; 

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.9.1.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.9.1.ts
@@ -27,6 +27,7 @@ import { FN002002_DEVDEP_microsoft_sp_module_interfaces } from "./rules/FN002002
 import { FN002003_DEVDEP_microsoft_sp_webpart_workbench } from "./rules/FN002003_DEVDEP_microsoft_sp_webpart_workbench";
 import { FN002009_DEVDEP_microsoft_sp_tslint_rules } from "./rules/FN002009_DEVDEP_microsoft_sp_tslint_rules";
 import { FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9 } from "./rules/FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9";
+import { FN002019_DEVDEP_spfx_fast_serve_helpers } from "./rules/FN002019_DEVDEP_spfx_fast_serve_helpers";
 import { FN010001_YORC_version } from "./rules/FN010001_YORC_version";
 import { FN020001_RES_types_react } from "./rules/FN020001_RES_types_react";
 import { FN021001_PKG_main } from "./rules/FN021001_PKG_main";
@@ -61,6 +62,7 @@ module.exports = [
   new FN002003_DEVDEP_microsoft_sp_webpart_workbench('1.9.1'),
   new FN002009_DEVDEP_microsoft_sp_tslint_rules('1.9.1'),
   new FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9('0.7.16'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.11.0'),
   new FN010001_YORC_version('1.9.1'),
   new FN020001_RES_types_react('16.8.8'),
   new FN021001_PKG_main(true, "lib/index.js"),

--- a/src/m365/spfx/commands/project/project-upgrade/upgrade-1.9.1.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/upgrade-1.9.1.ts
@@ -62,7 +62,7 @@ module.exports = [
   new FN002003_DEVDEP_microsoft_sp_webpart_workbench('1.9.1'),
   new FN002009_DEVDEP_microsoft_sp_tslint_rules('1.9.1'),
   new FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9('0.7.16'),
-  new FN002019_DEVDEP_spfx_fast_serve_helpers('~1.11.0'),
+  new FN002019_DEVDEP_spfx_fast_serve_helpers('1.11.0'),
   new FN010001_YORC_version('1.9.1'),
   new FN020001_RES_types_react('16.8.8'),
   new FN021001_PKG_main(true, "lib/index.js"),

--- a/src/m365/spfx/commands/project/test-projects/spfx-1100-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1100-webpart-optionaldeps/package.json
@@ -39,6 +39,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.11.0"
+    "spfx-fast-serve-helpers": "1.11.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1100-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1100-webpart-optionaldeps/package.json
@@ -38,6 +38,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.11.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1110-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1110-webpart-optionaldeps/package.json
@@ -39,6 +39,7 @@
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
     "@types/webpack-env": "1.13.1",
-    "@types/es6-promise": "0.0.33"
+    "@types/es6-promise": "0.0.33",
+    "spfx-fast-serve-helpers": "~1.11.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1110-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1110-webpart-optionaldeps/package.json
@@ -40,6 +40,6 @@
     "ajv": "~5.2.2",
     "@types/webpack-env": "1.13.1",
     "@types/es6-promise": "0.0.33",
-    "spfx-fast-serve-helpers": "~1.11.0"
+    "spfx-fast-serve-helpers": "1.11.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1120-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1120-webpart-optionaldeps/package.json
@@ -33,6 +33,7 @@
     "@microsoft/rush-stack-compiler-3.7": "0.2.3",
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "spfx-fast-serve-helpers": "~1.12.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1120-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1120-webpart-optionaldeps/package.json
@@ -34,6 +34,6 @@
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
     "@types/webpack-env": "1.13.1",
-    "spfx-fast-serve-helpers": "~1.12.0"
+    "spfx-fast-serve-helpers": "1.12.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1121-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1121-webpart-optionaldeps/package.json
@@ -33,6 +33,7 @@
     "@microsoft/rush-stack-compiler-3.7": "0.2.3",
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "spfx-fast-serve-helpers": "~1.12.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1121-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1121-webpart-optionaldeps/package.json
@@ -34,6 +34,6 @@
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
     "@types/webpack-env": "1.13.1",
-    "spfx-fast-serve-helpers": "~1.12.0"
+    "spfx-fast-serve-helpers": "1.12.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1130-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1130-webpart-optionaldeps/package.json
@@ -32,6 +32,7 @@
     "@microsoft/rush-stack-compiler-3.9": "0.4.47",
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "spfx-fast-serve-helpers": "~1.13.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1130-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1130-webpart-optionaldeps/package.json
@@ -33,6 +33,6 @@
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
     "@types/webpack-env": "1.13.1",
-    "spfx-fast-serve-helpers": "~1.13.0"
+    "spfx-fast-serve-helpers": "1.13.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1131-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1131-webpart-optionaldeps/package.json
@@ -32,6 +32,7 @@
     "@microsoft/rush-stack-compiler-3.9": "0.4.47",
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "spfx-fast-serve-helpers": "~1.13.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1131-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1131-webpart-optionaldeps/package.json
@@ -33,6 +33,6 @@
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
     "@types/webpack-env": "1.13.1",
-    "spfx-fast-serve-helpers": "~1.13.0"
+    "spfx-fast-serve-helpers": "1.13.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1140-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1140-webpart-optionaldeps/package.json
@@ -32,6 +32,7 @@
     "@microsoft/rush-stack-compiler-3.9": "0.4.47",
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
-    "@types/webpack-env": "1.14.0"
+    "@types/webpack-env": "1.14.0",
+    "spfx-fast-serve-helpers": "~1.14.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-1140-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-1140-webpart-optionaldeps/package.json
@@ -33,6 +33,6 @@
     "gulp": "~4.0.2",
     "ajv": "~5.2.2",
     "@types/webpack-env": "1.14.0",
-    "spfx-fast-serve-helpers": "~1.14.0"
+    "spfx-fast-serve-helpers": "1.14.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-141-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-141-webpart-optionaldeps/package.json
@@ -31,6 +31,7 @@
     "gulp": "~3.9.1",
     "@types/chai": ">=3.4.34 <3.6.0",
     "@types/mocha": ">=2.2.33 <2.6.0",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-141-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-141-webpart-optionaldeps/package.json
@@ -32,6 +32,6 @@
     "@types/chai": ">=3.4.34 <3.6.0",
     "@types/mocha": ">=2.2.33 <2.6.0",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-150-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-150-webpart-optionaldeps/package.json
@@ -35,6 +35,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-150-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-150-webpart-optionaldeps/package.json
@@ -34,6 +34,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-151-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-151-webpart-optionaldeps/package.json
@@ -35,6 +35,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-151-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-151-webpart-optionaldeps/package.json
@@ -34,6 +34,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-160-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-160-webpart-optionaldeps/package.json
@@ -35,6 +35,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-160-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-160-webpart-optionaldeps/package.json
@@ -36,6 +36,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-170-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-170-webpart-optionaldeps/package.json
@@ -36,6 +36,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-170-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-170-webpart-optionaldeps/package.json
@@ -37,6 +37,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-171-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-171-webpart-optionaldeps/package.json
@@ -36,6 +36,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-171-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-171-webpart-optionaldeps/package.json
@@ -37,6 +37,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-180-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-180-webpart-optionaldeps/package.json
@@ -39,6 +39,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-180-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-180-webpart-optionaldeps/package.json
@@ -38,6 +38,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-181-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-181-webpart-optionaldeps/package.json
@@ -39,6 +39,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-181-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-181-webpart-optionaldeps/package.json
@@ -38,6 +38,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-182-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-182-webpart-optionaldeps/package.json
@@ -39,6 +39,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.4.0"
+    "spfx-fast-serve-helpers": "1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-182-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-182-webpart-optionaldeps/package.json
@@ -38,6 +38,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.4.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-191-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-191-webpart-optionaldeps/package.json
@@ -39,6 +39,6 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
-    "spfx-fast-serve-helpers": "~1.11.0"
+    "spfx-fast-serve-helpers": "1.11.0"
   }
 }

--- a/src/m365/spfx/commands/project/test-projects/spfx-191-webpart-optionaldeps/package.json
+++ b/src/m365/spfx/commands/project/test-projects/spfx-191-webpart-optionaldeps/package.json
@@ -38,6 +38,7 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "ajv": "~5.2.2"
+    "ajv": "~5.2.2",
+    "spfx-fast-serve-helpers": "~1.11.0"
   }
 }


### PR DESCRIPTION
Extends `spfx project upgrade` with guidance for SPFx fast serve. Closes #3154 

Currently I haven't described anything within the documentation about this extension. Is it needed to document something about this change?