### PR TITLE
Adding search externalConnections get. Closes #3169

### DIFF
--- a/docs/docs/cmd/search/externalconnection/externalconnection-get.md
+++ b/docs/docs/cmd/search/externalconnection/externalconnection-get.md
@@ -1,0 +1,37 @@
+# search externalconnection get
+
+Retrieves an external connection for Microsoft Search by Id or Name.
+
+## Usage
+
+```sh
+m365 search externalconnection get [options]
+```
+
+## Options
+
+`-i, --id [id]`
+: Developer-provided unique ID of the connection within the Azure Active Directory tenant
+
+`-n, --name [name]`
+: The display name of the connection to be displayed in the Microsoft 365 admin center. Maximum length of 128 characters
+
+--8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+To retrieve the External Connection, either Id or Name should be supplied but not both.
+
+## Examples
+
+Returns an external connection with id of "TestApp"
+
+```sh
+m365 search externalconnection get --id "TestApp"
+```
+
+Returns an external connection with name of "Test App"
+
+```sh
+m365 search externalconnection get --name "Test App"
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -232,6 +232,7 @@ nav:
     - Search (search):
       - externalconnection:
         - externalconnection add: 'cmd/search/externalconnection/externalconnection-add.md'
+        - externalconnection get: 'cmd/search/externalconnection/externalconnection-get.md'
     - Skype (skype):
       - report:
         - report activitycounts: 'cmd/skype/report/report-activitycounts.md'

--- a/src/m365/search/commands.ts
+++ b/src/m365/search/commands.ts
@@ -1,5 +1,6 @@
 const prefix: string = 'search';
 
 export default {
-  EXTERNALCONNECTION_ADD: `${prefix} externalconnection add`
+  EXTERNALCONNECTION_ADD: `${prefix} externalconnection add`,
+  EXTERNALCONNECTION_GET: `${prefix} externalconnection get`
 };

--- a/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
@@ -1,0 +1,265 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils';
+import commands from '../../commands';
+const command: Command = require('./externalconnection-get');
+
+describe(commands.EXTERNALCONNECTION_GET, () => {
+  let log: string[];
+  let logger: Logger;
+
+  const externalConnectionGetResponse: any = {
+    configuration: {
+      authorizedAppIds: []
+    },
+    description: 'Test connection that will not do anything',
+    id: 'TestConnectionForCLI',
+    name: 'Test Connection for CLI'
+  };
+
+  const externalConnectionGetResponseWithAppIDs: any = {
+    configuration: {
+      'authorizedAppIds': [
+        '00000000-0000-0000-0000-000000000000',
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000002'
+      ]
+    },
+    description: 'Test connection that will not do anything',
+    id: 'TestConnectionForCLI',
+    name: 'Test Connection for CLI'
+  };
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.post
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.EXTERNALCONNECTION_GET), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('gets an external connection', (done: any) => {
+    const postStub = sinon.stub(request, 'get').callsFake((opts: any) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
+        return Promise.resolve(externalConnectionGetResponse);
+      }
+      return Promise.reject('Invalid request');
+    });
+    const options: any = {
+      debug: false,
+      id: 'TestConnectionForCLI',
+      name: 'Test Connection for CLI',
+      description: 'Test connection that will not do anything'
+    };
+    command.action(logger, { options: options } as any, () => {
+      try {
+        assert.deepStrictEqual(postStub.getCall(0).args[0].data, externalConnectionGetResponse);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets an external connection with authorized app id', (done: any) => {
+    const postStub = sinon.stub(request, 'get').callsFake((opts: any) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
+        return Promise.resolve(externalConnectionGetResponse);
+      }
+      return Promise.reject('Invalid request');
+    });
+    const options: any = {
+      debug: false,
+      id: 'TestConnectionForCLI',
+      name: 'Test Connection for CLI',
+      description: 'Test connection that will not do anything',
+      authorizedAppIds: '00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002'
+    };
+    command.action(logger, { options: options } as any, () => {
+      try {
+        assert.deepStrictEqual(postStub.getCall(0).args[0].data, externalConnectionGetResponseWithAppIDs);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets an external connection with authorised app IDs', (done: any) => {
+    const postStub = sinon.stub(request, 'post').callsFake((opts: any) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
+        return Promise.resolve(externalConnectionGetResponseWithAppIDs);
+      }
+      return Promise.reject('Invalid request');
+    });
+    const options: any = {
+      debug: false,
+      id: 'TestConnectionForCLI',
+      name: 'Test Connection for CLI',
+      description: 'Test connection that will not do anything',
+      authorizedAppIds: '00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002'
+    };
+    command.action(logger, { options: options } as any, () => {
+      try {
+        assert.deepStrictEqual(postStub.getCall(0).args[0].data, externalConnectionGetResponseWithAppIDs);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles error', (done) => {
+    sinon.stub(request, 'post').callsFake(() => {
+      return Promise.reject({
+        "error": {
+          "code": "Error",
+          "message": "An error has occurred",
+          "innerError": {
+            "request-id": "9b0df954-93b5-4de9-8b99-43c204a8aaf8",
+            "date": "2018-04-24T18:56:48"
+          }
+        }
+      });
+    });
+
+    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`An error has occurred`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails validation if id is less than 3 characters', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'T',
+        name: 'Test Connection for CLI'
+      }
+    });
+    assert.notStrictEqual(actual, false);
+    done();
+  });
+
+  it('fails validation if id is more than 32 characters', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'TestConnectionForCLIXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        name: 'Test Connection for CLI'
+      }
+    });
+    assert.notStrictEqual(actual, false);
+    done();
+  });
+
+  it('fails validation if id is not alphanumeric', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'Test_Connection!',
+        name: 'Test Connection for CLI'
+      }
+    });
+    assert.notStrictEqual(actual, false);
+    done();
+  });
+
+  it('fails validation if id starts with Microsoft', () => {
+    const actual = command.validate({
+      options: {
+        id: 'MicrosoftTestConnectionForCLI',
+        name: 'Test Connection for CLI'
+      }
+    });
+    assert.notStrictEqual(actual, false);
+  });
+
+  it('fails validation if id is SharePoint', () => {
+    const actual = command.validate({
+      options: {
+        id: 'SharePoint',
+        name: 'Test Connection for CLI'
+      }
+    });
+    assert.notStrictEqual(actual, false);
+  });
+
+  it('passes validation for a valid id', () => {
+    const actual = command.validate({
+      options: {
+        id: 'myapp',
+        name: 'Test Connection for CLI'
+      }
+    });
+    assert.strictEqual(actual, true);
+  });
+
+  it('supports specifying id', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--id') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying name', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--name') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+});

--- a/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
 import { Logger } from '../../../../cli';
-import Command, { CommandError } from '../../../../Command';
+import Command from '../../../../Command';
 import request from '../../../../request';
 import { sinonUtil } from '../../../../utils';
 import commands from '../../commands';

--- a/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
@@ -158,6 +158,25 @@ describe(commands.EXTERNALCONNECTION_GET, () => {
     });
   });
 
+  it('fails validation if neither id or name is set', () => {
+    const actual = command.validate({
+      options: {
+        broken: 'Broken'
+      }
+    });
+    assert.notStrictEqual(actual, false);
+  });
+
+  it('fails validation if id and name is set', () => {
+    const actual = command.validate({
+      options: {
+        id: 'Id',
+        name: 'Name'
+      }
+    });
+    assert.notStrictEqual(actual, false);
+  });
+
   it('fails validation if id is less than 3 characters', (done) => {
     const actual = command.validate({
       options: {

--- a/src/m365/search/commands/externalconnection/externalconnection-get.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-get.ts
@@ -2,7 +2,6 @@ import { Logger } from '../../../../cli';
 import { ExternalConnectors } from '@microsoft/microsoft-graph-types';
 import GraphCommand from '../../../base/GraphCommand';
 import GlobalOptions from '../../../../GlobalOptions';
-import { validation } from '../../../../utils';
 import commands from '../../commands';
 import { CommandOption } from '../../../../Command';
 import request from '../../../../request';
@@ -17,7 +16,6 @@ interface Options extends GlobalOptions {
 }
 
 class SearchExternalConnectionGetCommand extends GraphCommand {
-  private items: ExternalConnectors.ExternalConnection[] = [];
 
   public get name(): string {
     return commands.EXTERNALCONNECTION_GET;
@@ -41,7 +39,7 @@ class SearchExternalConnectionGetCommand extends GraphCommand {
       endpoint += `/'${encodeURIComponent(args.options.id)}'`;
     }
     else {
-      endpoint += `?$filter=displayName eq '${encodeURIComponent(args.options.name as string)}'`;
+      endpoint += `?$filter=name eq '${encodeURIComponent(args.options.name as string)}'`;
     }
 
     const requestOptions: any = {
@@ -51,11 +49,14 @@ class SearchExternalConnectionGetCommand extends GraphCommand {
       },
       responseType: 'json'
     };
+
     request.get<ExternalConnectors.ExternalConnection>(requestOptions)
-      .then((): void => {
-        logger.log(this.items);
+      .then((res: ExternalConnectors.ExternalConnection): void => {
+        logger.log(res);
         cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+      }, (err: any): void => {
+        this.handleRejectedODataJsonPromise(err, logger, cb);
+      });
   }
 
   public options(): CommandOption[] {
@@ -73,16 +74,12 @@ class SearchExternalConnectionGetCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (!args.options.name && !args.options.displayName) {
-      return 'Specify either name or displayName';
+    if (!args.options.name && !args.options.id) {
+      return 'Specify either name or id';
     }
 
-    if (args.options.name && args.options.displayName) {
-      return 'Specify either name or displayName but not both';
-    }
-
-    if (args.options.name && !validation.isValidGuid(args.options.name)) {
-      return `${args.options.name} is not a valid GUID`;
+    if (args.options.name && args.options.id) {
+      return 'Specify either name or id but not both';
     }
 
     return true;

--- a/src/m365/search/commands/externalconnection/externalconnection-get.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-get.ts
@@ -1,0 +1,92 @@
+import { Logger } from '../../../../cli';
+import { ExternalConnectors } from '@microsoft/microsoft-graph-types';
+import GraphCommand from '../../../base/GraphCommand';
+import GlobalOptions from '../../../../GlobalOptions';
+import { validation } from '../../../../utils';
+import commands from '../../commands';
+import { CommandOption } from '../../../../Command';
+import request from '../../../../request';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  id?: string;
+  name?: string;
+}
+
+class SearchExternalConnectionGetCommand extends GraphCommand {
+  private items: ExternalConnectors.ExternalConnection[] = [];
+
+  public get name(): string {
+    return commands.EXTERNALCONNECTION_GET;
+  }
+
+  public get description(): string {
+    return 'Retrieves the specified external connections';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.id = typeof args.options.id !== 'undefined';
+    telemetryProps.name = typeof args.options.name !== 'undefined';
+    return telemetryProps;
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    let endpoint: string = `${this.resource}/v1.0/external/connections`;
+    
+    if (args.options.id) {
+      endpoint += `/'${encodeURIComponent(args.options.id)}'`;
+    }
+    else {
+      endpoint += `?$filter=displayName eq '${encodeURIComponent(args.options.name as string)}'`;
+    }
+
+    const requestOptions: any = {
+      url: endpoint,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+    request.get<ExternalConnectors.ExternalConnection>(requestOptions)
+      .then((): void => {
+        logger.log(this.items);
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --id [id]'
+      },
+      {
+        option: '-n, --name [name]'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    if (!args.options.name && !args.options.displayName) {
+      return 'Specify either name or displayName';
+    }
+
+    if (args.options.name && args.options.displayName) {
+      return 'Specify either name or displayName but not both';
+    }
+
+    if (args.options.name && !validation.isValidGuid(args.options.name)) {
+      return `${args.options.name} is not a valid GUID`;
+    }
+
+    return true;
+  }
+}
+
+module.exports = new SearchExternalConnectionGetCommand();

--- a/src/m365/search/commands/externalconnection/externalconnection-get.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-get.ts
@@ -36,7 +36,7 @@ class SearchExternalConnectionGetCommand extends GraphCommand {
     let endpoint: string = `${this.resource}/v1.0/external/connections`;
     
     if (args.options.id) {
-      endpoint += `/'${encodeURIComponent(args.options.id)}'`;
+      endpoint += `/${encodeURIComponent(args.options.id)}`;
     }
     else {
       endpoint += `?$filter=name eq '${encodeURIComponent(args.options.name as string)}'`;


### PR DESCRIPTION
This starts adds the ability to retrieve a specific external connection for Microsoft search https://docs.microsoft.com/en-us/graph/api/externalconnectors-externalconnection-get?view=graph-rest-1.0&tabs=http

Please note that it requires the Application permission of ExternalConnection.ReadWrite.OwnedBy to work.