### PR TITLE
Adding search externalConnections remove. Closes #3170

### DIFF
--- a/docs/docs/cmd/search/externalconnection/externalconnection-remove.md
+++ b/docs/docs/cmd/search/externalconnection/externalconnection-remove.md
@@ -1,0 +1,37 @@
+# search externalconnection remove
+
+Removes the specified new external connection for Microsoft Search
+
+## Usage
+
+```sh
+m365 search externalconnection remove [options]
+```
+
+## Options
+
+`-i, --id [id]`
+: Developer-provided unique ID of the connection within the Azure Active Directory tenant
+
+`-n, --name [name]`
+: The display name of the connection to be displayed in the Microsoft 365 admin center. Maximum length of 128 characters
+
+--8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+The `id` must be at least 3 and no more than 32 characters long. It can contain only alphanumeric characters, can't begin with _Microsoft_ and can be any of the following values: *None, Directory, Exchange, ExchangeArchive, LinkedIn, Mailbox, OneDriveBusiness, SharePoint, Teams, Yammer, Connectors, TaskFabric, PowerBI, Assistant, TopicEngine, MSFT_All_Connectors*.
+
+## Examples
+
+Removes external connection with id of TestApp
+
+```sh
+m365 search externalconnection remove --id "TestApp"
+```
+
+Removes external connection with name of Test App
+
+```sh
+m365 search externalconnection remove --name "TestApp"
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -231,7 +231,8 @@ nav:
         - managementapp add: 'cmd/pp/managementapp/managementapp-add.md'
     - Search (search):
       - externalconnection:
-        - externalconnection add: 'cmd/search/externalconnection/externalconnection-add.md'
+        - externalconnection add: 'cmd/search/externalconnection/externalconnection-add.md',
+        - externalconnection remove: 'cmd/search/externalconnection/externalconnection-remove.md'
     - Skype (skype):
       - report:
         - report activitycounts: 'cmd/skype/report/report-activitycounts.md'

--- a/src/m365/search/commands.ts
+++ b/src/m365/search/commands.ts
@@ -1,5 +1,6 @@
 const prefix: string = 'search';
 
 export default {
-  EXTERNALCONNECTION_ADD: `${prefix} externalconnection add`
+  EXTERNALCONNECTION_ADD: `${prefix} externalconnection add`,
+  EXTERNALCONNECTION_REMOVE: `${prefix} externalconnection remove`
 };

--- a/src/m365/search/commands/externalconnection/externalconnection-remove.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-remove.spec.ts
@@ -1,0 +1,238 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Cli, Logger } from '../../../../cli';
+import Command from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils';
+import commands from '../../commands';
+const command: Command = require('./externalconnection-add');
+
+describe(commands.EXTERNALCONNECTION_REMOVE, () => {
+  let log: string[];
+  let logger: Logger;
+  let promptOptions: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    (command as any).items = [];
+
+    promptOptions = undefined;
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      promptOptions = options;
+      cb({ continue: false });
+    });
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      request.delete,
+      Cli.prompt
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.EXTERNALCONNECTION_REMOVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('passes validation when valid id is specified', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'TestApp'
+      }
+    });
+    assert.strictEqual(actual, true);
+    done();
+  });
+
+  it('passes validation when valid name is specified', (done) => {
+    const actual = command.validate({
+      options: {
+        name: 'Test App'
+      }
+    });
+    assert.strictEqual(actual, true);
+    done();
+  });
+
+  it('prompts before removing the specified team when confirm option not passed', (done) => {
+    command.action(logger, { options: { debug: false, id: "Test App"} }, () => {
+      let promptIssued = false;
+
+      if (promptOptions && promptOptions.type === 'confirm') {
+        promptIssued = true;
+      }
+
+      try {
+        assert(promptIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('prompts before removing the specified team when confirm option not passed (debug)', (done) => {
+    command.action(logger, { options: { debug: true, id: "TestApp" } }, () => {
+      let promptIssued = false;
+
+      if (promptOptions && promptOptions.type === 'confirm') {
+        promptIssued = true;
+      }
+
+      try {
+        assert(promptIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts removing the specified team when confirm option not passed and prompt not confirmed', (done) => {
+    const postSpy = sinon.spy(request, 'delete');
+    command.action(logger, { options: { debug: false, id: "TestApp" } }, () => {
+      try {
+        assert(postSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts removing the specified team when confirm option not passed and prompt not confirmed (debug)', (done) => {
+    const postSpy = sinon.spy(request, 'delete');
+    command.action(logger, { options: { debug: true, id: "TestApp" } }, () => {
+      try {
+        assert(postSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('removes the specified team when prompt confirmed (debug)', (done) => {
+    let externalConnectionDeleteCallIssued = false;
+   
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/external/connections/TestApp`) {
+        externalConnectionDeleteCallIssued = true;
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: true });
+    });
+    command.action(logger, { options: { debug: true, id: "TestApp" } }, () => {
+      try {
+        assert(externalConnectionDeleteCallIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('removes the specified team without prompting when confirmed specified', (done) => {
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/external/connections/TestApp`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: false, id: "TestApp", confirm: true } }, () => {
+      done();
+    });
+  });
+
+  it('should handle Microsoft graph error response', (done) => {
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/external/connections/TestAppXXX`) {
+        return Promise.reject({
+          "error": {
+            "code": "ItemNotFound",
+            "message": "No team found with Id TestAppXXX",
+            "innerError": {
+              "request-id": "27b49647-a335-48f8-9a7c-f1ed9b976aaa",
+              "date": "2019-04-05T12:16:48"
+            }
+          }
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: true });
+    });
+    command.action(logger, {
+      options: { id: 'TestApp' }
+    } as any, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, 'No team found with Id TestApp');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+  
+});

--- a/src/m365/search/commands/externalconnection/externalconnection-remove.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-remove.ts
@@ -1,0 +1,134 @@
+import { Cli,Logger } from '../../../../cli';
+import { CommandOption } from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import GraphCommand from '../../../base/GraphCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  id?: string;
+  name?: string;
+}
+
+class SearchExternalConnectionRemoveCommand extends GraphCommand {
+  public get name(): string {
+    return commands.EXTERNALCONNECTION_REMOVE;
+  }
+
+  public get description(): string {
+    return 'Removes the specified External Connection from Microsoft Search';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.authorizedAppIds = typeof args.options.authorizedAppIds !== undefined;
+    return telemetryProps;
+  }
+
+  private getExternalConnectionId(args: CommandArgs): Promise<string> {
+    if (args.options.id) {
+      return Promise.resolve(args.options.id);
+    }
+
+    const requestOptions: any = {
+      url: `${this.resource}/v1.0/external/connections?$filter=name eq '${encodeURIComponent(args.options.name as string)}'&$select=id`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    return request
+      .get<{ value: [{ id: string }] }>(requestOptions)
+      .then(response => {
+        const extConn: { id: string } | undefined = response.value[0];
+
+        if (!extConn) {
+          return Promise.reject(`The specified connection does not exist in Microsoft Search`);
+        }
+
+        if (response.value.length >= 2) {
+          return Promise.reject(`Multiple External Connections with name ${args.options.name} found: ${response.value.map(x => x.id)}`);
+        }
+
+        return Promise.resolve(extConn.id);
+      });
+  }
+
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    const removeExternalConnection: () => void = (): void => {
+      this
+        .getExternalConnectionId(args)
+        .then((externalConnectionId: string) => {
+          const requestOptions: any = {
+            url: `${this.resource}/v1.0/external/connections/${encodeURIComponent(externalConnectionId)}`,
+            headers: {
+              accept: 'application/json;odata.metadata=none'
+            },
+            responseType: 'json'
+          };
+
+          request
+            .delete(requestOptions)
+            .then(_ => cb(), (err: any) => this.handleRejectedODataJsonPromise(err, logger, cb));
+
+        }), (err: any) => this.handleRejectedODataJsonPromise(err, logger, cb);
+    };
+
+    if (args.options.confirm) {
+      removeExternalConnection();
+    }
+    else {
+      Cli.prompt({
+        type: 'confirm',
+        name: 'continue',
+        default: false,
+        message: `Are you sure you want to remove the team ${args.options.teamId}?`
+      }, (result: { continue: boolean }): void => {
+        if (!result.continue) {
+          cb();
+        }
+        else {
+          removeExternalConnection();
+        }
+      });
+    }
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --id [id]'
+      },
+      {
+        option: '-n, --name [name]'
+      },
+      {
+        option: '--confirm'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+
+    if (args.options.id && args.options.name) {
+      return 'Specify either teamId or teamName, but not both.';
+    }
+
+    if (!args.options.id && !args.options.name) {
+      return 'Specify teamId or teamName, one is required';
+    }
+
+    return true;
+  }
+}
+
+module.exports = new SearchExternalConnectionRemoveCommand();


### PR DESCRIPTION
This starts to implement Microsoft Search capability so that you can remove external connections as per https://docs.microsoft.com/en-us/graph/api/externalconnectors-externalconnection-delete?view=graph-rest-1.0

Please note that it requires the Application permission of ExternalConnection.ReadWrite.OwnedBy to work.