### PR TITLE
Extend `aad app add` and `aad app set` with options to add certificates. Closes #3115. Closes #3116.

### DIFF
--- a/docs/docs/cmd/aad/app/app-add.md
+++ b/docs/docs/cmd/aad/app/app-add.md
@@ -49,6 +49,15 @@ m365 aad app add [options]
 `--scopeAdminConsentDescription [scopeAdminConsentDescription]`
 : Scope admin consent description
 
+`--certificateFile [certificateFile]`
+: Path to the file with certificate public key. Specify either `certificateFile` or `certificateBase64Encoded`
+
+`--certificateBase64Encoded [certificateBase64Encoded]`
+: Base64-encoded string with certificate public key. Specify either `certificateFile` or `certificateBase64Encoded`
+
+`--certificateDisplayName [certificateDisplayName]`
+: Display name for the certificate. If not given, the displayName will be set to the certificate subject. When specified, also specify either `certificateFile` or `certificateBase64Encoded`
+
 `--manifest [manifest]`
 : Azure AD app manifest as retrieved from the Azure Portal to create the app registration from
 
@@ -151,4 +160,10 @@ Create new Azure AD app registration with the specified name. Store information 
 
 ```sh
 m365 aad app add --name 'My AAD app' --save
+```
+
+Create new Azure AD app registration with a certificate
+
+```sh
+m365 aad app add --name 'My AAD app' --certificateDisplayName "Some certificate name" --certificateFile c:\temp\some-certificate.cer
 ```

--- a/docs/docs/cmd/aad/app/app-set.md
+++ b/docs/docs/cmd/aad/app/app-set.md
@@ -31,6 +31,15 @@ m365 aad app set [options]
 `--redirectUrisToRemove [redirectUrisToRemove]`
 : Comma-separated list of existing redirect URIs to remove. Specify, when you want to replace existing redirect URIs with another
 
+`--certificateFile [certificateFile]`
+: Path to the file with certificate public key. Specify either `certificateFile` or `certificateBase64Encoded`
+
+`--certificateBase64Encoded [certificateBase64Encoded]`
+: Base64-encoded string with certificate public key. Specify either `certificateFile` or `certificateBase64Encoded`
+
+`--certificateDisplayName [certificateDisplayName]`
+: Display name for the certificate. If not given, the displayName will be set to the certificate subject. When specified, also specify either `certificateFile` or `certificateBase64Encoded`
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
@@ -69,4 +78,10 @@ Replace one redirect URI with another for SPA authentication
 
 ```sh
 m365 aad app set --objectId 95cfe30d-ed44-4f9d-b73d-c66560f72e83 --redirectUris https://contoso.com/auth --platform spa --redirectUrisToRemove https://contoso.com/old-auth
+```
+
+Add a certificate to the app
+
+```sh
+m365 aad app set --certificateDisplayName "Some certificate name" --certificateFile c:\temp\some-certificate.cer
 ```

--- a/docs/docs/cmd/aad/app/app-set.md
+++ b/docs/docs/cmd/aad/app/app-set.md
@@ -48,6 +48,8 @@ For best performance use the `objectId` option to reference the Azure AD applica
 
 If the command finds multiple Azure AD application registrations with the specified app name, it will prompt you to disambiguate which app it should use, listing the discovered object IDs.
 
+When a certificate is specified it will be added to the list of certificates of the app without changing existing certificates.
+
 ## Examples
 
 Update the app URI of the Azure AD application registration specified by its object ID

--- a/src/m365/aad/commands/app/app-add.spec.ts
+++ b/src/m365/aad/commands/app/app-add.spec.ts
@@ -5614,13 +5614,6 @@ describe(commands.APP_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation when certificate file is not found', () => {    
-    sinon.stub(fs, 'existsSync').callsFake(_ => false);    
-    
-    const actual = command.validate({ options: { debug: true, name: 'My AAD app', certificateDisplayName: 'some certificate', certificateFile: 'C:\\temp\\some-certificate.cer' } });
-    assert.notStrictEqual(actual, true);
-  });
-
   it('passes validation if platform value is spa', () => {
     const actual = command.validate({ options: { name: 'My AAD app', platform: 'spa' } });
     assert.strictEqual(actual, true);
@@ -5704,8 +5697,17 @@ describe(commands.APP_ADD, () => {
   });
   
   it('passes validation if certificateFile specified with certificateDisplayName', () => {
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+      
     const actual = command.validate({ options: { name: 'My AAD app', certificateDisplayName: 'Some certificate', certificateFile: 'c:\\temp\\some-certificate.cer' } });
     assert.strictEqual(actual, true);
+  });
+  
+  it('fails validation when certificate file is not found', () => {    
+    sinon.stub(fs, 'existsSync').callsFake(_ => false);    
+    
+    const actual = command.validate({ options: { debug: true, name: 'My AAD app', certificateDisplayName: 'some certificate', certificateFile: 'C:\\temp\\some-certificate.cer' } });
+    assert.notStrictEqual(actual, true);
   });
   
   it('passes validation if certificateBase64Encoded specified with certificateDisplayName', () => {

--- a/src/m365/aad/commands/app/app-add.spec.ts
+++ b/src/m365/aad/commands/app/app-add.spec.ts
@@ -1843,6 +1843,220 @@ describe(commands.APP_ADD, () => {
     });
   });
 
+  it('creates AAD app reg with a certificate using certificate file', (done) => {
+    sinon.stub(request, 'get').callsFake(_ => Promise.reject('Issues GET request'));
+    sinon.stub(request, 'patch').callsFake(_ => Promise.reject('Issued PATCH request'));
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications' &&
+        JSON.stringify(opts.data) === JSON.stringify({
+          "displayName": "My AAD app",
+          "signInAudience": "AzureADMyOrg",
+          "keyCredentials": [{
+            "type": "AsymmetricX509Cert",          
+            "usage": "Verify",
+            "displayName": "some certificate",
+            "key": "somecertificatebase64string"
+          }]
+        })) {
+        return Promise.resolve({
+          "id": "5b31c38c-2584-42f0-aa47-657fb3a84230",
+          "deletedDateTime": null,
+          "appId": "bc724b77-da87-43a9-b385-6ebaaf969db8",
+          "applicationTemplateId": null,
+          "createdDateTime": "2020-12-31T14:44:13.7945807Z",
+          "displayName": "My AAD app",
+          "description": null,
+          "groupMembershipClaims": null,
+          "identifierUris": [],
+          "isDeviceOnlyAuthSupported": null,
+          "isFallbackPublicClient": null,
+          "notes": null,
+          "optionalClaims": null,
+          "publisherDomain": "contoso.onmicrosoft.com",
+          "signInAudience": "AzureADMyOrg",
+          "tags": [],
+          "tokenEncryptionKeyId": null,
+          "verifiedPublisher": {
+            "displayName": null,
+            "verifiedPublisherId": null,
+            "addedDateTime": null
+          },
+          "spa": {
+            "redirectUris": []
+          },
+          "defaultRedirectUri": null,
+          "addIns": [],
+          "api": {
+            "acceptMappedClaims": null,
+            "knownClientApplications": [],
+            "requestedAccessTokenVersion": null,
+            "oauth2PermissionScopes": [],
+            "preAuthorizedApplications": []
+          },
+          "appRoles": [],
+          "info": {
+            "logoUrl": null,
+            "marketingUrl": null,
+            "privacyStatementUrl": null,
+            "supportUrl": null,
+            "termsOfServiceUrl": null
+          },
+          "keyCredentials": [],
+          "parentalControlSettings": {
+            "countriesBlockedForMinors": [],
+            "legalAgeGroupRule": "Allow"
+          },
+          "passwordCredentials": [],
+          "publicClient": {
+            "redirectUris": []
+          },
+          "requiredResourceAccess": [],
+          "web": {
+            "homePageUrl": null,
+            "logoutUrl": null,
+            "redirectUris": [],
+            "implicitGrantSettings": {
+              "enableAccessTokenIssuance": false,
+              "enableIdTokenIssuance": false
+            }
+          }
+        });
+      }
+
+      return Promise.reject(`Invalid POST request: ${JSON.stringify(opts, null, 2)}`);
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    sinon.stub(fs, 'readFileSync').callsFake(_ => "somecertificatebase64string");
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        name: 'My AAD app',
+        certificateDisplayName: 'some certificate',
+        certificateFile: 'C:\\temp\\some-certificate.cer'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
+        assert(loggerLogSpy.calledWith({
+          appId: 'bc724b77-da87-43a9-b385-6ebaaf969db8',
+          objectId: '5b31c38c-2584-42f0-aa47-657fb3a84230',
+          tenantId: ''
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('creates AAD app reg with a certificate using base64 string', (done) => {
+    sinon.stub(request, 'get').callsFake(_ => Promise.reject('Issues GET request'));
+    sinon.stub(request, 'patch').callsFake(_ => Promise.reject('Issued PATCH request'));
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications' &&
+        JSON.stringify(opts.data) === JSON.stringify({
+          "displayName": "My AAD app",
+          "signInAudience": "AzureADMyOrg",
+          "keyCredentials": [{
+            "type": "AsymmetricX509Cert",          
+            "usage": "Verify",
+            "displayName": "some certificate",
+            "key": "somecertificatebase64string"
+          }]
+        })) {
+        return Promise.resolve({
+          "id": "5b31c38c-2584-42f0-aa47-657fb3a84230",
+          "deletedDateTime": null,
+          "appId": "bc724b77-da87-43a9-b385-6ebaaf969db8",
+          "applicationTemplateId": null,
+          "createdDateTime": "2020-12-31T14:44:13.7945807Z",
+          "displayName": "My AAD app",
+          "description": null,
+          "groupMembershipClaims": null,
+          "identifierUris": [],
+          "isDeviceOnlyAuthSupported": null,
+          "isFallbackPublicClient": null,
+          "notes": null,
+          "optionalClaims": null,
+          "publisherDomain": "contoso.onmicrosoft.com",
+          "signInAudience": "AzureADMyOrg",
+          "tags": [],
+          "tokenEncryptionKeyId": null,
+          "verifiedPublisher": {
+            "displayName": null,
+            "verifiedPublisherId": null,
+            "addedDateTime": null
+          },
+          "spa": {
+            "redirectUris": []
+          },
+          "defaultRedirectUri": null,
+          "addIns": [],
+          "api": {
+            "acceptMappedClaims": null,
+            "knownClientApplications": [],
+            "requestedAccessTokenVersion": null,
+            "oauth2PermissionScopes": [],
+            "preAuthorizedApplications": []
+          },
+          "appRoles": [],
+          "info": {
+            "logoUrl": null,
+            "marketingUrl": null,
+            "privacyStatementUrl": null,
+            "supportUrl": null,
+            "termsOfServiceUrl": null
+          },
+          "keyCredentials": [],
+          "parentalControlSettings": {
+            "countriesBlockedForMinors": [],
+            "legalAgeGroupRule": "Allow"
+          },
+          "passwordCredentials": [],
+          "publicClient": {
+            "redirectUris": []
+          },
+          "requiredResourceAccess": [],
+          "web": {
+            "homePageUrl": null,
+            "logoutUrl": null,
+            "redirectUris": [],
+            "implicitGrantSettings": {
+              "enableAccessTokenIssuance": false,
+              "enableIdTokenIssuance": false
+            }
+          }
+        });
+      }
+
+      return Promise.reject(`Invalid POST request: ${JSON.stringify(opts, null, 2)}`);
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        name: 'My AAD app',
+        certificateDisplayName: 'some certificate',
+        certificateBase64Encoded: 'somecertificatebase64string'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
+        assert(loggerLogSpy.calledWith({
+          appId: 'bc724b77-da87-43a9-b385-6ebaaf969db8',
+          objectId: '5b31c38c-2584-42f0-aa47-657fb3a84230',
+          tenantId: ''
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('returns error when retrieving information about service principals failed', (done) => {
     sinon.stub(request, 'get').callsFake(_ => Promise.reject({
       error: {
@@ -2401,6 +2615,49 @@ describe(commands.APP_ADD, () => {
     }, (err?: any) => {
       try {
         assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+  
+  it('returns error when certificate file is not found', (done) => {    
+    sinon.stub(fs, 'existsSync').callsFake(_ => false);    
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        name: 'My AAD app',
+        certificateDisplayName: 'some certificate',
+        certificateFile: 'C:\\temp\\some-certificate.cer'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, `Certificate file not found`);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+  
+  it('returns error when certificate file cannot be read', (done) => {    
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);    
+    sinon.stub(fs, 'readFileSync').callsFake(_ => { throw new Error("An error has occurred"); });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        name: 'My AAD app',
+        certificateDisplayName: 'some certificate',
+        certificateFile: 'C:\\temp\\some-certificate.cer'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, `Error reading certificate file: Error: An error has occurred. Please add the certificate using base64 option '--certificateBase64Encoded'.`);
         done();
       }
       catch (e) {
@@ -5448,6 +5705,26 @@ describe(commands.APP_ADD, () => {
     const manifest = '{}';
     const actual = command.validate({ options: { manifest: manifest } });
     assert.notStrictEqual(actual, true);
+  });
+  
+  it('fails validation if certificateDisplayName is specified without certificate', () => {
+    const actual = command.validate({ options: { name: 'My AAD app', certificateDisplayName: 'Some certificate' } });
+    assert.notStrictEqual(actual, true);
+  });
+  
+  it('fails validation if both certificateBase64Encoded and certificateFile are specified', () => {
+    const actual = command.validate({ options: { name: 'My AAD app', certificateFile: 'c:\\temp\\some-certificate.cer', certificateBase64Encoded: 'somebase64string' } });
+    assert.notStrictEqual(actual, true);
+  });
+  
+  it('passes validation if certificateFile specified with certificateDisplayName', () => {
+    const actual = command.validate({ options: { name: 'My AAD app', certificateDisplayName: 'Some certificate', certificateFile: 'c:\\temp\\some-certificate.cer' } });
+    assert.strictEqual(actual, true);
+  });
+  
+  it('passes validation if certificateBase64Encoded specified with certificateDisplayName', () => {
+    const actual = command.validate({ options: { name: 'My AAD app', certificateDisplayName: 'Some certificate', certificateBase64Encoded: 'somebase64string' } });
+    assert.strictEqual(actual, true);
   });
 
   it('passes validation if manifest is valid JSON with name and name not specified', () => {

--- a/src/m365/aad/commands/app/app-add.spec.ts
+++ b/src/m365/aad/commands/app/app-add.spec.ts
@@ -2623,27 +2623,6 @@ describe(commands.APP_ADD, () => {
     });
   });
   
-  it('returns error when certificate file is not found', (done) => {    
-    sinon.stub(fs, 'existsSync').callsFake(_ => false);    
-
-    command.action(logger, {
-      options: {
-        debug: true,
-        name: 'My AAD app',
-        certificateDisplayName: 'some certificate',
-        certificateFile: 'C:\\temp\\some-certificate.cer'
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(err.message, `Certificate file not found`);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-  
   it('returns error when certificate file cannot be read', (done) => {    
     sinon.stub(fs, 'existsSync').callsFake(_ => true);    
     sinon.stub(fs, 'readFileSync').callsFake(_ => { throw new Error("An error has occurred"); });
@@ -5632,6 +5611,13 @@ describe(commands.APP_ADD, () => {
 
   it('fails validation if specified platform value is not valid', () => {
     const actual = command.validate({ options: { name: 'My AAD app', platform: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when certificate file is not found', () => {    
+    sinon.stub(fs, 'existsSync').callsFake(_ => false);    
+    
+    const actual = command.validate({ options: { debug: true, name: 'My AAD app', certificateDisplayName: 'some certificate', certificateFile: 'C:\\temp\\some-certificate.cer' } });
     assert.notStrictEqual(actual, true);
   });
 

--- a/src/m365/aad/commands/app/app-add.ts
+++ b/src/m365/aad/commands/app/app-add.ts
@@ -594,21 +594,17 @@ class AadAppAddCommand extends GraphCommand {
       return Promise.resolve(args.options.certificateBase64Encoded);
     }
     
-    if (fs.existsSync(args.options.certificateFile as string)) {
-      if (this.debug) {
-        logger.logToStderr(`Reading existing ${args.options.certificateFile}...`);
-      }
-
-      try {
-        const fileContents = fs.readFileSync(args.options.certificateFile as string, {encoding: 'base64'});
-        return Promise.resolve(fileContents);
-      }
-      catch (e) {
-        return Promise.reject(`Error reading certificate file: ${e}. Please add the certificate using base64 option '--certificateBase64Encoded'.`);
-      }
+    if (this.debug) {
+      logger.logToStderr(`Reading existing ${args.options.certificateFile}...`);
     }
 
-    return Promise.reject(`Certificate file not found`);
+    try {
+      const fileContents = fs.readFileSync(args.options.certificateFile as string, {encoding: 'base64'});
+      return Promise.resolve(fileContents);
+    }
+    catch (e) {
+      return Promise.reject(`Error reading certificate file: ${e}. Please add the certificate using base64 option '--certificateBase64Encoded'.`);
+    }  
   }
 
   private saveAppInfo(args: CommandArgs, appInfo: AppInfo, logger: Logger): Promise<AppInfo> {
@@ -744,6 +740,10 @@ class AadAppAddCommand extends GraphCommand {
     if (args.options.certificateDisplayName && !args.options.certificateFile && !args.options.certificateBase64Encoded) {
       return 'When you specify certificateDisplayName you also need to specify certificateFile or certificateBase64Encoded';
     }    
+
+    if (args.options.certificateFile && !fs.existsSync(args.options.certificateFile as string)) {
+      return 'Certificate file not found';
+    }
 
     if (args.options.scopeName) {
       if (!args.options.uri) {

--- a/src/m365/aad/commands/app/app-set.spec.ts
+++ b/src/m365/aad/commands/app/app-set.spec.ts
@@ -1169,6 +1169,13 @@ describe(commands.APP_SET, () => {
     assert.notStrictEqual(actual, true);
   });
   
+  it('passes validation if certificateFile specified with certificateDisplayName', () => {
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+      
+    const actual = command.validate({ options: { name: 'My AAD app', certificateDisplayName: 'Some certificate', certificateFile: 'c:\\temp\\some-certificate.cer' } });
+    assert.strictEqual(actual, true);
+  });
+  
   it('fails validation when certificate file is not found', () => {    
     sinon.stub(fs, 'existsSync').callsFake(_ => false);    
     

--- a/src/m365/aad/commands/app/app-set.spec.ts
+++ b/src/m365/aad/commands/app/app-set.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as fs from 'fs';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
 import { Logger } from '../../../../cli';
@@ -10,6 +11,11 @@ import commands from '../../commands';
 const command: Command = require('./app-set');
 
 describe(commands.APP_SET, () => {
+
+  //#region Mocked Responses  
+  const appDetailsResponse: any = { "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity", "id": "95cfe30d-ed44-4f9d-b73d-c66560f72e83", "deletedDateTime": null, "appId": "ff254847-12c7-44cf-921e-8883dbd622a7", "applicationTemplateId": null, "disabledByMicrosoftStatus": null, "createdDateTime": "2022-02-07T08:51:18Z", "displayName": "Angular Teams app", "description": null, "groupMembershipClaims": null, "identifierUris": [ "api://244e-2001-1c00-80c-d00-e5da-977c-7c52-5193.ngrok.io/ff254847-12c7-44cf-921e-8883dbd622a7" ], "isDeviceOnlyAuthSupported": null, "isFallbackPublicClient": null, "notes": null, "publisherDomain": "contoso.onmicrosoft.com", "serviceManagementReference": null, "signInAudience": "AzureADMyOrg", "tags": [], "tokenEncryptionKeyId": null, "defaultRedirectUri": null, "certification": null, "optionalClaims": null, "addIns": [], "api": { "acceptMappedClaims": null, "knownClientApplications": [], "requestedAccessTokenVersion": null, "oauth2PermissionScopes": [ { "adminConsentDescription": "Access as a user", "adminConsentDisplayName": "Access as a user", "id": "cf38eb5b-8fcd-4697-9bd5-d80b7f98dfc5", "isEnabled": true, "type": "User", "userConsentDescription": null, "userConsentDisplayName": null, "value": "access_as_user" } ], "preAuthorizedApplications": [ { "appId": "5e3ce6c0-2b1f-4285-8d4b-75ee78787346", "delegatedPermissionIds": [ "cf38eb5b-8fcd-4697-9bd5-d80b7f98dfc5" ] }, { "appId": "1fec8e78-bce4-4aaf-ab1b-5451cc387264", "delegatedPermissionIds": [ "cf38eb5b-8fcd-4697-9bd5-d80b7f98dfc5" ] } ] }, "appRoles": [], "info": { "logoUrl": null, "marketingUrl": null, "privacyStatementUrl": null, "supportUrl": null, "termsOfServiceUrl": null }, "keyCredentials": [], "parentalControlSettings": { "countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow" }, "passwordCredentials": [], "publicClient": { "redirectUris": [] }, "requiredResourceAccess": [ { "resourceAppId": "00000003-0000-0000-c000-000000000000", "resourceAccess": [ { "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d", "type": "Scope" } ] } ], "verifiedPublisher": { "displayName": null, "verifiedPublisherId": null, "addedDateTime": null }, "web": { "homePageUrl": null, "logoutUrl": null, "redirectUris": [], "implicitGrantSettings": { "enableAccessTokenIssuance": false, "enableIdTokenIssuance": false } }, "spa": { "redirectUris": [] } };
+  //#endregion
+
   let log: string[];
   let logger: Logger;
 
@@ -37,7 +43,9 @@ describe(commands.APP_SET, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.patch
+      request.patch,
+      fs.existsSync,
+      fs.readFileSync
     ]);
   });
 
@@ -796,6 +804,200 @@ describe(commands.APP_SET, () => {
       }
     });
   });
+  
+  it('adds new certificate using base64 string', (done) => {
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83`) {
+        return Promise.resolve(appDetailsResponse);
+      } 
+      else if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83?$select=keyCredentials`) {
+        return Promise.resolve({
+          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",          
+          "keyCredentials": []
+        });
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(request, 'patch').callsFake(opts => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83' &&
+        JSON.stringify(opts.data) === JSON.stringify({
+          "keyCredentials": [{
+            "type": "AsymmetricX509Cert",          
+            "usage": "Verify",
+            "displayName": "some certificate",
+            "key": "somecertificatebase64string"
+          }]
+        })) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        objectId: '95cfe30d-ed44-4f9d-b73d-c66560f72e83',
+        certificateDisplayName: 'some certificate',
+        certificateBase64Encoded: 'somecertificatebase64string'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined', err?.message);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('adds new certificate using certificate file', (done) => {
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83`) {
+        return Promise.resolve(appDetailsResponse);
+      } 
+      else if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83?$select=keyCredentials`) {
+        return Promise.resolve({
+          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",          
+          "keyCredentials": []
+        });
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(request, 'patch').callsFake(opts => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83' &&
+        JSON.stringify(opts.data) === JSON.stringify({
+          "keyCredentials": [{
+            "type": "AsymmetricX509Cert",          
+            "usage": "Verify",
+            "displayName": "some certificate",
+            "key": "somecertificatebase64string"
+          }]
+        })) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    sinon.stub(fs, 'readFileSync').callsFake(_ => "somecertificatebase64string");
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        objectId: '95cfe30d-ed44-4f9d-b73d-c66560f72e83',
+        certificateDisplayName: 'some certificate',
+        certificateFile: 'C:\\temp\\some-certificate.cer'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined', err?.message);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('does not add new certificate when key is already present', (done) => {
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83`) {
+        return Promise.resolve(appDetailsResponse);
+      } 
+      else if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83?$select=keyCredentials`) {
+        return Promise.resolve({
+          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",          
+          "keyCredentials": [{
+            "type": "AsymmetricX509Cert",          
+            "usage": "Verify",
+            "displayName": "some certificate",
+            "key": "somecertificatebase64string"
+          }]
+        });
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+    
+    command.action(logger, {
+      options: {
+        debug: true,
+        objectId: '95cfe30d-ed44-4f9d-b73d-c66560f72e83',
+        certificateDisplayName: 'some certificate',
+        certificateBase64Encoded: 'somecertificatebase64string'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined', err?.message);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+  
+  it('handles error when certificate file is not found', (done) => {
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83`) {
+        return Promise.resolve(appDetailsResponse);
+      } 
+     
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });    
+    sinon.stub(fs, 'existsSync').callsFake(_ => false);    
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        objectId: '95cfe30d-ed44-4f9d-b73d-c66560f72e83',
+        certificateDisplayName: 'some certificate',
+        certificateFile: 'C:\\temp\\some-certificate.cer'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, `Certificate file not found`);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('handles error when certificate file cannot be read', (done) => {
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/95cfe30d-ed44-4f9d-b73d-c66560f72e83`) {
+        return Promise.resolve(appDetailsResponse);
+      } 
+     
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });    
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);    
+    sinon.stub(fs, 'readFileSync').callsFake(_ => { throw new Error("An error has occurred"); });
+
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        objectId: '95cfe30d-ed44-4f9d-b73d-c66560f72e83',
+        certificateDisplayName: 'some certificate',
+        certificateFile: 'C:\\temp\\some-certificate.cer'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, `Error reading certificate file: Error: An error has occurred. Please add the certificate using base64 option '--certificateBase64Encoded'.`);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
 
   it('handles error when the app specified with objectId not found', (done) => {
     sinon.stub(request, 'patch').callsFake(_ => Promise.reject(`Resource '5b31c38c-2584-42f0-aa47-657fb3a84230' does not exist or one of its queried reference-property objects are not present.`));
@@ -972,6 +1174,16 @@ describe(commands.APP_SET, () => {
 
   it('fails validation if invalid platform specified', () => {
     const actual = command.validate({ options: { objectId: 'c75be2e1-0204-4f95-857d-51a37cf40be8', redirectUris: 'https://foo.com', platform: 'invalid' } });
+    assert.notStrictEqual(actual, true);
+  });
+  
+  it('fails validation if certificateDisplayName is specified without certificate', () => {
+    const actual = command.validate({ options: { objectId: 'c75be2e1-0204-4f95-857d-51a37cf40be8', certificateDisplayName: 'Some certificate' } });
+    assert.notStrictEqual(actual, true);
+  });
+  
+  it('fails validation if both certificateBase64Encoded and certificateFile are specified', () => {
+    const actual = command.validate({ options: { objectId: 'c75be2e1-0204-4f95-857d-51a37cf40be8', certificateFile: 'c:\\temp\\some-certificate.cer', certificateBase64Encoded: 'somebase64string' } });
     assert.notStrictEqual(actual, true);
   });
 

--- a/src/m365/aad/commands/app/app-set.ts
+++ b/src/m365/aad/commands/app/app-set.ts
@@ -1,6 +1,7 @@
-import { Application, PublicClientApplication, SpaApplication, WebApplication } from '@microsoft/microsoft-graph-types';
+import { Application, PublicClientApplication, KeyCredential, SpaApplication, WebApplication } from '@microsoft/microsoft-graph-types';
 import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli';
+import * as fs from 'fs';
 import {
   CommandOption
 } from '../../../../Command';
@@ -21,6 +22,9 @@ interface Options extends GlobalOptions {
   redirectUris?: string;
   redirectUrisToRemove?: string;
   uri?: string;
+  certificateFile?: string;
+  certificateBase64Encoded?: string;
+  certificateDisplayName?: string;
 }
 
 class AadAppSetCommand extends GraphCommand {
@@ -43,6 +47,9 @@ class AadAppSetCommand extends GraphCommand {
     telemetryProps.redirectUris = typeof args.options.redirectUris !== 'undefined';
     telemetryProps.redirectUrisToRemove = typeof args.options.redirectUrisToRemove !== 'undefined';
     telemetryProps.uri = typeof args.options.uri !== 'undefined';
+    telemetryProps.certificateFile = typeof args.options.certificateFile !== 'undefined';
+    telemetryProps.certificateBase64Encoded = typeof args.options.certificateBase64Encoded !== 'undefined';
+    telemetryProps.certificateDisplayName = typeof args.options.certificateDisplayName !== 'undefined';
     return telemetryProps;
   }
 
@@ -51,6 +58,7 @@ class AadAppSetCommand extends GraphCommand {
       .getAppObjectId(args, logger)
       .then(objectId => this.configureUri(args, objectId, logger))
       .then(objectId => this.configureRedirectUris(args, objectId, logger))
+      .then(objectId => this.configureCertificate(args, objectId, logger))
       .then(_ => cb(), (rawRes: any): void => this.handleRejectedODataJsonPromise(rawRes, logger, cb));
   }
 
@@ -206,6 +214,84 @@ class AadAppSetCommand extends GraphCommand {
       .then(_ => Promise.resolve(objectId));
   }
 
+  private configureCertificate(args: CommandArgs, objectId: string, logger: Logger): Promise<void> {
+    if (!args.options.certificateFile && !args.options.certificateBase64Encoded) {
+      return Promise.resolve();
+    }
+
+    if (this.verbose) {
+      logger.logToStderr(`Setting certificate for Azure AD app...`);
+    }
+
+    return this.getCertificateBase64Encoded(args, logger).then((certificateBase64Encoded) => {
+      const getAppRequestOptions: AxiosRequestConfig = {
+        url: `${this.resource}/v1.0/myorganization/applications/${objectId}?$select=keyCredentials`,
+        headers: {
+          'content-type': 'application/json;odata.metadata=none'
+        },
+        responseType: 'json'
+      };
+
+      return request
+        .get<Application>(getAppRequestOptions)
+        .then((application: Application): Promise<void> => {
+          
+          const keyCredentials = application.keyCredentials as KeyCredential[];
+          
+          // The graph types of  defines the 'key' property of KeyCredential as 'NullableOption<number>'
+          // while it is a base64 encoded string. This is any is used here.
+          if (keyCredentials.every(existingCredential => existingCredential.key !== certificateBase64Encoded as any)) {
+            const newKeyCredential = {
+              type: "AsymmetricX509Cert",          
+              usage: "Verify",
+              displayName: args.options.certificateDisplayName,
+              key: certificateBase64Encoded
+            } as any;
+
+            keyCredentials.push(newKeyCredential);
+               
+            const requestOptions: AxiosRequestConfig = {
+              url: `${this.resource}/v1.0/myorganization/applications/${objectId}`,
+              headers: {
+                'content-type': 'application/json;odata.metadata=none'
+              },
+              responseType: 'json',
+              data: {
+                keyCredentials: keyCredentials
+              }
+            };
+
+            return request.patch(requestOptions);
+          }
+
+          return Promise.resolve();
+        })
+        .then(_ => Promise.resolve());
+    });
+  }
+
+  private getCertificateBase64Encoded(args: CommandArgs, logger: Logger): Promise<string> {
+    if (args.options.certificateBase64Encoded) {
+      return Promise.resolve(args.options.certificateBase64Encoded);
+    }
+    
+    if (fs.existsSync(args.options.certificateFile as string)) {
+      if (this.debug) {
+        logger.logToStderr(`Reading existing ${args.options.certificateFile}...`);
+      }
+
+      try {
+        const fileContents = fs.readFileSync(args.options.certificateFile as string, {encoding: 'base64'});
+        return Promise.resolve(fileContents);
+      }
+      catch (e) {
+        return Promise.reject(`Error reading certificate file: ${e}. Please add the certificate using base64 option '--certificateBase64Encoded'.`);
+      }
+    }
+
+    return Promise.reject(`Certificate file not found`);
+  }
+
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       { option: '--appId [appId]' },
@@ -213,6 +299,9 @@ class AadAppSetCommand extends GraphCommand {
       { option: '-n, --name [name]' },
       { option: '-u, --uri [uri]' },
       { option: '-r, --redirectUris [redirectUris]' },
+      { option: '--certificateFile [certificateFile]' },
+      { option: '--certificateBase64Encoded [certificateBase64Encoded]' },
+      { option: '--certificateDisplayName [certificateDisplayName]' },
       {
         option: '--platform [platform]',
         autocomplete: AadAppSetCommand.aadApplicationPlatform
@@ -236,6 +325,14 @@ class AadAppSetCommand extends GraphCommand {
       (args.options.objectId && args.options.name)) {
       return 'Specify either appId, objectId or name but not both';
     }
+
+    if (args.options.certificateFile && args.options.certificateBase64Encoded) {
+      return 'Specify either certificateFile or certificateBase64Encoded but not both';
+    }
+
+    if (args.options.certificateDisplayName && !args.options.certificateFile && !args.options.certificateBase64Encoded) {
+      return 'When you specify certificateDisplayName you also need to specify certificateFile or certificateBase64Encoded';
+    }    
 
     if (args.options.redirectUris && !args.options.platform) {
       return `When you specify redirectUris you also need to specify platform`;


### PR DESCRIPTION
Closes #3115. 
Closes #3116.

Extend `aad app add` and `aad app set` with options to add certificates:
- the new option `--certificateFile` can be used to add a certificate to the Azure AD App based on a certificate file.
- the new option `--certificateBase64Encoded ` can be used to add a certificate to the Azure AD App by including the certificate as a base64 encoded string.
- the new option `--certificateDisplayName` can be used to include an optional display name.

## Remarks
With `aad app set`, any existing certificates are left as-is. The new certificate is added to the list of available certificates.
