### PR TITLE
Extends 'teams channel list' command with support for type filtering. Closes #3191

### DIFF
--- a/docs/docs/cmd/teams/channel/channel-list.md
+++ b/docs/docs/cmd/teams/channel/channel-list.md
@@ -16,18 +16,27 @@ m365 teams channel list [options]
 `--teamName [teamName]`
 : The display name of the team to list the channels of. Specify either `teamId` or `teamName` but not both
 
+`--type [type]`
+: Filter the results to only channels of a given type: `standard, private`. By default all channels are listed.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
   
-List the channels in a specified Microsoft Teams team with id 00000000-0000-0000-0000-000000000000
+List all channels in a specified Microsoft Teams team with id 00000000-0000-0000-0000-000000000000
 
 ```sh
 m365 teams channel list --teamId 00000000-0000-0000-0000-000000000000
 ```
 
-List the channels in a specified Microsoft Teams team with name _Team Name_
+List all channels in a specified Microsoft Teams team with name _Team Name_
 
 ```sh
 m365 teams channel list --teamName "Team Name"
+```
+
+List private channels in a specified Microsoft Teams team with id 00000000-0000-0000-0000-000000000000
+
+```sh
+m365 teams channel list --teamId 00000000-0000-0000-0000-000000000000 --type private
 ```

--- a/src/m365/teams/commands/channel/channel-list.spec.ts
+++ b/src/m365/teams/commands/channel/channel-list.spec.ts
@@ -88,6 +88,17 @@ describe(commands.CHANNEL_LIST, () => {
     done();
   });
 
+  it('fails validation when invalid type specified', (done) => {
+    const actual = command.validate({
+      options: {
+        teamId: '00000000-0000-0000-0000-000000000000',
+        type: 'Invalid'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
   it('defines correct properties for the default output', () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'displayName']);
   });
@@ -308,6 +319,74 @@ describe(commands.CHANNEL_LIST, () => {
               "isFavoriteByDefault": null,
               "email": "",
               "webUrl": "https://teams.microsoft.com/l/channel/19%3a12ff25ec5325468dba1f73522cd08248%40thread.skype/Social?teamId=290a87a4-38f4-4f6c-a664-9dddf09bdbcc&tenantId=3a7a651b-2620-433b-a1a3-42de27ae94e8"
+            }
+          ]
+        ));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly lists all channels in a Microsoft teams team with specified type parameter', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/00000000-0000-0000-0000-000000000000/channels?$filter=membershipType eq 'private'`) {
+        return Promise.resolve({
+          value: [
+            {
+              "id": "19:e14b10cd0b684901b53d14e89aa4221f@thread.skype",
+              "displayName": "Development",
+              "description": null,
+              "isFavoriteByDefault": null,
+              "email": "",
+              "webUrl": "https://teams.microsoft.com/l/channel/19%3ae14b10cd0b684901b53d14e89aa4221f%40thread.skype/Development?teamId=290a87a4-38f4-4f6c-a664-9dddf09bdbcc&tenantId=3a7a651b-2620-433b-a1a3-42de27ae94e8",
+              "membershipType": "private"
+            },
+            {
+              "id": "19:12ff25ec5325468dba1f73522cd08248@thread.skype",
+              "displayName": "Social",
+              "description": null,
+              "isFavoriteByDefault": null,
+              "email": "",
+              "webUrl": "https://teams.microsoft.com/l/channel/19%3a12ff25ec5325468dba1f73522cd08248%40thread.skype/Social?teamId=290a87a4-38f4-4f6c-a664-9dddf09bdbcc&tenantId=3a7a651b-2620-433b-a1a3-42de27ae94e8",
+              "membershipType": "private"
+            }
+          ]
+        });
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        teamId: '00000000-0000-0000-0000-000000000000',
+        type: 'private'
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith(
+          [
+            {
+              "id": "19:e14b10cd0b684901b53d14e89aa4221f@thread.skype",
+              "displayName": "Development",
+              "description": null,
+              "isFavoriteByDefault": null,
+              "email": "",
+              "webUrl": "https://teams.microsoft.com/l/channel/19%3ae14b10cd0b684901b53d14e89aa4221f%40thread.skype/Development?teamId=290a87a4-38f4-4f6c-a664-9dddf09bdbcc&tenantId=3a7a651b-2620-433b-a1a3-42de27ae94e8",
+              "membershipType": "private"
+            },
+            {
+              "id": "19:12ff25ec5325468dba1f73522cd08248@thread.skype",
+              "displayName": "Social",
+              "description": null,
+              "isFavoriteByDefault": null,
+              "email": "",
+              "webUrl": "https://teams.microsoft.com/l/channel/19%3a12ff25ec5325468dba1f73522cd08248%40thread.skype/Social?teamId=290a87a4-38f4-4f6c-a664-9dddf09bdbcc&tenantId=3a7a651b-2620-433b-a1a3-42de27ae94e8",
+              "membershipType": "private"
             }
           ]
         ));

--- a/src/m365/teams/commands/channel/channel-list.ts
+++ b/src/m365/teams/commands/channel/channel-list.ts
@@ -14,6 +14,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   teamId?: string;
   teamName?: string;
+  type?: string;
 }
 
 class TeamsChannelListCommand extends GraphCommand{
@@ -71,7 +72,11 @@ class TeamsChannelListCommand extends GraphCommand{
     this
       .getTeamId(args)
       .then((teamId: string): Promise<Channel[]> => {
-        const endpoint: string = `${this.resource}/v1.0/teams/${teamId}/channels`;
+        let endpoint: string = `${this.resource}/v1.0/teams/${teamId}/channels`;
+        if (args.options.type) {
+          endpoint += `?$filter=membershipType eq '${args.options.type}'`;
+        }
+
         return odata.getAllItems<Channel>(endpoint, logger);
       })
       .then((items): void => {
@@ -87,6 +92,10 @@ class TeamsChannelListCommand extends GraphCommand{
       },
       {
         option: '--teamName [teamName]'
+      },
+      {
+        option: '--type [type]',
+        autocomplete: ['standard', 'private']
       }
     ];
 
@@ -105,6 +114,10 @@ class TeamsChannelListCommand extends GraphCommand{
 
     if (args.options.teamId && !validation.isValidGuid(args.options.teamId)) {
       return `${args.options.teamId} is not a valid GUID`;
+    }
+
+    if (args.options.type && ['standard', 'private'].indexOf(args.options.type.toLowerCase()) === -1) {
+      return `${args.options.type} is not a valid type value. Allowed values standard|private`;
     }
 
     return true;


### PR DESCRIPTION
Extends 'teams channel list' command with support for type filtering. Closes #3191