### PR TITLE
new command: spo field list

### DIFF
--- a/docs/docs/cmd/spo/field/field-list.md
+++ b/docs/docs/cmd/spo/field/field-list.md
@@ -1,0 +1,42 @@
+# spo field list
+
+Retrieves list of columns for specified list or site
+
+## Usage
+
+```sh
+m365 spo field list [options]
+```
+
+## Options
+
+`-u, --webUrl <webUrl>`
+: Absolute URL of the site where the fields is located
+
+`-t, --listTitle [listTitle]`
+: Title of the list where the fields are located. Specify only one of listTitle, listId or listUrl
+
+`-i --listId [listId]`
+: ID of the list where the fields are located. Specify only one of listTitle, listId or listUrl
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Retrieves list columns for _https://contoso.sharepoint.com/sites/contoso-sales_.
+
+```sh
+m365 spo field list --webUrl https://contoso.sharepoint.com/sites/contoso-sales
+```
+
+Retrieves list columns for _https://contoso.sharepoint.com/sites/contoso-sales_. Retrieves the list by its title
+
+```sh
+m365 spo field list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listTitle Events
+```
+
+Retrieves list columns in site _https://contoso.sharepoint.com/sites/contoso-sales_. Retrieves the list by its id
+
+```sh
+m365 spo field list --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listId '202b8199-b9de-43fd-9737-7f213f51c991'
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -295,6 +295,7 @@ nav:
       - field:
         - field add: 'cmd/spo/field/field-add.md'
         - field get: 'cmd/spo/field/field-get.md'
+        - field list: 'cmd/spo/field/field-list.md'
         - field remove: 'cmd/spo/field/field-remove.md'
         - field set: 'cmd/spo/field/field-set.md'
       - file:

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -39,6 +39,7 @@ export default {
   FEATURE_LIST: `${prefix} feature list`,
   FIELD_ADD: `${prefix} field add`,
   FIELD_GET: `${prefix} field get`,
+  FIELD_LIST: `${prefix} field list`,
   FIELD_REMOVE: `${prefix} field remove`,
   FIELD_SET: `${prefix} field set`,
   FILE_ADD: `${prefix} file add`,

--- a/src/m365/spo/commands/field/field-list.spec.ts
+++ b/src/m365/spo/commands/field/field-list.spec.ts
@@ -1,0 +1,442 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils';
+import commands from '../../commands';
+const command: Command = require('./field-list');
+
+describe(commands.FIELD_LIST, () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.FIELD_LIST), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['Id', 'Title', 'Group', 'Hidden']);
+  });
+
+  it('fails validation if the specified site URL is not a valid SharePoint URL', () => {
+    const actual = command.validate({ options: { webUrl: 'site.com' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the list ID is not a valid GUID', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', listId: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when all required parameters are valid', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com/sites/sales' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('correctly handles list not found', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/lists/getByTitle('Documents')/fields`) > -1) {
+        return Promise.reject({
+          error: {
+            "odata.error": {
+              "code": "-1, System.ArgumentException",
+              "message": {
+                "lang": "en-US",
+                "value": "List 'Documents' does not exist at site with URL 'https://contoso.sharepoint.com/sites/portal'."
+              }
+            }
+          }
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/portal', listTitle: 'Documents' } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("List 'Documents' does not exist at site with URL 'https://contoso.sharepoint.com/sites/portal'.")));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('retrieves all site columns', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/fields`) > -1) {
+        return Promise.resolve({
+          "value": [{
+            "AutoIndexed": false,
+            "CanBeDeleted": true,
+            "ClientSideComponentId": "00000000-0000-0000-0000-000000000000",
+            "ClientSideComponentProperties": null,
+            "ClientValidationFormula": null,
+            "ClientValidationMessage": null,
+            "CustomFormatter": null,
+            "DefaultFormula": null,
+            "DefaultValue": null,
+            "Description": "",
+            "Direction": "none",
+            "EnforceUniqueValues": false,
+            "EntityPropertyName": "fieldname",
+            "FieldTypeKind": 2,
+            "Filterable": true,
+            "FromBaseType": false,
+            "Group": "Core Contact and Calendar Columns",
+            "Hidden": false,
+            "Id": "3c0e9e00-8fcc-479f-9d8d-3447cda34c5b",
+            "IndexStatus": 0,
+            "Indexed": false,
+            "InternalName": "fieldname",
+            "IsModern": false,
+            "JSLink": "clienttemplates.js",
+            "MaxLength": 255,
+            "PinnedToFiltersPane": false,
+            "ReadOnlyField": false,
+            "Required": false,
+            "SchemaXml": "<Field ID=\"{3C0E9E00-8FCC-479f-9D8D-3447CDA34C5B}\" Name=\"fieldname\" StaticName=\"fieldname\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" DisplayName=\"Field Name\" Group=\"Core Contact and Calendar Columns\" Type=\"Text\" Sealed=\"TRUE\" AllowDeletion=\"TRUE\" />",
+            "Scope": "/sites/portal",
+            "Sealed": true,
+            "ShowInFiltersPane": 0,
+            "Sortable": true,
+            "StaticName": "fieldname",
+            "Title": "Field Name",
+            "TypeAsString": "Text",
+            "TypeDisplayName": "Single line of text",
+            "TypeShortDescription": "Single line of text",
+            "ValidationFormula": null,
+            "ValidationMessage": null
+          }]
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: false, webUrl: 'https://contoso.sharepoint.com/sites/portal' } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "AutoIndexed": false,
+            "CanBeDeleted": true,
+            "ClientSideComponentId": "00000000-0000-0000-0000-000000000000",
+            "ClientSideComponentProperties": null,
+            "ClientValidationFormula": null,
+            "ClientValidationMessage": null,
+            "CustomFormatter": null,
+            "DefaultFormula": null,
+            "DefaultValue": null,
+            "Description": "",
+            "Direction": "none",
+            "EnforceUniqueValues": false,
+            "EntityPropertyName": "fieldname",
+            "FieldTypeKind": 2,
+            "Filterable": true,
+            "FromBaseType": false,
+            "Group": "Core Contact and Calendar Columns",
+            "Hidden": false,
+            "Id": "3c0e9e00-8fcc-479f-9d8d-3447cda34c5b",
+            "IndexStatus": 0,
+            "Indexed": false,
+            "InternalName": "fieldname",
+            "IsModern": false,
+            "JSLink": "clienttemplates.js",
+            "MaxLength": 255,
+            "PinnedToFiltersPane": false,
+            "ReadOnlyField": false,
+            "Required": false,
+            "SchemaXml": "<Field ID=\"{3C0E9E00-8FCC-479f-9D8D-3447CDA34C5B}\" Name=\"fieldname\" StaticName=\"fieldname\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" DisplayName=\"Field Name\" Group=\"Core Contact and Calendar Columns\" Type=\"Text\" Sealed=\"TRUE\" AllowDeletion=\"TRUE\" />",
+            "Scope": "/sites/portal",
+            "Sealed": true,
+            "ShowInFiltersPane": 0,
+            "Sortable": true,
+            "StaticName": "fieldname",
+            "Title": "Field Name",
+            "TypeAsString": "Text",
+            "TypeDisplayName": "Single line of text",
+            "TypeShortDescription": "Single line of text",
+            "ValidationFormula": null,
+            "ValidationMessage": null
+          }
+        ]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('retrieves all list columns from list queried by title', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/lists/getByTitle('Documents')/fields`) > -1) {
+        return Promise.resolve(
+          {
+            "value": [{
+              "AutoIndexed": false,
+              "CanBeDeleted": true,
+              "ClientSideComponentId": "00000000-0000-0000-0000-000000000000",
+              "ClientSideComponentProperties": null,
+              "ClientValidationFormula": null,
+              "ClientValidationMessage": null,
+              "CustomFormatter": null,
+              "DefaultFormula": null,
+              "DefaultValue": null,
+              "Description": "",
+              "Direction": "none",
+              "EnforceUniqueValues": false,
+              "EntityPropertyName": "fieldname",
+              "FieldTypeKind": 2,
+              "Filterable": true,
+              "FromBaseType": false,
+              "Group": "Core Contact and Calendar Columns",
+              "Hidden": false,
+              "Id": "3c0e9e00-8fcc-479f-9d8d-3447cda34c5b",
+              "IndexStatus": 0,
+              "Indexed": false,
+              "InternalName": "fieldname",
+              "IsModern": false,
+              "JSLink": "clienttemplates.js",
+              "MaxLength": 255,
+              "PinnedToFiltersPane": false,
+              "ReadOnlyField": false,
+              "Required": false,
+              "SchemaXml": "<Field ID=\"{3C0E9E00-8FCC-479f-9D8D-3447CDA34C5B}\" Name=\"fieldname\" StaticName=\"fieldname\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" DisplayName=\"Field Name\" Group=\"Core Contact and Calendar Columns\" Type=\"Text\" Sealed=\"TRUE\" AllowDeletion=\"TRUE\" />",
+              "Scope": "/sites/portal/Documents",
+              "Sealed": true,
+              "ShowInFiltersPane": 0,
+              "Sortable": true,
+              "StaticName": "fieldname",
+              "Title": "Field Name",
+              "TypeAsString": "Text",
+              "TypeDisplayName": "Single line of text",
+              "TypeShortDescription": "Single line of text",
+              "ValidationFormula": null,
+              "ValidationMessage": null
+            }]
+          }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/portal', listTitle: 'Documents' } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "AutoIndexed": false,
+            "CanBeDeleted": true,
+            "ClientSideComponentId": "00000000-0000-0000-0000-000000000000",
+            "ClientSideComponentProperties": null,
+            "ClientValidationFormula": null,
+            "ClientValidationMessage": null,
+            "CustomFormatter": null,
+            "DefaultFormula": null,
+            "DefaultValue": null,
+            "Description": "",
+            "Direction": "none",
+            "EnforceUniqueValues": false,
+            "EntityPropertyName": "fieldname",
+            "FieldTypeKind": 2,
+            "Filterable": true,
+            "FromBaseType": false,
+            "Group": "Core Contact and Calendar Columns",
+            "Hidden": false,
+            "Id": "3c0e9e00-8fcc-479f-9d8d-3447cda34c5b",
+            "IndexStatus": 0,
+            "Indexed": false,
+            "InternalName": "fieldname",
+            "IsModern": false,
+            "JSLink": "clienttemplates.js",
+            "MaxLength": 255,
+            "PinnedToFiltersPane": false,
+            "ReadOnlyField": false,
+            "Required": false,
+            "SchemaXml": "<Field ID=\"{3C0E9E00-8FCC-479f-9D8D-3447CDA34C5B}\" Name=\"fieldname\" StaticName=\"fieldname\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" DisplayName=\"Field Name\" Group=\"Core Contact and Calendar Columns\" Type=\"Text\" Sealed=\"TRUE\" AllowDeletion=\"TRUE\" />",
+            "Scope": "/sites/portal/Documents",
+            "Sealed": true,
+            "ShowInFiltersPane": 0,
+            "Sortable": true,
+            "StaticName": "fieldname",
+            "Title": "Field Name",
+            "TypeAsString": "Text",
+            "TypeDisplayName": "Single line of text",
+            "TypeShortDescription": "Single line of text",
+            "ValidationFormula": null,
+            "ValidationMessage": null
+          }
+        ]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('retrieves all list columns from list queried by id', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/lists(guid'3c0e9e00-8fcc-479f-9d8d-3447cda34c5b')/fields`) > -1) {
+        return Promise.resolve(
+          {
+            "value": [{
+              "AutoIndexed": false,
+              "CanBeDeleted": true,
+              "ClientSideComponentId": "00000000-0000-0000-0000-000000000000",
+              "ClientSideComponentProperties": null,
+              "ClientValidationFormula": null,
+              "ClientValidationMessage": null,
+              "CustomFormatter": null,
+              "DefaultFormula": null,
+              "DefaultValue": null,
+              "Description": "",
+              "Direction": "none",
+              "EnforceUniqueValues": false,
+              "EntityPropertyName": "fieldname",
+              "FieldTypeKind": 2,
+              "Filterable": true,
+              "FromBaseType": false,
+              "Group": "Core Contact and Calendar Columns",
+              "Hidden": false,
+              "Id": "3c0e9e00-8fcc-479f-9d8d-3447cda34c5b",
+              "IndexStatus": 0,
+              "Indexed": false,
+              "InternalName": "fieldname",
+              "IsModern": false,
+              "JSLink": "clienttemplates.js",
+              "MaxLength": 255,
+              "PinnedToFiltersPane": false,
+              "ReadOnlyField": false,
+              "Required": false,
+              "SchemaXml": "<Field ID=\"{3C0E9E00-8FCC-479f-9D8D-3447CDA34C5B}\" Name=\"fieldname\" StaticName=\"fieldname\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" DisplayName=\"Field Name\" Group=\"Core Contact and Calendar Columns\" Type=\"Text\" Sealed=\"TRUE\" AllowDeletion=\"TRUE\" />",
+              "Scope": "/sites/portal/Documents",
+              "Sealed": true,
+              "ShowInFiltersPane": 0,
+              "Sortable": true,
+              "StaticName": "fieldname",
+              "Title": "Field Name",
+              "TypeAsString": "Text",
+              "TypeDisplayName": "Single line of text",
+              "TypeShortDescription": "Single line of text",
+              "ValidationFormula": null,
+              "ValidationMessage": null
+            }]
+          }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/portal', listId: '3c0e9e00-8fcc-479f-9d8d-3447cda34c5b' } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([
+          {
+            "AutoIndexed": false,
+            "CanBeDeleted": true,
+            "ClientSideComponentId": "00000000-0000-0000-0000-000000000000",
+            "ClientSideComponentProperties": null,
+            "ClientValidationFormula": null,
+            "ClientValidationMessage": null,
+            "CustomFormatter": null,
+            "DefaultFormula": null,
+            "DefaultValue": null,
+            "Description": "",
+            "Direction": "none",
+            "EnforceUniqueValues": false,
+            "EntityPropertyName": "fieldname",
+            "FieldTypeKind": 2,
+            "Filterable": true,
+            "FromBaseType": false,
+            "Group": "Core Contact and Calendar Columns",
+            "Hidden": false,
+            "Id": "3c0e9e00-8fcc-479f-9d8d-3447cda34c5b",
+            "IndexStatus": 0,
+            "Indexed": false,
+            "InternalName": "fieldname",
+            "IsModern": false,
+            "JSLink": "clienttemplates.js",
+            "MaxLength": 255,
+            "PinnedToFiltersPane": false,
+            "ReadOnlyField": false,
+            "Required": false,
+            "SchemaXml": "<Field ID=\"{3C0E9E00-8FCC-479f-9D8D-3447CDA34C5B}\" Name=\"fieldname\" StaticName=\"fieldname\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" DisplayName=\"Field Name\" Group=\"Core Contact and Calendar Columns\" Type=\"Text\" Sealed=\"TRUE\" AllowDeletion=\"TRUE\" />",
+            "Scope": "/sites/portal/Documents",
+            "Sealed": true,
+            "ShowInFiltersPane": 0,
+            "Sortable": true,
+            "StaticName": "fieldname",
+            "Title": "Field Name",
+            "TypeAsString": "Text",
+            "TypeDisplayName": "Single line of text",
+            "TypeShortDescription": "Single line of text",
+            "ValidationFormula": null,
+            "ValidationMessage": null
+          }
+        ]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/m365/spo/commands/field/field-list.spec.ts
+++ b/src/m365/spo/commands/field/field-list.spec.ts
@@ -77,6 +77,12 @@ describe(commands.FIELD_LIST, () => {
     assert.strictEqual(actual, true);
   });
 
+  it('fails validation if title and id are specified together', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', listTitle: 'Demo List', listId: '935c13a0-cc53-4103-8b48-c1d0828eaa7f' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+
   it('supports debug mode', () => {
     const options = command.options();
     let containsOption = false;

--- a/src/m365/spo/commands/field/field-list.ts
+++ b/src/m365/spo/commands/field/field-list.ts
@@ -81,6 +81,10 @@ class SpoFieldListCommand extends SpoCommand {
     if (args.options.listId && !validation.isValidGuid(args.options.listId)) {
       return `${args.options.listId} is not a valid GUID`;
     }
+
+    if (args.options.listId && args.options.listTitle) {
+      return `Specify list id or title but not both`;
+    }
     
     return true;
   }

--- a/src/m365/spo/commands/field/field-list.ts
+++ b/src/m365/spo/commands/field/field-list.ts
@@ -1,0 +1,89 @@
+import { Logger } from '../../../../cli';
+import { CommandOption } from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import { validation } from '../../../../utils';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  listId?: string;
+  listTitle?: string;
+}
+
+class SpoFieldListCommand extends SpoCommand {
+  public get name(): string {
+    return commands.FIELD_LIST;
+  }
+
+  public get description(): string {
+    return 'Retrieves list of columns for specified list or site';
+  }
+
+  public defaultProperties(): string[] | undefined {
+    return ['Id', 'Title', 'Group', 'Hidden'];
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    let listUrl: string = '';
+
+    if (args.options.listId) {
+      listUrl = `lists(guid'${encodeURIComponent(args.options.listId)}')/`;
+    }
+    else if (args.options.listTitle) {
+      listUrl = `lists/getByTitle('${encodeURIComponent(args.options.listTitle)}')/`;
+    }
+
+    const requestOptions: any = {
+      url: `${args.options.webUrl}/_api/web/${listUrl}fields`,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    request
+      .get(requestOptions)
+      .then((res: any): void => {
+        logger.log(res.value);
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-t, --listTitle [listTitle]'
+      },
+      {
+        option: '-i --listId [listId]'
+      }   
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+    if (isValidSharePointUrl !== true) {
+      return isValidSharePointUrl;
+    }
+
+    if (args.options.listId && !validation.isValidGuid(args.options.listId)) {
+      return `${args.options.listId} is not a valid GUID`;
+    }
+    
+    return true;
+  }
+}
+
+module.exports = new SpoFieldListCommand();


### PR DESCRIPTION
### new command: spo field list
#### 🎯Aim
The aim of this PR is to add new command `m365 spo field list` which will allow to retrieve list of fields of site or specified list. The list we may specify by id or title (but not both)

#### 📷 Result
![howItWorks](https://user-images.githubusercontent.com/58668583/161447838-2a4dae8b-048e-4398-98ae-9ce78cfa2abf.gif)



### Linked Issue

Closes #2695
