### PR TITLE
Renames `teams conversationmember add` to `teams channel member add`. Closes #3174

### DIFF
--- a/docs/docs/cmd/teams/channel/channel-member-add.md
+++ b/docs/docs/cmd/teams/channel/channel-member-add.md
@@ -1,8 +1,14 @@
-# teams conversationmember add
+# teams channel member add
 
-Adds a conversation member in a private channel
+Adds a specified member in the specified Microsoft Teams private team channel
 
 ## Usage
+
+```sh
+m365 teams channel member add [options]
+```
+
+## Alias
 
 ```sh
 m365 teams conversationmember add [options]
@@ -44,11 +50,11 @@ You can only add members and owners of a Team to a private channel.
 Add members to a channel based on their id or user principal name
 
 ```sh
-m365 teams conversationmember add --teamId 47d6625d-a540-4b59-a4ab-19b787e40593 --channelId 19:586a8b9e36c4479bbbd378e439a96df2@thread.skype --userId "85a50aa1-e5b8-48ac-b8ce-8e338033c366,john.doe@contoso.com"
+m365 teams channel member add --teamId 47d6625d-a540-4b59-a4ab-19b787e40593 --channelId 19:586a8b9e36c4479bbbd378e439a96df2@thread.skype --userId "85a50aa1-e5b8-48ac-b8ce-8e338033c366,john.doe@contoso.com"
 ```
 
 Add owners to a channel based on their display names
 
 ```sh
-m365 teams conversationmember add --teamName "Human Resources" --channelName "Private Channel" --userDisplayName "Anne Matthews,John Doe" --owner
+m365 teams channel member add --teamName "Human Resources" --channelName "Private Channel" --userDisplayName "Anne Matthews,John Doe" --owner
 ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -544,6 +544,7 @@ nav:
         - channel add: 'cmd/teams/channel/channel-add.md'
         - channel get: 'cmd/teams/channel/channel-get.md'
         - channel list: 'cmd/teams/channel/channel-list.md'
+        - channel member add: 'cmd/teams/channel/channel-member-add.md'
         - channel member set: 'cmd/teams/channel/channel-member-set.md'
         - channel membership list: 'cmd/teams/channel/channel-membership-list.md'
         - channel remove: 'cmd/teams/channel/channel-remove.md'
@@ -555,7 +556,6 @@ nav:
         - chat message list: 'cmd/teams/chat/chat-message-list.md'
         - chat message send: 'cmd/teams/chat/chat-message-send.md'
       - conversationmember:
-        - conversationmember add: 'cmd/teams/conversationmember/conversationmember-add.md'
         - conversationmember list: 'cmd/teams/conversationmember/conversationmember-list.md'
       - funsettings:
         - funsettings list: 'cmd/teams/funsettings/funsettings-list.md'

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -57,6 +57,7 @@ describe('Lazy loading commands', () => {
       'spo sp permissionrequest deny',
       'spo sp permissionrequest list',
       'spo sp set',
+      'teams conversationmember add',
       'teams user add',
       'teams user list',
       'teams user remove',

--- a/src/m365/teams/commands.ts
+++ b/src/m365/teams/commands.ts
@@ -10,6 +10,7 @@ export default {
   CHANNEL_ADD: `${prefix} channel add`,
   CHANNEL_GET: `${prefix} channel get`,
   CHANNEL_LIST: `${prefix} channel list`,
+  CHANNEL_MEMBER_ADD: `${prefix} channel member add`,
   CHANNEL_MEMBER_SET: `${prefix} channel member set`,
   CHANNEL_MEMBERSHIP_LIST: `${prefix} channel membership list`,
   CHANNEL_REMOVE: `${prefix} channel remove`,

--- a/src/m365/teams/commands/channel/channel-member-add.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.spec.ts
@@ -8,9 +8,9 @@ import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
 import { sinonUtil } from '../../../../utils';
 import commands from '../../commands';
-const command: Command = require('./conversationmember-add');
+const command: Command = require('./channel-member-add');
 
-describe(commands.CONVERSATIONMEMBER_ADD, () => {
+describe(commands.CHANNEL_MEMBER_ADD, () => {
   //#region Mocked Responses 
   const multipleTeamsResponse: any = {
     "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups",
@@ -344,29 +344,21 @@ describe(commands.CONVERSATIONMEMBER_ADD, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.CONVERSATIONMEMBER_ADD), true);
+    assert.strictEqual(command.name.startsWith(commands.CHANNEL_MEMBER_ADD), true);
   });
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if teamId, channelId, and userId are not specified', () => {
-    const actual = command.validate({
-      options: {
-        debug: false
-      }
-    });
-    assert.notStrictEqual(actual, true);
+  it('defines correct alias', () => {
+    const alias = command.alias();
+    assert.strictEqual((alias && alias.indexOf(commands.CONVERSATIONMEMBER_ADD) !== -1), true);
   });
 
-  it('fails validation if teamName, channelName, and userDisplayName are not specified', () => {
-    const actual = command.validate({
-      options: {
-        debug: false
-      }
-    });
-    assert.notStrictEqual(actual, true);
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets();
+    assert.deepStrictEqual(optionSets, [[ 'teamId', 'teamName' ], [ 'channelId', 'channelName' ], [ 'userId', 'userDisplayName' ]]);
   });
 
   it('fails validation if the teamId is not a valid guid', () => {
@@ -402,75 +394,6 @@ describe(commands.CONVERSATIONMEMBER_ADD, () => {
     });
     assert.notStrictEqual(actual, true);
     done();
-  });
-
-  it('fails validation if the channelName is empty', () => {
-    const actual = command.validate({
-      options: {
-        teamName: "Human Resources",
-        channelName: "",
-        userId: "f410f714-29e3-43f7-874d-d7d35c33eaf1"
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if the teamName is empty', () => {
-    const actual = command.validate({
-      options: {
-        teamName: "",
-        channelName: "Private Channel",
-        userId: "f410f714-29e3-43f7-874d-d7d35c33eaf1"
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if the userDisplayName is empty', () => {
-    const actual = command.validate({
-      options: {
-        teamName: "Human Resources",
-        channelName: "Private Channel",
-        userDisplayName: ""
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if teamName and teamId are specified', () => {
-    const actual = command.validate({
-      options: {
-        teamId: "fce9e580-8bba-4638-ab5c-ab40016651e3",
-        teamName: "Human Resources",
-        channelName: "Private Channel",
-        userId: "f410f714-29e3-43f7-874d-d7d35c33eaf1"
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if channelName and channelId are specified', () => {
-    const actual = command.validate({
-      options: {
-        teamName: "Human Resources",
-        channelName: "Private Channel",
-        channelId: "19:586a8b9e36c4479bbbd378e439a96df2@thread.skype",
-        userId: "f410f714-29e3-43f7-874d-d7d35c33eaf1"
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if userId and userDisplayName are specified', () => {
-    const actual = command.validate({
-      options: {
-        teamName: "Human Resources",
-        channelName: "Private Channel",
-        userId: "f410f714-29e3-43f7-874d-d7d35c33eaf1",
-        userDisplayName: "admin@contoso.com"
-      }
-    });
-    assert.notStrictEqual(actual, true);
   });
 
   it('validates for a correct teamId, channelId, and userId input', () => {

--- a/src/m365/teams/commands/channel/channel-member-add.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.ts
@@ -24,13 +24,17 @@ interface Options extends GlobalOptions {
   owner: boolean;
 }
 
-class TeamsConversationMemberAddCommand extends GraphCommand {
+class TeamsChannelMemberAddCommand extends GraphCommand {
   public get name(): string {
-    return commands.CONVERSATIONMEMBER_ADD;
+    return commands.CHANNEL_MEMBER_ADD;
   }
 
   public get description(): string {
     return 'Adds a conversation member in a private channel.';
+  }
+
+  public alias(): string[] | undefined {
+    return [commands.CONVERSATIONMEMBER_ADD];
   }
 
   public getTelemetryProperties(args: CommandArgs): any {
@@ -46,6 +50,8 @@ class TeamsConversationMemberAddCommand extends GraphCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    this.showDeprecationWarning(logger, commands.CONVERSATIONMEMBER_ADD, commands.CHANNEL_MEMBER_ADD);
+
     let teamId: string = '';
     let channelId: string = '';
 
@@ -72,6 +78,14 @@ class TeamsConversationMemberAddCommand extends GraphCommand {
       })
       .then(_ => cb(),
         (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public optionSets(): string[][] | undefined {
+    return [
+      [ 'teamId', 'teamName' ],
+      [ 'channelId', 'channelName' ],
+      [ 'userId', 'userDisplayName' ]
+    ];
   }
 
   public options(): CommandOption[] {
@@ -104,36 +118,12 @@ class TeamsConversationMemberAddCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (args.options.teamId && args.options.teamName) {
-      return 'Specify either teamId or teamName, but not both.';
-    }
-
-    if (!args.options.teamId && !args.options.teamName) {
-      return 'Specify teamId or teamName, one is required';
-    }
-
     if (args.options.teamId && !validation.isValidGuid(args.options.teamId as string)) {
       return `${args.options.teamId} is not a valid GUID`;
     }
 
-    if (args.options.channelId && args.options.channelName) {
-      return 'Specify either channelId or channelName, but not both.';
-    }
-
-    if (!args.options.channelId && !args.options.channelName) {
-      return 'Specify channelId or channelName, one is required';
-    }
-
     if (args.options.channelId && !validation.isValidTeamsChannelId(args.options.channelId as string)) {
       return `${args.options.channelId} is not a valid Teams ChannelId`;
-    }
-
-    if (args.options.userId && args.options.userDisplayName) {
-      return 'Specify either userId or userDisplayName, but not both.';
-    }
-
-    if (!args.options.userId && !args.options.userDisplayName) {
-      return 'Specify userId or userDisplayName, one is required';
     }
 
     return true;
@@ -256,4 +246,4 @@ class TeamsConversationMemberAddCommand extends GraphCommand {
   }
 }
 
-module.exports = new TeamsConversationMemberAddCommand();
+module.exports = new TeamsChannelMemberAddCommand();


### PR DESCRIPTION
Closes #3174

### Info
* Renamed `teams conversationmember add` command to `teams channel member add`
* Added alias & deprecation warning
* Implemented option sets