### PR TITLE
Adds 'tenant security alerts list' command. Closes #2635

### DIFF
--- a/docs/docs/cmd/tenant/security/security-alerts-list.md
+++ b/docs/docs/cmd/tenant/security/security-alerts-list.md
@@ -1,0 +1,30 @@
+# tenant security alerts list
+
+Gets the security alerts for a tenant
+
+## Usage
+
+```sh
+m365 tenant security alerts list [options]
+```
+
+## Options
+
+`--vendor [vendor]`
+: The vendor to return alerts for. Allowed values `Azure Advanced Threat Protection`, `Azure Security Center`, `Microsoft Cloud App Security`, `Azure Active Directory Identity Protection`, `Azure Sentinel`, `Microsoft Defender ATP`. If omitted, all alerts are returned
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Get all security alerts for a tenant
+
+```sh
+m365 tenant security alerts list
+```
+
+Get security alerts for a vendor with name _Azure Sentinel_
+
+```sh
+m365 tenant security alerts list --vendor "Azure Sentinel"
+```

--- a/docs/docs/cmd/tenant/security/security-alerts-list.md
+++ b/docs/docs/cmd/tenant/security/security-alerts-list.md
@@ -11,7 +11,7 @@ m365 tenant security alerts list [options]
 ## Options
 
 `--vendor [vendor]`
-: The vendor to return alerts for. Allowed values `Azure Advanced Threat Protection`, `Azure Security Center`, `Microsoft Cloud App Security`, `Azure Active Directory Identity Protection`, `Azure Sentinel`, `Microsoft Defender ATP`. If omitted, all alerts are returned
+: The vendor to return alerts for. Possible values `Azure Advanced Threat Protection`, `Azure Security Center`, `Microsoft Cloud App Security`, `Azure Active Directory Identity Protection`, `Azure Sentinel`, `Microsoft Defender ATP`. If omitted, all alerts are returned
 
 --8<-- "docs/cmd/_global.md"
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -129,6 +129,8 @@ nav:
         - report office365activationsuserdetail: 'cmd/tenant/report/report-office365activationsuserdetail.md'
         - report office365activationsusercounts: 'cmd/tenant/report/report-office365activationsusercounts.md'
         - report servicesusercounts: 'cmd/tenant/report/report-servicesusercounts.md'
+      - security:
+        - security alerts list: 'cmd/tenant/security/security-alerts-list.md'
       - service announcement:
         - serviceannouncement health get: 'cmd/tenant/serviceannouncement/serviceannouncement-health-get.md'
         - serviceannouncement health list: 'cmd/tenant/serviceannouncement/serviceannouncement-health-list.md'

--- a/src/m365/tenant/commands.ts
+++ b/src/m365/tenant/commands.ts
@@ -8,6 +8,7 @@ export default {
   REPORT_OFFICE365ACTIVATIONSUSERDETAIL: `${prefix} report office365activationsuserdetail`,
   REPORT_OFFICE365ACTIVATIONSUSERCOUNTS: `${prefix} report office365activationsusercounts`,
   REPORT_SERVICESUSERCOUNTS: `${prefix} report servicesusercounts`,
+  SECURITY_ALERTS_LIST:`${prefix} security alerts list`,
   SERVICEANNOUNCEMENT_HEALTHISSUE_GET: `${prefix} serviceannouncement healthissue get`,
   SERVICEANNOUNCEMENT_HEALTH_GET: `${prefix} serviceannouncement health get`,
   SERVICEANNOUNCEMENT_HEALTH_LIST: `${prefix} serviceannouncement health list`,

--- a/src/m365/tenant/commands/security/security-alerts-list.spec.ts
+++ b/src/m365/tenant/commands/security/security-alerts-list.spec.ts
@@ -740,17 +740,6 @@ describe(commands.SECURITY_ALERTS_LIST, () => {
     });
   });
 
-  it('rejects invalid vendor name', () => {
-    const vendor = 'foo';
-    const actual = command.validate({ options: { vendor: vendor } });
-    assert.strictEqual(actual, `${vendor} is not a valid vendor. Allowed values are Azure Advanced Threat Protection, Azure Security Center, Microsoft Cloud App Security, Azure Active Directory Identity Protection, Azure Sentinel, Microsoft Defender ATP`);
-  });
-
-  it('doesn\'t fail validation if the optional vendor option not specified', () => {
-    const actual = command.validate({ options: {} });
-    assert.strictEqual(actual, true);
-  });
-
   it('correctly handles random API error', (done) => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));

--- a/src/m365/tenant/commands/security/security-alerts-list.spec.ts
+++ b/src/m365/tenant/commands/security/security-alerts-list.spec.ts
@@ -1,0 +1,779 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils';
+import commands from '../../commands';
+const command: Command = require('./security-alerts-list');
+
+describe(commands.SECURITY_ALERTS_LIST, () => {
+
+  const alertResponseCSV = `id,title,severity
+  4ece2cf8-cbc0-5a42-92c3-e23f96006907,SharePoint Bulk Edit Items,medium
+  33aed7062fce896e48e2f63fe3971153b0bb959a3ac25fd3b282c469b2cb54a7,Anonymous IP address,medium
+  6254ad90467a7d7b3d69f934,Multiple failed login attempts,low`;
+
+  const alertASC = {
+    "id": "2517536653831539999_658fa695-a5e6-4b60-ac7c-b2c1396df384",
+    "azureTenantId": "b8e1599d-b418-4be9-8f39-df03c3abe27a",
+    "azureSubscriptionId": "ee390228-e284-4e54-a464-d693a1d55540",
+    "riskScore": null,
+    "tags": [],
+    "activityGroupName": null,
+    "assignedTo": null,
+    "category": "Storage.Blob_GeoAnomaly",
+    "closedDateTime": null,
+    "comments": [],
+    "confidence": null,
+    "createdDateTime": "2022-03-30T13:19:15.8039138Z",
+    "description": "Someone has accessed your Azure Storage account 'westeuropegivcekj' from an unusual location.",
+    "detectionIds": [],
+    "eventDateTime": "2022-03-30T10:16:56.846Z",
+    "feedback": null,
+    "incidentIds": [],
+    "lastEventDateTime": null,
+    "lastModifiedDateTime": "2022-03-30T13:19:48.5196488Z",
+    "recommendedActions": [
+      "• Limit access to your storage account, following the 'least privilege' principle: https://go.microsoft.com/fwlink/?linkid=2187303.• Consider using identity-based authentication: https://go.microsoft.com/fwlink/?linkid=2187202.• Consider rotating the storage account access keys and ensure that your access tokens are only shared with authorized users.• Ensure that storage access tokens are stored in a secured location such as Azure Key Vault. Avoid storing or sharing storage access tokens in source code, documentation, and email."
+    ],
+    "severity": "low",
+    "sourceMaterials": [
+      "https://portal.azure.com/#blade/Microsoft_Azure_Security_AzureDefenderForData/AlertBlade/alertId/2517536653831539999_658fa695-a5e6-4b60-ac7c-b2c1396df384/subscriptionId/bbdf91d0-d75b-430e-b738-2c525452144f/resourceGroup/managed-rg-purview-mip-poc/referencedFrom/alertDeepLink/location/westeurope"
+    ],
+    "status": "newAlert",
+    "title": "Access from an unusual location to a storage blob container",
+    "CustomProperties": "[\"{\\\"Alert Id\\\":\\\"658fa695-a5e6-4b60-ac7c-b2c1396df384\\\",\\\"Azure AD user\\\":\\\"N/A (Azure AD user authentication was not used)\\\",\\\"User agent\\\":\\\"Azure-Storage/9.3.0 (.NET Core)\\\",\\\"API type\\\":\\\"Blob\\\",\\\"Client location\\\":\\\"Dublin, Ireland\\\",\\\"Authentication type\\\":\\\"Shared access signature (SAS)\\\",\\\"Investigation steps\\\":\\\"{\\\\\\\"displayValue\\\\\\\":\\\\\\\"View related storage activity using Storage Analytics Logging. See how to configure Storage Analytics logging and more information\\\\\\\",\\\\\\\"kind\\\\\\\":\\\\\\\"Link\\\\\\\",\\\\\\\"value\\\\\\\":\\\\\\\"https:\\\\\\\\/\\\\\\\\/go.microsoft.com\\\\\\\\/fwlink\\\\\\\\/?linkid=2075734\\\\\\\"}\\\",\\\"Operations types\\\":\\\"GetBlob\\\",\\\"Service type\\\":\\\"Azure Blobs\\\",\\\"Container\\\":\\\"temporary\\\",\\\"Potential causes\\\":\\\"This alert indicates that this account has been accessed successfully from an IP address that is unfamiliar and unexpected compared to recent access pattern on this account.\\\\\\Potential causes:\\\\\\• An attacker has accessed your storage account.\\\\\\• A legitimate user has accessed your storage account from a new location.\\\",\\\"resourceType\\\":\\\"Storage\\\",\\\"ReportingSystem\\\":\\\"Azure\\\"}\",\"\\\"InitialAccess\\\"\"]",
+    "vendorInformation": {
+      "provider": "ASC",
+      "providerVersion": null,
+      "subProvider": "StorageThreatDetection",
+      "vendor": "Microsoft"
+    },
+    "alertDetections": [],
+    "cloudAppStates": [],
+    "fileStates": [],
+    "hostStates": [],
+    "historyStates": [],
+    "investigationSecurityStates": [],
+    "malwareStates": [],
+    "messageSecurityStates": [],
+    "networkConnections": [
+      {
+        "applicationName": null,
+        "destinationAddress": null,
+        "destinationDomain": null,
+        "destinationLocation": null,
+        "destinationPort": null,
+        "destinationUrl": null,
+        "direction": null,
+        "domainRegisteredDateTime": null,
+        "localDnsName": null,
+        "natDestinationAddress": null,
+        "natDestinationPort": null,
+        "natSourceAddress": null,
+        "natSourcePort": null,
+        "protocol": "tcp",
+        "riskScore": null,
+        "sourceAddress": "52.214.204.49",
+        "sourceLocation": "Dublin, Dublin, IE",
+        "sourcePort": null,
+        "status": null,
+        "urlParameters": null
+      }
+    ],
+    "processes": [],
+    "registryKeyStates": [],
+    "securityResources": [
+      {
+        "resource": "/subscriptions/bbdf91d0-d75b-430e-b738-2c525452144f/resourceGroups/managed-rg-purview-mip-poc/providers/Microsoft.Storage/storageAccounts/scanwesteuropegivcebj",
+        "resourceType": "attacked"
+      }
+    ],
+    "triggers": [],
+    "userStates": [],
+    "uriClickSecurityStates": [],
+    "vulnerabilityStates": []
+  };
+
+  const alertMCAS = {
+    "id": "6254ad90467a7d7b3d69f934",
+    "azureTenantId": "b8e1599d-b418-4be9-8f39-df03c3abe27a",
+    "azureSubscriptionId": "ee390228-e284-4e54-a464-d693a1d55540",
+    "riskScore": null,
+    "tags": [],
+    "activityGroupName": null,
+    "assignedTo": null,
+    "category": "MCAS_ALERT_ANUBIS_DETECTION_REPEATED_ACTIVITY_FAILED_LOGIN",
+    "closedDateTime": null,
+    "comments": [],
+    "confidence": null,
+    "createdDateTime": "2022-04-11T22:37:04Z",
+    "description": "The user \"jondoe (jondoe@contoso.onmicrosoft.com)\" performed more than 103 failed logins attempts in a single session.",
+    "detectionIds": [],
+    "eventDateTime": "2022-04-11T07:22:39.69Z",
+    "feedback": null,
+    "incidentIds": [],
+    "lastEventDateTime": null,
+    "lastModifiedDateTime": "2022-04-11T22:37:05.5976027Z",
+    "recommendedActions": [],
+    "severity": "low",
+    "sourceMaterials": [
+      "https://contoso.portal.cloudappsecurity.com/#/alerts/6254ad90467a7d7b3d69f934",
+      "https://contoso.portal.cloudappsecurity.com/#/policy/?id=eq(5a4cd40810bc95f3d6cbaa83,)",
+      "https://contoso.portal.cloudappsecurity.com/#/alerts/6254ad90467a7d7b3d69f934"
+    ],
+    "status": "newAlert",
+    "title": "Multiple failed login attempts",
+    "vendorInformation": {
+      "provider": "MCAS",
+      "providerVersion": null,
+      "subProvider": null,
+      "vendor": "Microsoft"
+    },
+    "alertDetections": [],
+    "cloudAppStates": [
+      {
+        "destinationServiceIp": null,
+        "destinationServiceName": "Microsoft SharePoint Online",
+        "riskScore": null
+      },
+      {
+        "destinationServiceIp": null,
+        "destinationServiceName": "Office 365",
+        "riskScore": null
+      }
+    ],
+    "fileStates": [],
+    "hostStates": [],
+    "historyStates": [],
+    "investigationSecurityStates": [],
+    "malwareStates": [],
+    "messageSecurityStates": [],
+    "networkConnections": [],
+    "processes": [],
+    "registryKeyStates": [],
+    "securityResources": [],
+    "triggers": [],
+    "userStates": [
+      {
+        "aadUserId": "b9e36c12-4683-4da9-bf7d-d14f73e7bd2c",
+        "accountName": "jondoe",
+        "domainName": "contoso.onmicrosoft.com",
+        "emailRole": "unknown",
+        "isVpn": null,
+        "logonDateTime": null,
+        "logonId": null,
+        "logonIp": null,
+        "logonLocation": null,
+        "logonType": null,
+        "onPremisesSecurityIdentifier": null,
+        "riskScore": null,
+        "userAccountType": null,
+        "userPrincipalName": "jondoe@contoso.onmicrosoft.com"
+      }
+    ],
+    "uriClickSecurityStates": [],
+    "vulnerabilityStates": []
+  };
+  
+  const alertIPC = {
+    "id": "33aed7062fce896e48e2f63fe3971153b0bb959a3ac25fd3b282c469b2cb54a7",
+    "azureTenantId": "b8e1599d-b418-4be9-8f39-df03c3abe27a",
+    "azureSubscriptionId": "ee390228-e284-4e54-a464-d693a1d55540",
+    "riskScore": null,
+    "tags": [],
+    "activityGroupName": null,
+    "assignedTo": null,
+    "category": "AnonymousLogin",
+    "closedDateTime": null,
+    "comments": [],
+    "confidence": null,
+    "createdDateTime": "2022-04-12T01:49:42.3797106Z",
+    "description": "Sign-in from an anonymous IP address (e.g. Tor browser, anonymizer VPNs)",
+    "detectionIds": [],
+    "eventDateTime": "2022-04-12T01:49:42.3797106Z",
+    "feedback": null,
+    "incidentIds": [],
+    "lastEventDateTime": null,
+    "lastModifiedDateTime": "2022-04-12T01:51:14.5996188Z",
+    "recommendedActions": [],
+    "severity": "medium",
+    "sourceMaterials": [],
+    "status": "newAlert",
+    "title": "Anonymous IP address",
+    "vendorInformation": {
+      "provider": "IPC",
+      "providerVersion": null,
+      "subProvider": null,
+      "vendor": "Microsoft"
+    },
+    "alertDetections": [],
+    "cloudAppStates": [],
+    "fileStates": [],
+    "hostStates": [],
+    "historyStates": [],
+    "investigationSecurityStates": [],
+    "malwareStates": [],
+    "messageSecurityStates": [],
+    "networkConnections": [],
+    "processes": [],
+    "registryKeyStates": [],
+    "securityResources": [],
+    "triggers": [],
+    "userStates": [
+      {
+        "aadUserId": "0b0274d6-0398-4026-a742-03be2dd5f440",
+        "accountName": "jon.doe",
+        "domainName": "contoso.onmicrosoft.com",
+        "emailRole": "unknown",
+        "isVpn": null,
+        "logonDateTime": "2022-04-12T01:49:42.3797106Z",
+        "logonId": null,
+        "logonIp": "183.220.101.28",
+        "logonLocation": "Schoenwalde-Glien, Brandenburg, DE",
+        "logonType": null,
+        "onPremisesSecurityIdentifier": null,
+        "riskScore": null,
+        "userAccountType": null,
+        "userPrincipalName": "jon.doe@contoso.onmicrosoft.com"
+      }
+    ],
+    "uriClickSecurityStates": [],
+    "vulnerabilityStates": []
+  };
+
+  const alertResponse = [
+    {
+      "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#security/alerts",
+      "value": [
+        {
+          "id": "4ece2cf8-cbc0-5a42-92c3-e23f96006907",
+          "azureTenantId": "b8e1599d-b418-4be9-8f39-df03c3abe27a",
+          "azureSubscriptionId": "ee390228-e284-4e54-a464-d693a1d55540",
+          "riskScore": null,
+          "tags": [],
+          "activityGroupName": null,
+          "assignedTo": null,
+          "category": "5e462672-358b-48cb-9ca9-c910c99cb34d_0eb2a7bf-4d08-469a-8344-267c7b749779",
+          "closedDateTime": null,
+          "comments": [],
+          "confidence": null,
+          "createdDateTime": "2022-04-11T17:03:34.0185371Z",
+          "description": "Detect bulk edits in SharePoint",
+          "detectionIds": [],
+          "eventDateTime": "2022-04-11T12:52:50Z",
+          "feedback": null,
+          "incidentIds": [],
+          "lastEventDateTime": null,
+          "lastModifiedDateTime": "2022-04-11T17:03:34.4787699Z",
+          "recommendedActions": [],
+          "severity": "medium",
+          "sourceMaterials": [],
+          "status": "newAlert",
+          "title": "SharePoint Bulk Edit Items",
+          "vendorInformation": {
+            "provider": "Azure Sentinel",
+            "providerVersion": null,
+            "subProvider": null,
+            "vendor": "Microsoft"
+          },
+          "alertDetections": [],
+          "cloudAppStates": [],
+          "fileStates": [],
+          "hostStates": [],
+          "historyStates": [],
+          "investigationSecurityStates": [],
+          "malwareStates": [],
+          "messageSecurityStates": [],
+          "networkConnections": [],
+          "processes": [],
+          "registryKeyStates": [],
+          "securityResources": [],
+          "triggers": [],
+          "userStates": [],
+          "uriClickSecurityStates": [],
+          "vulnerabilityStates": []
+        },
+        {
+          "id": "33aed7062fce896e48e2f63fe3971153b0bb959a3ac25fd3b282c469b2cb54a7",
+          "azureTenantId": "b8e1599d-b418-4be9-8f39-df03c3abe27a",
+          "azureSubscriptionId": "ee390228-e284-4e54-a464-d693a1d55540",
+          "riskScore": null,
+          "tags": [],
+          "activityGroupName": null,
+          "assignedTo": null,
+          "category": "AnonymousLogin",
+          "closedDateTime": null,
+          "comments": [],
+          "confidence": null,
+          "createdDateTime": "2022-04-12T01:49:42.3797106Z",
+          "description": "Sign-in from an anonymous IP address (e.g. Tor browser, anonymizer VPNs)",
+          "detectionIds": [],
+          "eventDateTime": "2022-04-12T01:49:42.3797106Z",
+          "feedback": null,
+          "incidentIds": [],
+          "lastEventDateTime": null,
+          "lastModifiedDateTime": "2022-04-12T01:51:14.5996188Z",
+          "recommendedActions": [],
+          "severity": "medium",
+          "sourceMaterials": [],
+          "status": "newAlert",
+          "title": "Anonymous IP address",
+          "vendorInformation": {
+            "provider": "IPC",
+            "providerVersion": null,
+            "subProvider": null,
+            "vendor": "Microsoft"
+          },
+          "alertDetections": [],
+          "cloudAppStates": [],
+          "fileStates": [],
+          "hostStates": [],
+          "historyStates": [],
+          "investigationSecurityStates": [],
+          "malwareStates": [],
+          "messageSecurityStates": [],
+          "networkConnections": [],
+          "processes": [],
+          "registryKeyStates": [],
+          "securityResources": [],
+          "triggers": [],
+          "userStates": [
+            {
+              "aadUserId": "0b0274d6-0398-4026-a742-03be2dd5f440",
+              "accountName": "jon.doe",
+              "domainName": "contoso.onmicrosoft.com",
+              "emailRole": "unknown",
+              "isVpn": null,
+              "logonDateTime": "2022-04-12T01:49:42.3797106Z",
+              "logonId": null,
+              "logonIp": "183.220.101.28",
+              "logonLocation": "Schoenwalde-Glien, Brandenburg, DE",
+              "logonType": null,
+              "onPremisesSecurityIdentifier": null,
+              "riskScore": null,
+              "userAccountType": null,
+              "userPrincipalName": "jon.doe@contoso.onmicrosoft.com"
+            }
+          ],
+          "uriClickSecurityStates": [],
+          "vulnerabilityStates": []
+        },
+        {
+          "id": "6254ad90467a7d7b3d69f934",
+          "azureTenantId": "b8e1599d-b418-4be9-8f39-df03c3abe27a",
+          "azureSubscriptionId": "ee390228-e284-4e54-a464-d693a1d55540",
+          "riskScore": null,
+          "tags": [],
+          "activityGroupName": null,
+          "assignedTo": null,
+          "category": "MCAS_ALERT_ANUBIS_DETECTION_REPEATED_ACTIVITY_FAILED_LOGIN",
+          "closedDateTime": null,
+          "comments": [],
+          "confidence": null,
+          "createdDateTime": "2022-04-11T22:37:04Z",
+          "description": "The user \"jondoe (jondoe@contoso.onmicrosoft.com)\" performed more than 103 failed logins attempts in a single session.",
+          "detectionIds": [],
+          "eventDateTime": "2022-04-11T07:22:39.69Z",
+          "feedback": null,
+          "incidentIds": [],
+          "lastEventDateTime": null,
+          "lastModifiedDateTime": "2022-04-11T22:37:05.5976027Z",
+          "recommendedActions": [],
+          "severity": "low",
+          "sourceMaterials": [
+            "https://contoso.portal.cloudappsecurity.com/#/alerts/6254ad90467a7d7b3d69f934",
+            "https://contoso.portal.cloudappsecurity.com/#/policy/?id=eq(5a4cd40810bc95f3d6cbaa83,)",
+            "https://contoso.portal.cloudappsecurity.com/#/alerts/6254ad90467a7d7b3d69f934"
+          ],
+          "status": "newAlert",
+          "title": "Multiple failed login attempts",
+          "vendorInformation": {
+            "provider": "MCAS",
+            "providerVersion": null,
+            "subProvider": null,
+            "vendor": "Microsoft"
+          },
+          "alertDetections": [],
+          "cloudAppStates": [
+            {
+              "destinationServiceIp": null,
+              "destinationServiceName": "Microsoft SharePoint Online",
+              "riskScore": null
+            },
+            {
+              "destinationServiceIp": null,
+              "destinationServiceName": "Office 365",
+              "riskScore": null
+            }
+          ],
+          "fileStates": [],
+          "hostStates": [],
+          "historyStates": [],
+          "investigationSecurityStates": [],
+          "malwareStates": [],
+          "messageSecurityStates": [],
+          "networkConnections": [],
+          "processes": [],
+          "registryKeyStates": [],
+          "securityResources": [],
+          "triggers": [],
+          "userStates": [
+            {
+              "aadUserId": "b9e36c12-4683-4da9-bf7d-d14f73e7bd2c",
+              "accountName": "jondoe",
+              "domainName": "contoso.onmicrosoft.com",
+              "emailRole": "unknown",
+              "isVpn": null,
+              "logonDateTime": null,
+              "logonId": null,
+              "logonIp": null,
+              "logonLocation": null,
+              "logonType": null,
+              "onPremisesSecurityIdentifier": null,
+              "riskScore": null,
+              "userAccountType": null,
+              "userPrincipalName": "jondoe@contoso.onmicrosoft.com"
+            }
+          ],
+          "uriClickSecurityStates": [],
+          "vulnerabilityStates": []
+        },
+        {
+          "id": "2517536653831539999_658fa695-a5e6-4b60-ac7c-b2c1396df384",
+          "azureTenantId": "b8e1599d-b418-4be9-8f39-df03c3abe27a",
+          "azureSubscriptionId": "ee390228-e284-4e54-a464-d693a1d55540",
+          "riskScore": null,
+          "tags": [],
+          "activityGroupName": null,
+          "assignedTo": null,
+          "category": "Storage.Blob_GeoAnomaly",
+          "closedDateTime": null,
+          "comments": [],
+          "confidence": null,
+          "createdDateTime": "2022-03-30T13:19:15.8039138Z",
+          "description": "Someone has accessed your Azure Storage account 'westeuropegivcekj' from an unusual location.",
+          "detectionIds": [],
+          "eventDateTime": "2022-03-30T10:16:56.846Z",
+          "feedback": null,
+          "incidentIds": [],
+          "lastEventDateTime": null,
+          "lastModifiedDateTime": "2022-03-30T13:19:48.5196488Z",
+          "recommendedActions": [
+            "• Limit access to your storage account, following the 'least privilege' principle: https://go.microsoft.com/fwlink/?linkid=2187303.• Consider using identity-based authentication: https://go.microsoft.com/fwlink/?linkid=2187202.• Consider rotating the storage account access keys and ensure that your access tokens are only shared with authorized users.• Ensure that storage access tokens are stored in a secured location such as Azure Key Vault. Avoid storing or sharing storage access tokens in source code, documentation, and email."
+          ],
+          "severity": "low",
+          "sourceMaterials": [
+            "https://portal.azure.com/#blade/Microsoft_Azure_Security_AzureDefenderForData/AlertBlade/alertId/2517536653831539999_658fa695-a5e6-4b60-ac7c-b2c1396df384/subscriptionId/bbdf91d0-d75b-430e-b738-2c525452144f/resourceGroup/managed-rg-purview-mip-poc/referencedFrom/alertDeepLink/location/westeurope"
+          ],
+          "status": "newAlert",
+          "title": "Access from an unusual location to a storage blob container",
+          "CustomProperties": "[\"{\\\"Alert Id\\\":\\\"658fa695-a5e6-4b60-ac7c-b2c1396df384\\\",\\\"Azure AD user\\\":\\\"N/A (Azure AD user authentication was not used)\\\",\\\"User agent\\\":\\\"Azure-Storage/9.3.0 (.NET Core)\\\",\\\"API type\\\":\\\"Blob\\\",\\\"Client location\\\":\\\"Dublin, Ireland\\\",\\\"Authentication type\\\":\\\"Shared access signature (SAS)\\\",\\\"Investigation steps\\\":\\\"{\\\\\\\"displayValue\\\\\\\":\\\\\\\"View related storage activity using Storage Analytics Logging. See how to configure Storage Analytics logging and more information\\\\\\\",\\\\\\\"kind\\\\\\\":\\\\\\\"Link\\\\\\\",\\\\\\\"value\\\\\\\":\\\\\\\"https:\\\\\\\\/\\\\\\\\/go.microsoft.com\\\\\\\\/fwlink\\\\\\\\/?linkid=2075734\\\\\\\"}\\\",\\\"Operations types\\\":\\\"GetBlob\\\",\\\"Service type\\\":\\\"Azure Blobs\\\",\\\"Container\\\":\\\"temporary\\\",\\\"Potential causes\\\":\\\"This alert indicates that this account has been accessed successfully from an IP address that is unfamiliar and unexpected compared to recent access pattern on this account.\\\\\\Potential causes:\\\\\\• An attacker has accessed your storage account.\\\\\\• A legitimate user has accessed your storage account from a new location.\\\",\\\"resourceType\\\":\\\"Storage\\\",\\\"ReportingSystem\\\":\\\"Azure\\\"}\",\"\\\"InitialAccess\\\"\"]",
+          "vendorInformation": {
+            "provider": "ASC",
+            "providerVersion": null,
+            "subProvider": "StorageThreatDetection",
+            "vendor": "Microsoft"
+          },
+          "alertDetections": [],
+          "cloudAppStates": [],
+          "fileStates": [],
+          "hostStates": [],
+          "historyStates": [],
+          "investigationSecurityStates": [],
+          "malwareStates": [],
+          "messageSecurityStates": [],
+          "networkConnections": [
+            {
+              "applicationName": null,
+              "destinationAddress": null,
+              "destinationDomain": null,
+              "destinationLocation": null,
+              "destinationPort": null,
+              "destinationUrl": null,
+              "direction": null,
+              "domainRegisteredDateTime": null,
+              "localDnsName": null,
+              "natDestinationAddress": null,
+              "natDestinationPort": null,
+              "natSourceAddress": null,
+              "natSourcePort": null,
+              "protocol": "tcp",
+              "riskScore": null,
+              "sourceAddress": "52.214.204.49",
+              "sourceLocation": "Dublin, Dublin, IE",
+              "sourcePort": null,
+              "status": null,
+              "urlParameters": null
+            }
+          ],
+          "processes": [],
+          "registryKeyStates": [],
+          "securityResources": [
+            {
+              "resource": "/subscriptions/bbdf91d0-d75b-430e-b738-2c525452144f/resourceGroups/managed-rg-purview-mip-poc/providers/Microsoft.Storage/storageAccounts/scanwesteuropegivcebj",
+              "resourceType": "attacked"
+            }
+          ],
+          "triggers": [],
+          "userStates": [],
+          "uriClickSecurityStates": [],
+          "vulnerabilityStates": []
+        }
+      ]
+    }
+  ];
+
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.SECURITY_ALERTS_LIST), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['id', 'title', 'severity']);
+  });
+
+  it('correctly returns list of security alerts for vendor with name Azure Security Center', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/alerts?$filter=vendorInformation/provider eq 'ASC'`) {
+        return Promise.resolve(
+          {
+            value: alertASC
+          }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const options: any = {
+      vendor: 'Azure Security Center'
+    };
+
+    command.action(logger, { options } as any, () => {
+      try {
+        assert(loggerLogSpy.calledWith(alertASC));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly returns list of security alerts for vendor with name Microsoft Cloud App Security', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/alerts?$filter=vendorInformation/provider eq 'MCAS'`) {
+        return Promise.resolve(
+          {
+            value: alertMCAS
+          }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const options: any = {
+      vendor: 'Microsoft Cloud App Security'
+    };
+
+    command.action(logger, { options } as any, () => {
+      try {
+        assert(loggerLogSpy.calledWith(alertMCAS));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly returns list of security alerts for vendor with name Azure Active Directory Identity Protection', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/alerts?$filter=vendorInformation/provider eq 'IPC'`) {
+        return Promise.resolve(
+          {
+            value: alertIPC
+          }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const options: any = {
+      vendor: 'Azure Active Directory Identity Protection'
+    };
+
+    command.action(logger, { options } as any, () => {
+      try {
+        assert(loggerLogSpy.calledWith(alertIPC));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly returns list of security alerts as csv', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/alerts`) {
+        return Promise.resolve(
+          {
+            value: alertResponseCSV
+          }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const options: any = {
+      output: "csv"
+    };
+
+    command.action(logger, { options } as any, () => {
+      try {
+        assert(loggerLogSpy.calledWith(alertResponseCSV));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly returns list with security alerts', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/alerts`) {
+        return Promise.resolve(
+          {
+            value: alertResponse
+          }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const options: any = {
+    };
+
+    command.action(logger, { options } as any, () => {
+      try {
+        assert(loggerLogSpy.calledWith(alertResponse));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails when serviceAnnouncement endpoint fails', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/alerts`) {
+        return Promise.resolve({});
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const options: any = {};
+
+    command.action(logger, { options } as any, (err?: any) => {
+      try {
+        assert.strictEqual(err.message, "Error fetching security alerts");
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('rejects invalid vendor name', () => {
+    const vendor = 'foo';
+    const actual = command.validate({ options: { vendor: vendor } });
+    assert.strictEqual(actual, `${vendor} is not a valid vendor. Allowed values are Azure Advanced Threat Protection, Azure Security Center, Microsoft Cloud App Security, Azure Active Directory Identity Protection, Azure Sentinel, Microsoft Defender ATP`);
+  });
+
+  it('doesn\'t fail validation if the optional vendor option not specified', () => {
+    const actual = command.validate({ options: {} });
+    assert.strictEqual(actual, true);
+  });
+
+  it('correctly handles random API error', (done) => {
+    sinonUtil.restore(request.get);
+    sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));
+
+    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+});

--- a/src/m365/tenant/commands/security/security-alerts-list.ts
+++ b/src/m365/tenant/commands/security/security-alerts-list.ts
@@ -90,16 +90,6 @@ class TenantSecurityAlertsListCommand extends GraphCommand {
     const parentOptions: CommandOption[] = super.options();
     return options.concat(parentOptions);
   }
-
-  public validate(args: CommandArgs): boolean | string {
-    if (args.options.vendor) {
-      if (['azure advanced threat protection', 'azure security center', 'microsoft cloud app security', 'azure active directory identity protection', 'azure sentinel', 'microsoft defender atp'].indexOf(args.options.vendor.toLowerCase()) < 0) {
-        return `${args.options.vendor} is not a valid vendor. Allowed values are Azure Advanced Threat Protection, Azure Security Center, Microsoft Cloud App Security, Azure Active Directory Identity Protection, Azure Sentinel, Microsoft Defender ATP`;
-      }
-    }
-
-    return true;
-  }
 }
 
 module.exports = new TenantSecurityAlertsListCommand();

--- a/src/m365/tenant/commands/security/security-alerts-list.ts
+++ b/src/m365/tenant/commands/security/security-alerts-list.ts
@@ -1,0 +1,105 @@
+import { Alert } from '@microsoft/microsoft-graph-types';
+import { Logger } from '../../../../cli';
+import { CommandOption } from '../../../../Command';
+import GraphCommand from '../../../base/GraphCommand';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  vendor?: string;
+}
+
+class TenantSecurityAlertsListCommand extends GraphCommand {
+  public get name(): string {
+    return commands.SECURITY_ALERTS_LIST;
+  }
+
+  public get description(): string {
+    return 'Gets the security alerts for a tenant';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.vendor = typeof args.options.vendor !== 'undefined';
+    return telemetryProps;
+  }
+
+  public defaultProperties(): string[] | undefined {
+    return ['id', 'title', 'severity'];
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+    this
+      .listAlert(args.options)
+      .then((res: any): void => {
+        logger.log(res);
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  private listAlert(options: Options): Promise<Alert[]> {
+    let queryFilter: string = '';
+    if (options.vendor) {
+      let vendorName = options.vendor;
+
+      switch (options.vendor.toLowerCase()) {
+        case 'azure security center':
+          vendorName = 'ASC';
+          break;
+        case 'microsoft cloud app security':
+          vendorName = 'MCAS';
+          break;
+        case 'azure active directory identity protection':
+          vendorName = 'IPC';
+      }
+
+      queryFilter = `?$filter=vendorInformation/provider eq '${encodeURIComponent(vendorName)}'`;
+    }
+
+    const requestOptions: any = {
+      url: `${this.resource}/v1.0/security/alerts${queryFilter}`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    return request
+      .get<{ value: Alert[] }>(requestOptions)
+      .then(response => {
+        const alertList: Alert[] | undefined = response.value;
+
+        if (!alertList) {
+          return Promise.reject(`Error fetching security alerts`);
+        }
+
+        return Promise.resolve(alertList);
+      });
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      { option: '--vendor [vendor]' }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    if (args.options.vendor) {
+      if (['azure advanced threat protection', 'azure security center', 'microsoft cloud app security', 'azure active directory identity protection', 'azure sentinel', 'microsoft defender atp'].indexOf(args.options.vendor.toLowerCase()) < 0) {
+        return `${args.options.vendor} is not a valid vendor. Allowed values are Azure Advanced Threat Protection, Azure Security Center, Microsoft Cloud App Security, Azure Active Directory Identity Protection, Azure Sentinel, Microsoft Defender ATP`;
+      }
+    }
+
+    return true;
+  }
+}
+
+module.exports = new TenantSecurityAlertsListCommand();


### PR DESCRIPTION
Adds 'tenant security alerts list' command. Closes #2635

The scope `SecurityEvents.Read.All` needs to be consent for this command.