### PR TITLE
New Command - list reset role inheritance

### DIFF
--- a/docs/docs/cmd/spo/list/list-roleinheritance-reset.md
+++ b/docs/docs/cmd/spo/list/list-roleinheritance-reset.md
@@ -1,0 +1,26 @@
+# spo list roleinheritance reset
+
+Restore role inheritance on list or library.
+
+## Usage
+
+```sh
+m365 spo list roleinheritance reset [options]
+```
+
+## Options
+
+`-u, --webUrl <webUrl>`
+: URL of the site where the list is located
+
+`-i, --listId [listId]`
+: ID of the list. Specify either id or title but not both
+
+`-t, --listTitle [listTitle]`
+: Title of the list. Specify either id or title but not both
+
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+// ToDo

--- a/docs/docs/cmd/spo/list/list-roleinheritance-reset.md
+++ b/docs/docs/cmd/spo/list/list-roleinheritance-reset.md
@@ -19,8 +19,18 @@ m365 spo list roleinheritance reset [options]
 `-t, --listTitle [listTitle]`
 : Title of the list. Specify either id or title but not both
 
-
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
-// ToDo
+
+Restore role inheritance of list with ID _0cd891ef-afce-4e55-b836-fce03286cccf_ located in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+m365 spo list roleinheritance reset --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf
+```
+
+Restore role inheritance of list with title _test_ located in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+m365 spo list roleinheritance reset --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle test
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -357,6 +357,7 @@ nav:
         - list get: 'cmd/spo/list/list-get.md'
         - list list: 'cmd/spo/list/list-list.md'
         - list remove: 'cmd/spo/list/list-remove.md'
+        - list roleinheritance reset: 'cmd/spo/list/list-roleinheritance-reset.md'
         - list set: 'cmd/spo/list/list-set.md'
         - list contenttype add: 'cmd/spo/list/list-contenttype-add.md'
         - list contenttype list: 'cmd/spo/list/list-contenttype-list.md'

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -94,6 +94,7 @@ export default {
   LIST_LABEL_SET: `${prefix} list label set`,
   LIST_LIST: `${prefix} list list`,
   LIST_REMOVE: `${prefix} list remove`,
+  LIST_ROLEINHERITANCE_RESET: `${prefix} list roleinheritance reset`,
   LIST_SET: `${prefix} list set`,
   LIST_SITESCRIPT_GET: `${prefix} list sitescript get`,
   LIST_VIEW_GET: `${prefix} list view get`,

--- a/src/m365/spo/commands/list/list-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-reset.spec.ts
@@ -1,0 +1,189 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils';
+import commands from '../../commands';
+const command: Command = require('./list-roleinheritance-reset');
+
+describe(commands.LIST_ROLEINHERITANCE_RESET, () => {
+  let log: any[];
+  let logger: Logger;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.post
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.LIST_ROLEINHERITANCE_RESET), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsDebugOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsDebugOption = true;
+      }
+    });
+    assert(containsDebugOption);
+  });
+
+  it('supports specifying URL', () => {
+    const options = command.options();
+    let containsTypeOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('<webUrl>') > -1) {
+        containsTypeOption = true;
+      }
+    });
+    assert(containsTypeOption);
+  });
+
+  it('fails validation if both id and title options are not passed', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the url option is not a valid SharePoint site URL', () => {
+    const actual = command.validate({ options: { webUrl: 'foo' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the url option is a valid SharePoint site URL', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF' } });
+    assert(actual);
+  });
+
+  it('fails validation if the id option is not a valid GUID', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '12345' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the id option is a valid GUID', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF' } });
+    assert(actual);
+  });
+
+  it('fails validation if both id and title options are passed', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', listTitle: 'Documents' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('reset role inheritance on list by title', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/lists/getbytitle(\'test\)/resetroleinheritance') > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        listTitle: 'test'
+      }
+    }, () => {
+      try {
+        assert(true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('reset role inheritance on list by id', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/lists(guid\'202b8199-b9de-43fd-9737-7f213f51c991\')/resetroleinheritance') > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        listId: '202b8199-b9de-43fd-9737-7f213f51c991'
+      }
+    }, () => {
+      try {
+        assert(true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('list role inheritance reset command handles reject request correctly', (done) => {
+    const err = 'Invalid request';
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/lists/getbytitle(\'test\)/resetroleinheritance') > -1) {
+        return Promise.reject(err);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        listTitle: 'test'
+      }
+    }, (error?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(error), JSON.stringify(new CommandError(err)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/m365/spo/commands/list/list-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-reset.spec.ts
@@ -78,9 +78,9 @@ describe(commands.LIST_ROLEINHERITANCE_RESET, () => {
     assert(containsTypeOption);
   });
 
-  it('fails validation if both id and title options are not passed', () => {
-    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com' } });
-    assert.notStrictEqual(actual, true);
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets();
+    assert.deepStrictEqual(optionSets, [[ 'listId', 'listTitle' ]]);
   });
 
   it('fails validation if the url option is not a valid SharePoint site URL', () => {
@@ -103,14 +103,9 @@ describe(commands.LIST_ROLEINHERITANCE_RESET, () => {
     assert(actual);
   });
 
-  it('fails validation if both id and title options are passed', () => {
-    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', listTitle: 'Documents' } });
-    assert.notStrictEqual(actual, true);
-  });
-
   it('reset role inheritance on list by title', (done) => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists/getbytitle(\'test\)/resetroleinheritance') > -1) {
+      if ((opts.url as string).indexOf('/_api/web/lists/getbytitle(\'test\')/resetroleinheritance') > -1) {
         return Promise.resolve();
       }
 
@@ -123,9 +118,9 @@ describe(commands.LIST_ROLEINHERITANCE_RESET, () => {
         webUrl: 'https://contoso.sharepoint.com',
         listTitle: 'test'
       }
-    }, () => {
+    }, (err: any) => {
       try {
-        assert(true);
+        assert.strictEqual(typeof err, 'undefined');
         done();
       }
       catch (e) {
@@ -149,9 +144,9 @@ describe(commands.LIST_ROLEINHERITANCE_RESET, () => {
         webUrl: 'https://contoso.sharepoint.com',
         listId: '202b8199-b9de-43fd-9737-7f213f51c991'
       }
-    }, () => {
+    }, (err: any) => {
       try {
-        assert(true);
+        assert.strictEqual(typeof err, 'undefined');
         done();
       }
       catch (e) {
@@ -161,9 +156,9 @@ describe(commands.LIST_ROLEINHERITANCE_RESET, () => {
   });
 
   it('list role inheritance reset command handles reject request correctly', (done) => {
-    const err = 'Invalid request';
+    const err = 'request rejected';
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists/getbytitle(\'test\)/resetroleinheritance') > -1) {
+      if ((opts.url as string).indexOf('/_api/web/lists/getbytitle(\'test\')/resetroleinheritance') > -1) {
         return Promise.reject(err);
       }
 

--- a/src/m365/spo/commands/list/list-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-reset.ts
@@ -25,18 +25,24 @@ class SpoListRoleInHeritanceResetCommand extends SpoCommand {
     return 'Restore role inheritance on list or library.';
   }
 
+  public optionSets(): string[][] | undefined {
+    return [
+      [ 'listId', 'listTitle' ]
+    ];
+  }
+
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (this.verbose) {
-      logger.logToStderr(`reset role inheritance of list in site at ${args.options.webUrl}...`);
+      logger.logToStderr(`Reset role inheritance of list in site at ${args.options.webUrl}...`);
     }
 
-    let requestUrl: string = '';
+    let requestUrl: string = `${args.options.webUrl}/_api/web/lists`;
 
     if (args.options.listId) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')`;
+      requestUrl += `(guid'${encodeURIComponent(args.options.listId)}')`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/getbytitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+      requestUrl += `/getbytitle('${encodeURIComponent(args.options.listTitle as string)}')`;
     }
 
     const requestOptions: any = {
@@ -51,7 +57,7 @@ class SpoListRoleInHeritanceResetCommand extends SpoCommand {
 
     request
       .post(requestOptions)
-      .then((): void => { cb(); }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+      .then(_ => cb(), (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
   }
 
   public options(): CommandOption[] {
@@ -79,14 +85,6 @@ class SpoListRoleInHeritanceResetCommand extends SpoCommand {
 
     if (args.options.listId && !validation.isValidGuid(args.options.listId)) {
       return `${args.options.id} is not a valid GUID`;
-    }
-
-    if (args.options.listId && args.options.listTitle) {
-      return 'Specify id or title, but not both';
-    }
-
-    if (!args.options.listId && !args.options.listTitle) {
-      return 'Specify id or title';
     }
 
     return true;

--- a/src/m365/spo/commands/list/list-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-reset.ts
@@ -1,0 +1,96 @@
+import { Logger } from '../../../../cli';
+import { CommandOption } from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import { validation } from '../../../../utils';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  listId?: string;
+  listTitle?: string;
+}
+
+class SpoListRoleInHeritanceResetCommand extends SpoCommand {
+  public get name(): string {
+    return commands.LIST_ROLEINHERITANCE_RESET;
+  }
+
+  public get description(): string {
+    return 'Restore role inheritance on list or library.';
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    if (this.verbose) {
+      logger.logToStderr(`reset role inheritance of list in site at ${args.options.webUrl}...`);
+    }
+
+    let requestUrl: string = '';
+
+    if (args.options.listId) {
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')`;
+    }
+    else {
+      requestUrl = `${args.options.webUrl}/_api/web/lists/getbytitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+    }
+
+    const requestOptions: any = {
+      url: `${requestUrl}/resetroleinheritance`,
+      method: 'POST',
+      headers: {
+        'accept': 'application/json;odata=nometadata',
+        'content-type': 'application/json'
+      },
+      responseType: 'json'
+    };
+
+    request
+      .post(requestOptions)
+      .then((): void => { cb(); }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-i, --listId [listId]'
+      },
+      {
+        option: '-t, --listTitle [listTitle]'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+    if (isValidSharePointUrl !== true) {
+      return isValidSharePointUrl;
+    }
+
+    if (args.options.listId && !validation.isValidGuid(args.options.listId)) {
+      return `${args.options.id} is not a valid GUID`;
+    }
+
+    if (args.options.listId && args.options.listTitle) {
+      return 'Specify id or title, but not both';
+    }
+
+    if (!args.options.listId && !args.options.listTitle) {
+      return 'Specify id or title';
+    }
+
+    return true;
+  }
+}
+
+module.exports = new SpoListRoleInHeritanceResetCommand();


### PR DESCRIPTION
### New Command - list reset role inheritance

The aim of this PR is to add new command which allow to reset role inheritance on list or lib.

### Linked Issue

Closes #3220
