### PR TITLE
Querying sp approleassignment endpoint direclty

### DIFF
--- a/src/m365/aad/commands/approleassignment/AppRoleAssignment.ts
+++ b/src/m365/aad/commands/approleassignment/AppRoleAssignment.ts
@@ -1,6 +1,8 @@
 export interface AppRoleAssignment {
   id: string;
+  deletedDateTime: string;
   appRoleId: string;
+  createdDateTime: string;
   principalDisplayName: string;
   principalId: string;
   principalType: string;


### PR DESCRIPTION
- Extends 'aad approleassignment list' command to query directly service principal app role assignments endpoint, when object id is passed as input

Closes #2462 