### PR TITLE
Enhancement: extend `teams channel member` with check for private channel

### DIFF
--- a/src/m365/teams/Channel.ts
+++ b/src/m365/teams/Channel.ts
@@ -5,4 +5,5 @@ export interface Channel {
   isFavoriteByDefault: boolean | null;
   email: string | null;
   webUrl: string | null;
+  membershipType: string | null;
 }

--- a/src/m365/teams/commands/channel/channel-member-add.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.ts
@@ -200,6 +200,10 @@ class TeamsChannelMemberAddCommand extends GraphCommand {
           return Promise.reject(`The specified channel '${args.options.channelName}' does not exist in the Microsoft Teams team with ID '${teamId}'`);
         }
 
+        if (channelItem.membershipType !== "private") {
+          return Promise.reject(`The specified channel is not a private channel`);
+        }
+
         return Promise.resolve(channelItem.id);
       }, err => { return Promise.reject(err); });
   }

--- a/src/m365/teams/commands/channel/channel-member-add.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.ts
@@ -205,7 +205,7 @@ class TeamsChannelMemberAddCommand extends GraphCommand {
         }
 
         return Promise.resolve(channelItem.id!);
-      }, err => { return Promise.reject(err); });
+      });
   }
 
   private getUserId(args: CommandArgs): Promise<string[]> {

--- a/src/m365/teams/commands/channel/channel-member-add.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.ts
@@ -7,7 +7,7 @@ import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
 import GraphCommand from '../../../base/GraphCommand';
-import { Channel } from '../../Channel';
+import { Channel } from '@microsoft/microsoft-graph-types';
 import commands from '../../commands';
 
 interface CommandArgs {
@@ -204,7 +204,7 @@ class TeamsChannelMemberAddCommand extends GraphCommand {
           return Promise.reject(`The specified channel is not a private channel`);
         }
 
-        return Promise.resolve(channelItem.id);
+        return Promise.resolve(channelItem.id!);
       }, err => { return Promise.reject(err); });
   }
 

--- a/src/m365/teams/commands/channel/channel-member-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.spec.ts
@@ -311,6 +311,43 @@ describe(commands.CHANNEL_MEMBER_REMOVE, () => {
         done(e);
       }
     });
+  });  
+
+  it('fails to get channel when channel does is not private', (done) => {
+    sinonUtil.restore(request.get);
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent('00000000-0000-0000-0000-000000000000')}/channels?$filter=displayName eq '${encodeURIComponent('Other Channel')}'`) {
+        return Promise.resolve({
+          "value": [
+            {
+              "name": "Other Channel",
+              "membershipType": "standard"
+            }
+          ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        teamId: '00000000-0000-0000-0000-000000000000',
+        channelName: 'Other Channel',
+        id: '00000',
+        confirm: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(
+          JSON.stringify(err),
+          JSON.stringify(new CommandError(`The specified channel is not a private channel`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
   });
 
   it('correctly get channel id by channel name', (done) => {
@@ -319,7 +356,8 @@ describe(commands.CHANNEL_MEMBER_REMOVE, () => {
         return Promise.resolve({
           value: [
             {
-              "id": "19:00000000000000000000000000000000@thread.skype"
+              "id": "19:00000000000000000000000000000000@thread.skype",
+              "membershipType": "private"
             }
           ]
         });

--- a/src/m365/teams/commands/channel/channel-member-remove.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.ts
@@ -4,7 +4,7 @@ import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
 import GraphCommand from '../../../base/GraphCommand';
-import { Channel } from '../../Channel';
+import { Channel } from '@microsoft/microsoft-graph-types';
 import commands from '../../commands';
 import { ConversationMember } from '../../ConversationMember';
 
@@ -178,7 +178,7 @@ class TeamsChannelMemberRemoveCommand extends GraphCommand {
           return Promise.reject(`The specified channel is not a private channel`);
         }
 
-        return Promise.resolve(channelItem.id);
+        return Promise.resolve(channelItem.id!);
       });
   }
 

--- a/src/m365/teams/commands/channel/channel-member-remove.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.ts
@@ -174,6 +174,10 @@ class TeamsChannelMemberRemoveCommand extends GraphCommand {
           return Promise.reject(`The specified channel does not exist in the Microsoft Teams team`);
         }
 
+        if (channelItem.membershipType !== "private") {
+          return Promise.reject(`The specified channel is not a private channel`);
+        }
+
         return Promise.resolve(channelItem.id);
       });
   }

--- a/src/m365/teams/commands/channel/channel-member-set.ts
+++ b/src/m365/teams/commands/channel/channel-member-set.ts
@@ -136,6 +136,10 @@ class TeamsChannelMemberSetCommand extends GraphCommand {
           return Promise.reject(`The specified channel does not exist in the Microsoft Teams team`);
         }
 
+        if (channelItem.membershipType !== "private") {
+          return Promise.reject(`The specified channel is not a private channel`);
+        }
+
         return Promise.resolve(channelItem.id);
       });
   }

--- a/src/m365/teams/commands/channel/channel-member-set.ts
+++ b/src/m365/teams/commands/channel/channel-member-set.ts
@@ -1,4 +1,4 @@
-import { Channel } from '../../Channel';
+import { Channel } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import { validation } from '../../../../utils';
@@ -140,7 +140,7 @@ class TeamsChannelMemberSetCommand extends GraphCommand {
           return Promise.reject(`The specified channel is not a private channel`);
         }
 
-        return Promise.resolve(channelItem.id);
+        return Promise.resolve(channelItem.id!);
       });
   }
 


### PR DESCRIPTION
Closes #3254

- [x] teams channel member add
- [ ] ~~teams channel member list~~ (not necessary because this is allowed on all types of channels)
- [x] teams channel member remove
- [x] teams channel member set