### PR TITLE
Adds planner utils to get plans from group

### DIFF
--- a/src/m365/aad/commands/app/app-add.ts
+++ b/src/m365/aad/commands/app/app-add.ts
@@ -439,7 +439,7 @@ class AadAppAddCommand extends GraphCommand {
     }
 
     return odata
-      .getAllItems<ServicePrincipalInfo>(`${this.resource}/v1.0/myorganization/servicePrincipals?$select=servicePrincipalNames,appId,oauth2PermissionScopes,appRoles`, logger)
+      .getAllItems<ServicePrincipalInfo>(`${this.resource}/v1.0/myorganization/servicePrincipals?$select=servicePrincipalNames,appId,oauth2PermissionScopes,appRoles`)
       .then(servicePrincipals => {
         try {
           const resolvedApis = this.getRequiredResourceAccessForApis(servicePrincipals, args.options.apisDelegated, 'Scope', logger);

--- a/src/m365/aad/commands/app/app-role-list.ts
+++ b/src/m365/aad/commands/app/app-role-list.ts
@@ -43,7 +43,7 @@ class AadAppRoleListCommand extends GraphCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     this
       .getAppObjectId(args, logger)
-      .then(objectId => odata.getAllItems<AppRole>(`${this.resource}/v1.0/myorganization/applications/${objectId}/appRoles`, logger))
+      .then(objectId => odata.getAllItems<AppRole>(`${this.resource}/v1.0/myorganization/applications/${objectId}/appRoles`))
       .then(appRoles => {
         logger.log(appRoles);
         cb();

--- a/src/m365/aad/commands/group/group-list.ts
+++ b/src/m365/aad/commands/group/group-list.ts
@@ -41,7 +41,7 @@ class AadGroupListCommand extends GraphCommand   {
     const endpoint: string = args.options.deleted ? 'directory/deletedItems/microsoft.graph.group' : 'groups';
 
     odata
-      .getAllItems<Group>(`${this.resource}/v1.0/${endpoint}`, logger)
+      .getAllItems<Group>(`${this.resource}/v1.0/${endpoint}`)
       .then((groups): void => {
         if (args.options.output === 'text') {
           groups.forEach((group: ExtendedGroup) => {

--- a/src/m365/aad/commands/groupsetting/groupsetting-list.ts
+++ b/src/m365/aad/commands/groupsetting/groupsetting-list.ts
@@ -24,7 +24,7 @@ class AadGroupSettingListCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     odata
-      .getAllItems<GroupSetting>(`${this.resource}/v1.0/groupSettings`, logger)
+      .getAllItems<GroupSetting>(`${this.resource}/v1.0/groupSettings`)
       .then((groupSettings): void => {
         logger.log(groupSettings);
         cb();

--- a/src/m365/aad/commands/groupsettingtemplate/groupsettingtemplate-get.ts
+++ b/src/m365/aad/commands/groupsettingtemplate/groupsettingtemplate-get.ts
@@ -33,7 +33,7 @@ class AadGroupSettingTemplateGetCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
     odata
-      .getAllItems<GroupSettingTemplate>(`${this.resource}/v1.0/groupSettingTemplates`, logger)
+      .getAllItems<GroupSettingTemplate>(`${this.resource}/v1.0/groupSettingTemplates`)
       .then((templates): void => {
         const groupSettingTemplate: GroupSettingTemplate[] = templates.filter(t => args.options.id ? t.id === args.options.id : t.displayName === args.options.displayName);
 

--- a/src/m365/aad/commands/groupsettingtemplate/groupsettingtemplate-list.ts
+++ b/src/m365/aad/commands/groupsettingtemplate/groupsettingtemplate-list.ts
@@ -24,7 +24,7 @@ class AadGroupSettingTemplateListCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     odata
-      .getAllItems<GroupSettingTemplate>(`${this.resource}/v1.0/groupSettingTemplates`, logger)
+      .getAllItems<GroupSettingTemplate>(`${this.resource}/v1.0/groupSettingTemplates`)
       .then((templates): void => {
         logger.log(templates);
         cb();

--- a/src/m365/aad/commands/o365group/o365group-conversation-list.ts
+++ b/src/m365/aad/commands/o365group/o365group-conversation-list.ts
@@ -31,7 +31,7 @@ class AadO365GroupConversationListCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     odata
-      .getAllItems<Conversation>(`${this.resource}/v1.0/groups/${args.options.groupId}/conversations`, logger)
+      .getAllItems<Conversation>(`${this.resource}/v1.0/groups/${args.options.groupId}/conversations`)
       .then((conversations): void => {
         logger.log(conversations);
         cb();

--- a/src/m365/aad/commands/o365group/o365group-conversation-post-list.ts
+++ b/src/m365/aad/commands/o365group/o365group-conversation-post-list.ts
@@ -42,7 +42,7 @@ class AadO365GroupConversationPostListCommand extends GraphCommand {
     this
       .getGroupId(args)
       .then((retrievedgroupId: string): Promise<Post[]> => {
-        return odata.getAllItems<Post>(`${this.resource}/v1.0/groups/${retrievedgroupId}/threads/${args.options.threadId}/posts`, logger);
+        return odata.getAllItems<Post>(`${this.resource}/v1.0/groups/${retrievedgroupId}/threads/${args.options.threadId}/posts`);
       })
       .then((posts): void => {
         logger.log(posts);

--- a/src/m365/aad/commands/o365group/o365group-list.ts
+++ b/src/m365/aad/commands/o365group/o365group-list.ts
@@ -60,7 +60,7 @@ class AadO365GroupListCommand extends GraphCommand {
     let groups: GroupExtended[] = [];
 
     odata
-      .getAllItems<GroupExtended>(endpoint, logger)
+      .getAllItems<GroupExtended>(endpoint)
       .then((_groups): Promise<any> => {
         groups = _groups;
 

--- a/src/m365/aad/commands/o365group/o365group-recyclebinitem-clear.ts
+++ b/src/m365/aad/commands/o365group/o365group-recyclebinitem-clear.ts
@@ -34,7 +34,7 @@ class AadO365GroupRecycleBinItemClearCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     const clearO365GroupRecycleBinItems: () => void = (): void => {
-      this.processRecycleBinItemsClear(logger).then(_ => cb(), (rawRes: any): void => this.handleRejectedODataJsonPromise(rawRes, logger, cb));
+      this.processRecycleBinItemsClear().then(_ => cb(), (rawRes: any): void => this.handleRejectedODataJsonPromise(rawRes, logger, cb));
     };
 
     if (args.options.confirm) {
@@ -57,13 +57,13 @@ class AadO365GroupRecycleBinItemClearCommand extends GraphCommand {
     }
   }
 
-  public processRecycleBinItemsClear(logger: Logger): Promise<any> {
+  public processRecycleBinItemsClear(): Promise<any> {
     const filter: string = `?$filter=groupTypes/any(c:c+eq+'Unified')`;
     const topCount: string = '&$top=100';
     const endpoint: string = `${this.resource}/v1.0/directory/deletedItems/Microsoft.Graph.Group${filter}${topCount}`;
 
     return odata
-      .getAllItems<DirectoryObject>(endpoint, logger)
+      .getAllItems<DirectoryObject>(endpoint)
       .then((recycleBinItems): Promise<any> => {
         if (recycleBinItems.length === 0) {
           return Promise.resolve();

--- a/src/m365/aad/commands/o365group/o365group-recyclebinitem-list.ts
+++ b/src/m365/aad/commands/o365group/o365group-recyclebinitem-list.ts
@@ -46,7 +46,7 @@ class AadO365GroupRecycleBinItemListCommand extends GraphCommand {
     const endpoint: string = `${this.resource}/v1.0/directory/deletedItems/Microsoft.Graph.Group${filter}${displayNameFilter}${mailNicknameFilter}${topCount}`;
 
     odata
-      .getAllItems<DirectoryObject>(endpoint, logger)
+      .getAllItems<DirectoryObject>(endpoint)
       .then((recycleBinItems): void => {
         logger.log(recycleBinItems);
         cb();

--- a/src/m365/aad/commands/o365group/o365group-user-list.ts
+++ b/src/m365/aad/commands/o365group/o365group-user-list.ts
@@ -62,7 +62,7 @@ class AadO365GroupUserListCommand extends GraphCommand {
     const endpoint: string = `${this.resource}/v1.0/groups/${groupId}/owners?$select=id,displayName,userPrincipalName,userType`;
 
     return odata
-      .getAllItems<User>(endpoint, logger)
+      .getAllItems<User>(endpoint)
       .then(users => {
         // Currently there is a bug in the Microsoft Graph that returns Owners as
         // userType 'member'. We therefore update all returned user as owner
@@ -76,7 +76,7 @@ class AadO365GroupUserListCommand extends GraphCommand {
 
   private getMembersAndGuests(logger: Logger, groupId: string): Promise<User[]> {
     const endpoint: string = `${this.resource}/v1.0/groups/${groupId}/members?$select=id,displayName,userPrincipalName,userType`;
-    return odata.getAllItems<User>(endpoint, logger);
+    return odata.getAllItems<User>(endpoint);
   }
 
   public options(): CommandOption[] {

--- a/src/m365/aad/commands/o365group/o365group-user-set.ts
+++ b/src/m365/aad/commands/o365group/o365group-user-set.ts
@@ -134,7 +134,7 @@ class AadO365GroupUserSetCommand extends GraphCommand {
     const endpoint: string = `${this.resource}/v1.0/groups/${groupId}/owners?$select=id,displayName,userPrincipalName,userType`;
 
     return odata
-      .getAllItems<User>(endpoint, logger)
+      .getAllItems<User>(endpoint)
       .then(users => {
         // Currently there is a bug in the Microsoft Graph that returns Owners as
         // userType 'member'. We therefore update all returned user as owner
@@ -148,7 +148,7 @@ class AadO365GroupUserSetCommand extends GraphCommand {
 
   private getMembersAndGuests(logger: Logger, groupId: string): Promise<User[]> {
     const endpoint: string = `${this.resource}/v1.0/groups/${groupId}/members?$select=id,displayName,userPrincipalName,userType`;
-    return odata.getAllItems<User>(endpoint, logger);
+    return odata.getAllItems<User>(endpoint);
   }
 
   public options(): CommandOption[] {

--- a/src/m365/aad/commands/user/user-list.ts
+++ b/src/m365/aad/commands/user/user-list.ts
@@ -46,7 +46,7 @@ class AadUserListCommand extends GraphCommand {
     const url: string = `${this.resource}/v1.0/${endpoint}?$select=${properties.join(',')}${(filter.length > 0 ? '&' + filter : '')}&$top=100`;
 
     odata
-      .getAllItems<User>(url, logger)
+      .getAllItems<User>(url)
       .then((users): void => {
         logger.log(users);
         cb();

--- a/src/m365/aad/commands/user/user-signin-list.ts
+++ b/src/m365/aad/commands/user/user-signin-list.ts
@@ -57,7 +57,7 @@ class AadUserSigninListCommand extends GraphCommand {
     }
     endpoint += filter;
     odata
-      .getAllItems<SignIn>(endpoint, logger)
+      .getAllItems<SignIn>(endpoint)
       .then((signins): void => {
         logger.log(signins);
         cb();

--- a/src/m365/file/commands/file-list.ts
+++ b/src/m365/file/commands/file-list.ts
@@ -193,7 +193,7 @@ class FileListCommand extends GraphCommand {
       .all(folderIds.map((folderId: string): Promise<DriveItem[]> =>
         // get items from folder. Because we can't filter out folders here
         // we need to get all items from the folder and filter them out later
-        odata.getAllItems<DriveItem>(`${this.resource}/v1.0/drives/${driveId}/items/${folderId}/children`, logger)))
+        odata.getAllItems<DriveItem>(`${this.resource}/v1.0/drives/${driveId}/items/${folderId}/children`)))
       .then(res => {
         // flatten data from all promises
         files = files.concat(...res);

--- a/src/m365/outlook/commands/message/message-list.ts
+++ b/src/m365/outlook/commands/message/message-list.ts
@@ -46,7 +46,7 @@ class OutlookMessageListCommand extends GraphCommand {
       .then((folderId: string): Promise<Message[]> => {
         const url: string = folderId ? `me/mailFolders/${folderId}/messages` : 'me/messages';
 
-        return odata.getAllItems<Message>(`${this.resource}/v1.0/${url}?$top=50`, logger);
+        return odata.getAllItems<Message>(`${this.resource}/v1.0/${url}?$top=50`);
       })
       .then((messages): void => {
         logger.log(messages);

--- a/src/m365/outlook/commands/room/room-list.ts
+++ b/src/m365/outlook/commands/room/room-list.ts
@@ -43,7 +43,7 @@ class OutlookRoomListCommand extends GraphCommand {
     }
 
     odata
-      .getAllItems<Room>(endpoint, logger)
+      .getAllItems<Room>(endpoint)
       .then((rooms): void => {
         logger.log(rooms);
         cb();

--- a/src/m365/outlook/commands/roomlist/roomlist-list.ts
+++ b/src/m365/outlook/commands/roomlist/roomlist-list.ts
@@ -24,7 +24,7 @@ class OutlookRoomListListCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     odata
-      .getAllItems<RoomList>(`${this.resource}/v1.0/places/microsoft.graph.roomlist`, logger)
+      .getAllItems<RoomList>(`${this.resource}/v1.0/places/microsoft.graph.roomlist`)
       .then((roomLists): void => {
         logger.log(roomLists);
         cb();

--- a/src/m365/planner/commands/bucket/bucket-add.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.spec.ts
@@ -130,7 +130,7 @@ describe(commands.BUCKET_ADD, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'`) {
         return Promise.resolve(groupByDisplayNameResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve(plansInOwnerGroup);
       }
       return Promise.reject('Invalid Request');
@@ -364,7 +364,7 @@ describe(commands.BUCKET_ADD, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'`) {
         return Promise.resolve(groupByDisplayNameResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({ value: [] });
       }
       return Promise.reject('Invalid Request');

--- a/src/m365/planner/commands/bucket/bucket-add.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.ts
@@ -5,6 +5,7 @@ import {
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -76,24 +77,15 @@ class PlannerBucketAddCommand extends GraphCommand {
 
     return this
       .getGroupId(args)
-      .then((groupId: string) => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/plans?$filter=(owner eq '${groupId}')`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get<{ value: { id: string; title: string; }[] }>(requestOptions);
-      }).then((response) => {
-        const plan: { id: string; title: string; } | undefined = response.value.find(val => val.title === args.options.planName);
+      .then((groupId: string) => planner.getPlansByGroupId(groupId))
+      .then((response) => {
+        const plan = response.find(val => val.title === args.options.planName);
 
         if (!plan) {
           return Promise.reject(`The specified plan does not exist`);
         }
 
-        return Promise.resolve(plan.id);
+        return Promise.resolve(plan.id!);
       });
   }
 

--- a/src/m365/planner/commands/bucket/bucket-list.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.spec.ts
@@ -134,7 +134,7 @@ describe(commands.BUCKET_LIST, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'`) {
         return Promise.resolve(groupByDisplayNameResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve(plansInOwnerGroup);
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/iVPMIgdku0uFlou-KLNg6MkAE1O2/buckets`) {
@@ -355,7 +355,7 @@ describe(commands.BUCKET_LIST, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'`) {
         return Promise.resolve(groupByDisplayNameResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({ value: [] });
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/iVPMIgdku0uFlou-KLNg6MkAE1O2/buckets`) {

--- a/src/m365/planner/commands/bucket/bucket-list.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.ts
@@ -6,6 +6,7 @@ import {
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { odata, validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -59,25 +60,15 @@ class PlannerBucketListCommand extends GraphCommand {
 
     return this
       .getGroupId(args)
-      .then((groupId: string) => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/plans?$filter=(owner eq '${groupId}')`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get<{ value: { id: string; title: string; }[] }>(requestOptions);
-      })
+      .then((groupId: string) => planner.getPlansByGroupId(groupId))
       .then(response => {
-        const plan: { id: string; title: string; } | undefined = response.value.find(val => val.title === args.options.planName);
+        const plan = response.find(val => val.title === args.options.planName);
 
         if (!plan) {
           return Promise.reject(`The specified plan does not exist`);
         }
 
-        return Promise.resolve(plan.id);
+        return Promise.resolve(plan.id!);
       });
   }
 

--- a/src/m365/planner/commands/bucket/bucket-list.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.ts
@@ -46,7 +46,7 @@ class PlannerBucketListCommand extends GraphCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     this
       .getPlanId(args)
-      .then((planId: string): Promise<PlannerBucket[]> => odata.getAllItems<PlannerBucket>(`${this.resource}/v1.0/planner/plans/${planId}/buckets`, logger))
+      .then((planId: string): Promise<PlannerBucket[]> => odata.getAllItems<PlannerBucket>(`${this.resource}/v1.0/planner/plans/${planId}/buckets`))
       .then((buckets): void => {
         logger.log(buckets);
         cb();

--- a/src/m365/planner/commands/bucket/bucket-remove.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.spec.ts
@@ -352,7 +352,7 @@ describe(commands.BUCKET_REMOVE, () => {
 
   it('fails validation when no plans found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve({"value": []});
       }
 
@@ -379,7 +379,7 @@ describe(commands.BUCKET_REMOVE, () => {
 
   it('fails validation when multiple plans found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(multiplePlanResponse);
       }
 
@@ -493,7 +493,7 @@ describe(commands.BUCKET_REMOVE, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(singleGroupResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {

--- a/src/m365/planner/commands/bucket/bucket-remove.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.ts
@@ -1,4 +1,4 @@
-import { Group, PlannerBucket, PlannerPlan } from '@microsoft/microsoft-graph-types';
+import { Group, PlannerBucket } from '@microsoft/microsoft-graph-types';
 import { AxiosRequestConfig } from 'axios';
 import { Cli, Logger } from '../../../../cli';
 import {
@@ -9,6 +9,7 @@ import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
+import { planner } from '../../../../utils/planner';
 
 interface CommandArgs {
   options: Options;
@@ -134,19 +135,9 @@ class PlannerBucketRemoveCommand extends GraphCommand {
 
     return this
       .getGroupId(args)
-      .then(groupId => {
-        const requestOptions: AxiosRequestConfig = {
-          url: `${this.resource}/v1.0/planner/plans?$filter=owner eq '${groupId}'`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get<{ value: PlannerPlan[] }>(requestOptions);
-      })
+      .then(groupId => planner.getPlansByGroupId(groupId))
       .then(plans => {
-        const filteredPlans = plans.value.filter(p => p.title!.toLowerCase() === planName!.toLowerCase());
+        const filteredPlans = plans.filter(p => p.title!.toLowerCase() === planName!.toLowerCase());
 
         if (!filteredPlans.length) {
           return Promise.reject(`The specified plan ${planName} does not exist`);

--- a/src/m365/planner/commands/bucket/bucket-set.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.spec.ts
@@ -317,7 +317,7 @@ describe(commands.BUCKET_SET, () => {
 
   it('fails validation when no plans found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve({"value": []});
       }
 
@@ -343,7 +343,7 @@ describe(commands.BUCKET_SET, () => {
 
   it('fails validation when multiple plans found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(multiplePlanResponse);
       }
 
@@ -454,7 +454,7 @@ describe(commands.BUCKET_SET, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(singleGroupResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {

--- a/src/m365/planner/commands/bucket/bucket-set.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.ts
@@ -1,10 +1,11 @@
-import { Group, PlannerBucket, PlannerPlan } from '@microsoft/microsoft-graph-types';
+import { Group, PlannerBucket } from '@microsoft/microsoft-graph-types';
 import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -122,19 +123,9 @@ class PlannerBucketSetCommand extends GraphCommand {
 
     return this
       .getGroupId(args)
-      .then(groupId => {
-        const requestOptions: AxiosRequestConfig = {
-          url: `${this.resource}/v1.0/planner/plans?$filter=owner eq '${groupId}'`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get<{ value: PlannerPlan[] }>(requestOptions);
-      })
+      .then(groupId => planner.getPlansByGroupId(groupId))
       .then(plans => {
-        const filteredPlans = plans.value.filter(p => p.title!.toLowerCase() === planName!.toLowerCase());
+        const filteredPlans = plans.filter(p => p.title!.toLowerCase() === planName!.toLowerCase());
 
         if (filteredPlans.length === 0) {
           return Promise.reject(`The specified plan ${planName} does not exist`);

--- a/src/m365/planner/commands/plan/plan-details-get.ts
+++ b/src/m365/planner/commands/plan/plan-details-get.ts
@@ -3,7 +3,8 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { odata, validation } from '../../../../utils';
+import { validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -43,7 +44,7 @@ class PlannerPlanDetailsGetCommand extends GraphCommand {
       .getGroupId(args)
       .then((groupId: string): Promise<string> => {
         this.groupId = groupId;
-        return this.getPlanId(args, logger);
+        return this.getPlanId(args);
       })
       .then((planId: string): Promise<PlannerPlanDetails> => {
         args.options.planId = planId;
@@ -89,13 +90,13 @@ class PlannerPlanDetailsGetCommand extends GraphCommand {
       });
   }
 
-  private getPlanId(args: CommandArgs, logger: Logger): Promise<string> {
+  private getPlanId(args: CommandArgs): Promise<string> {
     if (args.options.planId) {
       return Promise.resolve(args.options.planId);
     }
 
-    return odata
-      .getAllItems<PlannerPlan>(`${this.resource}/v1.0/groups/${this.groupId}/planner/plans`, logger)
+    return planner
+      .getPlansByGroupId(this.groupId)
       .then((plans: PlannerPlan[]): Promise<string> => {
         const plansMatchingName = plans.filter((plan: PlannerPlan) => plan.title === args.options.planTitle);
 

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -5,7 +5,8 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { odata, validation } from '../../../../utils';
+import { validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -54,7 +55,7 @@ class PlannerPlanGetCommand extends GraphCommand {
     else {
       this
         .getGroupId(args)
-        .then((groupId: string): Promise<PlannerPlan[]> => odata.getAllItems<PlannerPlan>(`${this.resource}/v1.0/groups/${groupId}/planner/plans`, logger, 'minimal'))
+        .then((groupId: string): Promise<PlannerPlan[]> => planner.getPlansByGroupId(groupId))
         .then((plans): void => {
           const filteredPlan = plans.filter((plan: any) => plan.title === args.options.title);
           if (filteredPlan && filteredPlan.length > 0) {

--- a/src/m365/planner/commands/plan/plan-list.ts
+++ b/src/m365/planner/commands/plan/plan-list.ts
@@ -5,6 +5,7 @@ import {
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -40,20 +41,10 @@ class PlannerPlanListCommand extends GraphCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     this
       .getGroupId(args)
-      .then((groupId: string): Promise<any> => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/groups/${groupId}/planner/plans`,
-          headers: {
-            'accept': 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get(requestOptions);
-      })
-      .then((res: any): void => {
-        if (res.value && res.value.length > 0) {
-          logger.log(res.value);
+      .then((groupId: string) => planner.getPlansByGroupId(groupId))
+      .then((res): void => {
+        if (res && res.length > 0) {
+          logger.log(res);
         }
         cb();
       }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));

--- a/src/m365/planner/commands/task/task-add.spec.ts
+++ b/src/m365/planner/commands/task/task-add.spec.ts
@@ -441,7 +441,7 @@ describe(commands.TASK_ADD, () => {
   it('correctly adds planner bucket with title, bucketId, planName, and ownerGroupName', (done) => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({
           value: [
             {
@@ -481,7 +481,7 @@ describe(commands.TASK_ADD, () => {
   it('correctly adds planner task with title, bucketId, planName, and ownerGroupId', (done) => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '0d0402ee-970f-4951-90b5-2f24519d2e40')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({
           value: [
             {
@@ -775,7 +775,7 @@ describe(commands.TASK_ADD, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'`) {
         return Promise.resolve(groupByDisplayNameResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({ value: [] });
       }
       return Promise.reject('Invalid Request');

--- a/src/m365/planner/commands/task/task-add.ts
+++ b/src/m365/planner/commands/task/task-add.ts
@@ -4,6 +4,7 @@ import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { formatting, validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -201,18 +202,9 @@ class PlannerTaskAddCommand extends GraphCommand {
 
     return this
       .getGroupId(args)
-      .then((groupId: string) => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/plans?$filter=(owner eq '${groupId}')`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get<{ value: PlannerPlan[] }>(requestOptions);
-      }).then((response) => {
-        const plan: PlannerPlan | undefined = response.value.find(val => val.title === args.options.planName);
+      .then((groupId: string) => planner.getPlansByGroupId(groupId))
+      .then((response) => {
+        const plan: PlannerPlan | undefined = response.find(val => val.title === args.options.planName);
 
         if (!plan) {
           return Promise.reject(`The specified plan does not exist`);

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -321,7 +321,7 @@ describe(commands.TASK_GET, () => {
 
   it('fails validation when no plans found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve({"value": [ { "id": "" } ]});
       }
 
@@ -349,7 +349,7 @@ describe(commands.TASK_GET, () => {
   
   it('fails validation when multiple plans found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(multiplePlanResponse);
       }
 
@@ -481,7 +481,7 @@ describe(commands.TASK_GET, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'&$select=id`) {
         return Promise.resolve(singleGroupResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets?$select=id,name`) {

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -321,7 +321,7 @@ describe(commands.TASK_GET, () => {
 
   it('fails validation when no plans found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'&$select=id,title`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
         return Promise.resolve({"value": [ { "id": "" } ]});
       }
 
@@ -349,7 +349,7 @@ describe(commands.TASK_GET, () => {
   
   it('fails validation when multiple plans found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'&$select=id,title`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
         return Promise.resolve(multiplePlanResponse);
       }
 
@@ -476,12 +476,12 @@ describe(commands.TASK_GET, () => {
     });
   });
 
-  it('Correctly deletes bucket by name', (done) => {
+  it('Correctly gets task by name', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'&$select=id`) {
         return Promise.resolve(singleGroupResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'&$select=id,title`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
         return Promise.resolve(singlePlanResponse);
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets?$select=id,name`) {

--- a/src/m365/planner/commands/task/task-get.ts
+++ b/src/m365/planner/commands/task/task-get.ts
@@ -4,6 +4,7 @@ import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -126,20 +127,10 @@ class PlannerTaskGetCommand extends GraphCommand {
 
     return this
       .getGroupId(options)
-      .then((groupId: string) => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/plans?$filter=owner eq '${groupId}'&$select=id,title`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get<{ value: PlannerPlan[] }>(requestOptions);
-      })
-      .then((response) => {
+      .then(groupId => planner.getPlansByGroupId(groupId))
+      .then(response => {
         const planName = options.planName as string;
-        const plans: PlannerPlan[] | undefined = response.value.filter(val => val.title?.toLocaleLowerCase() === planName.toLocaleLowerCase());
+        const plans: PlannerPlan[] | undefined = response.filter(val => val.title?.toLocaleLowerCase() === planName.toLocaleLowerCase());
         
         if (!plans.length) {
           return Promise.reject(`The specified plan ${options.planName} does not exist`);

--- a/src/m365/planner/commands/task/task-list.spec.ts
+++ b/src/m365/planner/commands/task/task-list.spec.ts
@@ -270,7 +270,7 @@ describe(commands.TASK_LIST, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'`) {
         return Promise.resolve(groupByDisplayNameResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve(plansInOwnerGroup);
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/iVPMIgdku0uFlou-KLNg6MkAE1O2/buckets`) {
@@ -539,7 +539,7 @@ describe(commands.TASK_LIST, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'`) {
         return Promise.resolve(groupByDisplayNameResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve(plansInOwnerGroup);
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/iVPMIgdku0uFlou-KLNg6MkAE1O2/tasks`) {
@@ -611,7 +611,7 @@ describe(commands.TASK_LIST, () => {
       if (opts.url === `https://graph.microsoft.com/beta/me/planner/tasks`) {
         return Promise.resolve(taskListBetaResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({ value: [] });
       }
       return Promise.reject('Invalid Request');

--- a/src/m365/planner/commands/task/task-list.ts
+++ b/src/m365/planner/commands/task/task-list.ts
@@ -61,11 +61,11 @@ class PlannerTaskListCommand extends GraphCommand {
         .getBucketId(args)
         .then((retrievedBucketId: string): Promise<PlannerTask[]> => {
           bucketId = retrievedBucketId;
-          return odata.getAllItems<PlannerTask>(`${this.resource}/v1.0/planner/buckets/${bucketId}/tasks`, logger);
+          return odata.getAllItems<PlannerTask>(`${this.resource}/v1.0/planner/buckets/${bucketId}/tasks`);
         })
         .then((tasks): Promise<BetaPlannerTask[]> => {
           taskItems = tasks;
-          return odata.getAllItems<BetaPlannerTask>(`${this.resource}/beta/planner/buckets/${bucketId}/tasks`, logger);
+          return odata.getAllItems<BetaPlannerTask>(`${this.resource}/beta/planner/buckets/${bucketId}/tasks`);
         })
         .then((betaTasks): void => {
           logger.log(this.mergeTaskPriority(taskItems, betaTasks));
@@ -77,11 +77,11 @@ class PlannerTaskListCommand extends GraphCommand {
         .getPlanId(args)
         .then((retrievedPlanId: string): Promise<PlannerTask[]> => {
           planId = retrievedPlanId;
-          return odata.getAllItems<PlannerTask>(`${this.resource}/v1.0/planner/plans/${planId}/tasks`, logger);
+          return odata.getAllItems<PlannerTask>(`${this.resource}/v1.0/planner/plans/${planId}/tasks`);
         })
         .then((tasks): Promise<BetaPlannerTask[]> => {
           taskItems = tasks;
-          return odata.getAllItems<BetaPlannerTask>(`${this.resource}/beta/planner/plans/${planId}/tasks`, logger);
+          return odata.getAllItems<BetaPlannerTask>(`${this.resource}/beta/planner/plans/${planId}/tasks`);
         })
         .then((betaTasks): void => {
           logger.log(this.mergeTaskPriority(taskItems, betaTasks));
@@ -90,10 +90,10 @@ class PlannerTaskListCommand extends GraphCommand {
     }
     else {
       odata
-        .getAllItems<PlannerTask>(`${this.resource}/v1.0/me/planner/tasks`, logger)
+        .getAllItems<PlannerTask>(`${this.resource}/v1.0/me/planner/tasks`)
         .then((tasks): Promise<BetaPlannerTask[]> => {
           taskItems = tasks;
-          return odata.getAllItems<BetaPlannerTask>(`${this.resource}/beta/me/planner/tasks`, logger);
+          return odata.getAllItems<BetaPlannerTask>(`${this.resource}/beta/me/planner/tasks`);
         })
         .then((betaTasks): void => {
           logger.log(this.mergeTaskPriority(taskItems, betaTasks));

--- a/src/m365/planner/commands/task/task-list.ts
+++ b/src/m365/planner/commands/task/task-list.ts
@@ -4,6 +4,7 @@ import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { odata, validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -137,25 +138,15 @@ class PlannerTaskListCommand extends GraphCommand {
 
     return this
       .getGroupId(args)
-      .then((groupId: string) => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/plans?$filter=(owner eq '${groupId}')`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get<{ value: { id: string; title: string; }[] }>(requestOptions);
-      })
+      .then((groupId: string) => planner.getPlansByGroupId(groupId))
       .then(response => {
-        const plan: { id: string; title: string; } | undefined = response.value.find(val => val.title === args.options.planName);
+        const plan = response.find(val => val.title === args.options.planName);
 
         if (!plan) {
           return Promise.reject(`The specified plan does not exist`);
         }
 
-        return Promise.resolve(plan.id);
+        return Promise.resolve(plan.id!);
       });
   }
 

--- a/src/m365/planner/commands/task/task-set.spec.ts
+++ b/src/m365/planner/commands/task/task-set.spec.ts
@@ -414,7 +414,7 @@ describe(commands.TASK_SET, () => {
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')&$select=id,title`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({
           value: [
             {
@@ -480,7 +480,7 @@ describe(commands.TASK_SET, () => {
         });
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')&$select=id,title`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({
           value: [
             {
@@ -850,7 +850,7 @@ describe(commands.TASK_SET, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'&$select=id`) {
         return Promise.resolve(groupByDisplayNameResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=(owner eq '${encodeURIComponent('0d0402ee-970f-4951-90b5-2f24519d2e40')}')&$select=id,title`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
         return Promise.resolve({ value: [] });
       }
       return Promise.reject('Invalid Request');

--- a/src/m365/planner/commands/task/task-set.ts
+++ b/src/m365/planner/commands/task/task-set.ts
@@ -4,6 +4,7 @@ import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { formatting, validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import { AppliedCategories } from '../../AppliedCategories';
 import commands from '../../commands';
@@ -288,19 +289,9 @@ class PlannerTaskSetCommand extends GraphCommand {
 
     return this
       .getGroupId(options)
-      .then((groupId: string) => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/plans?$filter=(owner eq '${groupId}')&$select=id,title`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        return request.get<{ value: PlannerPlan[] }>(requestOptions);
-      })
+      .then((groupId: string) => planner.getPlansByGroupId(groupId))
       .then((response) => {
-        const plan: PlannerPlan | undefined = response.value.find(val => val.title === options.planName);
+        const plan: PlannerPlan | undefined = response.find(val => val.title === options.planName);
 
         if (!plan) {
           return Promise.reject(`The specified plan does not exist`);

--- a/src/m365/pp/commands/managementapp/managementapp-list.ts
+++ b/src/m365/pp/commands/managementapp/managementapp-list.ts
@@ -20,7 +20,7 @@ class PpManagementAppListCommand extends PowerPlatformCommand {
     const endpoint = `${this.resource}/providers/Microsoft.BusinessAppPlatform/adminApplications?api-version=2020-06-01`;
 
     odata
-      .getAllItems<ManagementApp>(endpoint, logger)
+      .getAllItems<ManagementApp>(endpoint)
       .then((managementApps): void => {
         logger.log(managementApps);
         cb();

--- a/src/m365/teams/commands/app/app-list.ts
+++ b/src/m365/teams/commands/app/app-list.ts
@@ -110,7 +110,7 @@ class TeamsAppListCommand extends GraphCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
     this
       .getEndpointUrl(args)
-      .then(endpoint => odata.getAllItems<TeamsApp>(endpoint, logger))
+      .then(endpoint => odata.getAllItems<TeamsApp>(endpoint))
       .then((items): void => {
         if (args.options.teamId || args.options.teamName) {
           items.forEach(t => {

--- a/src/m365/teams/commands/channel/channel-list.ts
+++ b/src/m365/teams/commands/channel/channel-list.ts
@@ -77,7 +77,7 @@ class TeamsChannelListCommand extends GraphCommand{
           endpoint += `?$filter=membershipType eq '${args.options.type}'`;
         }
 
-        return odata.getAllItems<Channel>(endpoint, logger);
+        return odata.getAllItems<Channel>(endpoint);
       })
       .then((items): void => {
         logger.log(items);

--- a/src/m365/teams/commands/channel/channel-member-list.ts
+++ b/src/m365/teams/commands/channel/channel-member-list.ts
@@ -60,7 +60,7 @@ class TeamsChannelMemberListCommand extends GraphCommand {
       })
       .then((channelId: string): Promise<ConversationMember[]> => {
         const endpoint = `${this.resource}/v1.0/teams/${this.teamId}/channels/${channelId}/members`;
-        return odata.getAllItems<ConversationMember>(endpoint, logger);
+        return odata.getAllItems<ConversationMember>(endpoint);
       })
       .then((memberships): void => {
         if (args.options.role) {

--- a/src/m365/teams/commands/chat/chat-get.ts
+++ b/src/m365/teams/commands/chat/chat-get.ts
@@ -43,7 +43,7 @@ class TeamsChatGetCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     this
-      .getChatId(logger, args)
+      .getChatId(args)
       .then(chatId => this.getChatDetailsById(chatId as string))
       .then((chat: Chat) => {
         logger.log(chat);
@@ -96,14 +96,14 @@ class TeamsChatGetCommand extends GraphCommand {
     return true;
   }
 
-  private async getChatId(logger: Logger, args: CommandArgs): Promise<string> {
+  private async getChatId(args: CommandArgs): Promise<string> {
     if (args.options.id) {
       return args.options.id;
     }    
     
     return args.options.participants 
-      ? this.getChatIdByParticipants(args.options.participants, logger)
-      : this.getChatIdByName(args.options.name as string, logger);
+      ? this.getChatIdByParticipants(args.options.participants)
+      : this.getChatIdByName(args.options.name as string);
   }
   
   private async getChatDetailsById(id: string): Promise<Chat> {
@@ -118,10 +118,10 @@ class TeamsChatGetCommand extends GraphCommand {
     return request.get<Chat>(requestOptions);    
   }
 
-  private async getChatIdByParticipants(participantsString: string, logger: Logger): Promise<string> {
+  private async getChatIdByParticipants(participantsString: string): Promise<string> {
     const participants = chatUtil.convertParticipantStringToArray(participantsString);
     const currentUserEmail = accessToken.getUserNameFromAccessToken(Auth.service.accessTokens[this.resource].accessToken).toLowerCase();
-    const existingChats = await chatUtil.findExistingChatsByParticipants([currentUserEmail, ...participants], logger);
+    const existingChats = await chatUtil.findExistingChatsByParticipants([currentUserEmail, ...participants]);
     
     if (!existingChats || existingChats.length === 0) {
       throw new Error('No chat conversation was found with these participants.');
@@ -138,8 +138,8 @@ class TeamsChatGetCommand extends GraphCommand {
     throw new Error(`Multiple chat conversations with these participants found. Please disambiguate:${os.EOL}${disambiguationText}`);
   }
   
-  private async getChatIdByName(name: string, logger: Logger): Promise<string> {
-    const existingChats = await chatUtil.findExistingGroupChatsByName(name, logger);
+  private async getChatIdByName(name: string): Promise<string> {
+    const existingChats = await chatUtil.findExistingGroupChatsByName(name);
 
     if (!existingChats || existingChats.length === 0) {
       throw new Error('No chat conversation was found with this name.');

--- a/src/m365/teams/commands/chat/chat-list.ts
+++ b/src/m365/teams/commands/chat/chat-list.ts
@@ -33,7 +33,7 @@ class TeamsChatListCommand extends GraphCommand {
     const endpoint: string = `${this.resource}/v1.0/chats${filter}`;
 
     odata
-      .getAllItems(endpoint, logger)
+      .getAllItems(endpoint)
       .then((items): void => {
         logger.log(items);
         cb();

--- a/src/m365/teams/commands/chat/chat-member-list.ts
+++ b/src/m365/teams/commands/chat/chat-member-list.ts
@@ -32,7 +32,7 @@ class TeamsChatMemberListCommand extends GraphCommand {
     const endpoint: string = `${this.resource}/v1.0/chats/${args.options.chatId}/members`;
 
     odata
-      .getAllItems(endpoint, logger)
+      .getAllItems(endpoint)
       .then((items): void => {
         logger.log(items);
         cb();

--- a/src/m365/teams/commands/chat/chat-message-list.ts
+++ b/src/m365/teams/commands/chat/chat-message-list.ts
@@ -37,7 +37,7 @@ class TeamsChatMessageListCommand extends GraphCommand {
     const endpoint: string = `${this.resource}/v1.0/chats/${args.options.chatId}/messages`;
 
     odata
-      .getAllItems<ExtendedMessage>(endpoint, logger)
+      .getAllItems<ExtendedMessage>(endpoint)
       .then((items): void => {
         if (args.options.output !== 'json') {
           items.forEach(i => {

--- a/src/m365/teams/commands/chat/chat-message-send.ts
+++ b/src/m365/teams/commands/chat/chat-message-send.ts
@@ -108,14 +108,14 @@ class TeamsChatMessageSendCommand extends GraphCommand {
     }    
 
     return args.options.userEmails 
-      ? this.ensureChatIdByUserEmails(args.options.userEmails, logger)
-      : this.getChatIdByName(args.options.chatName as string, logger);
+      ? this.ensureChatIdByUserEmails(args.options.userEmails)
+      : this.getChatIdByName(args.options.chatName as string);
   }
 
-  private async ensureChatIdByUserEmails(userEmailsOption: string, logger: Logger): Promise<string> {
+  private async ensureChatIdByUserEmails(userEmailsOption: string): Promise<string> {
     const userEmails = chatUtil.convertParticipantStringToArray(userEmailsOption);
     const currentUserEmail = accessToken.getUserNameFromAccessToken(Auth.service.accessTokens[this.resource].accessToken).toLowerCase();
-    const existingChats = await chatUtil.findExistingChatsByParticipants([currentUserEmail, ...userEmails], logger);
+    const existingChats = await chatUtil.findExistingChatsByParticipants([currentUserEmail, ...userEmails]);
     
     if (!existingChats || existingChats.length === 0) {
       const chat = await this.createConversation([currentUserEmail, ...userEmails]);
@@ -133,8 +133,8 @@ class TeamsChatMessageSendCommand extends GraphCommand {
     throw new Error(`Multiple chat conversations with this name found. Please disambiguate:${os.EOL}${disambiguationText}`);
   }
 
-  private async getChatIdByName(chatName: string, logger: Logger): Promise<string> {
-    const existingChats = await chatUtil.findExistingGroupChatsByName(chatName, logger);
+  private async getChatIdByName(chatName: string): Promise<string> {
+    const existingChats = await chatUtil.findExistingGroupChatsByName(chatName);
 
     if (!existingChats || existingChats.length === 0) {
       throw new Error('No chat conversation was found with this name.');

--- a/src/m365/teams/commands/chat/chatUtil.ts
+++ b/src/m365/teams/commands/chat/chatUtil.ts
@@ -1,4 +1,3 @@
-import { Logger } from "../../../../cli/Logger";
 import { AadUserConversationMember, Chat, ConversationMember } from '@microsoft/microsoft-graph-types';
 import { odata } from '../../../../utils/odata';
 
@@ -9,12 +8,12 @@ export const chatUtil = {
    * @param expectedMemberEmails a string array of participant emailaddresses   
    * @param logger a logger to pipe into the graph request odata helper.
    */
-  async findExistingChatsByParticipants(expectedMemberEmails: string[], logger: Logger): Promise<Chat[]> {
+  async findExistingChatsByParticipants(expectedMemberEmails: string[]): Promise<Chat[]> {
     const chatType = expectedMemberEmails.length === 2 ? 'oneOnOne' : 'group';
     const endpoint = `https://graph.microsoft.com/v1.0/chats?$filter=chatType eq '${chatType}'&$expand=members&$select=id,topic,createdDateTime,members`;
     const foundChats: Chat[] = [];
     
-    const chats = await odata.getAllItems<Chat>(endpoint, logger);
+    const chats = await odata.getAllItems<Chat>(endpoint);
 
     for (const chat of chats) {
       const chatMembers = chat.members as ConversationMember[];
@@ -35,9 +34,9 @@ export const chatUtil = {
    * @param name the name of the chat conversation to find
    * @param logger a logger to pipe into the graph request odata helper.
    */
-  async findExistingGroupChatsByName(name: string, logger: Logger): Promise<Chat[]> {
+  async findExistingGroupChatsByName(name: string): Promise<Chat[]> {
     const endpoint = `https://graph.microsoft.com/v1.0/chats?$filter=topic eq '${encodeURIComponent(name).replace("'", "''")}'&$expand=members&$select=id,topic,createdDateTime,chatType`;
-    return odata.getAllItems<Chat>(endpoint, logger);    
+    return odata.getAllItems<Chat>(endpoint);    
   },
   
   /**

--- a/src/m365/teams/commands/message/message-list.ts
+++ b/src/m365/teams/commands/message/message-list.ts
@@ -36,7 +36,7 @@ class TeamsMessageListCommand extends GraphCommand {
     const endpoint: string = `${this.resource}/v1.0/teams/${args.options.teamId}/channels/${args.options.channelId}/messages${deltaExtension}`;
 
     odata
-      .getAllItems<Message>(endpoint, logger)
+      .getAllItems<Message>(endpoint)
       .then((items): void => {
         if (args.options.output !== 'json') {
           items.forEach(i => {

--- a/src/m365/teams/commands/message/message-reply-list.ts
+++ b/src/m365/teams/commands/message/message-reply-list.ts
@@ -35,7 +35,7 @@ class TeamsMessageReplyListCommand extends GraphCommand  {
     const endpoint: string = `${this.resource}/v1.0/teams/${args.options.teamId}/channels/${args.options.channelId}/messages/${args.options.messageId}/replies`;
 
     odata
-      .getAllItems<Reply>(endpoint, logger)
+      .getAllItems<Reply>(endpoint)
       .then((items): void => {
         if (args.options.output !== 'json') {
           items.forEach(i => {

--- a/src/m365/teams/commands/tab/tab-list.ts
+++ b/src/m365/teams/commands/tab/tab-list.ts
@@ -34,7 +34,7 @@ class TeamsTabListCommand extends GraphCommand {
     const endpoint: string = `${this.resource}/v1.0/teams/${args.options.teamId}/channels/${encodeURIComponent(args.options.channelId)}/tabs?$expand=teamsApp`;
 
     odata
-      .getAllItems<Tab>(endpoint, logger)
+      .getAllItems<Tab>(endpoint)
       .then((items): void => {
         items.forEach(i => {
           (i as any).teamsAppTabId = i.teamsApp.id;

--- a/src/m365/teams/commands/team/team-list.ts
+++ b/src/m365/teams/commands/team/team-list.ts
@@ -39,7 +39,7 @@ class TeamsTeamListCommand extends GraphCommand {
       endpoint = `${this.resource}/v1.0/me/joinedTeams`;
     }
     odata
-      .getAllItems<Group>(endpoint, logger)
+      .getAllItems<Group>(endpoint)
       .then((items): Promise<Group[] | Team[]> => {
         if (args.options.joined) {
           return Promise.resolve(items);

--- a/src/m365/teams/commands/user/user-app-list.ts
+++ b/src/m365/teams/commands/user/user-app-list.ts
@@ -41,7 +41,7 @@ class TeamsUserAppListCommand extends GraphCommand {
         userId = _userId.value;
         const endpoint: string = `${this.resource}/v1.0/users/${encodeURIComponent(userId)}/teamwork/installedApps?$expand=teamsAppDefinition`;
 
-        return odata.getAllItems<TeamsAppInstallation>(endpoint, logger);
+        return odata.getAllItems<TeamsAppInstallation>(endpoint);
       })
       .then((items): void => {
         items.forEach(i => {

--- a/src/m365/teams/commands/user/user-list.ts
+++ b/src/m365/teams/commands/user/user-list.ts
@@ -67,7 +67,7 @@ class TeamsUserListCommand extends GraphCommand {
   private getOwners(logger: Logger, groupId: string): Promise<void> {
     const endpoint: string = `${this.resource}/v1.0/groups/${groupId}/owners?$select=id,displayName,userPrincipalName,userType`;
 
-    return odata.getAllItems<User>(endpoint, logger).then((items): void => {
+    return odata.getAllItems<User>(endpoint).then((items): void => {
       this.items = this.items.concat(items);
 
       // Currently there is a bug in the Microsoft Graph that returns Owners as
@@ -80,7 +80,7 @@ class TeamsUserListCommand extends GraphCommand {
 
   private getMembersAndGuests(logger: Logger, groupId: string): Promise<User[]> {
     const endpoint: string = `${this.resource}/v1.0/groups/${groupId}/members?$select=id,displayName,userPrincipalName,userType`;
-    return odata.getAllItems(endpoint, logger);
+    return odata.getAllItems(endpoint);
   }
 
   public options(): CommandOption[] {

--- a/src/m365/tenant/commands/serviceannouncement/serviceannouncement-healthissue-list.ts
+++ b/src/m365/tenant/commands/serviceannouncement/serviceannouncement-healthissue-list.ts
@@ -35,7 +35,7 @@ class TenantServiceAnnouncementHealthIssueListCommand extends GraphCommand {
     }
 
     odata
-      .getAllItems<ServiceHealthIssue>(endpoint, logger)
+      .getAllItems<ServiceHealthIssue>(endpoint)
       .then((items): void => {
         logger.log(items);
         cb();

--- a/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-list.ts
+++ b/src/m365/tenant/commands/serviceannouncement/serviceannouncement-message-list.ts
@@ -35,7 +35,7 @@ class TenantServiceAnnouncementMessageListCommand extends GraphCommand {
     }
 
     odata
-      .getAllItems<ServiceUpdateMessage>(endpoint, logger)
+      .getAllItems<ServiceUpdateMessage>(endpoint)
       .then((items): void => {
         logger.log(items);
         cb();

--- a/src/m365/todo/commands/list/list-list.ts
+++ b/src/m365/todo/commands/list/list-list.ts
@@ -24,7 +24,7 @@ class TodoListListCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
     odata
-      .getAllItems<ToDoList>(`${this.resource}/v1.0/me/todo/lists`, logger)
+      .getAllItems<ToDoList>(`${this.resource}/v1.0/me/todo/lists`)
       .then((items): void => {
         logger.log(items);
         cb();

--- a/src/m365/todo/commands/task/task-list.ts
+++ b/src/m365/todo/commands/task/task-list.ts
@@ -66,7 +66,7 @@ class TodoTaskListCommand extends GraphCommand {
       .getTodoListId(args)
       .then((listId: string): Promise<any> => {
         const endpoint: string = `${this.resource}/v1.0/me/todo/lists/${listId}/tasks`;
-        return odata.getAllItems(endpoint, logger);
+        return odata.getAllItems(endpoint);
       })
       .then((items: ToDoTask[]): void => {
         if (args.options.output === 'json') {

--- a/src/utils/odata.ts
+++ b/src/utils/odata.ts
@@ -1,4 +1,3 @@
-import { Logger } from "../cli";
 import request from "../request";
 
 export interface ODataResponse<T> {
@@ -19,7 +18,7 @@ export interface GraphResponseError {
 }
 
 export const odata = {
-  async getAllItems<T>(url: string, logger: Logger, metadata?: 'none' | 'minimal' | 'full'): Promise<T[]> {
+  async getAllItems<T>(url: string, metadata?: 'none' | 'minimal' | 'full'): Promise<T[]> {
     let items: T[] = [];
 
     const requestOptions: any = {
@@ -35,7 +34,7 @@ export const odata = {
 
     const nextLink = res['@odata.nextLink'] ?? res.nextLink;
     if (nextLink) {
-      const nextPageItems = await odata.getAllItems<T>(nextLink, logger, metadata);
+      const nextPageItems = await odata.getAllItems<T>(nextLink, metadata);
       items = items.concat(nextPageItems);
     }
     

--- a/src/utils/odata.ts
+++ b/src/utils/odata.ts
@@ -22,10 +22,11 @@ export const odata = {
   async getAllItems<T>(url: string, logger: Logger, metadata?: 'none' | 'minimal' | 'full'): Promise<T[]> {
     let items: T[] = [];
 
+    metadata ??= 'none';
     const requestOptions: any = {
       url: url,
       headers: {
-        accept: `application/json;odata.metadata=${metadata ?? 'none'}`
+        accept: `application/json;odata.metadata=${metadata}`
       },
       responseType: 'json'
     };

--- a/src/utils/odata.ts
+++ b/src/utils/odata.ts
@@ -22,11 +22,10 @@ export const odata = {
   async getAllItems<T>(url: string, logger: Logger, metadata?: 'none' | 'minimal' | 'full'): Promise<T[]> {
     let items: T[] = [];
 
-    metadata ??= 'none';
     const requestOptions: any = {
       url: url,
       headers: {
-        accept: `application/json;odata.metadata=${metadata}`
+        accept: `application/json;odata.metadata=${metadata ?? 'none'}`
       },
       responseType: 'json'
     };

--- a/src/utils/planner.spec.ts
+++ b/src/utils/planner.spec.ts
@@ -8,15 +8,12 @@ const validPlanId = 'oUHpnKBFekqfGE_PS6GGUZcAFY7b';
 const validPlanName = 'Plan name';
 const validOwnerGroupId = '00000000-0000-0000-0000-000000000000';
 
-const multiplePlanResponse = {
+const singlePlanResponse = {
   "value": [
     {
       "id": validPlanId,
-      "title": validPlanName
-    },
-    {
-      "id": validPlanId,
-      "title": validPlanName
+      "title": validPlanName,
+      "owner": validOwnerGroupId
     }
   ]
 };
@@ -30,14 +27,14 @@ describe('utils/planner', () => {
 
   it('correctly get all plans related to a specific group.', async () => {
     sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
-        return multiplePlanResponse;
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
+        return singlePlanResponse;
       }
 
       return 'Invalid Request';
     });
 
     const actual = await planner.getPlansByGroupId(validOwnerGroupId);
-    assert.strictEqual(actual, multiplePlanResponse.value);
+    assert.strictEqual(actual, singlePlanResponse.value);
   });
 });

--- a/src/utils/planner.spec.ts
+++ b/src/utils/planner.spec.ts
@@ -1,4 +1,4 @@
-import assert = require('assert');
+import * as assert from 'assert';
 import * as sinon from 'sinon';
 import request from "../request";
 import { planner } from './planner';
@@ -9,11 +9,11 @@ const validPlanName = 'Plan name';
 const validOwnerGroupId = '00000000-0000-0000-0000-000000000000';
 
 const singlePlanResponse = {
-  "value": [
+  value: [
     {
-      "id": validPlanId,
-      "title": validPlanName,
-      "owner": validOwnerGroupId
+      id: validPlanId,
+      title: validPlanName,
+      owner: validOwnerGroupId
     }
   ]
 };

--- a/src/utils/planner.spec.ts
+++ b/src/utils/planner.spec.ts
@@ -1,0 +1,43 @@
+import assert = require('assert');
+import * as sinon from 'sinon';
+import request from "../request";
+import { planner } from './planner';
+import { sinonUtil } from "./sinonUtil";
+
+const validPlanId = 'oUHpnKBFekqfGE_PS6GGUZcAFY7b';
+const validPlanName = 'Plan name';
+const validOwnerGroupId = '00000000-0000-0000-0000-000000000000';
+
+const multiplePlanResponse = {
+  "value": [
+    {
+      "id": validPlanId,
+      "title": validPlanName
+    },
+    {
+      "id": validPlanId,
+      "title": validPlanName
+    }
+  ]
+};
+
+describe('utils/planner', () => {
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get
+    ]);
+  });
+
+  it('correctly get all plans related to a specific group.', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans?$filter=owner eq '${validOwnerGroupId}'`) {
+        return multiplePlanResponse;
+      }
+
+      return 'Invalid Request';
+    });
+
+    const actual = await planner.getPlansByGroupId(validOwnerGroupId);
+    assert.strictEqual(actual, multiplePlanResponse.value);
+  });
+});

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -1,0 +1,20 @@
+import { PlannerPlan } from "@microsoft/microsoft-graph-types";
+import { AxiosRequestConfig } from "axios";
+import request from "../request";
+
+const graphResource = 'https://graph.microsoft.com';
+
+export const planner = {
+  async getPlansByGroupId(groupId: string): Promise<PlannerPlan[]> {
+    const requestOptions: AxiosRequestConfig = {
+      url: `${graphResource}/v1.0/planner/plans?$filter=owner eq '${groupId}'`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    const response = await request.get<{ value: PlannerPlan[] }>(requestOptions);
+    return response.value;
+  }
+};

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -1,20 +1,10 @@
 import { PlannerPlan } from "@microsoft/microsoft-graph-types";
-import { AxiosRequestConfig } from "axios";
-import request from "../request";
+import { odata } from "./odata";
 
 const graphResource = 'https://graph.microsoft.com';
 
 export const planner = {
   async getPlansByGroupId(groupId: string): Promise<PlannerPlan[]> {
-    const requestOptions: AxiosRequestConfig = {
-      url: `${graphResource}/v1.0/planner/plans?$filter=owner eq '${groupId}'`,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
-
-    const response = await request.get<{ value: PlannerPlan[] }>(requestOptions);
-    return response.value;
+    return odata.getAllItems<PlannerPlan>(`${graphResource}/v1.0/groups/${groupId}/planner/plans`, undefined as any);
   }
 };

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -4,7 +4,7 @@ import { odata } from "./odata";
 const graphResource = 'https://graph.microsoft.com';
 
 export const planner = {
-  async getPlansByGroupId(groupId: string): Promise<PlannerPlan[]> {
+  getPlansByGroupId(groupId: string): Promise<PlannerPlan[]> {
     return odata.getAllItems<PlannerPlan>(`${graphResource}/v1.0/groups/${groupId}/planner/plans`, undefined as any);
   }
 };

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -5,6 +5,6 @@ const graphResource = 'https://graph.microsoft.com';
 
 export const planner = {
   getPlansByGroupId(groupId: string): Promise<PlannerPlan[]> {
-    return odata.getAllItems<PlannerPlan>(`${graphResource}/v1.0/groups/${groupId}/planner/plans`, undefined as any);
+    return odata.getAllItems<PlannerPlan>(`${graphResource}/v1.0/groups/${groupId}/planner/plans`, undefined as any, 'none');
   }
 };

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -5,6 +5,6 @@ const graphResource = 'https://graph.microsoft.com';
 
 export const planner = {
   getPlansByGroupId(groupId: string): Promise<PlannerPlan[]> {
-    return odata.getAllItems<PlannerPlan>(`${graphResource}/v1.0/groups/${groupId}/planner/plans`, undefined as any, 'none');
+    return odata.getAllItems<PlannerPlan>(`${graphResource}/v1.0/groups/${groupId}/planner/plans`, 'none');
   }
 };


### PR DESCRIPTION
Implemented `getPlansByGroupId(groupId: string): Promise<PlannerPlan[]>` utility to return all plans from a certain group.

Updated commands:
1) planner bucket add
1) planner bucket list
1) planner bucket remove
1) planner bucket set
1) planner plan details get
1) planner plan get
1) planner plan list
1) planner task add
1) planner task get
1) planner task list
1) planner task set


This **partially** closes #3268 
Partially because another utility function has to be implemented in a separate PR #3287 .