### PR TITLE
Adds planner util getPlanById function

### DIFF
--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -6,6 +6,7 @@ import {
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { odata, validation } from '../../../../utils';
+import { planner } from '../../../../utils/planner';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -44,8 +45,8 @@ class PlannerPlanGetCommand extends GraphCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (args.options.id) {
-      this
-        .getPlan(args)
+      planner
+        .getPlanById(args.options.id)
         .then((res: any): void => {
           logger.log(res);
           cb();
@@ -89,18 +90,6 @@ class PlannerPlanGetCommand extends GraphCommand {
 
         return Promise.resolve(group.id);
       });
-  }
-
-  private getPlan(args: CommandArgs): Promise<any> {
-    const requestOptions: any = {
-      url: `${this.resource}/v1.0/planner/plans/${args.options.id}`,
-      headers: {
-        'accept': 'application/json'
-      },
-      responseType: 'json'
-    };
-
-    return request.get(requestOptions);
   }
 
   public options(): CommandOption[] {

--- a/src/utils/planner.spec.ts
+++ b/src/utils/planner.spec.ts
@@ -45,8 +45,9 @@ describe('utils/planner', () => {
 
     try {
       await planner.getPlanById(validPlanId);
-      assert.fail('No error message thrown.')
-    } catch (ex) {
+      assert.fail('No error message thrown.');
+    }
+    catch (ex) {
       assert.deepStrictEqual(ex, Error(`Planner plan with id ${validPlanId} was not found.`));
     }
   });

--- a/src/utils/planner.spec.ts
+++ b/src/utils/planner.spec.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import request from "../request";
+import { planner } from './planner';
+import { sinonUtil } from "./sinonUtil";
+
+const validPlanId = 'oUHpnKBFekqfGE_PS6GGUZcAFY7b';
+const validPlanName = 'Plan name';
+const validOwnerGroupId = '00000000-0000-0000-0000-000000000000';
+
+const singlePlanResponse = {
+  id: validPlanId,
+  title: validPlanName,
+  owner: validOwnerGroupId
+};
+
+describe('utils/planner', () => {
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get
+    ]);
+  });
+
+  it('correctly get a single plan by id.', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}`) {
+        return singlePlanResponse;
+      }
+
+      return 'Invalid Request';
+    });
+
+    const actual = await planner.getPlanById(validPlanId);
+    assert.strictEqual(actual, singlePlanResponse);
+  });
+
+  it('display error message when plan is not found.', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}`) {
+        throw Error('Plan not found.');
+      }
+
+      return 'Invalid Request';
+    });
+
+    try {
+      await planner.getPlanById(validPlanId);
+      assert.fail('No error message thrown.')
+    } catch (ex) {
+      assert.deepStrictEqual(ex, Error(`Planner plan with id ${validPlanId} was not found.`));
+    }
+  });
+});

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -1,0 +1,25 @@
+import request from "../request";
+import { PlannerPlan } from "@microsoft/microsoft-graph-types";
+import { AxiosRequestConfig } from "axios";
+
+const graphResource = 'https://graph.microsoft.com';
+
+const getRequestOptions = (url: string, metadata: 'none' | 'minimal' | 'full'): AxiosRequestConfig => ({
+  url: url,
+  headers: {
+    accept: `application/json;odata.metadata=${metadata}`
+  },
+  responseType: 'json'
+});
+
+export const planner = {
+  async getPlanById(id: string): Promise<PlannerPlan> {
+    const requestOptions = getRequestOptions(`${graphResource}/v1.0/planner/plans/${id}`, 'none');
+    
+    try {
+      return await request.get<PlannerPlan>(requestOptions);
+    } catch (ex) {
+      throw Error(`Planner plan with id ${id} was not found.`);
+    }
+  }
+};

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -18,7 +18,8 @@ export const planner = {
     
     try {
       return await request.get<PlannerPlan>(requestOptions);
-    } catch (ex) {
+    }
+    catch (ex) {
       throw Error(`Planner plan with id ${id} was not found.`);
     }
   }


### PR DESCRIPTION
Implemented `async getPlanById(id: string): Promise<PlannerPlan>` utility to get Planner plan by ID.

Updated commands:
1. planner plan get

This is the only command I found that gets a plan by ID.

This partially closes #3268 
Partially because another utility function has to be implemented in a separate PR #3286 .