### PR TITLE
Adds aadgroup utils getGroupById function

### DIFF
--- a/src/m365/aad/commands/o365group/o365group-get.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-get.spec.ts
@@ -442,7 +442,7 @@ describe(commands.O365GROUP_GET, () => {
 
     command.action(logger, { options: { debug: false, id: '1caf7dcd-7e83-4c3a-94f7-932a1299c843' } } as any, (err?: any) => {
       try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Resource '1caf7dcd-7e83-4c3a-94f7-932a1299c843' does not exist or one of its queried reference-property objects are not present.`)));
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Group with ID 1caf7dcd-7e83-4c3a-94f7-932a1299c843 was not found.')));
         done();
       }
       catch (e) {

--- a/src/m365/aad/commands/o365group/o365group-get.ts
+++ b/src/m365/aad/commands/o365group/o365group-get.ts
@@ -5,6 +5,7 @@ import {
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
+import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 import { GroupExtended } from './GroupExtended';
@@ -30,16 +31,8 @@ class AadO365GroupGetCommand extends GraphCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     let group: GroupExtended;
 
-    const requestOptions: any = {
-      url: `${this.resource}/v1.0/groups/${args.options.id}`,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
-
-    request
-      .get<GroupExtended>(requestOptions)
+    aadGroup
+      .getGroupById(args.options.id)
       .then((res: GroupExtended): Promise<{ webUrl: string }> => {
         group = res;
 

--- a/src/m365/teams/commands/team/team-add.ts
+++ b/src/m365/teams/commands/team/team-add.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
+import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -126,18 +127,12 @@ class TeamsTeamAddCommand extends GraphCommand {
             });
         });
       })
-      .then((teamsAsyncOperation: TeamsAsyncOperation) => {
+      .then((teamsAsyncOperation: TeamsAsyncOperation): any => {
         if (teamsAsyncOperation.status !== TeamsAsyncOperationStatus.Succeeded) {
           return Promise.resolve(teamsAsyncOperation);
         }
 
-        return request.get({
-          url: `${this.resource}/v1.0/groups/${teamsAsyncOperation.targetResourceId}`,
-          headers: {
-            accept: 'application/json;odata.metadata=minimal'
-          },
-          responseType: 'json'
-        });
+        return aadGroup.getGroupById(teamsAsyncOperation.targetResourceId);
       })
       .then((output: any) => {
         logger.log(output);

--- a/src/utils/aadGroup.spec.ts
+++ b/src/utils/aadGroup.spec.ts
@@ -1,0 +1,52 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import request from "../request";
+import { aadGroup } from './aadGroup';
+import { sinonUtil } from "./sinonUtil";
+
+const validGroupName = 'Group name';
+const validGroupId = '00000000-0000-0000-0000-000000000000';
+
+const singleGroupResponse = {
+  id: validGroupId,
+  displayName: validGroupName
+};
+
+describe('utils/aadGroup', () => {
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get
+    ]);
+  });
+
+  it('correctly get a single group by id.', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validGroupId}`) {
+        return singleGroupResponse;
+      }
+
+      return 'Invalid Request';
+    });
+
+    const actual = await aadGroup.getGroupById(validGroupId);
+    assert.strictEqual(actual, singleGroupResponse);
+  });
+
+  it('display error message when group is not found.', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validGroupId}`) {
+        throw Error('Group not found.');
+      }
+
+      return 'Invalid Request';
+    });
+
+    try {
+      await aadGroup.getGroupById(validGroupId);
+      assert.fail('No error message thrown.');
+    }
+    catch (ex) {
+      assert.deepStrictEqual(ex, Error(`Group with ID ${validGroupId} was not found.`));
+    }
+  });
+}); 

--- a/src/utils/aadGroup.ts
+++ b/src/utils/aadGroup.ts
@@ -14,7 +14,7 @@ const getRequestOptions = (url: string, metadata: 'none' | 'minimal' | 'full'): 
 
 export const aadGroup = {
   /**
-   * Retrieve a unique group.
+   * Retrieve a single group.
    * @param id Group ID.
    */
   async getGroupById(id: string): Promise<Group> {

--- a/src/utils/aadGroup.ts
+++ b/src/utils/aadGroup.ts
@@ -1,0 +1,30 @@
+import { Group } from "@microsoft/microsoft-graph-types";
+import { AxiosRequestConfig } from "axios";
+import request from "../request";
+
+const graphResource = 'https://graph.microsoft.com';
+
+const getRequestOptions = (url: string, metadata: 'none' | 'minimal' | 'full'): AxiosRequestConfig => ({
+  url: url,
+  headers: {
+    accept: `application/json;odata.metadata=${metadata}`
+  },
+  responseType: 'json'
+});
+
+export const aadGroup = {
+  /**
+   * Retrieve a unique group.
+   * @param id Group ID.
+   */
+  async getGroupById(id: string): Promise<Group> {
+    const requestOptions = getRequestOptions(`${graphResource}/v1.0/groups/${id}`, 'none');
+    
+    try {
+      return await request.get<Group>(requestOptions);
+    }
+    catch(ex) {
+      throw Error(`Group with ID ${id} was not found.`);
+    }
+  }
+};


### PR DESCRIPTION
Implemented `async getGroupById(id: string): Promise<Group>` utility to get groups by their ID.

Updated commands:
1. aad o365group get
1. spo site remove
1. teams team add

This partially closes #3267 
Partially because other utility functions has to be implemented in separate PR's.