### PR TITLE
Adds `planner task reference add` command. Closes #3283

### DIFF
--- a/docs/docs/cmd/planner/task/task-reference-add.md
+++ b/docs/docs/cmd/planner/task/task-reference-add.md
@@ -1,0 +1,45 @@
+# planner task reference add
+
+Adds a new reference to a Planner task.
+
+## Usage
+
+```sh
+m365 planner task reference add [options]
+```
+
+## Options
+
+`-i, --taskId <taskId>`
+: ID of the task.
+
+`-u, --url <url>`
+: URL location of the reference.
+
+`--alias [alias]`
+: A name alias to describe the reference.
+
+`--type [type]`
+: Used to describe the type of the reference. Types include: `PowerPoint`, `Word`, `Excel`, `Other`.
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Add a new reference with the url _https://www.microsoft.com_ to a Planner task with the id _2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2_
+
+```sh
+m365 planner task reference add --taskId "2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2" --url "https://www.microsoft.com"
+```
+
+Add a new reference with the url _https://www.microsoft.com_ and with the alias _Parker_ to a Planner task with the id _2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2_
+
+```sh
+m365 planner task reference add --taskId "2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2" --url "https://www.microsoft.com" --alias "Parker"
+```
+
+Add a new reference with the url _https://www.microsoft.com_ and with the type Excel to a Planner task with the id _2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2_
+
+```sh
+m365 planner task reference add --taskId "2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2" --url "https://www.microsoft.com" --type "Excel"
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -188,15 +188,16 @@ nav:
         - bucket remove: 'cmd/planner/bucket/bucket-remove.md'
       - plan:
         - plan add: 'cmd/planner/plan/plan-add.md'
-        - plan get: 'cmd/planner/plan/plan-get.md'
         - plan details get: 'cmd/planner/plan/plan-details-get.md'
+        - plan get: 'cmd/planner/plan/plan-get.md'
         - plan list: 'cmd/planner/plan/plan-list.md'
       - task:
         - task add: 'cmd/planner/task/task-add.md'
+        - task details get: 'cmd/planner/task/task-details-get.md'
         - task get: 'cmd/planner/task/task-get.md'
         - task list: 'cmd/planner/task/task-list.md'
+        - task reference add: 'cmd/planner/task/task-reference-add.md'
         - task set: 'cmd/planner/task/task-set.md'
-        - task details get: 'cmd/planner/task/task-details-get.md'
     - Power Apps (pa):
       - app:
         - app get: 'cmd/pa/app/app-get.md'

--- a/src/m365/planner/commands.ts
+++ b/src/m365/planner/commands.ts
@@ -6,12 +6,13 @@ export default {
   BUCKET_SET: `${prefix} bucket set`,
   BUCKET_REMOVE: `${prefix} bucket remove`,
   PLAN_ADD: `${prefix} plan add`,
-  PLAN_GET: `${prefix} plan get`,
   PLAN_DETAILS_GET: `${prefix} plan details get`,
+  PLAN_GET: `${prefix} plan get`,
   PLAN_LIST: `${prefix} plan list`,
   TASK_ADD: `${prefix} task add`,
   TASK_DETAILS_GET: `${prefix} task details get`,
   TASK_GET: `${prefix} task get`,
   TASK_LIST: `${prefix} task list`,
+  TASK_REFERENCE_ADD: `${prefix} task reference add`,
   TASK_SET: `${prefix} task set`
 };

--- a/src/m365/planner/commands/task/task-reference-add.spec.ts
+++ b/src/m365/planner/commands/task/task-reference-add.spec.ts
@@ -1,0 +1,236 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils';
+import commands from '../../commands';
+const command: Command = require('./task-reference-add');
+
+describe(commands.TASK_REFERENCE_ADD, () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+  const validTaskId = '2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2';
+  const validUrl = 'https://www.microsoft.com';
+  const validAlias = 'Test';
+  const validType = 'Word';
+
+  const referenceResponse = {
+    "https%3A//www%2Emicrosoft%2Ecom": {
+      "alias": "Test",
+      "type": "Word",
+      "previewPriority": "8585493318091789098Pa",
+      "lastModifiedDateTime": "2022-05-11T13:18:56.3142944Z",
+      "lastModifiedBy": {
+        "user": {
+          "displayName": null,
+          "id": "dd8b99a7-77c6-4238-a609-396d27844921"
+        }
+      }
+    }
+  };
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      request.patch
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.TASK_REFERENCE_ADD), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if incorrect type is specified.', (done) => {
+    const actual = command.validate({
+      options: {
+        taskId: validTaskId,
+        url: validUrl,
+        type: "wrong"
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('passes validation when valid options specified', (done) => {
+    const actual = command.validate({
+      options: {
+        taskId: validTaskId,
+        url: validUrl
+      }
+    });
+    assert.strictEqual(actual, true);
+    done();
+  });
+
+  it('correctly adds reference', (done) => {
+    sinon.stub(request, 'patch').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details`) {
+        return Promise.resolve({
+          references: referenceResponse
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details` &&
+        JSON.stringify(opts.headers) === JSON.stringify({
+          'accept': 'application/json'
+        })) {
+        return Promise.resolve({
+          "@odata.etag": "TestEtag"
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const options: any = {
+      taskId: validTaskId,
+      url: validUrl
+    };
+
+    command.action(logger, { options: options } as any, () => {
+      try {
+        assert(loggerLogSpy.calledWith(referenceResponse));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly adds reference with type and alias', (done) => {
+    sinon.stub(request, 'patch').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details`) {
+        return Promise.resolve({
+          references: referenceResponse
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details` &&
+        JSON.stringify(opts.headers) === JSON.stringify({
+          'accept': 'application/json'
+        })) {
+        return Promise.resolve({
+          "@odata.etag": "TestEtag"
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const options: any = {
+      taskId: validTaskId,
+      url: validUrl,
+      alias: validAlias,
+      type: validType
+    };
+
+    command.action(logger, { options: options } as any, () => {
+      try {
+        assert(loggerLogSpy.calledWith(referenceResponse));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails validation when task details endpoint fails', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('invalid')}/details`) {
+        return Promise.resolve(undefined);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        taskId: 'invalid',
+        url: validUrl
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Error fetching task details`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles random API error', (done) => {
+    sinonUtil.restore(request.get);
+    sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));
+
+    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+});

--- a/src/m365/planner/commands/task/task-reference-add.ts
+++ b/src/m365/planner/commands/task/task-reference-add.ts
@@ -2,6 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
+import { formatting } from '../../../../utils';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -39,7 +40,7 @@ class PlannerTaskReferenceAddCommand extends GraphCommand {
           responseType: 'json',
           data: {
             references: {
-              [this.customURIEncoder(args.options.url)]: {
+              [formatting.openTypesEncoder(args.options.url)]: {
                 '@odata.type': 'microsoft.graph.plannerExternalReference',
                 previewPriority: ' !',
                 ...(args.options.alias && {alias: args.options.alias}),
@@ -77,15 +78,6 @@ class PlannerTaskReferenceAddCommand extends GraphCommand {
 
         return Promise.resolve(etag);
       });
-  }
-
-  private customURIEncoder(value: string): string {
-    return value
-      .replace(/\%/g, '%25')
-      .replace(/\./g, '%2E')
-      .replace(/:/g, '%3A')
-      .replace(/@/g, '%40')
-      .replace(/#/g, '%23');
   }
 
   public options(): CommandOption[] {

--- a/src/m365/planner/commands/task/task-reference-add.ts
+++ b/src/m365/planner/commands/task/task-reference-add.ts
@@ -1,0 +1,112 @@
+import { Logger } from '../../../../cli';
+import { CommandOption } from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import GraphCommand from '../../../base/GraphCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  taskId: string;
+  url: string;
+  alias?: string;
+  type?: string;
+}
+
+class PlannerTaskReferenceAddCommand extends GraphCommand {  
+  public get name(): string {
+    return commands.TASK_REFERENCE_ADD;
+  }
+
+  public get description(): string {
+    return 'Adds a new reference to a Planner task';
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    this
+      .getTaskDetailsEtag(args.options.taskId)
+      .then(etag => {
+        const requestOptionsTaskDetails: any = {
+          url: `${this.resource}/v1.0/planner/tasks/${args.options.taskId}/details`,
+          headers: {
+            'accept': 'application/json;odata.metadata=none',
+            'If-Match': etag,
+            'Prefer': 'return=representation'
+          },
+          responseType: 'json',
+          data: {
+            references: {
+              [this.customURIEncoder(args.options.url)]: {
+                '@odata.type': 'microsoft.graph.plannerExternalReference',
+                previewPriority: ' !',
+                ...(args.options.alias && {alias: args.options.alias}),
+                ...(args.options.type && {type: args.options.type})
+              }
+            }
+          }
+        };
+
+        return request.patch(requestOptionsTaskDetails);
+      })
+      .then((res: any): void => {
+        logger.log(res.references);
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  private getTaskDetailsEtag(taskId: string): Promise<string> {
+    const requestOptions: any = {
+      url: `${this.resource}/v1.0/planner/tasks/${encodeURIComponent(taskId)}/details`,
+      headers: {
+        accept: 'application/json'
+      },
+      responseType: 'json'
+    };
+
+    return request
+      .get(requestOptions)
+      .then((response: any) => {
+        const etag: string | undefined = response ? response['@odata.etag'] : undefined;
+
+        if (!etag) {
+          return Promise.reject(`Error fetching task details`);
+        }
+
+        return Promise.resolve(etag);
+      });
+  }
+
+  private customURIEncoder(value: string): string {
+    return value
+      .replace(/\%/g, '%25')
+      .replace(/\./g, '%2E')
+      .replace(/:/g, '%3A')
+      .replace(/@/g, '%40')
+      .replace(/#/g, '%23');
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      { option: '-i, --taskId <taskId>' },
+      { option: '-u, --url <url>' },
+      { option: '--alias [alias]' },
+      { option: '--type [type]' }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+  
+  public validate(args: CommandArgs): boolean | string {
+    if (args.options.type && ['powerpoint', 'word', 'excel', 'other'].indexOf(args.options.type.toLocaleLowerCase()) === -1) {
+      return `${args.options.type} is not a valid type value. Allowed values PowerPoint|Word|Excel|Other`;
+    } 
+
+    return true;
+  }
+}
+
+module.exports = new PlannerTaskReferenceAddCommand();

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -74,5 +74,14 @@ export const formatting = {
 
   splitAndTrim(s: string): string[] {
     return s.split(',').map(c => c.trim());
+  },
+
+  openTypesEncoder(value: string): string {
+    return value
+      .replace(/\%/g, '%25')
+      .replace(/\./g, '%2E')
+      .replace(/:/g, '%3A')
+      .replace(/@/g, '%40')
+      .replace(/#/g, '%23');
   }
 };


### PR DESCRIPTION
Closes #3283

Bit of additional context. 
I created the method `customURIEncoder` to encode some of the special characters needed to pass the url along. [More info](https://docs.microsoft.com/en-us/graph/api/resources/plannerexternalreferences?view=graph-rest-1.0#properties)
Also within `planner/commands.ts` and `docs/mkdocs.yml` were a few commands that were not in alphabetical order. I rearranged them aswell.
