### PR TITLE
Fixes 'planner task get'. Closes #3324

### DIFF
--- a/docs/docs/cmd/planner/task/task-get.md
+++ b/docs/docs/cmd/planner/task/task-get.md
@@ -1,6 +1,6 @@
 # planner task get
 
-Retrieve the the specified planner task
+Retrieve the specified planner task
 
 ## Usage
 
@@ -36,20 +36,15 @@ m365 planner task get [options]
 
 --8<-- "docs/cmd/_global.md"
 
-## Remarks
-
-!!! attention
-    This command uses an API that is currently in preview to enrich the results with the `priority` field. Keep in mind that this preview API is subject to change once the API reached general availability.
-
 ## Examples
 
-Retrieve the the specified planner task by id.
+Retrieve the specified planner task by id
 
 ```sh
-m365 planner task get --id 'vzCcZoOv-U27PwydxHB8opcADJo-'
+m365 planner task get --id "vzCcZoOv-U27PwydxHB8opcADJo-"
 ```
 
-Retrieve the the specified planner task with the title _My Planner Task_ from the bucket named _My Planner Bucket_. Based on the plan with the name _My Planner Plan_ owned by the group _My Planner Group_.
+Retrieve the specified planner task with the title _My Planner Task_ from the bucket named _My Planner Bucket_ based on the plan with the name _My Planner Plan_ owned by the group _My Planner Group_
 
 ```sh
 m365 planner task get --title "My Planner Task" --bucketName "My Planner Bucket" --planName "My Planner Plan" --ownerGroupName "My Planner Group"

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -198,6 +198,7 @@ describe(commands.TASK_GET, () => {
   it('fails validation when bucket name is used with both plan name and plan id', () => {
     const actual = command.validate({
       options: {
+        title: validTaskTitle,
         name: validBucketName,
         bucketName: validBucketName,
         planId: validPlanId,

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -157,7 +157,73 @@ describe(commands.TASK_GET, () => {
 
   it('defines correct option sets', () => {
     const optionSets = command.optionSets();
-    assert.deepStrictEqual(optionSets, [['id', 'title'], ['title', 'bucketId', 'bucketName'], ['bucketName', 'planId', 'planName'], ['planName', 'ownerGroupId', 'ownerGroupName']]);
+    assert.deepStrictEqual(optionSets, [['id', 'title']]);
+  });
+
+  it('fails validation when title is used without bucket id', () => {
+    const actual = command.validate({
+      options: {
+        title: validTaskTitle
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when title is used with both bucket id and bucketname', () => {
+    const actual = command.validate({
+      options: {
+        title: validTaskTitle,
+        bucketId: validBucketId,
+        bucketName: validBucketName
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when bucket name is used without plan name or plan id', () => {
+    const actual = command.validate({
+      options: {
+        title: validTaskTitle,
+        bucketName: validBucketName
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when bucket name is used with both plan name and plan id', () => {
+    const actual = command.validate({
+      options: {
+        name: validBucketName,
+        bucketName: validBucketName,
+        planId: validPlanId,
+        planName: validPlanName
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when plan name is used without owner group name or owner group id', () => {
+    const actual = command.validate({
+      options: {
+        title: validTaskTitle,
+        bucketName: validBucketName,
+        planName: validPlanName
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when plan name is used with both owner group name and owner group id', () => {
+    const actual = command.validate({
+      options: {
+        title: validTaskTitle,
+        bucketName: validBucketName,
+        planName: validPlanName,
+        ownerGroupName: validOwnerGroupName,
+        ownerGroupId: validOwnerGroupId
+      }
+    });
+    assert.notStrictEqual(actual, true);
   });
 
   it('fails validation when owner group id is not a guid', () => {

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -155,81 +155,9 @@ describe(commands.TASK_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if neither id nor title specified', () => {
-    const actual = command.validate({ options: {} });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if both id and title specified', () => {
-    const actual = command.validate({ options: { id: 'vzCcZoOv-U27PwydxHB8opcADJo-', title: 'My Planner Task' } });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when title is used without bucket id', () => {
-    const actual = command.validate({
-      options: {
-        title: validTaskTitle
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when title is used with both bucket id and bucketname', () => {
-    const actual = command.validate({
-      options: {
-        title: validTaskTitle,
-        bucketId: validBucketId,
-        bucketName: validBucketName
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when bucket name is used without plan name or plan id', () => {
-    const actual = command.validate({
-      options: {
-        title: validTaskTitle,
-        bucketName: validBucketName
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when bucket name is used with both plan name and plan id', () => {
-    const actual = command.validate({
-      options: {
-        title: validTaskTitle,
-        name: validBucketName,
-        bucketName: validBucketName,
-        planId: validPlanId,
-        planName: validPlanName
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when plan name is used without owner group name or owner group id', () => {
-    const actual = command.validate({
-      options: {
-        title: validTaskTitle,
-        bucketName: validBucketName,
-        planName: validPlanName
-      }
-    });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when plan name is used with both owner group name and owner group id', () => {
-    const actual = command.validate({
-      options: {
-        title: validTaskTitle,
-        bucketName: validBucketName,
-        planName: validPlanName,
-        ownerGroupName: validOwnerGroupName,
-        ownerGroupId: validOwnerGroupId
-      }
-    });
-    assert.notStrictEqual(actual, true);
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets();
+    assert.deepStrictEqual(optionSets, [['id', 'title'], ['title', 'bucketId', 'bucketName'], ['bucketName', 'planId', 'planName'], ['planName', 'ownerGroupId', 'ownerGroupName']]);
   });
 
   it('fails validation when owner group id is not a guid', () => {

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -22,7 +22,7 @@ describe(commands.TASK_GET, () => {
   const validOwnerGroupName = 'Group name';
   const validOwnerGroupId = '00000000-0000-0000-0000-000000000000';
   const invalidOwnerGroupId = 'Invalid GUID';
-  
+
   const singleGroupResponse = {
     "value": [
       {
@@ -155,6 +155,16 @@ describe(commands.TASK_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('fails validation if neither id nor title specified', () => {
+    const actual = command.validate({ options: {} });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both id and title specified', () => {
+    const actual = command.validate({ options: { id: 'vzCcZoOv-U27PwydxHB8opcADJo-', title: 'My Planner Task' } });
+    assert.notStrictEqual(actual, true);
+  });
+
   it('fails validation when title is used without bucket id', () => {
     const actual = command.validate({
       options: {
@@ -276,7 +286,7 @@ describe(commands.TASK_GET, () => {
   it('fails validation when no groups found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'&$select=id`) {
-        return Promise.resolve({"value": []});
+        return Promise.resolve({ "value": [] });
       }
 
       return Promise.reject('Invalid Request');
@@ -299,7 +309,7 @@ describe(commands.TASK_GET, () => {
       }
     });
   });
-  
+
   it('fails validation when multiple groups found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'&$select=id`) {
@@ -330,7 +340,7 @@ describe(commands.TASK_GET, () => {
   it('fails validation when no buckets found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets?$select=id,name`) {
-        return Promise.resolve({"value": [ { "id": "" } ]});
+        return Promise.resolve({ "value": [{ "id": "" }] });
       }
 
       return Promise.reject('Invalid Request');
@@ -382,7 +392,7 @@ describe(commands.TASK_GET, () => {
   it('fails validation when no tasks found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}/tasks?$select=id,title`) {
-        return Promise.resolve({"value": [ { "id": "" } ]});
+        return Promise.resolve({ "value": [{ "id": "" }] });
       }
 
       return Promise.reject('Invalid Request');
@@ -429,6 +439,10 @@ describe(commands.TASK_GET, () => {
     });
   });
 
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['id', 'title', 'priority']);
+  });
+
   it('Correctly gets task by name', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'&$select=id`) {
@@ -443,7 +457,7 @@ describe(commands.TASK_GET, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}/tasks?$select=id,title`) {
         return Promise.resolve(singleTaskByTitleResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/beta/planner/tasks/${encodeURIComponent(validTaskId)}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}`) {
         return Promise.resolve(taskResponse);
       }
 
@@ -479,7 +493,7 @@ describe(commands.TASK_GET, () => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}/tasks?$select=id,title`) {
         return Promise.resolve(singleTaskByTitleResponse);
       }
-      if (opts.url === `https://graph.microsoft.com/beta/planner/tasks/${encodeURIComponent(validTaskId)}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}`) {
         return Promise.resolve(taskResponse);
       }
 
@@ -506,7 +520,7 @@ describe(commands.TASK_GET, () => {
 
   it('successfully handles item found', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/planner/tasks/01gzSlKkIUSUl6DF_EilrmQAKDhh`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/01gzSlKkIUSUl6DF_EilrmQAKDhh`) {
         return Promise.resolve({
           "createdBy": {
             "user": {

--- a/src/m365/planner/commands/task/task-get.ts
+++ b/src/m365/planner/commands/task/task-get.ts
@@ -185,6 +185,15 @@ class PlannerTaskGetCommand extends GraphCommand {
       });
   }
 
+  public optionSets(): string[][] | undefined {
+    return [
+      ['id', 'title'],
+      ['title', 'bucketId', 'bucketName'],
+      ['bucketName', 'planId', 'planName'],
+      ['planName', 'ownerGroupId', 'ownerGroupName']
+    ];
+  }
+
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       { option: '-i, --id [id]' },
@@ -202,38 +211,6 @@ class PlannerTaskGetCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (!args.options.id && !args.options.title) {
-      return 'Specify either id or title';
-    }
-
-    if (args.options.id && args.options.title) {
-      return 'Specify either id or title but not both';
-    }
-
-    if (args.options.title && !args.options.bucketId && !args.options.bucketName) {
-      return 'Specify either bucketId or bucketName when using title';
-    }
-
-    if (args.options.title && args.options.bucketId && args.options.bucketName) {
-      return 'Specify either bucketId or bucketName when using title but not both';
-    }
-
-    if (args.options.bucketName && !args.options.planId && !args.options.planName) {
-      return 'Specify either planId or planName when using bucketName';
-    }
-
-    if (args.options.bucketName && args.options.planId && args.options.planName) {
-      return 'Specify either planId or planName when using bucketName but not both';
-    }
-
-    if (args.options.planName && !args.options.ownerGroupId && !args.options.ownerGroupName) {
-      return 'Specify either ownerGroupId or ownerGroupName when using planName';
-    }
-
-    if (args.options.planName && args.options.ownerGroupId && args.options.ownerGroupName) {
-      return 'Specify either ownerGroupId or ownerGroupName when using planName but not both';
-    }
-
     if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId as string)) {
       return `${args.options.ownerGroupId} is not a valid GUID`;
     }

--- a/src/m365/planner/commands/task/task-get.ts
+++ b/src/m365/planner/commands/task/task-get.ts
@@ -187,10 +187,7 @@ class PlannerTaskGetCommand extends GraphCommand {
 
   public optionSets(): string[][] | undefined {
     return [
-      ['id', 'title'],
-      ['title', 'bucketId', 'bucketName'],
-      ['bucketName', 'planId', 'planName'],
-      ['planName', 'ownerGroupId', 'ownerGroupName']
+      ['id', 'title']
     ];
   }
 
@@ -211,6 +208,30 @@ class PlannerTaskGetCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
+    if (args.options.title && !args.options.bucketId && !args.options.bucketName) {
+      return 'Specify either bucketId or bucketName when using title';
+    }
+
+    if (args.options.title && args.options.bucketId && args.options.bucketName) {
+      return 'Specify either bucketId or bucketName when using title but not both';
+    }
+
+    if (args.options.bucketName && !args.options.planId && !args.options.planName) {
+      return 'Specify either planId or planName when using bucketName';
+    }
+
+    if (args.options.bucketName && args.options.planId && args.options.planName) {
+      return 'Specify either planId or planName when using bucketName but not both';
+    }
+
+    if (args.options.planName && !args.options.ownerGroupId && !args.options.ownerGroupName) {
+      return 'Specify either ownerGroupId or ownerGroupName when using planName';
+    }
+
+    if (args.options.planName && args.options.ownerGroupId && args.options.ownerGroupName) {
+      return 'Specify either ownerGroupId or ownerGroupName when using planName but not both';
+    }
+
     if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId as string)) {
       return `${args.options.ownerGroupId} is not a valid GUID`;
     }


### PR DESCRIPTION
Fixes `planner task get`. Closes #3324

1. `--id` or `--title` option is required.
2. Upgraded `/beta/planner/tasks/{id}` endpoint from `beta` to `v1.0`
3. Added `defaultProperties`
4. Added `getTelemetryProperties`
