### PR TITLE
Fix docs typo on `planner bucket get`. Closes #3351

### DIFF
--- a/docs/docs/cmd/planner/bucket/bucket-get.md
+++ b/docs/docs/cmd/planner/bucket/bucket-get.md
@@ -13,7 +13,7 @@ m365 planner bucket get [options]
 `-i, --id [id]`
 : ID of the bucket to retrieve details. Specify either `id` or `name` but not both.
 
-`-name, --name [name]`
+`--name [name]`
 : Name of the bucket to retrieve details. Specify either `id` or `name` but not both. 
 
 `--planId [planId]`


### PR DESCRIPTION
Fix docs typo on `planner bucket get`. Closes #3351