### PR TITLE
Fixes `spo listitem roleinheritance break` docs option description formatting. Closes #3358

### DIFF
--- a/docs/docs/cmd/spo/listitem/listitem-roleinheritance-break.md
+++ b/docs/docs/cmd/spo/listitem/listitem-roleinheritance-break.md
@@ -20,7 +20,7 @@ m365 spo listitem roleinheritance break [options]
 : ID of the list. Specify listId or listTitle but not both
 
 `-t, --listTitle [listTitle]`
-Title of the list. Specify listId or listTitle but not both
+: Title of the list. Specify listId or listTitle but not both
 
 `-c, --clearExistingPermissions`
 : Set to clear existing roles from the list item


### PR DESCRIPTION
Fixes `spo listitem roleinheritance break` docs option description. Closes #3358

## Contents
* Fixes description on new line
* Added new line at the end of the docs file (required to make `--help` option work properly)