### PR TITLE
Fixes `listTitle` option values with single quote . Closes #3357

### DIFF
--- a/src/m365/spo/commands/contenttype/contenttype-add.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-add.ts
@@ -150,7 +150,7 @@ class SpoContentTypeAddCommand extends SpoCommand {
           }
 
           const requestOptions: any = {
-            url: `${webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(listTitle)}')?$select=Id`,
+            url: `${webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitle)}')?$select=Id`,
             headers: {
               accept: 'application/json;odata=nometadata'
             },

--- a/src/m365/spo/commands/contenttype/contenttype-field-remove.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-field-remove.ts
@@ -95,7 +95,7 @@ class SpoContentTypeFieldRemoveCommand extends SpoCommand {
           }
           // Request for the ListId
           const requestOptions: any = {
-            url: `${args.options.webUrl}/_api/lists/GetByTitle('${encodeURIComponent(args.options.listTitle)}')?$select=Id`,
+            url: `${args.options.webUrl}/_api/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle)}')?$select=Id`,
             headers: {
               accept: 'application/json;odata=nometadata'
             },

--- a/src/m365/spo/commands/contenttype/contenttype-get.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-get.ts
@@ -2,7 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandError, CommandOption, CommandTypes } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -33,7 +33,7 @@ class SpoContentTypeGetCommand extends SpoCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
-    let requestUrl: string = `${args.options.webUrl}/_api/web/${(args.options.listTitle ? `lists/getByTitle('${encodeURIComponent(args.options.listTitle)}')/` : '')}contenttypes`;
+    let requestUrl: string = `${args.options.webUrl}/_api/web/${(args.options.listTitle ? `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle)}')/` : '')}contenttypes`;
 
     if (args.options.id) {
       requestUrl += `('${encodeURIComponent(args.options.id)}')`;

--- a/src/m365/spo/commands/eventreceiver/eventreceiver-get.ts
+++ b/src/m365/spo/commands/eventreceiver/eventreceiver-get.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -48,14 +48,14 @@ class SpoEventreceiverGetCommand extends SpoCommand {
     let filter: string = '?$filter=';
 
     if (args.options.listId) {
-      listUrl = `lists(guid'${encodeURIComponent(args.options.listId)}')/`;
+      listUrl = `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/`;
     }
     else if (args.options.listTitle) {
-      listUrl = `lists/getByTitle('${encodeURIComponent(args.options.listTitle)}')/`;
+      listUrl = `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle)}')/`;
     }
     else if (args.options.listUrl) {
       const listServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
-      listUrl = `GetList('${encodeURIComponent(listServerRelativeUrl)}')/`;
+      listUrl = `GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/`;
     }
 
     if (!args.options.scope || args.options.scope === 'web') {

--- a/src/m365/spo/commands/field/field-add.ts
+++ b/src/m365/spo/commands/field/field-add.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { spo, ContextInfo, validation } from '../../../../utils';
+import { spo, ContextInfo, validation, formatting } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -33,7 +33,7 @@ class SpoFieldAddCommand extends SpoCommand {
       .getRequestDigest(args.options.webUrl)
       .then((res: ContextInfo): Promise<any> => {
         const requestOptions: any = {
-          url: `${args.options.webUrl}/_api/web/${(args.options.listTitle ? `lists/getByTitle('${encodeURIComponent(args.options.listTitle)}')/` : '')}fields/CreateFieldAsXml`,
+          url: `${args.options.webUrl}/_api/web/${(args.options.listTitle ? `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle)}')/` : '')}fields/CreateFieldAsXml`,
           headers: {
             'X-RequestDigest': res.FormDigestValue,
             accept: 'application/json;odata=nometadata'

--- a/src/m365/spo/commands/field/field-get.ts
+++ b/src/m365/spo/commands/field/field-get.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -44,23 +44,23 @@ class SpoFieldGetCommand extends SpoCommand {
     let listRestUrl: string = '';
 
     if (args.options.listId) {
-      listRestUrl = `lists(guid'${encodeURIComponent(args.options.listId)}')/`;
+      listRestUrl = `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/`;
     }
     else if (args.options.listTitle) {
-      listRestUrl = `lists/getByTitle('${encodeURIComponent(args.options.listTitle as string)}')/`;
+      listRestUrl = `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/`;
     }
     else if (args.options.listUrl) {
       const listServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
 
-      listRestUrl = `GetList('${encodeURIComponent(listServerRelativeUrl)}')/`;
+      listRestUrl = `GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/`;
     }
 
     let fieldRestUrl: string = '';
     if (args.options.id) {
-      fieldRestUrl = `/getbyid('${encodeURIComponent(args.options.id)}')`;
+      fieldRestUrl = `/getbyid('${formatting.encodeQueryParameter(args.options.id)}')`;
     }
     else {
-      fieldRestUrl = `/getbyinternalnameortitle('${encodeURIComponent(args.options.fieldTitle as string)}')`;
+      fieldRestUrl = `/getbyinternalnameortitle('${formatting.encodeQueryParameter(args.options.fieldTitle as string)}')`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/field/field-list.ts
+++ b/src/m365/spo/commands/field/field-list.ts
@@ -2,7 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -42,15 +42,15 @@ class SpoFieldListCommand extends SpoCommand {
     let listUrl: string = '';
 
     if (args.options.listId) {
-      listUrl = `lists(guid'${encodeURIComponent(args.options.listId)}')/`;
+      listUrl = `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/`;
     }
     else if (args.options.listTitle) {
-      listUrl = `lists/getByTitle('${encodeURIComponent(args.options.listTitle)}')/`;
+      listUrl = `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle)}')/`;
     }
     else if (args.options.listUrl) {
       const listServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
 
-      listUrl = `GetList('${encodeURIComponent(listServerRelativeUrl)}')/`;
+      listUrl = `GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/field/field-remove.ts
+++ b/src/m365/spo/commands/field/field-remove.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -60,10 +60,10 @@ class SpoFieldRemoveCommand extends SpoCommand {
 
       let fieldRestUrl: string = '';
       if (fieldId) {
-        fieldRestUrl = `/getbyid('${encodeURIComponent(fieldId)}')`;
+        fieldRestUrl = `/getbyid('${formatting.encodeQueryParameter(fieldId)}')`;
       }
       else {
-        fieldRestUrl = `/getbyinternalnameortitle('${encodeURIComponent(fieldTitle as string)}')`;
+        fieldRestUrl = `/getbyinternalnameortitle('${formatting.encodeQueryParameter(fieldTitle as string)}')`;
       }
 
       const requestOptions: any = {
@@ -84,14 +84,14 @@ class SpoFieldRemoveCommand extends SpoCommand {
       let listRestUrl: string = '';
 
       if (args.options.listId) {
-        listRestUrl = `lists(guid'${encodeURIComponent(args.options.listId)}')/`;
+        listRestUrl = `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/`;
       }
       else if (args.options.listTitle) {
-        listRestUrl = `lists/getByTitle('${encodeURIComponent(args.options.listTitle as string)}')/`;
+        listRestUrl = `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/`;
       }
       else if (args.options.listUrl) {
         const listServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
-        listRestUrl = `GetList('${encodeURIComponent(listServerRelativeUrl)}')/`;
+        listRestUrl = `GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/`;
       }
 
       if (args.options.group) {

--- a/src/m365/spo/commands/file/file-sharinginfo-get.ts
+++ b/src/m365/spo/commands/file/file-sharinginfo-get.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { FileSharingPrincipalType } from './FileSharingPrincipalType';
@@ -81,7 +81,7 @@ class SpoFileSharinginfoGetCommand extends SpoCommand {
         }
 
         const requestOptions: any = {
-          url: `${args.options.webUrl}/_api/web/lists/getbytitle('${fileInformation.libraryName}')/items(${fileInformation.fileItemId})/GetSharingInformation?$select=permissionsInformation&$Expand=permissionsInformation`,
+          url: `${args.options.webUrl}/_api/web/lists/getbytitle('${formatting.encodeQueryParameter(fileInformation.libraryName)}')/items(${fileInformation.fileItemId})/GetSharingInformation?$select=permissionsInformation&$Expand=permissionsInformation`,
           headers: {
             'accept': 'application/json;odata=nometadata'
           },

--- a/src/m365/spo/commands/list/list-contenttype-add.ts
+++ b/src/m365/spo/commands/list/list-contenttype-add.ts
@@ -44,7 +44,7 @@ class SpoListContentTypeAddCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (this.verbose) {
-      const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
+      const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
       logger.logToStderr(`Adding content type ${args.options.contentTypeId} to list ${list} in site at ${args.options.webUrl}...`);
     }
 

--- a/src/m365/spo/commands/list/list-contenttype-add.ts
+++ b/src/m365/spo/commands/list/list-contenttype-add.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -51,10 +51,10 @@ class SpoListContentTypeAddCommand extends SpoCommand {
     let requestUrl: string = '';
 
     if (args.options.listId) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/ContentTypes/AddAvailableContentType`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/ContentTypes/AddAvailableContentType`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/ContentTypes/AddAvailableContentType`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/ContentTypes/AddAvailableContentType`;
     }
 
     const requestBody: any = this.mapRequestBody(args.options);

--- a/src/m365/spo/commands/list/list-contenttype-default-set.ts
+++ b/src/m365/spo/commands/list/list-contenttype-default-set.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -55,8 +55,8 @@ class SpoListContentTypeDefaultSetCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     const baseUrl: string = args.options.listId ?
-      `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')` :
-      `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+      `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')` :
+      `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
 
     if (this.verbose) {
       logger.logToStderr('Retrieving content type order...');

--- a/src/m365/spo/commands/list/list-contenttype-list.ts
+++ b/src/m365/spo/commands/list/list-contenttype-list.ts
@@ -40,7 +40,7 @@ class SpoListContentTypeListCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (this.verbose) {
-      const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
+      const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
       logger.logToStderr(`Retrieving content types information for list ${list} in site at ${args.options.webUrl}...`);
     }
 

--- a/src/m365/spo/commands/list/list-contenttype-list.ts
+++ b/src/m365/spo/commands/list/list-contenttype-list.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -47,10 +47,10 @@ class SpoListContentTypeListCommand extends SpoCommand {
     let requestUrl: string = '';
 
     if (args.options.listId) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/ContentTypes`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/ContentTypes`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/ContentTypes`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/ContentTypes`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-contenttype-remove.ts
+++ b/src/m365/spo/commands/list/list-contenttype-remove.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -54,10 +54,10 @@ class SpoListContentTypeRemoveCommand extends SpoCommand {
       let requestUrl: string = '';
 
       if (args.options.listId) {
-        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/ContentTypes('${encodeURIComponent(args.options.contentTypeId)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/ContentTypes('${encodeURIComponent(args.options.contentTypeId)}')`;
       }
       else {
-        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/ContentTypes('${encodeURIComponent(args.options.contentTypeId)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/ContentTypes('${encodeURIComponent(args.options.contentTypeId)}')`;
       }
 
       const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-contenttype-remove.ts
+++ b/src/m365/spo/commands/list/list-contenttype-remove.ts
@@ -47,7 +47,7 @@ class SpoListContentTypeRemoveCommand extends SpoCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     const removeContentTypeFromList: () => void = (): void => {
       if (this.verbose) {
-        const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
+        const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
         logger.logToStderr(`Removing content type ${args.options.contentTypeId} from list ${list} in site at ${args.options.webUrl}...`);
       }
 

--- a/src/m365/spo/commands/list/list-get.ts
+++ b/src/m365/spo/commands/list/list-get.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListInstance } from "./ListInstance";
@@ -47,10 +47,10 @@ class SpoListGetCommand extends SpoCommand {
     let requestUrl: string = '';
 
     if (args.options.id) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.id)}')`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.id)}')`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.title as string)}')`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.title as string)}')`;
     }
 
     let propertiesSelect: string = args.options.properties ? `?$select=${encodeURIComponent(args.options.properties)}` : ``;

--- a/src/m365/spo/commands/list/list-label-get.ts
+++ b/src/m365/spo/commands/list/list-label-get.ts
@@ -37,7 +37,7 @@ class SpoListLabelGetCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
     if (this.verbose) {
-      const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
+      const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
       logger.logToStderr(`Getting label set on the list ${list} in site at ${args.options.webUrl}...`);
     }
 

--- a/src/m365/spo/commands/list/list-label-get.ts
+++ b/src/m365/spo/commands/list/list-label-get.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListInstance } from './ListInstance';
@@ -48,14 +48,14 @@ class SpoListLabelGetCommand extends SpoCommand {
         logger.logToStderr(`Retrieving List Url from Id '${args.options.listId}'...`);
       }
 
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')?$expand=RootFolder&$select=RootFolder`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')?$expand=RootFolder&$select=RootFolder`;
     }
     else {
       if (this.debug) {
         logger.logToStderr(`Retrieving List Url from Title '${args.options.listTitle}'...`);
       }
 
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')?$expand=RootFolder&$select=RootFolder`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')?$expand=RootFolder&$select=RootFolder`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-label-set.ts
+++ b/src/m365/spo/commands/list/list-label-set.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListInstance } from './ListInstance';
@@ -54,10 +54,10 @@ class SpoListLabelSetCommand extends SpoCommand {
         return Promise.resolve(listServerRelativeUrl);
       }
       else if (args.options.listId) {
-        listRestUrl = `lists(guid'${encodeURIComponent(args.options.listId)}')/`;
+        listRestUrl = `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/`;
       }
       else {
-        listRestUrl = `lists/getByTitle('${encodeURIComponent(args.options.listTitle as string)}')/`;
+        listRestUrl = `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/`;
       }
 
       const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-remove.ts
+++ b/src/m365/spo/commands/list/list-remove.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -45,10 +45,10 @@ class SpoListRemoveCommand extends SpoCommand {
       let requestUrl: string = '';
 
       if (args.options.id) {
-        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.id)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.id)}')`;
       }
       else {
-        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.title as string)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.title as string)}')`;
       }
 
       const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-roleinheritance-break.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-break.ts
@@ -2,7 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -48,10 +48,10 @@ class SpoListRoleInheritanceBreakCommand extends SpoCommand {
     let requestUrl: string = `${args.options.webUrl}/_api/web/lists`;
 
     if (args.options.listId) {
-      requestUrl += `(guid'${encodeURIComponent(args.options.listId)}')`;
+      requestUrl += `(guid'${formatting.encodeQueryParameter(args.options.listId)}')`;
     }
     else {
-      requestUrl += `/getbytitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+      requestUrl += `/getbytitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
     }
 
     let keepExistingPermissions: boolean = true;

--- a/src/m365/spo/commands/list/list-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-reset.ts
@@ -2,7 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -46,10 +46,10 @@ class SpoListRoleInheritanceResetCommand extends SpoCommand {
     let requestUrl: string = `${args.options.webUrl}/_api/web/lists`;
 
     if (args.options.listId) {
-      requestUrl += `(guid'${encodeURIComponent(args.options.listId)}')`;
+      requestUrl += `(guid'${formatting.encodeQueryParameter(args.options.listId)}')`;
     }
     else {
-      requestUrl += `/getbytitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+      requestUrl += `/getbytitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-sitescript-get.ts
+++ b/src/m365/spo/commands/list/list-sitescript-get.ts
@@ -37,7 +37,7 @@ class SpoListSiteScriptGetCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
     if (this.verbose) {
-      const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
+      const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
       logger.logToStderr(`Extracting Site Script from list ${list} in site at ${args.options.webUrl}...`);
     }
 

--- a/src/m365/spo/commands/list/list-sitescript-get.ts
+++ b/src/m365/spo/commands/list/list-sitescript-get.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListInstance } from './ListInstance';
@@ -47,13 +47,13 @@ class SpoListSiteScriptGetCommand extends SpoCommand {
       if (this.debug) {
         logger.logToStderr(`Retrieving List Url from Id '${args.options.listId}'...`);
       }
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')?$expand=RootFolder`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')?$expand=RootFolder`;
     }
     else {
       if (this.debug) {
         logger.logToStderr(`Retrieving List Url from Title '${args.options.listTitle}'...`);
       }
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')?$expand=RootFolder`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')?$expand=RootFolder`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-view-add.ts
+++ b/src/m365/spo/commands/list/list-view-add.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import SpoCommand from '../../../base/SpoCommand';
@@ -80,13 +80,13 @@ class SpoListViewAddCommand extends SpoCommand {
   private getRestUrl(options: Options): string {
     let result: string = `${options.webUrl}/_api/web/`;
     if (options.listId) {
-      result += `lists(guid'${encodeURIComponent(options.listId)}')`;
+      result += `lists(guid'${formatting.encodeQueryParameter(options.listId)}')`;
     }
     else if (options.listTitle) {
-      result += `lists/getByTitle('${encodeURIComponent(options.listTitle)}')`;
+      result += `lists/getByTitle('${formatting.encodeQueryParameter(options.listTitle)}')`;
     }
     else if (options.listUrl) {
-      result += `GetList('${encodeURIComponent(urlUtil.getServerRelativePath(options.webUrl, options.listUrl))}')`;
+      result += `GetList('${formatting.encodeQueryParameter(urlUtil.getServerRelativePath(options.webUrl, options.listUrl))}')`;
     }
     result += '/views/add';
     

--- a/src/m365/spo/commands/list/list-view-field-add.ts
+++ b/src/m365/spo/commands/list/list-view-field-add.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -45,7 +45,7 @@ class SpoListViewFieldAddCommand extends SpoCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    const listSelector: string = args.options.listId ? `(guid'${encodeURIComponent(args.options.listId)}')` : `/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+    const listSelector: string = args.options.listId ? `(guid'${formatting.encodeQueryParameter(args.options.listId)}')` : `/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
     let viewSelector: string = '';
     let currentField: { InternalName: string; };
 
@@ -62,7 +62,7 @@ class SpoListViewFieldAddCommand extends SpoCommand {
 
         currentField = field;
 
-        viewSelector = args.options.viewId ? `('${encodeURIComponent(args.options.viewId)}')` : `/GetByTitle('${encodeURIComponent(args.options.viewTitle as string)}')`;
+        viewSelector = args.options.viewId ? `('${formatting.encodeQueryParameter(args.options.viewId)}')` : `/GetByTitle('${formatting.encodeQueryParameter(args.options.viewTitle as string)}')`;
         const postRequestUrl: string = `${args.options.webUrl}/_api/web/lists${listSelector}/views${viewSelector}/viewfields/addviewfield('${field.InternalName}')`;
 
         const postRequestOptions: any = {

--- a/src/m365/spo/commands/list/list-view-field-remove.ts
+++ b/src/m365/spo/commands/list/list-view-field-remove.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -45,7 +45,7 @@ class SpoListViewFieldRemoveCommand extends SpoCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    const listSelector: string = args.options.listId ? `(guid'${encodeURIComponent(args.options.listId)}')` : `/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+    const listSelector: string = args.options.listId ? `(guid'${formatting.encodeQueryParameter(args.options.listId)}')` : `/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
 
     const removeFieldFromView: () => void = (): void => {
       if (this.verbose) {
@@ -59,7 +59,7 @@ class SpoListViewFieldRemoveCommand extends SpoCommand {
             logger.logToStderr(`Removing field ${args.options.fieldId || args.options.fieldTitle} from view ${args.options.viewId || args.options.viewTitle}...`);
           }
 
-          const viewSelector: string = args.options.viewId ? `('${encodeURIComponent(args.options.viewId)}')` : `/GetByTitle('${encodeURIComponent(args.options.viewTitle as string)}')`;
+          const viewSelector: string = args.options.viewId ? `('${formatting.encodeQueryParameter(args.options.viewId)}')` : `/GetByTitle('${formatting.encodeQueryParameter(args.options.viewTitle as string)}')`;
           const postRequestUrl: string = `${args.options.webUrl}/_api/web/lists${listSelector}/views${viewSelector}/viewfields/removeviewfield('${field.InternalName}')`;
 
           const postRequestOptions: any = {

--- a/src/m365/spo/commands/list/list-view-field-set.ts
+++ b/src/m365/spo/commands/list/list-view-field-set.ts
@@ -2,7 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -42,8 +42,8 @@ class SpoListViewFieldSetCommand extends SpoCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    const listSelector: string = args.options.listId ? `(guid'${encodeURIComponent(args.options.listId)}')` : `/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
-    const viewSelector: string = args.options.viewId ? `('${encodeURIComponent(args.options.viewId)}')` : `/GetByTitle('${encodeURIComponent(args.options.viewTitle as string)}')`;
+    const listSelector: string = args.options.listId ? `(guid'${formatting.encodeQueryParameter(args.options.listId)}')` : `/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
+    const viewSelector: string = args.options.viewId ? `('${formatting.encodeQueryParameter(args.options.viewId)}')` : `/GetByTitle('${formatting.encodeQueryParameter(args.options.viewTitle as string)}')`;
 
     if (this.verbose) {
       logger.logToStderr(`Getting field ${args.options.fieldId || args.options.fieldTitle}...`);

--- a/src/m365/spo/commands/list/list-view-get.ts
+++ b/src/m365/spo/commands/list/list-view-get.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { urlUtil, validation } from '../../../../utils';
+import { formatting, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -45,18 +45,18 @@ class SpoListViewGetCommand extends SpoCommand {
     let listRestUrl: string = '';
 
     if (args.options.listId) {
-      listRestUrl = `/lists(guid'${encodeURIComponent(args.options.listId)}')`;
+      listRestUrl = `/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')`;
     }
     else if (args.options.listTitle) {
-      listRestUrl = `/lists/getByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+      listRestUrl = `/lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
     }
     else if (args.options.listUrl) {
       const listServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
 
-      listRestUrl = `/GetList('${encodeURIComponent(listServerRelativeUrl)}')`;
+      listRestUrl = `/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
     }
 
-    const viewRestUrl: string = `/views/${(args.options.viewId ? `getById('${encodeURIComponent(args.options.viewId)}')` : `getByTitle('${encodeURIComponent(args.options.viewTitle as string)}')`)}`;
+    const viewRestUrl: string = `/views/${(args.options.viewId ? `getById('${formatting.encodeQueryParameter(args.options.viewId)}')` : `getByTitle('${formatting.encodeQueryParameter(args.options.viewTitle as string)}')`)}`;
 
     const requestOptions: any = {
       url: `${baseRestUrl}${listRestUrl}${viewRestUrl}`,

--- a/src/m365/spo/commands/list/list-view-list.ts
+++ b/src/m365/spo/commands/list/list-view-list.ts
@@ -40,7 +40,7 @@ class SpoListViewListCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (this.verbose) {
-      const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
+      const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
       logger.logToStderr(`Retrieving views information for list ${list} in site at ${args.options.webUrl}...`);
     }
 

--- a/src/m365/spo/commands/list/list-view-list.ts
+++ b/src/m365/spo/commands/list/list-view-list.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -47,10 +47,10 @@ class SpoListViewListCommand extends SpoCommand {
     let requestUrl: string = '';
 
     if (args.options.listId) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/views`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/views`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/views`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/views`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-view-remove.ts
+++ b/src/m365/spo/commands/list/list-view-remove.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -48,8 +48,8 @@ class SpoListViewRemoveCommand extends SpoCommand {
       }
 
       let requestUrl: string = '';
-      const listSelector: string = args.options.listId ? `(guid'${encodeURIComponent(args.options.listId)}')` : `/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
-      const viewSelector: string = args.options.viewId ? `(guid'${encodeURIComponent(args.options.viewId)}')` : `/GetByTitle('${encodeURIComponent(args.options.viewTitle as string)}')`;
+      const listSelector: string = args.options.listId ? `(guid'${formatting.encodeQueryParameter(args.options.listId)}')` : `/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
+      const viewSelector: string = args.options.viewId ? `(guid'${formatting.encodeQueryParameter(args.options.viewId)}')` : `/GetByTitle('${formatting.encodeQueryParameter(args.options.viewTitle as string)}')`;
 
       requestUrl = `${args.options.webUrl}/_api/web/lists${listSelector}/views${viewSelector}`;
 

--- a/src/m365/spo/commands/list/list-view-remove.ts
+++ b/src/m365/spo/commands/list/list-view-remove.ts
@@ -43,7 +43,7 @@ class SpoListViewRemoveCommand extends SpoCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     const removeViewFromList: () => void = (): void => {
       if (this.verbose) {
-        const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
+        const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
         logger.logToStderr(`Removing view ${args.options.viewId || args.options.viewTitle} from list ${list} in site at ${args.options.webUrl}...`);
       }
 

--- a/src/m365/spo/commands/list/list-view-set.ts
+++ b/src/m365/spo/commands/list/list-view-set.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { ContextInfo, spo, validation } from '../../../../utils';
+import { ContextInfo, formatting, spo, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -45,9 +45,9 @@ class SpoListViewSetCommand extends SpoCommand {
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     const baseRestUrl: string = `${args.options.webUrl}/_api/web/lists`;
     const listRestUrl: string = args.options.listId ?
-      `(guid'${encodeURIComponent(args.options.listId)}')`
-      : `/getByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
-    const viewRestUrl: string = `/views/${(args.options.viewId ? `getById('${encodeURIComponent(args.options.viewId)}')` : `getByTitle('${encodeURIComponent(args.options.viewTitle as string)}')`)}`;
+      `(guid'${formatting.encodeQueryParameter(args.options.listId)}')`
+      : `/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
+    const viewRestUrl: string = `/views/${(args.options.viewId ? `getById('${formatting.encodeQueryParameter(args.options.viewId)}')` : `getByTitle('${formatting.encodeQueryParameter(args.options.viewTitle as string)}')`)}`;
 
     spo
       .getRequestDigest(args.options.webUrl)

--- a/src/m365/spo/commands/list/list-webhook-add.ts
+++ b/src/m365/spo/commands/list/list-webhook-add.ts
@@ -46,7 +46,7 @@ class SpoListWebhookAddCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (this.verbose) {
-      logger.logToStderr(`Adding webhook to list ${args.options.listId ? encodeURIComponent(args.options.listId) : encodeURIComponent(args.options.listTitle as string)} located at site ${args.options.webUrl}...`);
+      logger.logToStderr(`Adding webhook to list ${args.options.listId ? formatting.encodeQueryParameter(args.options.listId) : formatting.encodeQueryParameter(args.options.listTitle as string)} located at site ${args.options.webUrl}...`);
     }
 
     let requestUrl: string = '';

--- a/src/m365/spo/commands/list/list-webhook-add.ts
+++ b/src/m365/spo/commands/list/list-webhook-add.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -52,10 +52,10 @@ class SpoListWebhookAddCommand extends SpoCommand {
     let requestUrl: string = '';
 
     if (args.options.listId) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/Subscriptions')`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/Subscriptions')`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/Subscriptions')`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/Subscriptions')`;
     }
 
     const requestBody: any = {};

--- a/src/m365/spo/commands/list/list-webhook-get.ts
+++ b/src/m365/spo/commands/list/list-webhook-get.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -45,10 +45,10 @@ class SpoListWebhookGetCommand extends SpoCommand {
     let requestUrl: string = '';
 
     if (args.options.listId) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/Subscriptions('${encodeURIComponent(args.options.id)}')`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/Subscriptions('${formatting.encodeQueryParameter(args.options.id)}')`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/Subscriptions('${encodeURIComponent(args.options.id)}')`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/Subscriptions('${formatting.encodeQueryParameter(args.options.id)}')`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-webhook-get.ts
+++ b/src/m365/spo/commands/list/list-webhook-get.ts
@@ -38,7 +38,7 @@ class SpoListWebhookGetCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (this.verbose) {
-      const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
+      const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
       logger.logToStderr(`Retrieving information for webhook ${args.options.id} belonging to list ${list} in site at ${args.options.webUrl}...`);
     }
 

--- a/src/m365/spo/commands/list/list-webhook-list.ts
+++ b/src/m365/spo/commands/list/list-webhook-list.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -60,16 +60,16 @@ class SpoListWebhookListCommand extends SpoCommand {
     let requestUrl: string = '';
 
     if (args.options.id) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.id)}')/Subscriptions`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.id)}')/Subscriptions`;
     }
     else if (args.options.listId) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/Subscriptions`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/Subscriptions`;
     }
     else if (args.options.listTitle) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/Subscriptions`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/Subscriptions`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.title as string)}')/Subscriptions`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.title as string)}')/Subscriptions`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-webhook-list.ts
+++ b/src/m365/spo/commands/list/list-webhook-list.ts
@@ -53,7 +53,7 @@ class SpoListWebhookListCommand extends SpoCommand {
     }
 
     if (this.verbose) {
-      const list: string = args.options.id ? encodeURIComponent(args.options.id as string) : (args.options.listId ? encodeURIComponent(args.options.listId as string) : (args.options.title ? encodeURIComponent(args.options.title as string) : encodeURIComponent(args.options.listTitle as string)));
+      const list: string = args.options.id ? formatting.encodeQueryParameter(args.options.id as string) : (args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : (args.options.title ? formatting.encodeQueryParameter(args.options.title as string) : formatting.encodeQueryParameter(args.options.listTitle as string)));
       logger.logToStderr(`Retrieving webhook information for list ${list} in site at ${args.options.webUrl}...`);
     }
 

--- a/src/m365/spo/commands/list/list-webhook-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-webhook-remove.spec.ts
@@ -203,7 +203,7 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
 
     command.action(logger, {
       options: {
-        debug: false,
+        debug: true,
         id: '0cd891ef-afce-4e55-b836-fce03286cccf',
         webUrl: 'https://contoso.sharepoint.com',
         listId: 'cc27a922-8224-4296-90a5-ebbc54da2e81',

--- a/src/m365/spo/commands/list/list-webhook-remove.ts
+++ b/src/m365/spo/commands/list/list-webhook-remove.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -49,10 +49,10 @@ class SpoListWebhookRemoveCommand extends SpoCommand {
       let requestUrl: string = '';
 
       if (args.options.listId) {
-        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/Subscriptions('${encodeURIComponent(args.options.id)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/Subscriptions('${formatting.encodeQueryParameter(args.options.id)}')`;
       }
       else {
-        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/Subscriptions('${encodeURIComponent(args.options.id)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/Subscriptions('${formatting.encodeQueryParameter(args.options.id)}')`;
       }
 
       const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-webhook-remove.ts
+++ b/src/m365/spo/commands/list/list-webhook-remove.ts
@@ -39,10 +39,9 @@ class SpoListWebhookRemoveCommand extends SpoCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    const list: string = args.options.listId ? encodeURIComponent(args.options.listId as string) : encodeURIComponent(args.options.listTitle as string);
-
     const removeWebhook: () => void = (): void => {
       if (this.verbose) {
+        const list: string = args.options.listId ? formatting.encodeQueryParameter(args.options.listId as string) : formatting.encodeQueryParameter(args.options.listTitle as string);
         logger.logToStderr(`Webhook ${args.options.id} is about to be removed from list ${list} located at site ${args.options.webUrl}...`);
       }
 
@@ -82,7 +81,7 @@ class SpoListWebhookRemoveCommand extends SpoCommand {
         type: 'confirm',
         name: 'continue',
         default: false,
-        message: `Are you sure you want to remove webhook ${args.options.id} from list ${list} located at site ${args.options.webUrl}?`
+        message: `Are you sure you want to remove webhook ${args.options.id} from list ${args.options.listTitle || args.options.listId} located at site ${args.options.webUrl}?`
       }, (result: { continue: boolean }): void => {
         if (!result.continue) {
           cb();

--- a/src/m365/spo/commands/list/list-webhook-set.ts
+++ b/src/m365/spo/commands/list/list-webhook-set.ts
@@ -42,7 +42,7 @@ class SpoListWebhookSetCommand extends SpoCommand {
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (this.verbose) {
-      logger.logToStderr(`Updating webhook ${args.options.id} belonging to list ${args.options.listId ? encodeURIComponent(args.options.listId) : encodeURIComponent(args.options.listTitle as string)} located at site ${args.options.webUrl}...`);
+      logger.logToStderr(`Updating webhook ${args.options.id} belonging to list ${args.options.listId ? formatting.encodeQueryParameter(args.options.listId) : formatting.encodeQueryParameter(args.options.listTitle as string)} located at site ${args.options.webUrl}...`);
     }
 
     let requestUrl: string = '';

--- a/src/m365/spo/commands/list/list-webhook-set.ts
+++ b/src/m365/spo/commands/list/list-webhook-set.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -48,10 +48,10 @@ class SpoListWebhookSetCommand extends SpoCommand {
     let requestUrl: string = '';
 
     if (args.options.listId) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')/Subscriptions('${encodeURIComponent(args.options.id)}')`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/Subscriptions('${formatting.encodeQueryParameter(args.options.id)}')`;
     }
     else {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')/Subscriptions('${encodeURIComponent(args.options.id)}')`;
+      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/Subscriptions('${formatting.encodeQueryParameter(args.options.id)}')`;
     }
 
     const requestBody: any = {};

--- a/src/m365/spo/commands/listitem/listitem-add.ts
+++ b/src/m365/spo/commands/listitem/listitem-add.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { spo, urlUtil, validation } from '../../../../utils';
+import { formatting, spo, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListItemInstance } from './ListItemInstance';
@@ -56,8 +56,8 @@ class SpoListItemAddCommand extends SpoCommand {
     const listIdArgument = args.options.listId || '';
     const listTitleArgument = args.options.listTitle || '';
     const listRestUrl: string = (args.options.listId ?
-      `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(listIdArgument)}')`
-      : `${args.options.webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(listTitleArgument)}')`);
+      `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listIdArgument)}')`
+      : `${args.options.webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitleArgument)}')`);
     let contentTypeName: string = '';
     let targetFolderServerRelativeUrl: string = '';
 

--- a/src/m365/spo/commands/listitem/listitem-attachment-list.ts
+++ b/src/m365/spo/commands/listitem/listitem-attachment-list.ts
@@ -2,7 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -41,8 +41,8 @@ class SpoListItemAttachmentListCommand extends SpoCommand {
     const listIdArgument = args.options.listId || '';
     const listTitleArgument = args.options.listTitle || '';
     const listRestUrl: string = (args.options.listId ?
-      `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(listIdArgument)}')`
-      : `${args.options.webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(listTitleArgument)}')`);
+      `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listIdArgument)}')`
+      : `${args.options.webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitleArgument)}')`);
 
     const requestOptions: any = {
       url: `${listRestUrl}/items(${args.options.itemId})?$select=AttachmentFiles&$expand=AttachmentFiles`,

--- a/src/m365/spo/commands/listitem/listitem-get.ts
+++ b/src/m365/spo/commands/listitem/listitem-get.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListItemInstance } from './ListItemInstance';
@@ -46,8 +46,8 @@ class SpoListItemGetCommand extends SpoCommand {
     const listIdArgument = args.options.listId || '';
     const listTitleArgument = args.options.listTitle || '';
     const listRestUrl: string = (args.options.listId ?
-      `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(listIdArgument)}')`
-      : `${args.options.webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(listTitleArgument)}')`);
+      `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listIdArgument)}')`
+      : `${args.options.webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitleArgument)}')`);
 
     const propertiesSelect: string = args.options.properties ?
       `?$select=${encodeURIComponent(args.options.properties)}` :

--- a/src/m365/spo/commands/listitem/listitem-isrecord.ts
+++ b/src/m365/spo/commands/listitem/listitem-isrecord.ts
@@ -6,7 +6,7 @@ import {
 import config from '../../../../config';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { ClientSvcResponse, ClientSvcResponseContents, ContextInfo, IdentityResponse, spo, validation } from '../../../../utils';
+import { ClientSvcResponse, ClientSvcResponseContents, ContextInfo, formatting, IdentityResponse, spo, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -48,8 +48,8 @@ class SpoListItemIsRecordCommand extends SpoCommand {
     const listIdArgument: string = args.options.listId || '';
     const listTitleArgument: string = args.options.listTitle || '';
     const listRestUrl: string = (args.options.listId ?
-      `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(listIdArgument)}')`
-      : `${args.options.webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(listTitleArgument)}')`);
+      `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listIdArgument)}')`
+      : `${args.options.webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitleArgument)}')`);
 
     let formDigestValue: string = '';
     let listId: string = '';

--- a/src/m365/spo/commands/listitem/listitem-list.ts
+++ b/src/m365/spo/commands/listitem/listitem-list.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { ContextInfo, spo, validation } from '../../../../utils';
+import { ContextInfo, formatting, spo, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListItemInstanceCollection } from './ListItemInstanceCollection';
@@ -56,8 +56,8 @@ class SpoListItemListCommand extends SpoCommand {
       : (!args.options.output || args.options.output === "text") ? ["Title", "Id"] : [];
 
     const listRestUrl: string = (args.options.id ?
-      `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(listIdArgument)}')`
-      : `${args.options.webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(listTitleArgument)}')`);
+      `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listIdArgument)}')`
+      : `${args.options.webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitleArgument)}')`);
 
     ((): Promise<any> => {
       if (args.options.camlQuery) {

--- a/src/m365/spo/commands/listitem/listitem-record-declare.ts
+++ b/src/m365/spo/commands/listitem/listitem-record-declare.ts
@@ -5,7 +5,7 @@ import {
 import config from "../../../../config";
 import GlobalOptions from "../../../../GlobalOptions";
 import request from '../../../../request';
-import { ClientSvcResponse, ClientSvcResponseContents, ContextInfo, IdentityResponse, spo, validation } from "../../../../utils";
+import { ClientSvcResponse, ClientSvcResponseContents, ContextInfo, formatting, IdentityResponse, spo, validation } from "../../../../utils";
 import SpoCommand from "../../../base/SpoCommand";
 import commands from "../../commands";
 
@@ -44,8 +44,8 @@ class SpoListItemRecordDeclareCommand extends SpoCommand {
     let listId: string = '';
 
     const listRestUrl: string = args.options.listId
-      ? `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')`
-      : `${args.options.webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+      ? `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')`
+      : `${args.options.webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
 
     spo
       .getRequestDigest(args.options.webUrl)

--- a/src/m365/spo/commands/listitem/listitem-record-undeclare.ts
+++ b/src/m365/spo/commands/listitem/listitem-record-undeclare.ts
@@ -5,7 +5,7 @@ import {
 import config from '../../../../config';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { ContextInfo, IdentityResponse, spo, validation } from '../../../../utils';
+import { ContextInfo, formatting, IdentityResponse, spo, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -40,8 +40,8 @@ class SpoListItemRecordUndeclareCommand extends SpoCommand {
     const listIdArgument: string = args.options.listId || '';
     const listTitleArgument: string = args.options.listTitle || '';
     const listRestUrl: string = (args.options.listId ?
-      `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(listIdArgument)}')`
-      : `${args.options.webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(listTitleArgument)}')`);
+      `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listIdArgument)}')`
+      : `${args.options.webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitleArgument)}')`);
 
     let formDigestValue: string = '';
     let environmentListId: string = '';

--- a/src/m365/spo/commands/listitem/listitem-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-remove.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -48,10 +48,10 @@ class SpoListItemRemoveCommand extends SpoCommand {
       let requestUrl: string = '';
 
       if (args.options.listId) {
-        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(args.options.listId)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')`;
       }
       else {
-        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
       }
 
       requestUrl += `/items(${args.options.id})`;

--- a/src/m365/spo/commands/listitem/listitem-roleinheritance-break.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleinheritance-break.ts
@@ -2,7 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -41,10 +41,10 @@ class SpoListItemRoleInheritanceBreakCommand extends SpoCommand {
     let requestUrl: string = `${args.options.webUrl}/_api/web/lists`;
 
     if (args.options.listId) {
-      requestUrl += `(guid'${encodeURIComponent(args.options.listId)}')`;
+      requestUrl += `(guid'${formatting.encodeQueryParameter(args.options.listId)}')`;
     }
     else {
-      requestUrl += `/getbytitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+      requestUrl += `/getbytitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
     }
 
     let keepExistingPermissions: boolean = true;

--- a/src/m365/spo/commands/listitem/listitem-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleinheritance-reset.ts
@@ -2,7 +2,7 @@ import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 
@@ -37,10 +37,10 @@ class SpoListItemRoleInheritanceResetCommand extends SpoCommand {
     let requestUrl: string = `${args.options.webUrl}/_api/web/lists`;
 
     if (args.options.listId) {
-      requestUrl += `(guid'${encodeURIComponent(args.options.listId)}')`;
+      requestUrl += `(guid'${formatting.encodeQueryParameter(args.options.listId)}')`;
     }
     else {
-      requestUrl += `/getbytitle('${encodeURIComponent(args.options.listTitle as string)}')`;
+      requestUrl += `/getbytitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')`;
     }
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/listitem/listitem-set.ts
+++ b/src/m365/spo/commands/listitem/listitem-set.ts
@@ -6,7 +6,7 @@ import {
 import config from '../../../../config';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { ClientSvcResponse, ClientSvcResponseContents, ContextInfo, spo, validation } from '../../../../utils';
+import { ClientSvcResponse, ClientSvcResponseContents, ContextInfo, formatting, spo, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListItemInstance } from './ListItemInstance';
@@ -50,8 +50,8 @@ class SpoListItemSetCommand extends SpoCommand {
     const listIdArgument = args.options.listId || '';
     const listTitleArgument = args.options.listTitle || '';
     const listRestUrl: string = (args.options.listId ?
-      `${args.options.webUrl}/_api/web/lists(guid'${encodeURIComponent(listIdArgument)}')`
-      : `${args.options.webUrl}/_api/web/lists/getByTitle('${encodeURIComponent(listTitleArgument)}')`);
+      `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listIdArgument)}')`
+      : `${args.options.webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitleArgument)}')`);
     let contentTypeName: string = '';
 
     let formDigestValue: string = '';


### PR DESCRIPTION
Fixes `listTitle` option values with single quote. Closes #3357

## Remarks
I've updated also the URLs to retrieve lists by GUID and URL. However they don't contain a single quote, I updated them also to maintain consistency.

## Updated commands
1. spo contenttype add
2. spo contenttype field remove
3. spo contenttype get
4. spo eventreceiver get
5. spo field add
6. spo field get
7. spo field list
8. spo field remove
9. spo file sharinginfo get
10. spo list contenttype add
11. spo list contenttype default set
12. spo list contenttype list
13. spo list contenttype remove
14. spo list get
15. spo list label get
16. spo list label set
17. spo list remove
18. spo list roleinheritance break
19. spo list roleinheritance reset
20. spo list sitescript get
21. spo list view add
22. spo list view field add
23. spo list view field remove
24. spo list view field set
25. spo list view get
26. spo list view list
27. spo list view remove
28. spo list view set
29. spo list webhook add
30. spo list webhook get
31. spo list webhook list
32. spo list webhook remove
33. spo list webhook set
34. spo listitem add
35. spo listitem attachment list
36. spo listitem get
37. spo listitem isrecord
38. spo listitem list
39. spo listitem record declare
40. spo listitem record undeclare
41. spo listitem remove
42. spo listitem roleinheritance break
43. spo listitem roleinheritance reset
44. spo listitem set