### PR TITLE
Fixes documenation of "m365 file list" command. Closes #3368

### DIFF
--- a/docs/docs/cmd/file/file-list.md
+++ b/docs/docs/cmd/file/file-list.md
@@ -14,7 +14,7 @@ m365 file list [options]
 : The URL of the site where the folder from which to retrieve files is located
 
 `-f, --folderUrl <folderUrl>`
-: The site-relative URL of the folder from which to retrieve files
+: The server- or site-relative URL of the folder from which to retrieve files
 
 `--recursive`
 : Set to retrieve files from subfolders
@@ -27,13 +27,13 @@ This command is an improved version of the `spo file list` command. The main dif
 
 ## Examples
 
-Return all files from site-relative URL of the folder _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all files from the folder _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents'
 ```
 
-Return all files from the site-relative URL of the folder _Shared Documents_ and all the sub-folders of _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all files from the folder _Shared Documents_ and all the sub-folders of _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --recursive

--- a/docs/docs/cmd/file/file-list.md
+++ b/docs/docs/cmd/file/file-list.md
@@ -27,20 +27,20 @@ This command is an improved version of the `spo file list` command. The main dif
 
 ## Examples
 
-Return all files from folder _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all files from server- or site-relative URL of the folder _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
-m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents'
+m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents'
 ```
 
-Return all files from the folder _Shared Documents_ and all the sub-folders of _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all files from the server- or site-relative URL of the folder _Shared Documents_ and all the sub-folders of _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
-m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --recursive
+m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --recursive
 ```
 
-Return all files from the _Important_ folder in the _Shared Documents_ document library located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all files from the _Important_ folder in the server- or site-relative URL of the folder _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
-m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents/Important'
+m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents/Important'
 ```

--- a/docs/docs/cmd/file/file-list.md
+++ b/docs/docs/cmd/file/file-list.md
@@ -14,7 +14,7 @@ m365 file list [options]
 : The URL of the site where the folder from which to retrieve files is located
 
 `-f, --folderUrl <folderUrl>`
-: The server- or site-relative URL of the folder from which to retrieve files
+: The site-relative URL of the folder from which to retrieve files
 
 `--recursive`
 : Set to retrieve files from subfolders
@@ -27,19 +27,19 @@ This command is an improved version of the `spo file list` command. The main dif
 
 ## Examples
 
-Return all files from server- or site-relative URL of the folder _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all files from site-relative URL of the folder _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents'
 ```
 
-Return all files from the server- or site-relative URL of the folder _Shared Documents_ and all the sub-folders of _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all files from the site-relative URL of the folder _Shared Documents_ and all the sub-folders of _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents' --recursive
 ```
 
-Return all files from the _Important_ folder in the server- or site-relative URL of the folder _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all files from the _Important_ folder in the _Shared Documents_ document library located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 m365 file list --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl 'Shared Documents/Important'


### PR DESCRIPTION
Fixes documenation of `m365 file list` command. Closes #3368
Updated examples with `folderUrl` option.