### PR TITLE
Fix bug with `spo list list` throwing access denied. Closes #3373

### DIFF
--- a/docs/docs/cmd/spo/list/list-list.md
+++ b/docs/docs/cmd/spo/list/list-list.md
@@ -13,6 +13,9 @@ m365 spo list list [options]
 `-u, --webUrl <webUrl>`
 : URL of the site where the lists to retrieve are located
 
+`--executeWithLimitedPermissions`
+: Use this option to execute this command with site member or visitor permissions. Not specifying this option will require site owner (or admin) permissions.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples

--- a/src/m365/spo/commands/list/list-list.spec.ts
+++ b/src/m365/spo/commands/list/list-list.spec.ts
@@ -192,6 +192,137 @@ describe(commands.LIST_LIST, () => {
     });
   });
 
+  it('retrieves all lists (with limited permissions)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/lists') > -1) {
+        return Promise.resolve(
+          {"value":[{
+            "AllowContentTypes": true,
+            "BaseTemplate": 109,
+            "BaseType": 1,
+            "ContentTypesEnabled": false,
+            "CrawlNonDefaultViews": false,
+            "Created": null,
+            "CurrentChangeToken": null,
+            "CustomActionElements": null,
+            "DefaultContentApprovalWorkflowId": "00000000-0000-0000-0000-000000000000",
+            "DefaultItemOpenUseListSetting": false,
+            "Description": "",
+            "Direction": "none",
+            "DocumentTemplateUrl": null,
+            "DraftVersionVisibility": 0,
+            "EnableAttachments": false,
+            "EnableFolderCreation": true,
+            "EnableMinorVersions": false,
+            "EnableModeration": false,
+            "EnableVersioning": false,
+            "EntityTypeName": "Documents",
+            "ExemptFromBlockDownloadOfNonViewableFiles": false,
+            "FileSavePostProcessingEnabled": false,
+            "ForceCheckout": false,
+            "HasExternalDataSource": false,
+            "Hidden": false,
+            "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
+            "ImagePath": null,
+            "ImageUrl": null,
+            "IrmEnabled": false,
+            "IrmExpire": false,
+            "IrmReject": false,
+            "IsApplicationList": false,
+            "IsCatalog": false,
+            "IsPrivate": false,
+            "ItemCount": 69,
+            "LastItemDeletedDate": null,
+            "LastItemModifiedDate": null,
+            "LastItemUserModifiedDate": null,
+            "ListExperienceOptions": 0,
+            "ListItemEntityTypeFullName": null,
+            "MajorVersionLimit": 0,
+            "MajorWithMinorVersionsLimit": 0,
+            "MultipleDataList": false,
+            "NoCrawl": false,
+            "ParentWebPath": null,
+            "ParentWebUrl": null,
+            "ParserDisabled": false,
+            "ServerTemplateCanCreateFolders": true,
+            "TemplateFeatureId": null,
+            "Title": "Documents",
+            "RootFolder": {"ServerRelativeUrl":"Documents"}
+          }]}
+        );
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: {
+      output: 'json',
+      debug: true,
+      webUrl: 'https://contoso.sharepoint.com',
+      executeWithLimitedPermissions: true
+    } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith([{
+          "AllowContentTypes": true,
+          "BaseTemplate": 109,
+          "BaseType": 1,
+          "ContentTypesEnabled": false,
+          "CrawlNonDefaultViews": false,
+          "Created": null,
+          "CurrentChangeToken": null,
+          "CustomActionElements": null,
+          "DefaultContentApprovalWorkflowId": "00000000-0000-0000-0000-000000000000",
+          "DefaultItemOpenUseListSetting": false,
+          "Description": "",
+          "Direction": "none",
+          "DocumentTemplateUrl": null,
+          "DraftVersionVisibility": 0,
+          "EnableAttachments": false,
+          "EnableFolderCreation": true,
+          "EnableMinorVersions": false,
+          "EnableModeration": false,
+          "EnableVersioning": false,
+          "EntityTypeName": "Documents",
+          "ExemptFromBlockDownloadOfNonViewableFiles": false,
+          "FileSavePostProcessingEnabled": false,
+          "ForceCheckout": false,
+          "HasExternalDataSource": false,
+          "Hidden": false,
+          "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
+          "ImagePath": null,
+          "ImageUrl": null,
+          "IrmEnabled": false,
+          "IrmExpire": false,
+          "IrmReject": false,
+          "IsApplicationList": false,
+          "IsCatalog": false,
+          "IsPrivate": false,
+          "ItemCount": 69,
+          "LastItemDeletedDate": null,
+          "LastItemModifiedDate": null,
+          "LastItemUserModifiedDate": null,
+          "ListExperienceOptions": 0,
+          "ListItemEntityTypeFullName": null,
+          "MajorVersionLimit": 0,
+          "MajorWithMinorVersionsLimit": 0,
+          "MultipleDataList": false,
+          "NoCrawl": false,
+          "ParentWebPath": null,
+          "ParentWebUrl": null,
+          "ParserDisabled": false,
+          "ServerTemplateCanCreateFolders": true,
+          "TemplateFeatureId": null,
+          "Title": "Documents",
+          "RootFolder": {"ServerRelativeUrl":"Documents"},
+          Url: "Documents"
+        }]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('command correctly handles list list reject request', (done) => {
     const err = 'Invalid request';
     sinon.stub(request, 'get').callsFake((opts) => {

--- a/src/m365/spo/commands/list/list-list.ts
+++ b/src/m365/spo/commands/list/list-list.ts
@@ -15,6 +15,7 @@ interface CommandArgs {
 
 interface Options extends GlobalOptions {
   webUrl: string;
+  executeWithLimitedPermissions?:boolean;
 }
 
 class SpoListListCommand extends SpoCommand {
@@ -35,8 +36,10 @@ class SpoListListCommand extends SpoCommand {
       logger.logToStderr(`Retrieving all lists in site at ${args.options.webUrl}...`);
     }
 
+    const suffix = args.options.executeWithLimitedPermissions ? "&$select=RootFolder/ServerRelativeUrl,*" : "";
+
     const requestOptions: any = {
-      url: `${args.options.webUrl}/_api/web/lists?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl,*`,
+      url: `${args.options.webUrl}/_api/web/lists?$expand=RootFolder${suffix}`,
       method: 'GET',
       headers: {
         'accept': 'application/json;odata=nometadata'
@@ -60,6 +63,9 @@ class SpoListListCommand extends SpoCommand {
     const options: CommandOption[] = [
       {
         option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '--executeWithLimitedPermissions'
       }
     ];
 

--- a/src/m365/spo/commands/list/list-list.ts
+++ b/src/m365/spo/commands/list/list-list.ts
@@ -36,7 +36,7 @@ class SpoListListCommand extends SpoCommand {
     }
 
     const requestOptions: any = {
-      url: `${args.options.webUrl}/_api/web/lists?$expand=RootFolder`,
+      url: `${args.options.webUrl}/_api/web/lists?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl,*`,
       method: 'GET',
       headers: {
         'accept': 'application/json;odata=nometadata'


### PR DESCRIPTION
Closes #3373

**🛑 The problem** (@Adam-it style with emoji's 😊)
In certain scenario's the command `spo list list` throws an access denied error:
1) If you are authenticated using App Only permissions with Sites.Manage.All scope. (_It does work correctly with Sites.FullControl.All_)
2) If you are authenticated with a regular user (A Global admin/SharePoint service admin does not have this issue), being a member on a site, using any scope (_AllSites.FullControl or AllSites.Manage_).

**👀 When diving in**
The code calls the REST url /_api/web/lists?$expand=RootFolder.
If I remove the $expand, the calls come through without access denieds.
If I add a `$select=RootFolder/ServerRelativeUrl,*` statement, the calls come through as well with the required properties.

**🏁 The solution**
The solution is to correctly use `$select` in combination with `$expand`. In this way, less permissions are necessary, and the same data is still returned.