### PR TITLE
Added `spo roledefinition remove` command. Closses #3272

### DIFF
--- a/docs/docs/cmd/spo/roledefinition/roledefinition-remove.md
+++ b/docs/docs/cmd/spo/roledefinition/roledefinition-remove.md
@@ -1,0 +1,36 @@
+# spo roledefinition remove
+
+Should remove roledefinition from web
+
+## Usage
+
+```sh
+m365 spo roledefinition remove [options]
+```
+
+## Options
+
+`-u, --webUrl <webUrl>`
+: URL of the site from which role should be removed
+
+`-i, --id <id>`
+: Role definition id
+
+`--confirm`
+: Don't prompt for confirming removing the role definition
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Remove the role definition from site  _https://contoso.sharepoint.com/sites/project-x_ with id _1_
+
+```sh
+m365 spo roledefinition remove --webUrl https://contoso.sharepoint.com/sites/project-x --id 1
+```
+
+Remove the role definition from site  _https://contoso.sharepoint.com/sites/project-x_ with id _1_ and don't prompt for confirmation
+
+```sh
+m365 spo roledefinition remove --webUrl https://contoso.sharepoint.com/sites/project-x --id 1 --confirm
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -456,6 +456,7 @@ nav:
         - report siteusagestorage: 'cmd/spo/report/report-siteusagestorage.md'
       - roledefinition:
         - roledefinition list: 'cmd/spo/roledefinition/roledefinition-list.md'
+        - roledefinition remove: 'cmd/spo/roledefinition/roledefinition-remove.md'
       - serviceprincipal:
         - serviceprincipal grant add: 'cmd/spo/serviceprincipal/serviceprincipal-grant-add.md'
         - serviceprincipal grant list: 'cmd/spo/serviceprincipal/serviceprincipal-grant-list.md'

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -166,6 +166,7 @@ export default {
   REPORT_SITEUSAGESITECOUNTS: `${prefix} report siteusagesitecounts`,
   REPORT_SITEUSAGESTORAGE: `${prefix} report siteusagestorage`,
   ROLEDEFINITION_LIST: `${prefix} roledefinition list`,
+  ROLEDEFINITION_REMOVE: `${prefix} roledefinition remove`,
   SEARCH: `${prefix} search`,
   SERVICEPRINCIPAL_GRANT_ADD: `${prefix} serviceprincipal grant add`,
   SERVICEPRINCIPAL_GRANT_LIST: `${prefix} serviceprincipal grant list`,

--- a/src/m365/spo/commands/roledefinition/roledefinition-remove.spec.ts
+++ b/src/m365/spo/commands/roledefinition/roledefinition-remove.spec.ts
@@ -1,0 +1,231 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Cli, Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils';
+import commands from '../../commands';
+const command: Command = require('./roledefinition-remove');
+
+describe(commands.ROLEDEFINITION_REMOVE, () => {
+  let log: any[];
+  let logger: Logger;
+  let requests: any[];
+  let promptOptions: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    requests = [];
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      promptOptions = options;
+      cb({ continue: false });
+    });
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.delete,
+      Cli.prompt
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.ROLEDEFINITION_REMOVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options();
+    let containsDebugOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsDebugOption = true;
+      }
+    });
+    assert(containsDebugOption);
+  });
+
+  it('fails validation if the webUrl option is not a valid SharePoint site URL', () => {
+    const actual = command.validate({ options: { webUrl: 'foo', id: 1} });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the webUrl option is a valid SharePoint site URL', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1 } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if id is not a number', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if id is a number', () => {
+    const actual = command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: '1' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('remove role definitions handles reject request correctly', (done) => {
+    const err = 'request rejected';
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/roledefinitions') > -1) {
+        return Promise.reject(err);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        id: 1,
+        confirm: true
+      }
+    }, (error?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(error), JSON.stringify(new CommandError(err)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('prompts before removing role definition when confirmation argument not passed', (done) => {
+    command.action(logger, { options: { debug: false, webUrl: 'https://contoso.sharepoint.com', id: 1 } }, () => {
+      let promptIssued = false;
+
+      if (promptOptions && promptOptions.type === 'confirm') {
+        promptIssued = true;
+      }
+
+      try {
+        assert(promptIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts removing role definition when prompt not confirmed', (done) => {
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: false });
+    });
+    command.action(logger, { options: { debug: false, webUrl: 'https://contoso.sharepoint.com', id: 1 } }, () => {
+      try {
+        assert(requests.length === 0);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('removes the role definition when prompt confirmed', (done) => {
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      requests.push(opts);
+
+      if ((opts.url as string).indexOf(`/_api/web/roledefinitions(1)`) > -1) {
+        if (opts.headers &&
+          opts.headers.accept &&
+          (opts.headers.accept as string).indexOf('application/json') === 0) {
+          return Promise.resolve();
+        }
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: true });
+    });
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com', id: 1 } }, () => {
+      let correctRequestIssued = false;
+      requests.forEach(r => {
+        if (r.url.indexOf(`/_api/web/roledefinitions(1)`) > -1 &&
+          r.headers.accept &&
+          r.headers.accept.indexOf('application/json') === 0) {
+          correctRequestIssued = true;
+        }
+      });
+      try {
+        assert(correctRequestIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('removes the role definition without confirm prompt', (done) => {
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      requests.push(opts);
+
+      if ((opts.url as string).indexOf(`/_api/web/roledefinitions(1)`) > -1) {
+        if (opts.headers &&
+          opts.headers.accept &&
+          (opts.headers.accept as string).indexOf('application/json') === 0) {
+          return Promise.resolve();
+        }
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com', id: 1, confirm: true } }, () => {
+      let correctRequestIssued = false;
+      requests.forEach(r => {
+        if (r.url.indexOf(`/_api/web/roledefinitions(1)`) > -1 &&
+          r.headers.accept &&
+          r.headers.accept.indexOf('application/json') === 0) {
+          correctRequestIssued = true;
+        }
+      });
+      try {
+        assert(correctRequestIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/m365/spo/commands/roledefinition/roledefinition-remove.ts
+++ b/src/m365/spo/commands/roledefinition/roledefinition-remove.ts
@@ -1,0 +1,110 @@
+import { Cli, Logger } from '../../../../cli';
+import { CommandOption } from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import { validation } from '../../../../utils';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  id: string;
+  confirm?: boolean;
+}
+
+class SpoRoleDefinitionRemoveCommand extends SpoCommand {
+  public get name(): string {
+    return commands.ROLEDEFINITION_REMOVE;
+  }
+
+  public get description(): string {
+    return 'Should remove roledefinition from web';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.confirm = (!(!args.options.confirm)).toString();
+    return telemetryProps;
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    const removeRoleDefinition: () => void = (): void => {
+      if (this.verbose) {
+        logger.logToStderr(`Removing role definition from site ${args.options.webUrl}...`);
+      }
+
+      const requestOptions: any = {
+        url: `${args.options.webUrl}/_api/web/roledefinitions(${args.options.id})`,
+        method: 'delete',
+        headers: {
+          'X-HTTP-Method': 'DELETE',
+          'If-Match': '*',
+          'accept': 'application/json;odata=nometadata'
+        },
+        responseType: 'json'
+      };
+
+      request
+        .delete(requestOptions)
+        .then((): void => {
+          cb();
+        }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+    };
+
+    if (args.options.confirm) {
+      removeRoleDefinition();
+    }
+    else {
+      Cli.prompt({
+        type: 'confirm',
+        name: 'continue',
+        default: false,
+        message: `Are you sure you want to remove the role definition with id ${args.options.id} from site ${args.options.webUrl}?`
+      }, (result: { continue: boolean }): void => {
+        if (!result.continue) {
+          cb();
+        }
+        else {
+          removeRoleDefinition();
+        }
+      });
+    }
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-i, --id <id>'
+      },
+      {
+        option: '--confirm'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(args: CommandArgs): boolean | string {
+    const id: number = parseInt(args.options.id);
+    if (isNaN(id)) {
+      return `${args.options.id} is not a valid list item ID`;
+    }
+
+    const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+    if (isValidSharePointUrl !== true) {
+      return isValidSharePointUrl;
+    }
+
+    return true;
+  }
+}
+
+module.exports = new SpoRoleDefinitionRemoveCommand();


### PR DESCRIPTION
### 🎯Added spo roledefinition remove command

The aim of the PR is to add a new command to the CLI which will allow to remove a role definition from the web by id

### 🔗Linked Issue

Closes #3272

### 📸 Result

https://user-images.githubusercontent.com/58668583/171996144-038ecd8c-2f16-4f1a-8386-7610926d4a55.mp4


