### PR TITLE
Extends `planner task add` and `planner task set` commands with `priority` option. Closes #3383

### DIFF
--- a/docs/docs/cmd/planner/task/task-add.md
+++ b/docs/docs/cmd/planner/task/task-add.md
@@ -39,9 +39,6 @@ m365 planner task add [options]
 
 `--percentComplete [percentComplete]`
 : Percentage of task completion. Number between 0 and 100.
-  - When set to 0, the task is considered _Not started_. 
-  - When set between 1 and 99, the task is considered _In progress_.
-  - When set to 100, the task is considered _Completed_.
 
 `--assignedToUserIds [assignedToUserIds]`
 : The comma-separated IDs of the assignees the task is assigned to. Specify either `assignedToUserIds` or `assignedToUserNames` but not both.
@@ -55,7 +52,25 @@ m365 planner task add [options]
 `--orderHint [orderHint]`
 : Hint used to order items of this type in a list view. The format is defined as outlined [here](https://docs.microsoft.com/en-us/graph/api/resources/planner-order-hint-format?view=graph-rest-1.0).
 
+`--priority [priority]`
+: Priority of the task. Number between 0 and 10.
+
 --8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+When you specify the value for `percentComplete`, consider the following:
+
+- when set to 0, the task is considered _Not started_
+- when set between 1 and 99, the task is considered _In progress_
+- when set to 100, the task is considered _Completed_
+
+When you specify the value for `priority`, consider the following:
+
+- values 0 and 1 are interpreted as _Urgent_
+- values 2, 3 and 4 are interpreted as _Important_
+- values 5, 6 and 7 are interpreted as _Medium_
+- values 8, 9 and 10 are interpreted as _Low_
 
 ## Examples
 

--- a/docs/docs/cmd/planner/task/task-set.md
+++ b/docs/docs/cmd/planner/task/task-set.md
@@ -61,15 +61,25 @@ m365 planner task set [options]
 `--appliedCategories [appliedCategories]`
 : Comma-separated categories that should be added to the task
 
+`--priority [priority]`
+: Priority of the task. Number between 0 and 10.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
-When you specify the value for `percentageComplete`, consider the following:
+When you specify the value for `percentComplete`, consider the following:
 
 - when set to 0, the task is considered _Not started_
 - when set between 1 and 99, the task is considered _In progress_
 - when set to 100, the task is considered _Completed_
+
+When you specify the value for `priority`, consider the following:
+
+- values 0 and 1 are interpreted as _Urgent_
+- values 2, 3 and 4 are interpreted as _Important_
+- values 5, 6 and 7 are interpreted as _Medium_
+- values 8, 9 and 10 are interpreted as _Low_
 
 You can add up to 6 categories to the task. An example to add _category1_ and _category3_ would be `category1,category3`.
 

--- a/src/m365/planner/commands/task/task-add.spec.ts
+++ b/src/m365/planner/commands/task/task-add.spec.ts
@@ -422,6 +422,32 @@ describe(commands.TASK_ADD, () => {
     done();
   });
 
+  it('fails validation if priority lower than 0 is specified.', (done) => {
+    const actual = command.validate({
+      options: {
+        title: 'My Planner Task',
+        planId: '8QZEH7b3wkS_bGQobscsM5gADCBb',
+        bucketId: 'IK8tuFTwQEa5vTonM7ZMRZgAKdno',
+        priority: -1
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation if priority higher than 10 is specified.', (done) => {
+    const actual = command.validate({
+      options: {
+        title: 'My Planner Task',
+        planId: '8QZEH7b3wkS_bGQobscsM5gADCBb',
+        bucketId: 'IK8tuFTwQEa5vTonM7ZMRZgAKdno',
+        priority: 11
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
   it('correctly adds planner task with title, planId, and bucketId', (done) => {
     const options: any = {
       title: 'My Planner Task',

--- a/src/m365/planner/commands/task/task-add.ts
+++ b/src/m365/planner/commands/task/task-add.ts
@@ -28,6 +28,7 @@ interface Options extends GlobalOptions {
   assignedToUserNames?: string;
   description?: string;
   orderHint?: string;
+  priority?: number;
 }
 
 class PlannerTaskAddCommand extends GraphCommand {
@@ -57,6 +58,7 @@ class PlannerTaskAddCommand extends GraphCommand {
     telemetryProps.assignedToUserNames = typeof args.options.assignedToUserNames !== 'undefined';
     telemetryProps.description = typeof args.options.description !== 'undefined';
     telemetryProps.orderHint = typeof args.options.orderHint !== 'undefined';
+    telemetryProps.priority = typeof args.options.priority !== 'undefined';
     return telemetryProps;
   }
 
@@ -91,7 +93,8 @@ class PlannerTaskAddCommand extends GraphCommand {
             dueDateTime: args.options.dueDateTime,
             percentComplete: args.options.percentComplete,
             assignments: assignments,
-            orderHint: args.options.orderHint
+            orderHint: args.options.orderHint,
+            priority: args.options.priority
           }
         };
 
@@ -294,7 +297,8 @@ class PlannerTaskAddCommand extends GraphCommand {
       { option: '--assignedToUserIds [assignedToUserIds]' },
       { option: '--assignedToUserNames [assignedToUserNames]' },
       { option: '--description [description]' },
-      { option: '--orderHint [orderHint]' }
+      { option: '--orderHint [orderHint]' },
+      { option: '--priority [priority]' }
     ];
 
     const parentOptions: CommandOption[] = super.options();
@@ -343,7 +347,7 @@ class PlannerTaskAddCommand extends GraphCommand {
     }
 
     if (args.options.percentComplete && (args.options.percentComplete < 0 || args.options.percentComplete > 100)) {
-      return `percentComplete should be between 0 and 100 `;
+      return `percentComplete should be between 0 and 100`;
     }
 
     if (args.options.assignedToUserIds && !validation.isValidGuidArray(args.options.assignedToUserIds.split(','))) {
@@ -352,6 +356,10 @@ class PlannerTaskAddCommand extends GraphCommand {
 
     if (args.options.assignedToUserIds && args.options.assignedToUserNames) {
       return 'Specify either assignedToUserIds or assignedToUserNames but not both';
+    }
+
+    if (args.options.priority && (isNaN(args.options.priority) || args.options.priority < 0 || args.options.priority > 10)) {
+      return 'priority should be a number between 0 and 10';
     }
 
     return true;

--- a/src/m365/planner/commands/task/task-set.spec.ts
+++ b/src/m365/planner/commands/task/task-set.spec.ts
@@ -337,6 +337,28 @@ describe(commands.TASK_SET, () => {
     done();
   });
 
+  it('fails validation if priority lower than 0 is specified.', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'Z-RLQGfppU6H3663DBzfs5gAMD3o',
+        priority: -1
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation if priority higher than 10 is specified.', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'Z-RLQGfppU6H3663DBzfs5gAMD3o',
+        priority: 11
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
   it('passes validation when valid options specified', (done) => {
     const actual = command.validate({
       options: {
@@ -730,7 +752,7 @@ describe(commands.TASK_SET, () => {
     });
   });
 
-  it('correctly updates planner task with appliedCategories, bucketId, startDateTime, dueDateTime, percentComplete, assigneePriority, and orderHint', (done) => {
+  it('correctly updates planner task with appliedCategories, bucketId, startDateTime, dueDateTime, percentComplete, assigneePriority, orderHint and priority', (done) => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -760,7 +782,8 @@ describe(commands.TASK_SET, () => {
       dueDateTime: '2023-01-01T00:00:00Z',
       percentComplete: '50',
       assigneePriority: ' !',
-      orderHint: ' !'
+      orderHint: ' !',
+      priority: 3
     };
 
     command.action(logger, { options: options } as any, () => {

--- a/src/m365/planner/commands/task/task-set.ts
+++ b/src/m365/planner/commands/task/task-set.ts
@@ -33,6 +33,7 @@ interface Options extends GlobalOptions {
   description?: string;
   appliedCategories?: string;
   orderHint?: string;
+  priority?: number;
 }
 
 class PlannerTaskSetCommand extends GraphCommand {
@@ -66,6 +67,7 @@ class PlannerTaskSetCommand extends GraphCommand {
     telemetryProps.description = typeof args.options.description !== 'undefined';
     telemetryProps.appliedCategories = typeof args.options.appliedCategories !== 'undefined';
     telemetryProps.orderHint = typeof args.options.orderHint !== 'undefined';
+    telemetryProps.priority = typeof args.options.priority !== 'undefined';
     return telemetryProps;
   }
 
@@ -364,6 +366,10 @@ class PlannerTaskSetCommand extends GraphCommand {
       requestBody.orderHint = options.orderHint;
     }
 
+    if (options.priority != undefined) {
+      requestBody.priority = options.priority;
+    }
+
     return requestBody;
   }
 
@@ -385,7 +391,8 @@ class PlannerTaskSetCommand extends GraphCommand {
       { option: '--assigneePriority [assigneePriority]' },
       { option: '--description [description]' },
       { option: '--appliedCategories [appliedCategories]' },
-      { option: '--orderHint [orderHint]' }
+      { option: '--orderHint [orderHint]' },
+      { option: '--priority [priority]' }
     ];
 
     const parentOptions: CommandOption[] = super.options();
@@ -442,6 +449,10 @@ class PlannerTaskSetCommand extends GraphCommand {
     }
     if (args.options.appliedCategories && args.options.appliedCategories.split(',').filter(category => this.allowedAppliedCategories.indexOf(category.toLocaleLowerCase()) < 0).length !== 0) {
       return 'The appliedCategories contains invalid value. Specify either category1, category2, category3, category4, category5 and/or category6 as properties';
+    }
+
+    if (args.options.priority && (isNaN(args.options.priority) || args.options.priority < 0 || args.options.priority > 10)) {
+      return 'priority should be a number between 0 and 10';
     }
 
     return true;


### PR DESCRIPTION
Extends `planner task add` and `planner task set` commands with `priority` option. Closes #3383

## Remarks

Noticed that both commands have the `percentComplete` option. However explanation for the values were displayed differently in the docs.

For the `planner task add` command, values were explained in the description of the option.
![image](https://user-images.githubusercontent.com/11723921/172215678-5c2d28ab-724d-432b-8e5d-4ce1bc1a7f7d.png)

For the `planner task set` command, values were explained in the remarks section (noticed a typo here, option name should be `percentComplete`).
![image](https://user-images.githubusercontent.com/11723921/172215838-bd641e32-5c22-44ed-9bd6-e447895b191d.png)

Personally I found the last one the clearest. For the sake of consistency, I moved the explanation for command `planner task add` to the remarks section. Correct me if I made made the wrong choice. ☺️