### PR TITLE
Adds the ability to provide comma separated identifier URIs in 'aad app set'

### DIFF
--- a/docs/docs/cmd/aad/app/app-set.md
+++ b/docs/docs/cmd/aad/app/app-set.md
@@ -20,7 +20,7 @@ m365 aad app set [options]
 : Name of the Azure AD application registration to update. Specify either `appId`, `objectId` or `name`
 
 `-u, --uri [uri]`
-: Application ID URI to update
+: Comma-separated list of Application ID URIs to update
 
 `-r, --redirectUris [redirectUris]`
 : Comma-separated list of redirect URIs to add to the app registration. Requires `platform` to be specified

--- a/src/m365/aad/commands/app/app-set.spec.ts
+++ b/src/m365/aad/commands/app/app-set.spec.ts
@@ -104,6 +104,46 @@ describe(commands.APP_SET, () => {
     });
   });
 
+  it('updates multiple URIs for the specified appId', (done) => {
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq 'bc724b77-da87-43a9-b385-6ebaaf969db8'&$select=id`) {
+        return Promise.resolve({
+          value: [{
+            id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
+          }]
+        });
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(request, 'patch').callsFake(opts => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230' &&
+        opts.data &&
+        opts.data.identifierUris[0] === 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8' &&
+        opts.data.identifierUris[1] === 'api://testapi') {
+        return Promise.resolve();
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        appId: 'bc724b77-da87-43a9-b385-6ebaaf969db8',
+        uri: 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8,api://testapi'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined', err?.message);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('updates uri for the specified objectId', (done) => {
     sinon.stub(request, 'patch').callsFake(opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230' &&
@@ -120,6 +160,35 @@ describe(commands.APP_SET, () => {
         debug: false,
         objectId: '5b31c38c-2584-42f0-aa47-657fb3a84230',
         uri: 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined', err?.message);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('updates multiple URIs for the specified objectId', (done) => {
+    sinon.stub(request, 'patch').callsFake(opts => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230' &&
+        opts.data &&
+        opts.data.identifierUris[0] === 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8' &&
+        opts.data.identifierUris[1] === 'api://testapi') {
+        return Promise.resolve();
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        objectId: '5b31c38c-2584-42f0-aa47-657fb3a84230',
+        uri: 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8,api://testapi'
       }
     }, (err?: any) => {
       try {
@@ -159,6 +228,46 @@ describe(commands.APP_SET, () => {
         debug: true,
         name: 'My app',
         uri: 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8'
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined', err?.message);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('updates multiple URIs for the specified name', (done) => {
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=displayName eq 'My%20app'&$select=id`) {
+        return Promise.resolve({
+          value: [{
+            id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
+          }]
+        });
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(request, 'patch').callsFake(opts => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230' &&
+        opts.data &&
+        opts.data.identifierUris[0] === 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8' &&
+        opts.data.identifierUris[1] === 'api://testapi') {
+        return Promise.resolve();
+      }
+
+      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        name: 'My app',
+        uri: 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8,api://testapi'
       }
     }, (err?: any) => {
       try {

--- a/src/m365/aad/commands/app/app-set.ts
+++ b/src/m365/aad/commands/app/app-set.ts
@@ -110,8 +110,12 @@ class AadAppSetCommand extends GraphCommand {
       logger.logToStderr(`Configuring Azure AD application ID URI...`);
     }
 
+    const identifierUris: string[] = args.options.uri
+      .split(',')
+      .map(u => u.trim());
+
     const applicationInfo: any = {
-      identifierUris: [args.options.uri]
+      identifierUris: identifierUris
     };
 
     const requestOptions: any = {


### PR DESCRIPTION
### Extend `aad app set` command
Closes #3333 - Adds the ability to provide multiple comma-separated identifierURIs to the `aad app set` command
