### PR TITLE
Fixes documentation for `spo file checkout`

### DIFF
--- a/docs/docs/cmd/spo/file/file-checkout.md
+++ b/docs/docs/cmd/spo/file/file-checkout.md
@@ -32,5 +32,5 @@ m365 spo file checkout --webUrl https://contoso.sharepoint.com/sites/project-x -
 Checks out file with server-relative url _/sites/project-x/documents/Test1.docx_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
-m365 spo file checkout --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/documents/Test1.docx'
+m365 spo file checkout --webUrl https://contoso.sharepoint.com/sites/project-x --fileUrl '/sites/project-x/documents/Test1.docx'
 ```


### PR DESCRIPTION
Fixes documentation of `m365 spo file checkout` command.
While I was writing a script sample, I had copied the example from the documentation. Upon executing this example (after obviously adding my parameters), I got error message: `Error: Invalid option: 'url'`

This option should be `fileUrl`.