### PR TITLE
Fix issue with `mkdocs serve` because of pygments version. Closes #3389

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
   && apt-get install nodejs -y \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install mkdocs-material==7.1.7 pymdown-extensions==9.0
+RUN pip3 install mkdocs-material==7.1.7 pymdown-extensions==9.0 pygments==2.11
 
 RUN useradd \
   --user-group \


### PR DESCRIPTION
### 🎯 Aim
The purpose of this PR is to fix a bug running `mkdocs serve`. This bug is due to an issue between mkdocs and version 2.12 of the Pygments dependency. When you get started contributing to the CLI, the _latest_ version is installed after first cloning the repo. At least, if you use docker. The latest version is 2.12. As 2.12 has this issue, the fix is to define the version we want to use in the pip requirements list: version 2.11

### 🔗 Linked issue
Closes #3389