### PR TITLE
Fixes 'spo list get' command. Closes #3379

### DIFF
--- a/src/m365/spo/commands/list/ListInstance.ts
+++ b/src/m365/spo/commands/list/ListInstance.ts
@@ -1,4 +1,5 @@
 export interface ListInstance {
+  RoleAssignments: RoleAssignment[];
   AllowContentTypes: boolean;
   BaseTemplate: number;
   BaseType: number;
@@ -55,4 +56,13 @@ export interface ListInstance {
 
 export interface RootFolder {
   ServerRelativeUrl: string;
+}
+
+export interface RoleAssignment {
+  Member: Member;
+}
+
+export interface Member {
+  PrincipalType: number;
+  PrincipalTypeString: string;
 }

--- a/src/m365/spo/commands/list/ListPrincipalType.ts
+++ b/src/m365/spo/commands/list/ListPrincipalType.ts
@@ -1,0 +1,8 @@
+export enum ListPrincipalType {
+  None = 0,
+  User = 1,
+  DistributionList = 2,
+  SecurityGroup = 4, 
+  SharePointGroup = 8,
+  All = 15
+}

--- a/src/m365/spo/commands/list/list-get.spec.ts
+++ b/src/m365/spo/commands/list/list-get.spec.ts
@@ -265,7 +265,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -296,7 +297,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -327,7 +329,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -361,7 +364,8 @@ describe(commands.LIST_GET, () => {
                   "NameId": "10032000f65ded70",
                   "NameIdIssuer": "urn:federation:microsoftonline"
                 },
-                "UserPrincipalName": "user@contoso.onmicrosoft.com"
+                "UserPrincipalName": "user@contoso.onmicrosoft.com",
+                "PrincipalTypeString": "User"
               },
               "RoleDefinitionBindings": [
                 {
@@ -507,7 +511,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -538,7 +543,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -569,7 +575,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -603,7 +610,8 @@ describe(commands.LIST_GET, () => {
                   NameId: "10032000f65ded70",
                   NameIdIssuer: "urn:federation:microsoftonline"
                 },
-                UserPrincipalName: "user@contoso.onmicrosoft.com"
+                UserPrincipalName: "user@contoso.onmicrosoft.com",
+                PrincipalTypeString: "User"
               },
               RoleDefinitionBindings: [
                 {
@@ -653,7 +661,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -684,7 +693,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -715,7 +725,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -749,7 +760,8 @@ describe(commands.LIST_GET, () => {
                   "NameId": "10032000f65ded70",
                   "NameIdIssuer": "urn:federation:microsoftonline"
                 },
-                "UserPrincipalName": "user@contoso.onmicrosoft.com"
+                "UserPrincipalName": "user@contoso.onmicrosoft.com",
+                "PrincipalTypeString": "User"
               },
               "RoleDefinitionBindings": [
                 {
@@ -802,7 +814,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -833,7 +846,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -864,7 +878,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -898,7 +913,8 @@ describe(commands.LIST_GET, () => {
                   NameId: "10032000f65ded70",
                   NameIdIssuer: "urn:federation:microsoftonline"
                 },
-                UserPrincipalName: "user@contoso.onmicrosoft.com"
+                UserPrincipalName: "user@contoso.onmicrosoft.com",
+                PrincipalTypeString: "User"
               },
               RoleDefinitionBindings: [
                 {
@@ -945,7 +961,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -976,7 +993,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -1007,7 +1025,8 @@ describe(commands.LIST_GET, () => {
                 "Description": null,
                 "OnlyAllowMembersViewMembership": false,
                 "OwnerTitle": "MySite Owners",
-                "RequestToJoinLeaveEmailSetting": ""
+                "RequestToJoinLeaveEmailSetting": "",
+                "PrincipalTypeString": "SharePointGroup"
               },
               "RoleDefinitionBindings": [
                 {
@@ -1041,7 +1060,8 @@ describe(commands.LIST_GET, () => {
                   "NameId": "10032000f65ded70",
                   "NameIdIssuer": "urn:federation:microsoftonline"
                 },
-                "UserPrincipalName": "user@contoso.onmicrosoft.com"
+                "UserPrincipalName": "user@contoso.onmicrosoft.com",
+                "PrincipalTypeString": "User"
               },
               "RoleDefinitionBindings": [
                 {
@@ -1094,7 +1114,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -1125,7 +1146,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -1156,7 +1178,8 @@ describe(commands.LIST_GET, () => {
                 Description: null,
                 OnlyAllowMembersViewMembership: false,
                 OwnerTitle: "MySite Owners",
-                RequestToJoinLeaveEmailSetting: ""
+                RequestToJoinLeaveEmailSetting: "",
+                PrincipalTypeString: "SharePointGroup"
               },
               RoleDefinitionBindings: [
                 {
@@ -1190,7 +1213,8 @@ describe(commands.LIST_GET, () => {
                   NameId: "10032000f65ded70",
                   NameIdIssuer: "urn:federation:microsoftonline"
                 },
-                UserPrincipalName: "user@contoso.onmicrosoft.com"
+                UserPrincipalName: "user@contoso.onmicrosoft.com",
+                PrincipalTypeString: "User"
               },
               RoleDefinitionBindings: [
                 {

--- a/src/m365/spo/commands/list/list-get.ts
+++ b/src/m365/spo/commands/list/list-get.ts
@@ -69,7 +69,6 @@ class SpoListGetCommand extends SpoCommand {
       .get<ListInstance>(requestOptions)
       .then((listInstance: ListInstance): void => {
         if (args.options.withPermissions) {
-          // Add custom property "PrincipalTypeString"
           listInstance.RoleAssignments.forEach(r => {
             r.Member.PrincipalTypeString = ListPrincipalType[r.Member.PrincipalType];
           });

--- a/src/m365/spo/commands/list/list-get.ts
+++ b/src/m365/spo/commands/list/list-get.ts
@@ -8,6 +8,7 @@ import { formatting, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListInstance } from "./ListInstance";
+import { ListPrincipalType } from './ListPrincipalType';
 
 interface CommandArgs {
   options: Options;
@@ -67,6 +68,13 @@ class SpoListGetCommand extends SpoCommand {
     request
       .get<ListInstance>(requestOptions)
       .then((listInstance: ListInstance): void => {
+        if (args.options.withPermissions) {
+          // Add custom property "PrincipalTypeString"
+          listInstance.RoleAssignments.forEach(r => {
+            r.Member.PrincipalTypeString = ListPrincipalType[r.Member.PrincipalType];
+          });
+        }
+
         logger.log(listInstance);
         cb();
       }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));


### PR DESCRIPTION
Fixes `spo list get` command. Closes #3379

Included `PrincipalTypeString` property.
The [spo list get](https://pnp.github.io/cli-microsoft365/cmd/spo/list/list-get/) command when used with `--withPermissions` option, will now return `PrincipalTypeString` property (human readable string) along with original `PrincipalType` property (number). 