### PR TITLE
Fixes `teams team get` command throws error with name parameter. Closes #3395

### DIFF
--- a/src/m365/teams/commands/team/team-get.spec.ts
+++ b/src/m365/teams/commands/team/team-get.spec.ts
@@ -124,7 +124,7 @@ describe(commands.TEAM_GET, () => {
 
   it('fails when team name does not exist', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
         return Promise.resolve({
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
           "@odata.count": 1,
@@ -143,7 +143,7 @@ describe(commands.TEAM_GET, () => {
     command.action(logger, {
       options: {
         debug: true,
-        name: 'Team Name'
+        name: 'Finance'
       }
     }, (err?: any) => {
       try {
@@ -258,7 +258,7 @@ describe(commands.TEAM_GET, () => {
   it('retrieves information about the specified Microsoft Teams team by name', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
 
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
         return Promise.resolve({
           "value": [
             {

--- a/src/m365/teams/commands/team/team-get.ts
+++ b/src/m365/teams/commands/team/team-get.ts
@@ -45,7 +45,7 @@ class TeamsTeamGetCommand extends GraphCommand {
     }
 
     return aadGroup
-      .getGroupByDisplayName(args.options.teamName!)
+      .getGroupByDisplayName(args.options.name!)
       .then(group => {
         if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
           return Promise.reject(`The specified team does not exist in the Microsoft Teams`);


### PR DESCRIPTION
Fixes `teams team get` command throws error with name parameter. Closes #3395

##  Extra
Updated the tests so next time they will actually fail when a wrong parameter is passed.