### PR TITLE
Fix --includeAssociatedSites doesn't include associated sites in the result. Closes #3400

### DIFF
--- a/docs/docs/cmd/spo/hubsite/hubsite-list.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-list.md
@@ -20,7 +20,7 @@ m365 spo hubsite list [options]
 !!! attention
     This command is based on a SharePoint API that is currently in preview and is subject to change once the API reached general availability.
 
-When using the text output type (default), the command lists only the values of the `ID`, `SiteUrl` and `Title` properties of the hub site. When setting the output type to JSON, all available properties are included in the command output.
+When using the text or csv output type, the command lists only the values of the `ID`, `SiteUrl` and `Title` properties of the hub site. With the output type as JSON, all available properties are included in the command output.
 
 ## Examples
 

--- a/src/m365/spo/commands/hubsite/hubsite-list.spec.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-list.spec.ts
@@ -689,7 +689,7 @@ describe(commands.HUBSITE_LIST, () => {
       }
       return Promise.reject('Invalid request');
     });
-    command.action(logger, { options: { debug: true, includeAssociatedSites: true, output: 'json' } }, () => {
+    command.action(logger, { options: { debug: true, includeAssociatedSites: true } }, () => {
       try {
         assert.strictEqual(firstPagedRequest, true);
         done();

--- a/src/m365/spo/commands/hubsite/hubsite-list.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-list.ts
@@ -65,7 +65,7 @@ class SpoHubSiteListCommand extends SpoCommand {
       .then((res: { value: HubSite[] }): Promise<any[] | void> => {
         hubSites = res.value;
 
-        if (args.options.includeAssociatedSites !== true || args.options.output !== 'json') {
+        if (args.options.includeAssociatedSites !== true || args.options.output && args.options.output !== 'json') {
           return Promise.resolve();
         }
         else {


### PR DESCRIPTION
Closes #3400

@waldekmastykarz, the docs mentions that the command makes use of a SharePoint API that is in preview and is subject to change. Is this still the case for the endpoint `_api/hubsites`?