### PR TITLE
Update MkDocs, add tagging support, move to requirements text file. Closes #3416

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,9 @@ RUN apt-get update && apt-get install -y \
   && apt-get install nodejs -y \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install mkdocs-material==7.1.7 pymdown-extensions==9.0 pygments==2.11
+COPY ../docs/pip_requirements.txt .
+
+RUN pip install -r pip_requirements.txt
 
 RUN useradd \
   --user-group \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "CLI for Microsoft 365",
   "dockerFile": "Dockerfile",
+  "context": "..",
   "settings": {
     "terminal.integrated.profiles.linux": {
       "zsh": {

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material==7.1.7 pymdown-extensions==9.0 pygments==2.11
+      - run: pip install -r docs/pip_requirements.txt
       - run: mkdocs gh-deploy --force -m "[ci skip]"
         working-directory: docs
   deploy_docker:

--- a/docs/docs/css/styles2.css
+++ b/docs/docs/css/styles2.css
@@ -1,3 +1,26 @@
+/*
+    colorcodes:
+    https://github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/main/_colors.scss
+*/
+
+:root {
+
+}
+
+[data-md-color-scheme="default"] {
+    --md-primary-fg-color: #ef5552;
+    --md-accent-fg-color: #526cfe;
+    --md-accent-bg-color: #e53734;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #ef5552;
+  --md-accent-fg-color: #526cfe;
+  --md-accent-bg-color: #e53734;
+  --md-default-bg-color: #272626;
+  --md-code-bg-color: #3d3e3e;
+}
+
 .md-logo {
   height: 32px;
   width: 150px;

--- a/docs/docs/doc-tags.md
+++ b/docs/docs/doc-tags.md
@@ -1,0 +1,5 @@
+# :material-tag-multiple-outline: Doc tags
+
+Following is a list of relevant tags:
+
+[TAGS]

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -783,8 +783,20 @@ nav:
     - License: 'about/license.md'
 theme:
     name: 'material'
-    palette:
-        primary: 'red'
+    palette:        
+        - media: "(prefers-color-scheme: light)"
+          scheme: default
+          primary: 'red'
+          accent: 'indigo'
+          toggle:
+            icon: material/weather-sunny
+            name: Switch to dark mode
+        - media: "(prefers-color-scheme: dark)"
+          scheme: slate 
+          primary: 'red'
+          toggle:
+            icon: material/weather-night
+            name: Switch to light mode
     logo: 'images/pnp-cli-microsoft365-white.svg'
     features:
         - navigation.tabs
@@ -795,12 +807,18 @@ extra_css:
     - 'css/styles2.css'
 markdown_extensions:
     - admonition
+    - meta
     - toc:
           permalink: true
     - pymdownx.highlight
     - pymdownx.snippets
     - pymdownx.superfences
+    - pymdownx.tabbed:
+        alternate_style: true 
     - pymdownx.tabbed
+    - pymdownx.emoji:
+          emoji_index: !!python/name:materialx.emoji.twemoji
+          emoji_generator: !!python/name:materialx.emoji.to_svg
     - def_list
 extra:
     social:
@@ -814,3 +832,7 @@ extra:
           link: 'https://aka.ms/sppnp'
 repo_url: http://github.com/pnp/cli-microsoft365
 edit_uri: blob/main/docs/docs
+plugins:
+    - search
+    - tags:
+        tags_file: doc-tags.md

--- a/docs/pip_requirements.txt
+++ b/docs/pip_requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material==8.3.6 
+pymdown-extensions==9.5 
+pygments==2.12


### PR DESCRIPTION
Closes #3416

## 🎯 Aim
The aim of this PR is _to update and enhance MkDocs to allow for tagging markdown files_. 
- To do this, the MkDocs version needed to be updated. 
- Updating the MkDocs version currently needs to be done in two places (release pipeline and docker file). This has now been refactored to using a requirements file, to centralize the required versions we need.
- As an extra, dark mode is introduced.

## Remark
- I tested the pipeline change in a test pipeline. It worked fine.
- To properly test this change you need to install the mkdocs requirements. It's easy to do this in a remote container and delete the container afterwards. This way your system is not impacted with my new dependencies.
