### PR TITLE
Fixes issue with wrong _global.md reference breaking the docs and cli help. Closes #3425

### DIFF
--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-health-get.md
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-health-get.md
@@ -16,7 +16,7 @@ m365 tenant serviceannouncement health get [options]
 `-i, --issues`
 : Return the collection of issues that happened on the service, with detailed information for each issue. Is only returned in JSON output mode.
 
---8<-- "docs/cmd/\_global.md"
+--8<-- "docs/cmd/_global.md"
 
 ## Examples
 

--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-healthissue-list.md
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-healthissue-list.md
@@ -13,7 +13,7 @@ m365 tenant serviceannouncement healthissue list [options]
 `-s, --service [service]`
 : Retrieve service health issues for the particular service. If not provided, retrieves health issues for all services
 
---8<-- "docs/cmd/\_global.md"
+--8<-- "docs/cmd/_global.md"
 
 ## Examples
 

--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-message-list.md
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-message-list.md
@@ -13,7 +13,7 @@ m365 tenant serviceannouncement message list [options]
 `-s, --service [service]`
 : Retrieve service update messages for the particular service. If not provided, retrieves messages for all services
 
---8<-- "docs/cmd/\_global.md"
+--8<-- "docs/cmd/_global.md"
 
 ## Examples
 


### PR DESCRIPTION
Closes #3425

Fixes issue with wrong _global.md reference breaking the docs and cli help. 