### PR TITLE
Extends `aad o365group recyclebinitem restore` command with extra options. Closes #2031

### DIFF
--- a/docs/docs/cmd/aad/o365group/o365group-recyclebinitem-restore.md
+++ b/docs/docs/cmd/aad/o365group/o365group-recyclebinitem-restore.md
@@ -29,7 +29,7 @@ m365 aad o365group restore [options]
 
 ## Examples
 
-Restores the Microsoft 365 Group with specific id
+Restores the Microsoft 365 Group with specific ID
 
 ```sh
 m365 aad o365group recyclebinitem restore --id 28beab62-7540-4db1-a23f-29a6018a3848

--- a/docs/docs/cmd/aad/o365group/o365group-recyclebinitem-restore.md
+++ b/docs/docs/cmd/aad/o365group/o365group-recyclebinitem-restore.md
@@ -16,15 +16,33 @@ m365 aad o365group restore [options]
 
 ## Options
 
-`-i, --id <id>`
-: The ID of the Microsoft 365 Group to restore
+`-i, --id [id]`
+: The ID of the Microsoft 365 Group to restore. Specify either `id`, `displayName` or `mailNickname` but not multiple.
+
+`-d, --displayName [displayName]`
+: Display name for the Microsoft 365 Group to restore. Specify either `id`, `displayName` or `mailNickname` but not multiple.
+
+`-m, --mailNickname [mailNickname]`
+: Name of the group e-mail (part before the @). Specify either `id`, `displayName` or `mailNickname` but not multiple.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Restores the Microsoft 365 Group with id _28beab62-7540-4db1-a23f-29a6018a3848_
+Restores the Microsoft 365 Group with specific id
 
 ```sh
 m365 aad o365group recyclebinitem restore --id 28beab62-7540-4db1-a23f-29a6018a3848
+```
+
+Restores the Microsoft 365 Group with specific name
+
+```sh
+m365 aad o365group recyclebinitem restore --displayName "My Group"
+```
+
+Restores the Microsoft 365 Group with specific mail nickname
+
+```sh
+m365 aad o365group recyclebinitem restore --mailNickname "Mygroup"
 ```

--- a/src/m365/aad/commands/o365group/o365group-recyclebinitem-remove.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-recyclebinitem-remove.spec.ts
@@ -245,7 +245,7 @@ describe(commands.O365GROUP_RECYCLEBINITEM_REMOVE, () => {
     });
   });
 
-  it('correctly deletes plan by displayName', (done) => {
+  it('correctly deletes group by displayName', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/directory/deletedItems/Microsoft.Graph.Group?$filter=displayName eq '${formatting.encodeQueryParameter(validGroupDisplayName)}'`) {
         return Promise.resolve(singleGroupsResponse);
@@ -280,7 +280,7 @@ describe(commands.O365GROUP_RECYCLEBINITEM_REMOVE, () => {
     });
   });
 
-  it('correctly deletes plan by mailNickname', (done) => {
+  it('correctly deletes group by mailNickname', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/directory/deletedItems/Microsoft.Graph.Group?$filter=mailNickname eq '${formatting.encodeQueryParameter(validGroupMailNickname)}'`) {
         return Promise.resolve(singleGroupsResponse);

--- a/src/m365/aad/commands/o365group/o365group-recyclebinitem-restore.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-recyclebinitem-restore.spec.ts
@@ -5,15 +5,55 @@ import auth from '../../../../Auth';
 import { Logger } from '../../../../cli';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { sinonUtil } from '../../../../utils';
+import { formatting, sinonUtil } from '../../../../utils';
 import commands from '../../commands';
 const command: Command = require('./o365group-recyclebinitem-restore');
 
 describe(commands.O365GROUP_RECYCLEBINITEM_RESTORE, () => {
+
+  const validGroupId = '00000000-0000-0000-0000-000000000000';
+  const validGroupDisplayName = 'Dev Team';
+  const validGroupMailNickname = 'Devteam';
+
+  const singleGroupsResponse = {
+    value: [
+      {
+        id: validGroupId,
+        displayName: validGroupDisplayName,
+        mailNickname: validGroupDisplayName,
+        mail: 'Devteam@contoso.com',
+        groupTypes: [
+          "Unified"
+        ]
+      }
+    ]
+  };
+
+  const multipleGroupsResponse = {
+    value: [
+      {
+        id: validGroupId,
+        displayName: validGroupDisplayName,
+        mailNickname: validGroupDisplayName,
+        mail: 'Devteam@contoso.com',
+        groupTypes: [
+          "Unified"
+        ]
+      },
+      {
+        id: validGroupId,
+        displayName: validGroupDisplayName,
+        mailNickname: validGroupDisplayName,
+        mail: 'Devteam@contoso.com',
+        groupTypes: [
+          "Unified"
+        ]
+      }
+    ]
+  };
+
   let log: string[];
   let logger: Logger;
-  let loggerLogSpy: sinon.SinonSpy;
-  let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
@@ -34,12 +74,11 @@ describe(commands.O365GROUP_RECYCLEBINITEM_RESTORE, () => {
         log.push(msg);
       }
     };
-    loggerLogSpy = sinon.spy(logger, 'log');
-    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
   });
 
   afterEach(() => {
     sinonUtil.restore([
+      request.get,
       request.post,
       global.setTimeout
     ]);
@@ -71,18 +110,38 @@ describe(commands.O365GROUP_RECYCLEBINITEM_RESTORE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('restores the specified group', (done) => {
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets();
+    assert.deepStrictEqual(optionSets, [['id', 'displayName', 'mailNickname']]);
+  });
+
+  it('fails validation if the id is not a valid GUID', () => {
+    const actual = command.validate({ options: { id: 'abc' } });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the id is a valid GUID', () => {
+    const actual = command.validate({ options: { id: '2c1ba4c4-cd9b-4417-832f-92a34bc34b2a' } });
+    assert.strictEqual(actual, true);
+  });
+
+  it('restores the specified group by id', (done) => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if (opts.url === 'https://graph.microsoft.com/v1.0/directory/deleteditems/28beab62-7540-4db1-a23f-29a6018a3848/restore/') {
+      if (opts.url === `https://graph.microsoft.com/v1.0/directory/deleteditems/${validGroupId}/restore`) {
         return Promise.resolve();
       }
 
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, { options: { debug: false, id: '28beab62-7540-4db1-a23f-29a6018a3848'} }, () => {
+    command.action(logger, {
+      options: {
+        verbose: true,
+        id: validGroupId
+      }
+    }, (err?: any) => {
       try {
-        assert(loggerLogSpy.notCalled);
+        assert.strictEqual(typeof err, 'undefined', err?.message);
         done();
       }
       catch (e) {
@@ -91,18 +150,62 @@ describe(commands.O365GROUP_RECYCLEBINITEM_RESTORE, () => {
     });
   });
 
-  it('restores the specified group (debug)', (done) => {
+  it('correctly restores group by displayName', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/directory/deletedItems/Microsoft.Graph.Group?$filter=displayName eq '${formatting.encodeQueryParameter(validGroupDisplayName)}'`) {
+        return Promise.resolve(singleGroupsResponse);
+      }
+
+      return Promise.reject('Invalid Request');
+    });
     sinon.stub(request, 'post').callsFake((opts) => {
-      if (opts.url === 'https://graph.microsoft.com/v1.0/directory/deleteditems/28beab62-7540-4db1-a23f-29a6018a3848/restore/') {
+      if (opts.url === `https://graph.microsoft.com/v1.0/directory/deleteditems/${validGroupId}/restore`) {
         return Promise.resolve();
       }
 
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, { options: { debug: true, id: '28beab62-7540-4db1-a23f-29a6018a3848'} } as any, () => {
+    command.action(logger, {
+      options: {
+        verbose: true,
+        displayName: validGroupDisplayName
+      }
+    }, (err?: any) => {
       try {
-        assert(loggerLogToStderrSpy.called);
+        assert.strictEqual(typeof err, 'undefined', err?.message);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly restores group by mailNickname', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/directory/deletedItems/Microsoft.Graph.Group?$filter=mailNickname eq '${formatting.encodeQueryParameter(validGroupMailNickname)}'`) {
+        return Promise.resolve(singleGroupsResponse);
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/directory/deleteditems/${validGroupId}/restore`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        verbose: true,
+        mailNickname: validGroupMailNickname
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined', err?.message);
         done();
       }
       catch (e) {
@@ -113,12 +216,62 @@ describe(commands.O365GROUP_RECYCLEBINITEM_RESTORE, () => {
 
   it('correctly handles error when group is not found', (done) => {
     sinon.stub(request, 'post').callsFake(() => {
-      return Promise.reject({ error: { 'odata.error': { message: { value: 'File Not Found.' } } } });
+      return Promise.reject({ error: { 'odata.error': { message: { value: 'Group Not Found.' } } } });
     });
 
     command.action(logger, { options: { debug: false, id: '28beab62-7540-4db1-a23f-29a6018a3848' } } as any, (err?: any) => {
       try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('File Not Found.')));
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Group Not Found.')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('throws error message when no group was found', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/directory/deletedItems/Microsoft.Graph.Group?$filter=mailNickname eq '${formatting.encodeQueryParameter(validGroupMailNickname)}'`) {
+        return Promise.resolve({ value: [] });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        mailNickname: validGroupMailNickname,
+        confirm: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group '${validGroupMailNickname}' does not exist.`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('throws error message when multiple groups were found', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/directory/deletedItems/Microsoft.Graph.Group?$filter=mailNickname eq '${formatting.encodeQueryParameter(validGroupMailNickname)}'`) {
+        return Promise.resolve(multipleGroupsResponse);
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    command.action(logger, {
+      options: {
+        mailNickname: validGroupMailNickname,
+        confirm: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple groups with name '${validGroupMailNickname}' found: ${multipleGroupsResponse.value.map(x => x.id).join(',')}.`)));
         done();
       }
       catch (e) {
@@ -136,26 +289,5 @@ describe(commands.O365GROUP_RECYCLEBINITEM_RESTORE, () => {
       }
     });
     assert(containsOption);
-  });
-
-  it('supports specifying id', () => {
-    const options = command.options();
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--id') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('fails validation if the id is not a valid GUID', () => {
-    const actual = command.validate({ options: { id: 'abc' } });
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('passes validation when the id is a valid GUID', () => {
-    const actual = command.validate({ options: { id: '2c1ba4c4-cd9b-4417-832f-92a34bc34b2a' } });
-    assert.strictEqual(actual, true);
   });
 });

--- a/src/m365/aad/commands/o365group/o365group-recyclebinitem-restore.ts
+++ b/src/m365/aad/commands/o365group/o365group-recyclebinitem-restore.ts
@@ -33,29 +33,39 @@ class AadO365GroupRecycleBinItemRestoreCommand extends GraphCommand {
     return [commands.O365GROUP_RESTORE];
   }
 
-  public async commandAction(logger: Logger, args: CommandArgs, cb: () => void): Promise<void> {
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.id = typeof args.options.id !== 'undefined';
+    telemetryProps.displayName = typeof args.options.displayName !== 'undefined';
+    telemetryProps.mailNickname = typeof args.options.mailNickname !== 'undefined';
+    return telemetryProps;
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
     if (this.verbose) {
       logger.logToStderr(`Restoring Microsoft 365 Group: ${args.options.id || args.options.displayName || args.options.mailNickname}...`);
     }
 
-    try {
-      const groupId = await this.getGroupId(args.options);
-
-      const requestOptions: AxiosRequestConfig = {
-        url: `${this.resource}/v1.0/directory/deleteditems/${groupId}/restore`,
-        headers: {
-          accept: 'application/json;odata.metadata=none',
-          'content-type': 'application/json'
-        },
-        responseType: 'json'
-      };
-
-      await request.post(requestOptions);
-      cb();
-    }
-    catch(err: any) {
-      this.handleRejectedODataJsonPromise(err, logger, cb);
-    }
+    (async () => {
+      try {
+        const groupId = await this.getGroupId(args.options);
+  
+        const requestOptions: AxiosRequestConfig = {
+          url: `${this.resource}/v1.0/directory/deleteditems/${groupId}/restore`,
+          headers: {
+            accept: 'application/json;odata.metadata=none',
+            'content-type': 'application/json'
+          },
+          responseType: 'json'
+        };
+  
+        await request.post(requestOptions);
+        cb();
+      }
+      catch(err: any) {
+        this.handleRejectedODataJsonPromise(err, logger, cb);
+      }
+    })();
   }
 
   private async getGroupId(options: Options): Promise<string> {

--- a/src/m365/aad/commands/o365group/o365group-recyclebinitem-restore.ts
+++ b/src/m365/aad/commands/o365group/o365group-recyclebinitem-restore.ts
@@ -1,10 +1,12 @@
+import { Group } from '@microsoft/microsoft-graph-types';
+import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli';
 import {
   CommandOption
 } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils';
+import { formatting, validation } from '../../../../utils';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 
@@ -13,7 +15,9 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  id: string;
+  id?: string;
+  displayName?: string;
+  mailNickname?: string;
 }
 
 class AadO365GroupRecycleBinItemRestoreCommand extends GraphCommand {
@@ -29,29 +33,83 @@ class AadO365GroupRecycleBinItemRestoreCommand extends GraphCommand {
     return [commands.O365GROUP_RESTORE];
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs, cb: () => void): Promise<void> {
     if (this.verbose) {
-      logger.logToStderr(`Restoring Microsoft 365 Group: ${args.options.id}...`);
+      logger.logToStderr(`Restoring Microsoft 365 Group: ${args.options.id || args.options.displayName || args.options.mailNickname}...`);
     }
 
-    const requestOptions: any = {
-      url: `${this.resource}/v1.0/directory/deleteditems/${args.options.id}/restore/`,
+    try {
+      const groupId = await this.getGroupId(args.options);
+
+      const requestOptions: AxiosRequestConfig = {
+        url: `${this.resource}/v1.0/directory/deleteditems/${groupId}/restore`,
+        headers: {
+          accept: 'application/json;odata.metadata=none',
+          'content-type': 'application/json'
+        },
+        responseType: 'json'
+      };
+
+      await request.post(requestOptions);
+      cb();
+    }
+    catch(err: any) {
+      this.handleRejectedODataJsonPromise(err, logger, cb);
+    }
+  }
+
+  private async getGroupId(options: Options): Promise<string> {
+    const { id, displayName, mailNickname } = options;
+
+    if (id) {
+      return id;
+    }
+
+    let filterValue: string = '';
+    if (displayName) {
+      filterValue = `displayName eq '${formatting.encodeQueryParameter(displayName)}'`;
+    }
+
+    if (mailNickname) {
+      filterValue = `mailNickname eq '${formatting.encodeQueryParameter(mailNickname)}'`;
+    }
+
+    const requestOptions: AxiosRequestConfig = {
+      url: `${this.resource}/v1.0/directory/deletedItems/Microsoft.Graph.Group?$filter=${filterValue}`,
       headers: {
-        'accept': 'application/json;odata.metadata=none',
-        'content-type': 'application/json'
+        accept: 'application/json;odata.metadata=none'
       },
       responseType: 'json'
     };
 
-    request
-      .post(requestOptions)
-      .then(_ => cb(), (rawRes: any): void => this.handleRejectedODataJsonPromise(rawRes, logger, cb));
+    const response = await request.get<{ value: Group[] }>(requestOptions);
+    const groups = response.value;
+
+    if (groups.length === 0) {
+      throw Error(`The specified group '${displayName || mailNickname}' does not exist.`);
+    }
+
+    if (groups.length > 1) {
+      throw Error(`Multiple groups with name '${displayName || mailNickname}' found: ${groups.map(x => x.id).join(',')}.`);
+    }
+
+    return groups[0].id!;
+  }
+
+  public optionSets(): string[][] | undefined {
+    return [['id', 'displayName', 'mailNickname']];
   }
 
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       {
-        option: '-i, --id <id>'
+        option: '-i, --id [id]'
+      },
+      {
+        option: '-d, --displayName [displayName]'
+      },
+      {
+        option: '-m, --mailNickname [mailNickname]'
       }
     ];
 
@@ -60,7 +118,7 @@ class AadO365GroupRecycleBinItemRestoreCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (!validation.isValidGuid(args.options.id)) {
+    if (args.options.id && !validation.isValidGuid(args.options.id)) {
       return `${args.options.id} is not a valid GUID`;
     }
 


### PR DESCRIPTION
Extends `aad o365group recyclebinitem restore` command with extra options. Closes #2031

## Comments
In the issue, the `--confirm` flag is specified as option. I did not implement this because both commands `spo tenant recyclebinitem restore` and `spo site recyclebinitem restore` don't implement this either. In addition, this would also be a breaking change.