### PR TITLE
Fixes `flow export` command with support for illegal file characters. Closes #3404

### DIFF
--- a/src/m365/flow/commands/flow-export.ts
+++ b/src/m365/flow/commands/flow-export.ts
@@ -129,6 +129,9 @@ class FlowExportCommand extends AzmgmtCommand {
         const downloadFileUrl: string = formatArgument === 'json' ? '' : res.packageLink.value;
         const filenameRegEx: RegExp = /([^\/]+\.zip)/i;
         filenameFromApi = formatArgument === 'json' ? `${res.properties.displayName}.json` : (filenameRegEx.exec(downloadFileUrl) || ['output.zip'])[0];
+        // Replace all illegal characters from the file name
+        const illegalCharsRegEx = /[\\\/:*?"<>|]/g;
+        filenameFromApi = filenameFromApi.replace(illegalCharsRegEx, '_');
 
         if (this.debug) {
           logger.logToStderr(`Filename from PowerApps API: ${filenameFromApi}`);


### PR DESCRIPTION
Fixes `flow export` command with support for illegal file characters. Closes #3404

### Comments

I'm sure that I've covered all illegal characters for Windows. When I lookup the illegal characters for Mac OS, there seems to be some discussion. I think that all illegal characters for Mac OS and Linux are covered by the windows characters, but not entirely sure. @waldekmastykarz could you enlighten us about illegal characters in Mac OS? ☺️

What I found:
| OS | Illegal chars | Certainty |
| --- | --- | --- |
| Windows | `\ / : * ? " < > \|` | 100% sure |
| Mac OS | `: /` | not entirely sure |
| Linux | `/` | pretty sure |