### PR TITLE
Extends `spfx doctor` command with support for SPFx v1.15.0. Closes #3432

### DIFF
--- a/src/m365/spfx/commands/spfx-doctor.ts
+++ b/src/m365/spfx/commands/spfx-doctor.ts
@@ -408,6 +408,21 @@ class SpfxDoctorCommand extends AnonymousCommand {
         range: '^4',
         fix: 'npm i -g yo@4'
       }
+    },
+    '1.15.0': {
+      gulp: {
+        range: '^4',
+        fix: 'npm i -g gulp@4'
+      },
+      node: {
+        range: '^12.13 || ^14.15 || ^16.13',
+        fix: 'Install Node.js v12.13, v14.15, v16.13 or higher'
+      },
+      sp: SharePointVersion.SPO,
+      yo: {
+        range: '^4',
+        fix: 'npm i -g yo@4'
+      }
     }
   };
 


### PR DESCRIPTION
Extends `spfx doctor` command with support for SPFx v1.15.0. Closes #3432

## Comments
Noticed that in `spfx doctor` command past versions just specify a major version of Node.js. However for SPFx v1.15.0 this is not strict enough. This is why I specified a minor version.

![image](https://user-images.githubusercontent.com/11723921/175696576-11f34995-0fb9-4691-9fdf-491b5f6feaab.png)