### PR TITLE
Extends 'spo hubsite get' command. Closes #3421Add includeAssociatedSites

### DIFF
--- a/docs/docs/cmd/spo/hubsite/hubsite-get.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-get.md
@@ -13,6 +13,9 @@ m365 spo hubsite get [options]
 `-i, --id <id>`
 : Hub site ID
 
+`--includeAssociatedSites`
+: Include the associated sites in the result (only in JSON output)
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
@@ -29,6 +32,11 @@ Get information about the hub site with ID _2c1ba4c4-cd9b-4417-832f-92a34bc34b2a
 ```sh
 m365 spo hubsite get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a
 ```
+
+Get information about the hub site with ID _2c1ba4c4-cd9b-4417-832f-92a34bc34b2a_, including its associated sites. Associated site info is only shown in JSON output.
+
+```sh
+m365 spo hubsite get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --includeAssociatedSites --output json
 
 ## More information
 

--- a/src/m365/spo/commands/hubsite/hubsite-get.spec.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-get.spec.ts
@@ -136,6 +136,86 @@ describe(commands.HUBSITE_GET, () => {
     });
   });
 
+  it('retrieves the associated sites of the specified hub site', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/hubsites/getbyid('ee8b42c3-3e6f-4822-87c1-c21ad666046b')`) > -1) {
+        return Promise.resolve({
+          "Description": null,
+          "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Sales"
+        });
+      }
+
+      if ((opts.url as string).indexOf(`DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS`) > -1) {
+        return Promise.resolve([
+          {
+            "Title": "Lucky Charms",
+            "GroupId": "3c109d21-9936-4315-b05c-7d53a8b12650",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/LuckyCharms"
+          },
+          {
+            "Title": "Great Mates",
+            "GroupId": "97505525-d3db-41e5-8393-bcb59ca2139c",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/GreatMates"
+          },
+          {
+            "Title": "Life and Music",
+            "GroupId": "c892d52b-954d-4348-a269-6cf3a7339306",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/LifeAndMusic"
+          },
+          {
+            "Title": "Leadership Connection",
+            "GroupId": "00000000-0000-0000-0000-000000000000",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/leadership-connection"
+          }
+        ]);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, { options: { debug: true, id: 'ee8b42c3-3e6f-4822-87c1-c21ad666046b', includeAssociatedSites: true, output: 'json' } }, () => {
+      try {
+        assert(loggerLogSpy.calledWith({
+          "Description": null,
+          "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Sales",
+          "AssociatedSites": [
+            {
+              "Title": "Lucky Charms",
+              "SiteId": "c08c7be1-4b97-4caa-b88f-ec91100d7774",
+              "SiteUrl": "https://contoso.sharepoint.com/sites/LuckyCharms"
+            },
+            {
+              "Title": "Great Mates",
+              "SiteId": "7c371590-d9dd-4eb1-beb3-20f3613fdd9a",
+              "SiteUrl": "https://contoso.sharepoint.com/sites/GreatMates"
+            },
+            {
+              "Title": "Life and Music",
+              "SiteId": "dd007944-c7f9-4742-8c21-de8a7718696f",
+              "SiteUrl": "https://contoso.sharepoint.com/sites/LifeAndMusic"
+            }
+          ]
+        }));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('correctly handles error when hub site not found', (done) => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject({

--- a/src/m365/spo/commands/listitem/listitem-list.ts
+++ b/src/m365/spo/commands/listitem/listitem-list.ts
@@ -14,7 +14,7 @@ interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
+export interface Options extends GlobalOptions {
   id?: string;
   listId?: string;
   listTitle?: string;


### PR DESCRIPTION
Extends 'spo hubsite get' command. Closes #3421
Add the `includeAssociatedSites` option to the command to return all associated sites for the individual hubsite.