### PR TITLE
Updates spo tenant appcatalog add reference to deprecated spo site classic add command. Closes #3457

### DIFF
--- a/src/m365/spo/commands/tenant/tenant-appcatalog-add.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-appcatalog-add.spec.ts
@@ -6,7 +6,7 @@ import { Cli, Logger } from '../../../../cli';
 import Command, { CommandError, CommandErrorWithOutput } from '../../../../Command';
 import { sinonUtil } from '../../../../utils';
 import commands from '../../commands';
-import * as spoSiteClassicAddCommand from '../site/site-classic-add';
+import * as spoSiteAddCommand from '../site/site-add';
 import * as spoSiteGetCommand from '../site/site-get';
 import * as spoSiteRemoveCommand from '../site/site-remove';
 import * as spoTenantAppCatalogUrlGetCommand from './tenant-appcatalogurl-get';
@@ -71,7 +71,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -120,7 +120,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -171,7 +171,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.reject(new CommandError('An error has occurred'));
         }
@@ -222,7 +222,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         return Promise.reject('Should not be called');
       }
 
@@ -266,7 +266,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -316,7 +316,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -366,7 +366,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.reject(new CommandError('An error has occurred'));
         }
@@ -529,7 +529,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -579,7 +579,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.reject(new CommandError('An error has occurred'));
         }
@@ -697,7 +697,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
 
   it(`creates app catalog when app catalog and site with different URL don't exist`, (done) => {
     sinon.stub(Cli, 'executeCommand').callsFake((command, args) => {
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -737,7 +737,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
 
   it(`handles error when creating app catalog fails, when app catalog when app catalog does and site with different URL don't exist`, (done) => {
     sinon.stub(Cli, 'executeCommand').callsFake((command, args) => {
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.reject(new CommandError('An error has occurred'));
         }
@@ -818,7 +818,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -865,7 +865,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -912,7 +912,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
         return Promise.reject(new CommandError('Invalid URL'));
       }
 
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.reject(new CommandError('An error has occurred'));
         }
@@ -1018,7 +1018,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
 
   it(`creates app catalog when app catalog not registered and site with different URL doesn't exist`, (done) => {
     sinon.stub(Cli, 'executeCommand').callsFake((command, args) => {
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.resolve();
         }
@@ -1057,7 +1057,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
 
   it(`handles error when creating app catalog when app catalog not registered and site with different URL doesn't exist`, (done) => {
     sinon.stub(Cli, 'executeCommand').callsFake((command, args) => {
-      if (command === spoSiteClassicAddCommand) {
+      if (command === spoSiteAddCommand) {
         if (args.options.url === 'https://contoso.sharepoint.com/sites/new-app-catalog') {
           return Promise.reject(new CommandError('An error has occurred'));
         }

--- a/src/m365/spo/commands/tenant/tenant-appcatalog-add.ts
+++ b/src/m365/spo/commands/tenant/tenant-appcatalog-add.ts
@@ -4,7 +4,7 @@ import GlobalOptions from '../../../../GlobalOptions';
 import { validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
-import * as spoSiteClassicAddCommand from '../site/site-classic-add';
+import * as spoSiteAddCommand from '../site/site-add';
 import * as spoSiteGetCommand from '../site/site-get';
 import * as spoSiteRemoveCommand from '../site/site-remove';
 import * as spoTenantAppCatalogUrlGetCommand from './tenant-appcatalogurl-get';
@@ -36,7 +36,7 @@ class SpoTenantAppCatalogAddCommand extends SpoCommand {
     }
 
     Cli
-      .executeCommandWithOutput(spoTenantAppCatalogUrlGetCommand as Command, { options: { _: [] } })
+      .executeCommandWithOutput(spoTenantAppCatalogUrlGetCommand as Command, { options: { output: 'text', _: [] } })
       .then((spoTenantAppCatalogUrlGetCommandOutput: CommandOutput): Promise<void> => {
         const appCatalogUrl: string | undefined = spoTenantAppCatalogUrlGetCommandOutput.stdout;
         if (!appCatalogUrl) {
@@ -51,6 +51,7 @@ class SpoTenantAppCatalogAddCommand extends SpoCommand {
           logger.logToStderr(`Found app catalog URL ${appCatalogUrl}`);
         }
 
+        //Using JSON.parse
         return this.ensureNoExistingSite(appCatalogUrl, args.options.force, logger);
       })
       .then(() => this.ensureNoExistingSite(args.options.url, args.options.force, logger))
@@ -118,17 +119,19 @@ class SpoTenantAppCatalogAddCommand extends SpoCommand {
       logger.logToStderr(`Creating app catalog at ${options.url}...`);
     }
 
-    const siteClassicAddOptions = {
+    const siteAddOptions = {
       webTemplate: 'APPCATALOG#0',
       title: 'App catalog',
+      type: 'ClassicSite',
       url: options.url,
       timeZone: options.timeZone,
-      owner: options.owner,
+      owners: options.owner,
       wait: options.wait,
       verbose: this.verbose,
-      debug: this.debug
-    };
-    return Cli.executeCommand(spoSiteClassicAddCommand as Command, { options: { ...siteClassicAddOptions, _: [] } });
+      debug: this.debug,
+      removeDeletedSite: false
+    } as spoSiteAddCommand.Options;
+    return Cli.executeCommand(spoSiteAddCommand as Command, { options: { ...siteAddOptions, _: [] } });
   }
 
   public options(): CommandOption[] {


### PR DESCRIPTION
Closes #3457

Updates `spo tenant appcatalog add` reference to deprecated `spo site classic add` command. 

## Remark
We're currently still creating a classic AppCatalog site. This is OK, but SharePoint itself creates a modern AppCatalog site these days. This means SharePoint is much faster creating it. We might look into that using another issue. Maybe we can update the creation as well. 