### PR TITLE
v6: Remove references and alias for deprecated planner task details get. Closes #3435

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -200,7 +200,6 @@ nav:
         - task checklistitem add: 'cmd/planner/task/task-checklistitem-add.md'        
         - task checklistitem list: 'cmd/planner/task/task-checklistitem-list.md'
         - task checklistitem remove: 'cmd/planner/task/task-checklistitem-remove.md'
-        - task details get: 'cmd/planner/task/task-get.md'
         - task get: 'cmd/planner/task/task-get.md'
         - task list: 'cmd/planner/task/task-list.md'
         - task reference add: 'cmd/planner/task/task-reference-add.md'

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -48,7 +48,6 @@ describe('Lazy loading commands', () => {
       'flow connector list',
       'outlook sendmail',
       'planner plan details get',
-      'planner task details get',
       'spo site classic remove',
       'spo sp grant add',
       'spo sp grant list',

--- a/src/m365/planner/commands.ts
+++ b/src/m365/planner/commands.ts
@@ -15,7 +15,6 @@ export default {
   TASK_CHECKLISTITEM_ADD: `${prefix} task checklistitem add`,
   TASK_CHECKLISTITEM_LIST: `${prefix} task checklistitem list`,
   TASK_CHECKLISTITEM_REMOVE: `${prefix} task checklistitem remove`,
-  TASK_DETAILS_GET: `${prefix} task details get`,
   TASK_GET: `${prefix} task get`,
   TASK_LIST: `${prefix} task list`,
   TASK_REFERENCE_ADD: `${prefix} task reference add`,

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -165,11 +165,6 @@ describe(commands.TASK_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines alias', () => {
-    const alias = command.alias();
-    assert.notStrictEqual(typeof alias, 'undefined');
-  });
-  
   it('defines correct option sets', () => {
     const optionSets = command.optionSets();
     assert.deepStrictEqual(optionSets, [['id', 'title']]);
@@ -587,34 +582,6 @@ describe(commands.TASK_GET, () => {
     command.action(logger, {
       options: {
         id: validTaskId
-      }
-    }, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  // This test has been added to support task details get alias. Needs to be removed when deprecation is removed. 
-  it('correctly gets task by task ID from task details get', (done) => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}`) {
-        return Promise.resolve(taskResponse);
-      }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details`) {
-        return Promise.resolve(taskDetailsResponse);
-      }
-
-      return Promise.reject('Invalid Request');
-    });
-
-    command.action(logger, {
-      options: {
-        taskId: validTaskId
       }
     }, () => {
       try {

--- a/src/m365/planner/commands/task/task-get.ts
+++ b/src/m365/planner/commands/task/task-get.ts
@@ -15,7 +15,6 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  taskId?: string; // This option has been added to support task details get alias. Needs to be removed when deprecation is removed. 
   id?: string;
   title?: string;
   bucketId?: string;
@@ -30,10 +29,6 @@ interface Options extends GlobalOptions {
 class PlannerTaskGetCommand extends GraphCommand {
   public get name(): string {
     return commands.TASK_GET;
-  }
-
-  public alias(): string[] | undefined {
-    return [commands.TASK_DETAILS_GET];
   }
 
   public get description(): string {
@@ -54,8 +49,6 @@ class PlannerTaskGetCommand extends GraphCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    this.showDeprecationWarning(logger, commands.TASK_DETAILS_GET, commands.TASK_GET);
-    
     if (args.options.planName) {
       args.options.planTitle = args.options.planName;
 
@@ -67,11 +60,6 @@ class PlannerTaskGetCommand extends GraphCommand {
       return;
     }
 
-    // This check has been added to support task details get alias. Needs to be removed when deprecation is removed. 
-    if (args.options.taskId) {
-      args.options.id = args.options.taskId;
-    }
-    
     this
       .getTaskId(args.options)
       .then(taskId => this.getTask(taskId))
@@ -208,7 +196,6 @@ class PlannerTaskGetCommand extends GraphCommand {
 
   public options(): CommandOption[] {
     const options: CommandOption[] = [
-      { option: '--taskId [taskId]' }, // This option has been added to support task details get alias. Needs to be removed when deprecation is removed. 
       { option: '-i, --id [id]' },
       { option: '-t, --title [title]' },
       { option: '--bucketId [bucketId]' },


### PR DESCRIPTION
Closes #3435

Remove references to and alias for deprecated `planner task details get` command. 