### PR TITLE
v6: Remove references and alias for deprecated planner plan details get. Closes #3435

### DIFF
--- a/docs/docs/cmd/planner/plan/plan-get.md
+++ b/docs/docs/cmd/planner/plan/plan-get.md
@@ -8,12 +8,6 @@ Retrieve information about the specified plan
 m365 planner plan get [options]
 ```
 
-## Alias
-
-```sh
-m365 planner plan details get [options]
-```
-
 ## Options
 
 `-i, --id [id]`

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -191,7 +191,6 @@ nav:
         - bucket remove: 'cmd/planner/bucket/bucket-remove.md'
       - plan:
         - plan add: 'cmd/planner/plan/plan-add.md'
-        - plan details get: 'cmd/planner/plan/plan-get.md'
         - plan get: 'cmd/planner/plan/plan-get.md'
         - plan list: 'cmd/planner/plan/plan-list.md'
         - plan remove: 'cmd/planner/plan/plan-remove.md'

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -47,7 +47,6 @@ describe('Lazy loading commands', () => {
       'flow connector export',
       'flow connector list',
       'outlook sendmail',
-      'planner plan details get',
       'planner task details get',
       'spo site classic remove',
       'spo sp grant add',

--- a/src/m365/planner/commands.ts
+++ b/src/m365/planner/commands.ts
@@ -7,7 +7,6 @@ export default {
   BUCKET_SET: `${prefix} bucket set`,
   BUCKET_REMOVE: `${prefix} bucket remove`,
   PLAN_ADD: `${prefix} plan add`,
-  PLAN_DETAILS_GET: `${prefix} plan details get`,
   PLAN_GET: `${prefix} plan get`,
   PLAN_LIST: `${prefix} plan list`,
   PLAN_REMOVE:`${prefix} plan remove`,

--- a/src/m365/planner/commands/plan/plan-get.spec.ts
+++ b/src/m365/planner/commands/plan/plan-get.spec.ts
@@ -94,11 +94,6 @@ describe(commands.PLAN_GET, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'title', 'createdDateTime', 'owner', '@odata.etag']);
   });
   
-  it('defines alias', () => {
-    const alias = command.alias();
-    assert.notStrictEqual(typeof alias, 'undefined');
-  });
-
   it('fails validation if neither id nor title are provided.', (done) => {
     const actual = command.validate({ options: {} });
     assert.notStrictEqual(actual, true);

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -28,10 +28,6 @@ class PlannerPlanGetCommand extends GraphCommand {
     return commands.PLAN_GET;
   }
 
-  public alias(): string[] | undefined {
-    return [commands.PLAN_DETAILS_GET];
-  }
-
   public get description(): string {
     return 'Get a Microsoft Planner plan';
   }
@@ -52,8 +48,6 @@ class PlannerPlanGetCommand extends GraphCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    this.showDeprecationWarning(logger, commands.PLAN_DETAILS_GET, commands.PLAN_GET);
-
     if (accessToken.isAppOnlyAccessToken(Auth.service.accessTokens[this.resource].accessToken)) {
       this.handleError('This command does not support application permissions.', logger, cb);
       return;


### PR DESCRIPTION
Closes #3435

Remove references and alias for deprecated `planner plan details get`. 