### PR TITLE
v6: Remove the setting autoOpenBrowserOnLogin to follow new settings autoOpenLinksInBrowser. Closes #3163

### DIFF
--- a/docs/docs/_clisettings.md
+++ b/docs/docs/_clisettings.md
@@ -4,8 +4,7 @@ Following is the list of configuration settings available in CLI for Microsoft 3
 
 Setting name|Definition|Default value
 ------------|----------|-------------
-`autoOpenBrowserOnLogin`|Automatically open the browser to the Azure AD login page after running `m365 login` command in device code mode. This setting will be replaced by `autoOpenLinksInBrowser` in the next major release.|`false`
-`autoOpenLinksInBrowser`|Automatically open the browser for all commands which return a url and expect the user to copy paste this to the browser. For example when logging in, using `m365 login` in device code mode. This setting will replace `autoOpenBrowserOnLogin` in the next major release.|`false`
+`autoOpenLinksInBrowser`|Automatically open the browser for all commands which return a url and expect the user to copy paste this to the browser. For example when logging in, using `m365 login` in device code mode.|`false`
 `copyDeviceCodeToClipboard`|Automatically copy the device code to the clipboard when running `m365 login` command in device code mode|`false`
 `csvEscape`|Single character used for escaping; only apply to characters matching the quote and the escape options|`"`
 `csvHeader`|Display the column names on the first line|`true`

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -432,16 +432,10 @@ describe('Auth', () => {
     });
   });
 
-  it('opens the browser with the login (using autoOpenBrowserOnLogin)', () => {
-    (auth as any).processDeviceCodeCallback(response, logger, false);
-    assert(openStub.called);
-  });
-
   it('opens the browser with the login (using autoOpenLinksInBrowser)', () => {
     getSettingWithDefaultValueStub.restore();
     getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(((settingName, defaultValue) => {
-      if (settingName === "autoOpenBrowserOnLogin") { return false; }
-      else if (settingName === "autoOpenLinksInBrowser") { return true; }
+      if (settingName === "autoOpenLinksInBrowser") { return true; }
       else {
         return defaultValue;
       }

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -361,8 +361,7 @@ export class Auth {
 
     logger.log(response.message);
 
-    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenBrowserOnLogin, false)
-      || Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false)) {
+    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false)) {
       // _open is never set before hitting this line, but this check
       // is implemented so that we can support lazy loading
       // but also stub it for testing

--- a/src/m365/cli/commands/config/config-set.spec.ts
+++ b/src/m365/cli/commands/config/config-set.spec.ts
@@ -62,25 +62,6 @@ describe(commands.CONFIG_SET, () => {
     });
   });
 
-  it(`sets ${settingsNames.autoOpenBrowserOnLogin} property`, (done) => {
-    const config = Cli.getInstance().config;
-    let actualKey: string, actualValue: any;
-    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
-      actualKey = key;
-      actualValue = value;
-    }) as any);
-    command.action(logger, { options: { key: settingsNames.autoOpenBrowserOnLogin, value: false } }, () => {
-      try {
-        assert.strictEqual(actualKey, settingsNames.autoOpenBrowserOnLogin, 'Invalid key');
-        assert.strictEqual(actualValue, false, 'Invalid value');
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
   it(`sets ${settingsNames.autoOpenLinksInBrowser} property`, (done) => {
     const config = Cli.getInstance().config;
     let actualKey: string, actualValue: any;

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -78,7 +78,6 @@ class CliConfigSetCommand extends AnonymousCommand {
     let value: any = undefined;
 
     switch (args.options.key) {
-      case settingsNames.autoOpenBrowserOnLogin:
       case settingsNames.autoOpenLinksInBrowser:
       case settingsNames.copyDeviceCodeToClipboard:
       case settingsNames.csvHeader:

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -1,5 +1,4 @@
 const settingsNames = {
-  autoOpenBrowserOnLogin: 'autoOpenBrowserOnLogin',
   autoOpenLinksInBrowser: 'autoOpenLinksInBrowser',
   copyDeviceCodeToClipboard: 'copyDeviceCodeToClipboard',
   csvEscape: 'csvEscape',


### PR DESCRIPTION
Closes #3163

Remove the setting `autoOpenBrowserOnLogin` to follow new settings `autoOpenLinksInBrowser`. 