### PR TITLE
Update `planner task get` docs to include alias. Closes #3495

### DIFF
--- a/docs/docs/cmd/planner/task/task-get.md
+++ b/docs/docs/cmd/planner/task/task-get.md
@@ -8,6 +8,12 @@ Retrieve the specified planner task
 m365 planner task get [options]
 ```
 
+## Alias
+
+```sh
+m365 planner task details get [options]
+```
+
 ## Options
 
 `-i, --id  [id]`


### PR DESCRIPTION
Closes #3495

With merging the command `planner task details get` with `planner task get`, I forgot to include the alias in the docs. This PR resolves this.

Issue #3435 and PR #3466 should also include the removal of the alias within the docs. Sorry for the inconvenience @martinlingstuyl 😅 