### PR TITLE
Extends commands "teams team remove", "teams team archive", and "teams team unarchive" to add an extra option to get to the correct team. Closes #3483

### DIFF
--- a/docs/docs/cmd/teams/team/team-archive.md
+++ b/docs/docs/cmd/teams/team/team-archive.md
@@ -10,8 +10,14 @@ m365 teams team archive [options]
 
 ## Options
 
-`-i, --teamId <teamId>`
-: The ID of the Microsoft Teams team to archive
+`-i, --id [id]`
+: The ID of the Microsoft Teams team to archive. Specify either id or name but not both
+
+`-n, --name [name]`
+: The display name of the Microsoft Teams team to archive. Specify either id or name but not both
+
+`--teamId [teamId]`
+: (deprecated. Use `id` instead) The ID of the Microsoft Teams team to archive
 
 `--shouldSetSpoSiteReadOnlyForMembers`
 : Sets the permissions for team members to read-only on the SharePoint Online site associated with the team
@@ -22,18 +28,27 @@ m365 teams team archive [options]
 
 Using this command, global admins and Microsoft Teams service admins can access teams that they are not a member of.
 
+If the command finds multiple Microsoft Teams teams with the specified name, it will prompt you to disambiguate which team it should use, listing the discovered team IDs.
+
 When a team is archived, users can no longer send or like messages on any channel in the team, edit the team's name, description, or other settings, or in general make most changes to the team. Membership changes to the team continue to be allowed.
+
 
 ## Examples
 
-Archive the specified Microsoft Teams team
+Archive the specified Microsoft Teams team with id _6f6fd3f7-9ba5-4488-bbe6-a789004d0d55_
 
 ```sh
-m365 teams team archive --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
+m365 teams team archive --id 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
+```
+
+Archive the specified Microsoft Teams team with name _Team Name_
+
+```sh
+m365 teams team archive --name "Team Name"
 ```
 
 Archive the specified Microsoft Teams team and set permissions for team members to read-only on the SharePoint Online site associated with the team
 
 ```sh
-m365 teams team archive --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55 --shouldSetSpoSiteReadOnlyForMembers
+m365 teams team archive --id 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55 --shouldSetSpoSiteReadOnlyForMembers
 ```

--- a/docs/docs/cmd/teams/team/team-remove.md
+++ b/docs/docs/cmd/teams/team/team-remove.md
@@ -10,8 +10,14 @@ m365 teams team remove [options]
 
 ## Options
 
-`-i, --teamId <teamId>`
-: The ID of the Teams team to remove
+`-i, --id [id]`
+: The ID of the Microsoft Teams team to remove. Specify either id or name but not both
+
+`-n, --name [name]`
+: The display name of the Microsoft Teams team to remove. Specify either id or name but not both
+
+`--teamId [teamId]`
+: (deprecated. Use `id` instead) The ID of the Teams team to remove
 
 `--confirm`
 : Don't prompt for confirming removing the specified team
@@ -22,18 +28,26 @@ m365 teams team remove [options]
 
 When deleted, Microsoft 365 groups are moved to a temporary container and can be restored within 30 days. After that time, they are permanently deleted. This applies only to Microsoft 365 groups.
 
+If the command finds multiple Microsoft Teams teams with the specified name, it will prompt you to disambiguate which team it should use, listing the discovered team IDs.
+
 ## Examples
 
-Removes the specified team
+Removes the specified Microsoft Teams team with id _00000000-0000-0000-0000-000000000000_
 
 ```sh
-m365 teams team remove --teamId '00000000-0000-0000-0000-000000000000'
+m365 teams team remove --id 00000000-0000-0000-0000-000000000000
+```
+
+Removes the specified Microsoft Teams team with name _Team Name_
+
+```sh
+m365 teams team remove --name "Team Name"
 ```
 
 Removes the specified team without confirmation
 
 ```sh
-m365 teams team remove --teamId '00000000-0000-0000-0000-000000000000' --confirm
+m365 teams team remove --id 00000000-0000-0000-0000-000000000000 --confirm
 ```
 
 ## More information

--- a/docs/docs/cmd/teams/team/team-unarchive.md
+++ b/docs/docs/cmd/teams/team/team-unarchive.md
@@ -10,8 +10,14 @@ m365 teams team unarchive [options]
 
 ## Options
 
-`-i, --teamId <teamId>`
-: The ID of the Microsoft Teams team to restore
+`-i, --id [id]`
+: The ID of the Microsoft Teams team to restore. Specify either id or name but not both
+
+`-n, --name [name]`
+: The display name of the Microsoft Teams team to restore. Specify either id or name but not both
+
+`--teamId [teamId]`
+: (deprecated. Use `id` instead) The ID of the Microsoft Teams team to restore
 
 --8<-- "docs/cmd/_global.md"
 
@@ -19,12 +25,20 @@ m365 teams team unarchive [options]
 
 This command supports admin permissions. Global admins and Microsoft Teams service admins can restore teams that they are not a member of.
 
+If the command finds multiple Microsoft Teams teams with the specified name, it will prompt you to disambiguate which team it should use, listing the discovered team IDs.
+
 This command restores users' ability to send messages and edit the team, abiding by tenant and team settings.
 
 ## Examples
 
-Restore an archived Microsoft Teams team
+Restore an archived Microsoft Teams team with id _6f6fd3f7-9ba5-4488-bbe6-a789004d0d55_
 
 ```sh
-m365 teams team unarchive --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
+m365 teams team unarchive --id 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
+```
+
+Restore an archived Microsoft Teams team with name _Team Name_
+
+```sh
+m365 teams team unarchive --name "Team Name"
 ```

--- a/src/m365/teams/commands/team/team-archive.ts
+++ b/src/m365/teams/commands/team/team-archive.ts
@@ -1,17 +1,25 @@
+import { Group } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
+import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
+
+interface ExtendedGroup extends Group {
+  resourceProvisioningOptions: string[];
+}
 
 interface CommandArgs {
   options: Options;
 }
 
 interface Options extends GlobalOptions {
-  teamId: string;
+  id?: string;
+  name?: string;
+  teamId?: string;
   shouldSetSpoSiteReadOnlyForMembers: boolean;
 }
 
@@ -30,29 +38,61 @@ class TeamsTeamArchiveCommand extends GraphCommand {
     return telemetryProps;
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
-    const siteReadOnlyForMembers: boolean = args.options.shouldSetSpoSiteReadOnlyForMembers === true;
-    const requestOptions: any = {
-      url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.teamId)}/archive`,
-      headers: {
-        'content-type': 'application/json;odata=nometadata',
-        'accept': 'application/json;odata.metadata=none'
-      },
-      responseType: 'json',
-      data: {
-        shouldSetSpoSiteReadOnlyForMembers: siteReadOnlyForMembers
-      }
-    };
+  private getTeamId(args: CommandArgs): Promise<string> {
+    if (args.options.id) {
+      return Promise.resolve(args.options.id);
+    }
 
-    request
-      .post(requestOptions)
+    return aadGroup
+      .getGroupByDisplayName(args.options.name!)
+      .then(group => {
+        if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
+          return Promise.reject(`The specified team does not exist in the Microsoft Teams`);
+        }
+
+        return group.id!;
+      });
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    if (args.options.teamId) {
+      args.options.id = args.options.teamId;
+
+      this.warn(logger, `Option 'teamId' is deprecated. Please use 'id' instead.`);
+    }
+
+    const siteReadOnlyForMembers: boolean = args.options.shouldSetSpoSiteReadOnlyForMembers === true;
+
+    this
+      .getTeamId(args)
+      .then((teamId: string): Promise<void> => {
+        const requestOptions: any = {
+          url: `${this.resource}/v1.0/teams/${encodeURIComponent(teamId)}/archive`,
+          headers: {
+            'content-type': 'application/json;odata=nometadata',
+            'accept': 'application/json;odata.metadata=none'
+          },
+          responseType: 'json',
+          data: {
+            shouldSetSpoSiteReadOnlyForMembers: siteReadOnlyForMembers
+          }
+        };
+
+        return request.post(requestOptions);
+      })
       .then(_ => cb(), (res: any): void => this.handleRejectedODataJsonPromise(res, logger, cb));
   }
 
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       {
-        option: '-i, --teamId <teamId>'
+        option: '-i, --id [id]'
+      },
+      {
+        option: '-n, --name [name]'
+      },
+      {
+        option: '--teamId [teamId]'
       },
       {
         option: '--shouldSetSpoSiteReadOnlyForMembers'
@@ -64,8 +104,20 @@ class TeamsTeamArchiveCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (!validation.isValidGuid(args.options.teamId)) {
+    if (!args.options.id && !args.options.name && !args.options.teamId) {
+      return 'Specify either id or name';
+    }
+
+    if (args.options.name && (args.options.id || args.options.teamId)) {
+      return 'Specify either id or name but not both';
+    }
+
+    if (args.options.teamId && !validation.isValidGuid(args.options.teamId)) {
       return `${args.options.teamId} is not a valid GUID`;
+    }
+
+    if (args.options.id && !validation.isValidGuid(args.options.id)) {
+      return `${args.options.id} is not a valid GUID`;
     }
 
     return true;

--- a/src/m365/teams/commands/team/team-unarchive.spec.ts
+++ b/src/m365/teams/commands/team/team-unarchive.spec.ts
@@ -1,9 +1,10 @@
 import * as assert from 'assert';
+import chalk = require('chalk');
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
 import { Logger } from '../../../../cli';
-import Command from '../../../../Command';
+import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
 import { sinonUtil } from '../../../../utils';
 import commands from '../../commands';
@@ -13,10 +14,11 @@ describe(commands.TEAM_UNARCHIVE, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
   });
 
@@ -34,11 +36,13 @@ describe(commands.TEAM_UNARCHIVE, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
+    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
     (command as any).items = [];
   });
 
   afterEach(() => {
     sinonUtil.restore([
+      request.get,
       request.post
     ]);
   });
@@ -68,16 +72,65 @@ describe(commands.TEAM_UNARCHIVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if the id is not a valid guid.', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'invalid'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
   it('passes validation when the input is correct', () => {
     const actual = command.validate({
       options: {
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
       }
     });
     assert.strictEqual(actual, true);
   });
 
-  it('restores an archived Microsoft Team', (done) => {
+  it('fails validation when no option is specified', () => {
+    const actual = command.validate({
+      options: {
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when all options are specified', () => {
+    const actual = command.validate({
+      options: {
+        name: 'Finance',
+        id: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402',
+        teamId: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when both id and name are specified', () => {
+    const actual = command.validate({
+      options: {
+        name: 'Finance',
+        id: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when both teamId and name are specified', () => {
+    const actual = command.validate({
+      options: {
+        name: 'Finance',
+        teamId: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
+      }
+    });
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('logs deprecation warning when option teamId is specified', (done) => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/teams/f5dba91d-6494-4d5e-89a7-ad832f6946d6/unarchive`) {
         return Promise.resolve();
@@ -89,6 +142,103 @@ describe(commands.TEAM_UNARCHIVE, () => {
     command.action(logger, {
       options: {
         teamId: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6'
+      }
+    } as any, () => {
+      try {
+        assert(loggerLogToStderrSpy.calledWith(chalk.yellow(`Option 'teamId' is deprecated. Please use 'id' instead.`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails when team name does not exist', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
+        return Promise.resolve({
+          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
+          "@odata.count": 1,
+          "value": [
+            {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "resourceProvisioningOptions": []
+            }
+          ]
+        }
+        );
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        name: 'Finance',
+        confirm: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified team does not exist in the Microsoft Teams`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('restores an archived Microsoft Team by id', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/f5dba91d-6494-4d5e-89a7-ad832f6946d6/unarchive`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        id: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6'
+      }
+    } as any, () => {
+      try {
+        assert(loggerLogSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('restores an archived Microsoft Team by name', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
+        return Promise.resolve({
+          "value": [
+            {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "resourceProvisioningOptions": ["Team"]
+            }
+          ]
+        });
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/00000000-0000-0000-0000-000000000000/unarchive`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        name: 'Finance'
       }
     } as any, () => {
       try {
@@ -122,7 +272,7 @@ describe(commands.TEAM_UNARCHIVE, () => {
 
     command.action(logger, {
       options: {
-        teamId: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6'
+        id: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6'
       }
     } as any, (err?: any) => {
       try {

--- a/src/m365/teams/commands/team/team-unarchive.ts
+++ b/src/m365/teams/commands/team/team-unarchive.ts
@@ -1,17 +1,25 @@
+import { Group } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils';
+import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
+
+interface ExtendedGroup extends Group {
+  resourceProvisioningOptions: string[];
+}
 
 interface CommandArgs {
   options: Options;
 }
 
 interface Options extends GlobalOptions {
-  teamId: string;
+  id?: string;
+  name?: string;
+  teamId?: string;
 }
 
 class TeamsTeamUnarchiveCommand extends GraphCommand {
@@ -23,27 +31,58 @@ class TeamsTeamUnarchiveCommand extends GraphCommand {
     return 'Restores an archived Microsoft Teams team';
   }
 
+  private getTeamId(args: CommandArgs): Promise<string> {
+    if (args.options.id) {
+      return Promise.resolve(args.options.id);
+    }
+
+    return aadGroup
+      .getGroupByDisplayName(args.options.name!)
+      .then(group => {
+        if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
+          return Promise.reject(`The specified team does not exist in the Microsoft Teams`);
+        }
+
+        return group.id!;
+      });
+  }
+
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    if (args.options.teamId) {
+      args.options.id = args.options.teamId;
+
+      this.warn(logger, `Option 'teamId' is deprecated. Please use 'id' instead.`);
+    }
+
     const endpoint: string = `${this.resource}/v1.0`;
 
-    const requestOptions: any = {
-      url: `${endpoint}/teams/${encodeURIComponent(args.options.teamId)}/unarchive`,
-      headers: {
-        'content-type': 'application/json;odata=nometadata',
-        'accept': 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
+    this
+      .getTeamId(args)
+      .then((teamId: string): Promise<void> => {
+        const requestOptions: any = {
+          url: `${endpoint}/teams/${encodeURIComponent(teamId)}/unarchive`,
+          headers: {
+            'content-type': 'application/json;odata=nometadata',
+            'accept': 'application/json;odata.metadata=none'
+          },
+          responseType: 'json'
+        };
 
-    request
-      .post(requestOptions)
+        return request.post(requestOptions);
+      })
       .then(_ => cb(), (res: any): void => this.handleRejectedODataJsonPromise(res, logger, cb));
   }
 
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       {
-        option: '-i, --teamId <teamId>'
+        option: '-i, --id [id]'
+      },
+      {
+        option: '-n, --name [name]'
+      },
+      {
+        option: '--teamId [teamId]'
       }
     ];
 
@@ -52,8 +91,20 @@ class TeamsTeamUnarchiveCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (!validation.isValidGuid(args.options.teamId)) {
+    if (!args.options.id && !args.options.name && !args.options.teamId) {
+      return 'Specify either id or name';
+    }
+
+    if (args.options.name && (args.options.id || args.options.teamId)) {
+      return 'Specify either id or name but not both';
+    }
+
+    if (args.options.teamId && !validation.isValidGuid(args.options.teamId)) {
       return `${args.options.teamId} is not a valid GUID`;
+    }
+
+    if (args.options.id && !validation.isValidGuid(args.options.id)) {
+      return `${args.options.id} is not a valid GUID`;
     }
 
     return true;


### PR DESCRIPTION
Extends commands `teams team remove`, `teams team archive`, and `teams team unarchive` to add an extra option to get to the correct team. Closes #3483