### PR TITLE
v6: Fixes "teams team remove", "teams team archive", and "teams team unarchive" commands. Closes #3502

### DIFF
--- a/src/m365/teams/commands/team/team-archive.spec.ts
+++ b/src/m365/teams/commands/team/team-archive.spec.ts
@@ -98,15 +98,6 @@ describe(commands.TEAM_ARCHIVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation when both id and name are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'Finance',
-        id: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
 
   it('fails when team name does not exist', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {

--- a/src/m365/teams/commands/team/team-remove.spec.ts
+++ b/src/m365/teams/commands/team/team-remove.spec.ts
@@ -67,32 +67,9 @@ describe(commands.TEAM_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation when no option is specified', async () => {
-    const actual = await command.validate({
-      options: {
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when all options are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'Finance',
-        id: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when both id and name are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'Finance',
-        id: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets;
+    assert.deepStrictEqual(optionSets, [['id', 'name']]);
   });
 
   it('fails validation if the id is not a valid guid.', async () => {
@@ -104,10 +81,10 @@ describe(commands.TEAM_REMOVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('passes validation when valid id is specified', async () => {
+  it('passes validation when the input is correct', async () => {
     const actual = await command.validate({
       options: {
-        id: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
@@ -148,7 +125,7 @@ describe(commands.TEAM_REMOVE, () => {
     });
   });
 
-  it('prompts before removing the specified team when confirm option not passed', (done) => {
+  it('prompts before removing the specified team by id when confirm option not passed', (done) => {
     command.action(logger, { options: { debug: false, id: "00000000-0000-0000-0000-000000000000" } }, () => {
       let promptIssued = false;
 
@@ -166,8 +143,8 @@ describe(commands.TEAM_REMOVE, () => {
     });
   });
 
-  it('prompts before removing the specified team when confirm option not passed (debug)', (done) => {
-    command.action(logger, { options: { debug: true, id: "00000000-0000-0000-0000-000000000000" } }, () => {
+  it('prompts before removing the specified team by name when confirm option not passed (debug)', (done) => {
+    command.action(logger, { options: { debug: true, name: "Finance" } }, () => {
       let promptIssued = false;
 
       if (promptOptions && promptOptions.type === 'confirm') {

--- a/src/m365/teams/commands/team/team-remove.ts
+++ b/src/m365/teams/commands/team/team-remove.ts
@@ -36,6 +36,7 @@ class TeamsTeamRemoveCommand extends GraphCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initTelemetry(): void {
@@ -60,17 +61,13 @@ class TeamsTeamRemoveCommand extends GraphCommand {
     );
   }
 
+  #initOptionSets(): void {
+    this.optionSets.push(['id', 'name']);
+  }
+
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (!args.options.id && !args.options.name) {
-	      return 'Specify either id or name';
-	    }
-
-	    if (args.options.name && args.options.id) {
-	      return 'Specify either id or name but not both';
-	    }
-
 	    if (args.options.id && !validation.isValidGuid(args.options.id)) {
 	      return `${args.options.id} is not a valid GUID`;
 	    }
@@ -122,7 +119,7 @@ class TeamsTeamRemoveCommand extends GraphCommand {
         type: 'confirm',
         name: 'continue',
         default: false,
-        message: `Are you sure you want to remove the team ${args.options.teamId}?`
+        message: `Are you sure you want to remove the team ${args.options.id ? args.options.id : args.options.name}?`
       }, (result: { continue: boolean }): void => {
         if (!result.continue) {
           cb();

--- a/src/m365/teams/commands/team/team-unarchive.spec.ts
+++ b/src/m365/teams/commands/team/team-unarchive.spec.ts
@@ -35,6 +35,7 @@ describe(commands.TEAM_UNARCHIVE, () => {
         log.push(msg);
       }
     };
+
     loggerLogSpy = sinon.spy(logger, 'log');
     (command as any).items = [];
   });
@@ -62,6 +63,11 @@ describe(commands.TEAM_UNARCHIVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets;
+    assert.deepStrictEqual(optionSets, [['id', 'name']]);
+  });
+
   it('fails validation if the id is not a valid guid.', async () => {
     const actual = await command.validate({
       options: {
@@ -78,34 +84,6 @@ describe(commands.TEAM_UNARCHIVE, () => {
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
-  });
-
-  it('fails validation when no option is specified', async () => {
-    const actual = await command.validate({
-      options: {
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when all options are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'Finance',
-        id: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when both id and name are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'Finance',
-        id: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
   });
 
   it('fails when team name does not exist', (done) => {

--- a/src/m365/teams/commands/team/team-unarchive.ts
+++ b/src/m365/teams/commands/team/team-unarchive.ts
@@ -34,6 +34,7 @@ class TeamsTeamUnarchiveCommand extends GraphCommand {
 
     this.#initOptions();
     this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initOptions(): void {
@@ -47,17 +48,13 @@ class TeamsTeamUnarchiveCommand extends GraphCommand {
     );
   }
 
+  #initOptionSets(): void {
+    this.optionSets.push(['id', 'name']);
+  }
+
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (!args.options.id && !args.options.name) {
-	      return 'Specify either id or name';
-	    }
-
-	    if (args.options.name && args.options.id) {
-	      return 'Specify either id or name but not both';
-	    }
-
 	    if (args.options.id && !validation.isValidGuid(args.options.id)) {
 	      return `${args.options.id} is not a valid GUID`;
 	    }


### PR DESCRIPTION
Fixes `teams team remove`, `teams team archive`, and `teams team unarchive` commands by removing obsolete `teamId` option. Closes #3502