### PR TITLE
Fixes 'spo field get' and 'spo field remove' commands. Closes #3480

### DIFF
--- a/docs/docs/cmd/spo/field/field-get.md
+++ b/docs/docs/cmd/spo/field/field-get.md
@@ -23,10 +23,13 @@ m365 spo field get [options]
 : Server- or web-relative URL of the list where the field is located. Specify only one of listTitle, listId or listUrl
 
 `-i, --id [id]`
-: The ID of the field to retrieve. Specify id or fieldTitle but not both
+: The ID of the field to retrieve. Specify id or title but not both
 
 `--fieldTitle [fieldTitle]`
-: The display name (case-sensitive) of the field to retrieve. Specify id or fieldTitle but not both
+: (deprecated. Use `title` instead) The display name (case-sensitive) of the field to retrieve. Specify id or fieldTitle but not both
+
+`-t, --title [title]`
+: The display name (case-sensitive) of the field to remove. Specify id or title, or group but not both
 
 --8<-- "docs/cmd/_global.md"
 
@@ -47,5 +50,5 @@ m365 spo field get --webUrl https://contoso.sharepoint.com/sites/contoso-sales -
 Retrieves list column by display name located in site _https://contoso.sharepoint.com/sites/contoso-sales_. Retrieves the list by its url
 
 ```sh
-m365 spo field get --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl 'Lists/Events' --fieldTitle 'Title'
+m365 spo field get --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl "Lists/Events" --title "Title"
 ```

--- a/docs/docs/cmd/spo/field/field-remove.md
+++ b/docs/docs/cmd/spo/field/field-remove.md
@@ -23,13 +23,16 @@ m365 spo field remove [options]
 : Server- or web-relative URL of the list where the field is located. Specify only one of `listTitle`, `listId` or `listUrl`
 
 `-i, --id [id]`
-: The ID of the field to remove. Specify id, fieldTitle, or group
+: The ID of the field to remove. Specify id, title, or group
 
-`-t, --fieldTitle [fieldTitle]`
-: The display name (case-sensitive) of the field to remove. Specify id, fieldTitle, or group
+`--fieldTitle [fieldTitle]`
+: (deprecated. Use `title` instead) The display name (case-sensitive) of the field to remove. Specify id, fieldTitle, or group
+
+`-t, --title [title]`
+: The display name (case-sensitive) of the field to remove. Specify id, title, or group
 
 `-g, --group [group]`
-: Delete all fields from this group (case-sensitive). Specify id, fieldTitle, or group
+: Delete all fields from this group (case-sensitive). Specify id, title, or group
 
 `--confirm`
 : Don't prompt for confirming removing the field
@@ -53,11 +56,11 @@ m365 spo field remove --webUrl https://contoso.sharepoint.com/sites/contoso-sale
 Remove the list column with the specified display name, located in site _https://contoso.sharepoint.com/sites/contoso-sales_. Retrieves the list by its url
 
 ```sh
-m365 spo field remove --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl 'Lists/Events' --fieldTitle 'Title'
+m365 spo field remove --webUrl https://contoso.sharepoint.com/sites/contoso-sales --listUrl "Lists/Events" --title "Title"
 ```
 
 Remove all site columns from group _MyGroup_
 
 ```sh
-m365 spo field remove --webUrl https://contoso.sharepoint.com/sites/contoso-sales --group 'MyGroup'
+m365 spo field remove --webUrl https://contoso.sharepoint.com/sites/contoso-sales --group "MyGroup"
 ```

--- a/src/m365/spo/commands/field/field-get.ts
+++ b/src/m365/spo/commands/field/field-get.ts
@@ -19,6 +19,7 @@ interface Options extends GlobalOptions {
   listUrl?: string;
   id?: string;
   fieldTitle?: string;
+  title?: string;
 }
 
 class SpoFieldGetCommand extends SpoCommand {
@@ -36,11 +37,23 @@ class SpoFieldGetCommand extends SpoCommand {
     telemetryProps.listTitle = typeof args.options.listTitle !== 'undefined';
     telemetryProps.listUrl = typeof args.options.listUrl !== 'undefined';
     telemetryProps.id = typeof args.options.id !== 'undefined';
-    telemetryProps.fieldTitle = typeof args.options.fieldTitle !== 'undefined';
+    telemetryProps.title = typeof args.options.title !== 'undefined';
     return telemetryProps;
   }
 
+  public optionSets(): string[][] | undefined {
+    return [
+      ['id', 'title', 'fieldTitle']
+    ];
+  }
+
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    if (args.options.fieldTitle) {
+      args.options.title = args.options.fieldTitle;
+
+      this.warn(logger, `Option 'fieldTitle' is deprecated. Please use 'title' instead.`);
+    }
+
     let listRestUrl: string = '';
 
     if (args.options.listId) {
@@ -60,7 +73,7 @@ class SpoFieldGetCommand extends SpoCommand {
       fieldRestUrl = `/getbyid('${formatting.encodeQueryParameter(args.options.id)}')`;
     }
     else {
-      fieldRestUrl = `/getbyinternalnameortitle('${formatting.encodeQueryParameter(args.options.fieldTitle as string)}')`;
+      fieldRestUrl = `/getbyinternalnameortitle('${formatting.encodeQueryParameter(args.options.title as string)}')`;
     }
 
     const requestOptions: any = {
@@ -98,6 +111,9 @@ class SpoFieldGetCommand extends SpoCommand {
       },
       {
         option: '--fieldTitle [fieldTitle]'
+      },
+      {
+        option: '-t, --title [title]'
       }
     ];
 
@@ -109,10 +125,6 @@ class SpoFieldGetCommand extends SpoCommand {
     const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
     if (isValidSharePointUrl !== true) {
       return isValidSharePointUrl;
-    }
-
-    if (!args.options.id && !args.options.fieldTitle) {
-      return 'Specify id or fieldTitle, one is required';
     }
 
     if (args.options.id && !validation.isValidGuid(args.options.id)) {


### PR DESCRIPTION
Fixes `spo field get` and `spo field remove` commands. Closes #3480
Marked the `fieldTitle` option as deprecated and introduced a new option called `title`.