### PR TITLE
Fixes 'teams team set' and 'teams team clone' to include 'id' and 'name' command options. Closes #3482

### DIFF
--- a/docs/docs/cmd/teams/team/team-clone.md
+++ b/docs/docs/cmd/teams/team/team-clone.md
@@ -10,11 +10,17 @@ m365 teams team clone [options]
 
 ## Options
 
-`-i, --teamId <teamId>`
+`-i, --id [id]`
 : The ID of the Microsoft Teams team to clone
 
-`-n, --displayName <displayName>`
-: The display name for the new Microsoft Teams Team
+`--teamId [teamId]`
+: (deprecated. Use `id` instead) The ID of the Microsoft Teams team to clone
+
+`-n, --name [name]`
+: The display name for the new Microsoft Teams Team to clone
+
+`--displayName [displayName]`
+: (deprecated. Use `name` instead) The display name for the new Microsoft Teams Team to clone
 
 `-p, --partsToClone <partsToClone>`
 : A comma-separated list of the parts to clone. Allowed values are `apps,channels,members,settings,tabs`
@@ -41,11 +47,11 @@ When tabs are cloned, they are put into an unconfigured state. The first time yo
 Creates a clone of a Microsoft Teams team with mandatory parameters
 
 ```sh
-m365 teams team clone --teamId 15d7a78e-fd77-4599-97a5-dbb6372846c5 --displayName "Library Assist" --partsToClone "apps,tabs,settings,channels,members"
+m365 teams team clone --id 15d7a78e-fd77-4599-97a5-dbb6372846c5 --name "Library Assist" --partsToClone "apps,tabs,settings,channels,members"
 ```
 
 Creates a clone of a Microsoft Teams team with mandatory and optional parameters
 
 ```sh
-m365 teams team clone --teamId 15d7a78e-fd77-4599-97a5-dbb6372846c5 --displayName "Library Assist" --partsToClone "apps,tabs,settings,channels,members" --description "Self help community for library" --classification "Library" --visibility "public"
+m365 teams team clone --id 15d7a78e-fd77-4599-97a5-dbb6372846c5 --name "Library Assist" --partsToClone "apps,tabs,settings,channels,members" --description "Self help community for library" --classification "Library" --visibility "public"
 ```

--- a/docs/docs/cmd/teams/team/team-set.md
+++ b/docs/docs/cmd/teams/team/team-set.md
@@ -10,11 +10,17 @@ m365 teams team set [options]
 
 ## Options
 
-`-i, --teamId <teamId>`
+`-i, --id [id]`
 : The ID of the Microsoft Teams team for which to update settings
 
+`--teamId [teamId]`
+: (deprecated. Use `id` instead) The ID of the Microsoft Teams team for which to update settings
+
+`-n, --name [name]`
+: The display name for the Microsoft Teams team for which to update settings
+
 `--displayName [displayName]`
-: The display name for the Microsoft Teams team
+: (deprecated. Use `name` instead) The display name for the Microsoft Teams team for which to update settings
 
 `--description [description]`
 : The description for the Microsoft Teams team
@@ -35,11 +41,11 @@ m365 teams team set [options]
 Set Microsoft Teams team visibility as Private
 
 ```sh
-m365 teams team set --teamId '00000000-0000-0000-0000-000000000000' --visibility Private
+m365 teams team set --id "00000000-0000-0000-0000-000000000000" --visibility Private
 ```
 
 Set Microsoft Teams team classification as MBI
 
 ```sh
-m365 teams team set --teamId '00000000-0000-0000-0000-000000000000' --classification MBI
+m365 teams team set --id "00000000-0000-0000-0000-000000000000" --classification MBI
 ```

--- a/src/m365/teams/commands/team/team-clone.spec.ts
+++ b/src/m365/teams/commands/team/team-clone.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import chalk = require('chalk');
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
@@ -13,6 +14,7 @@ describe(commands.TEAM_CLONE, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
@@ -34,6 +36,7 @@ describe(commands.TEAM_CLONE, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
+    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
     (command as any).items = [];
   });
 
@@ -63,7 +66,19 @@ describe(commands.TEAM_CLONE, () => {
     const actual = command.validate({
       options: {
         teamId: 'invalid',
-        displayName: "Library Assist",
+        name: "Library Assist",
+        partsToClone: "apps,tabs,settings,channels,members"
+      }
+    });
+    assert.notStrictEqual(actual, true);
+    done();
+  });
+
+  it('fails validation if the id is not a valid GUID.', (done) => {
+    const actual = command.validate({
+      options: {
+        id: 'invalid',
+        name: "Library Assist",
         partsToClone: "apps,tabs,settings,channels,members"
       }
     });
@@ -72,15 +87,22 @@ describe(commands.TEAM_CLONE, () => {
   });
 
   it('fails validation on invalid visibility', () => {
-    const actual = command.validate({ options: { visibility: 'abc' } });
+    const actual = command.validate({
+      options: {
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
+        partsToClone: "apps,tabs,settings,channels,members",
+        visibility: 'abc'
+      }
+    });
     assert.notStrictEqual(actual, true);
   });
 
   it('passes validation on valid \'private\' visibility', () => {
     const actual = command.validate({
       options: {
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: "Library Assist",
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
         partsToClone: "apps,tabs,settings,channels,members",
         visibility: 'private'
       }
@@ -91,8 +113,8 @@ describe(commands.TEAM_CLONE, () => {
   it('passes validation on valid \'public\' visibility', () => {
     const actual = command.validate({
       options: {
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: "Library Assist",
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
         partsToClone: "apps,tabs,settings,channels,members",
         visibility: 'public'
       }
@@ -103,8 +125,8 @@ describe(commands.TEAM_CLONE, () => {
   it('passes validation when the input is correct with mandatory parameters', () => {
     const actual = command.validate({
       options: {
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: "Library Assist",
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
         partsToClone: "apps,tabs,settings,channels,members"
       }
     });
@@ -114,8 +136,8 @@ describe(commands.TEAM_CLONE, () => {
   it('passes validation when the input is correct with mandatory and optional parameters', () => {
     const actual = command.validate({
       options: {
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: "Library Assist",
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
         partsToClone: "apps,tabs,settings,channels,members",
         description: "Self help community for library",
         visibility: "public",
@@ -128,8 +150,8 @@ describe(commands.TEAM_CLONE, () => {
   it('fails validation if visibility is set to private', () => {
     const actual = command.validate({
       options: {
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: "Library Assist",
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
         partsToClone: "apps,tabs,settings,channels,members",
         visibility: "abc"
       }
@@ -140,8 +162,8 @@ describe(commands.TEAM_CLONE, () => {
   it('fails validation if partsToClone is set to invalid value', () => {
     const actual = command.validate({
       options: {
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: "Library Assist",
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
         partsToClone: "abc"
       }
     });
@@ -151,13 +173,76 @@ describe(commands.TEAM_CLONE, () => {
   it('passes validation if visibility is set to private', () => {
     const actual = command.validate({
       options: {
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: "Library Assist",
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
         partsToClone: "apps,tabs,settings,channels,members",
         visibility: "private"
       }
     });
     assert.strictEqual(actual, true);
+  });
+
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets();
+    assert.deepStrictEqual(optionSets, [['id', 'teamId'], ['name', 'displayName']]);
+  });
+
+  it('logs deprecation warning when option teamId is specified', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/15d7a78e-fd77-4599-97a5-dbb6372846c5/clone`) {
+        return Promise.resolve({
+          "location": "/teams('f9526e6a-1d0d-4421-8882-88a70975a00c')/operations('6cf64f96-08c3-4173-9919-eaf7684aae9a')"
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
+        partsToClone: "apps,tabs,settings,channels,members"
+      }
+    } as any, () => {
+      try {
+        assert(loggerLogToStderrSpy.calledWith(chalk.yellow(`Option 'teamId' is deprecated. Please use 'id' instead.`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('logs deprecation warning when option displayName is specified', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/15d7a78e-fd77-4599-97a5-dbb6372846c5/clone`) {
+        return Promise.resolve({
+          "location": "/teams('f9526e6a-1d0d-4421-8882-88a70975a00c')/operations('6cf64f96-08c3-4173-9919-eaf7684aae9a')"
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: false,
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        displayName: "Library Assist",
+        partsToClone: "apps,tabs,settings,channels,members"
+      }
+    } as any, () => {
+      try {
+        assert(loggerLogToStderrSpy.calledWith(chalk.yellow(`Option 'displayName' is deprecated. Please use 'name' instead.`)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
   });
 
   it('creates a clone of a Microsoft Teams team with mandatory parameters', (done) => {
@@ -174,8 +259,8 @@ describe(commands.TEAM_CLONE, () => {
     command.action(logger, {
       options: {
         debug: false,
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: "Library Assist",
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: "Library Assist",
         partsToClone: "apps,tabs,settings,channels,members"
       }
     } as any, () => {
@@ -203,8 +288,8 @@ describe(commands.TEAM_CLONE, () => {
     command.action(logger, {
       options: {
         debug: true,
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: 'Library Assist',
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: 'Library Assist',
         partsToClone: 'apps,tabs,settings,channels,members',
         description: 'abc',
         visibility: 'public',
@@ -233,8 +318,8 @@ describe(commands.TEAM_CLONE, () => {
     command.action(logger, {
       options: {
         debug: true,
-        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
-        displayName: 'Library Assist',
+        id: '15d7a78e-fd77-4599-97a5-dbb6372846c5',
+        name: 'Library Assist',
         partsToClone: 'apps,tabs,settings,channels,members',
         description: 'abc',
         visibility: 'public',

--- a/src/m365/teams/commands/team/team-clone.ts
+++ b/src/m365/teams/commands/team/team-clone.ts
@@ -1,4 +1,3 @@
-
 import { Logger } from '../../../../cli';
 import { CommandOption } from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
@@ -12,8 +11,10 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  teamId: string;
-  displayName: string;
+  id?: string;
+  teamId?: string;
+  name?: string;
+  displayName?: string;
   partsToClone: string;
   description?: string;
   classification?: string;
@@ -38,23 +39,38 @@ class TeamsTeamCloneCommand extends GraphCommand {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    if (args.options.teamId) {
+      args.options.id = args.options.teamId;
+
+      this.warn(logger, `Option 'teamId' is deprecated. Please use 'id' instead.`);
+    }
+
+    if (args.options.displayName) {
+      args.options.name = args.options.displayName;
+
+      this.warn(logger, `Option 'displayName' is deprecated. Please use 'name' instead.`);
+    }
+
     const data: any = {
-      displayName: args.options.displayName,
-      mailNickname: this.generateMailNickname(args.options.displayName),
+      displayName: args.options.name,
+      mailNickname: this.generateMailNickname(args.options.name as string),
       partsToClone: args.options.partsToClone
     };
+
     if (args.options.description) {
       data.description = args.options.description;
     }
+
     if (args.options.classification) {
       data.classification = args.options.classification;
     }
+
     if (args.options.visibility) {
       data.visibility = args.options.visibility;
     }
 
     const requestOptions: any = {
-      url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.teamId)}/clone`,
+      url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.id as string)}/clone`,
       headers: {
         "content-type": "application/json",
         accept: 'application/json;odata.metadata=none'
@@ -68,13 +84,26 @@ class TeamsTeamCloneCommand extends GraphCommand {
       .then(_ => cb(), (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
   }
 
+  public optionSets(): string[][] | undefined {
+    return [
+      ['id', 'teamId'],
+      ['name', 'displayName']
+    ];
+  }
+
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       {
-        option: '-i, --teamId <teamId>'
+        option: '-i, --id [teamId]'
       },
       {
-        option: '-n, --displayName <displayName>'
+        option: '--teamId [teamId]'
+      },
+      {
+        option: '-n, --name [name]'
+      },
+      {
+        option: '--displayName [displayName]'
       },
       {
         option: '-p, --partsToClone <partsToClone>',
@@ -97,8 +126,12 @@ class TeamsTeamCloneCommand extends GraphCommand {
   }
 
   public validate(args: CommandArgs): boolean | string {
-    if (!validation.isValidGuid(args.options.teamId)) {
+    if (args.options.teamId && !validation.isValidGuid(args.options.teamId)) {
       return `${args.options.teamId} is not a valid GUID`;
+    }
+
+    if (args.options.id && !validation.isValidGuid(args.options.id)) {
+      return `${args.options.id} is not a valid GUID`;
     }
 
     const partsToClone: string[] = args.options.partsToClone.replace(/\s/g, '').split(',');


### PR DESCRIPTION
Fixes `teams team set` and `teams team clone` to include `id` and `name` command options. Closes #3482