### PR TITLE
Extends `spfx doctor` command with support for SPFx v1.15.2

### DIFF
--- a/src/m365/spfx/commands/spfx-doctor.ts
+++ b/src/m365/spfx/commands/spfx-doctor.ts
@@ -423,6 +423,21 @@ class SpfxDoctorCommand extends AnonymousCommand {
         range: '^4',
         fix: 'npm i -g yo@4'
       }
+    },
+    '1.15.2': {
+      gulp: {
+        range: '^4',
+        fix: 'npm i -g gulp@4'
+      },
+      node: {
+        range: '^12.13 || ^14.15 || ^16.13',
+        fix: 'Install Node.js v12.13, v14.15, v16.13 or higher'
+      },
+      sp: SharePointVersion.SPO,
+      yo: {
+        range: '^4',
+        fix: 'npm i -g yo@4'
+      }
     }
   };
 


### PR DESCRIPTION
Extends `spfx doctor` command with support for SPFx v1.15.2. Closes #3558