### PR TITLE
Refactor `commandAction` to return a Promise, first result.

### DIFF
--- a/src/Command.spec.ts
+++ b/src/Command.spec.ts
@@ -45,10 +45,8 @@ class MockCommand1 extends Command {
     this.validators.push(() => Promise.resolve(true));
   }
 
-  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
+  public async commandAction(logger: Logger): Promise<void> {
     this.showDeprecationWarning(logger, 'mc1', this.name);
-
-    cb();
   }
 
   public trackUnknownOptionsPublic(telemetryProps: any, options: any) {
@@ -69,15 +67,15 @@ class MockCommand2 extends Command {
     return 'Mock command 2 description';
   }
 
-  public commandAction(): void {
+  public async commandAction(): Promise<void> {
   }
 
   public commandHelp(args: any, log: (message: string) => void): void {
     log('MockCommand2 help');
   }
 
-  public handlePromiseError(response: any, logger: Logger, callback: (err?: any) => void): void {
-    this.handleRejectedODataJsonPromise(response, logger, callback);
+  public handlePromiseError(response: any): void {
+    this.handleRejectedODataJsonPromise(response);
   }
 }
 
@@ -103,7 +101,7 @@ class MockCommand3 extends Command {
     );
   }
 
-  public commandAction(): void {
+  public async commandAction(): Promise<void> {
   }
 
   public commandHelp(): void {
@@ -120,7 +118,7 @@ class MockCommand4 extends Command {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
+  public async commandAction(logger: Logger, args: any): Promise<void> {
     throw 'Exception';
   }
 }
@@ -181,100 +179,120 @@ describe('Command', () => {
   });
 
   it('displays error message when it\'s serialized in the error property', () => {
-    const mock = new MockCommand2();
-    mock.handlePromiseError({
-      error: JSON.stringify({
-        error: {
-          message: 'An error has occurred'
-        }
-      })
-    }, logger, (err?: any) => {
+    try {
+      const mock = new MockCommand2();
+      mock.handlePromiseError({
+        error: JSON.stringify({
+          error: {
+            message: 'An error has occurred'
+          }
+        })
+      });
+      assert.fail('No exception was thrown.');
+    }
+    catch (err: any) {
       assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-    });
+    }
   });
 
   it('displays the raw error message when the serialized value from the error property is not an error object', () => {
-    const mock = new MockCommand2();
-    mock.handlePromiseError({
-      error: JSON.stringify({
-        error: {
-          id: '123'
-        }
-      })
-    }, logger, (err?: any) => {
+    try {
+      const mock = new MockCommand2();
+      mock.handlePromiseError({
+        error: JSON.stringify({
+          error: {
+            id: '123'
+          }
+        })
+      });
+      assert.fail('No exception was thrown.');
+    }
+    catch (err: any) {
       assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(JSON.stringify({
         error: {
           id: '123'
         }
       }))));
-    });
+    }
   });
 
   it('displays the raw error message when the serialized value from the error property is not a JSON object', () => {
-    const mock = new MockCommand2();
-    mock.handlePromiseError({
-      error: 'abc'
-    }, logger, (err?: any) => {
+    try {
+      const mock = new MockCommand2();
+      mock.handlePromiseError({
+        error: 'abc'
+      });
+      assert.fail('No exception was thrown.');
+    }
+    catch (err: any) {
       assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('abc')));
-    });
+    }
   });
 
   it('displays error message coming from ADALJS', () => {
-    const mock = new MockCommand2();
-    mock.handlePromiseError({
-      error: { error_description: 'abc' }
-    }, logger, (err?: any) => {
+    try {
+      const mock = new MockCommand2();
+      mock.handlePromiseError({
+        error: { error_description: 'abc' }
+      });
+      assert.fail('No exception was thrown.');
+    }
+    catch (err: any) {
       assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('abc')));
-    });
+    }
   });
 
-  it('shows deprecation warning when command executed using the deprecated name', () => {
-    cli.currentCommandName = 'mc1';
-    const mock = new MockCommand1();
-    mock.commandAction(logger, {}, (): void => {
+  it('shows deprecation warning when command executed using the deprecated name', async () => {
+    try {
+      cli.currentCommandName = 'mc1';
+      const mock = new MockCommand1();
+      await mock.commandAction(logger);
       assert(loggerLogToStderrSpy.calledWith(chalk.yellow(`Command 'mc1' is deprecated. Please use 'mock-command' instead`)));
-    });
+    }
+    catch (err: any) {
+      assert.fail(err);
+    }
   });
 
-  it('logs command name in the telemetry when command name used', (done) => {
-    const mock = new MockCommand1();
-    mock.action(logger, { options: {} }, () => {
-      try {
-        assert.strictEqual(telemetry.name, 'mock-command');
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+  it('logs command name in the telemetry when command name used', async (done) => {
+    try {
+      const mock = new MockCommand1();
+      await mock.action(logger, { options: {} });
+
+      assert.strictEqual(telemetry.name, 'mock-command');
+      done();
+    }
+    catch (err: any) {
+      done(err);
+    }
   });
 
-  it('logs command alias in the telemetry when command alias used', (done) => {
-    cli.currentCommandName = 'mc1';
-    const mock = new MockCommand1();
-    mock.action(logger, { options: {} }, () => {
-      try {
-        assert.strictEqual(telemetry.name, 'mc1');
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+  it('logs command alias in the telemetry when command alias used', async (done) => {
+    try {
+      cli.currentCommandName = 'mc1';
+      const mock = new MockCommand1();
+      await mock.action(logger, { options: {} });
+
+      assert.strictEqual(telemetry.name, 'mc1');
+      done();
+    }
+    catch (err: any) {
+      done(err);
+    }
   });
 
-  it('logs empty command name in telemetry when command called using something else than name or alias', (done) => {
-    cli.currentCommandName = 'foo';
-    const mock = new MockCommand1();
-    mock.action(logger, { options: {} }, () => {
-      try {
-        assert.strictEqual(telemetry.name, '');
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+  it('logs empty command name in telemetry when command called using something else than name or alias', async (done) => {
+    try {
+      cli.currentCommandName = 'foo';
+      const mock = new MockCommand1();
+      await mock.action(logger, { options: {} });
+
+      assert.strictEqual(telemetry.name, '');
+      done();
+    }
+    catch (err: any) {
+      done(err);
+    }
   });
 
   it('correctly handles error when instance of error returned from the promise', (done) => {
@@ -348,16 +366,14 @@ describe('Command', () => {
     assert.strictEqual(JSON.stringify(actual), expected);
   });
 
-  it('catches exception thrown by commandAction', (done) => {
-    const command = new MockCommand4();
-    command.action(logger, { options: {} }, (err) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Exception')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+  it('catches exception thrown by commandAction', async (done) => {
+    try {
+      const command = new MockCommand4();
+      await command.action(logger, { options: {} });
+    }
+    catch (err: any) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('Exception')));
+      done();
+    }
   });
 });

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -244,6 +244,9 @@ export default abstract class Command {
       await this.commandAction(logger, args);
     }
     catch (ex) {
+      if (ex instanceof CommandError) {
+        throw ex;
+      }
       throw new CommandError(ex as any);
     }
   }

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import { Cli, CommandOutput } from '.';
 import appInsights from '../appInsights';
-import Command, { CommandArgs, CommandError } from '../Command';
+import Command, { CommandError } from '../Command';
 import AnonymousCommand from '../m365/base/AnonymousCommand';
 import { settingsNames } from '../settingsNames';
 import { md, sinonUtil } from '../utils';
@@ -36,9 +36,8 @@ class MockCommand extends AnonymousCommand {
     this.types.string.push('x');
     this.types.boolean.push('y');
   }
-  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
+  public async commandAction(logger: Logger, args: any): Promise<void> {
     logger.log(args.options.parameterX);
-    cb();
   }
 }
 
@@ -62,8 +61,7 @@ class MockCommandWithOptionSets extends AnonymousCommand {
     );
     this.optionSets.push(['opt1', 'opt2']);
   }
-  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
-    cb();
+  public async commandAction(): Promise<void> {
   }
 }
 
@@ -77,8 +75,7 @@ class MockCommandWithAlias extends AnonymousCommand {
   public alias(): string[] {
     return ['cli mock alt'];
   }
-  public commandAction(logger: Logger, args: any, cb: () => void): void {
-    cb();
+  public async commandAction(): Promise<void> {
   }
 }
 
@@ -101,8 +98,7 @@ class MockCommandWithValidation extends AnonymousCommand {
       }
     );
   }
-  public commandAction(logger: Logger, args: any, cb: () => void): void {
-    cb();
+  public async commandAction(): Promise<void> {
   }
 }
 
@@ -113,14 +109,12 @@ class MockCommandWithPrompt extends AnonymousCommand {
   public get description(): string {
     return 'Mock command with prompt';
   }
-  public commandAction(logger: Logger, args: any, cb: () => void): void {
-    Cli.prompt({
+  public async commandAction(): Promise<void> {
+    await Cli.prompt({
       type: 'confirm',
       name: 'continue',
       default: false,
       message: `Continue?`
-    }, (): void => {
-      cb();
     });
   }
 }
@@ -132,9 +126,7 @@ class MockCommandWithOutput extends AnonymousCommand {
   public get description(): string {
     return 'Mock command with output';
   }
-  public commandAction(logger: Logger, args: any, cb: () => void): void {
-    logger.log('Command output');
-    cb();
+  public async commandAction(): Promise<void> {
   }
 }
 
@@ -145,13 +137,12 @@ class MockCommandWithRawOutput extends AnonymousCommand {
   public get description(): string {
     return 'Mock command with output';
   }
-  public commandAction(logger: Logger, args: any, cb: () => void): void {
+  public async commandAction(logger: Logger): Promise<void> {
     if (this.debug) {
       logger.logToStderr('Debug output');
     }
 
     logger.logRaw('Raw output');
-    cb();
   }
 }
 
@@ -803,7 +794,7 @@ describe('Cli', () => {
   });
 
   it('correctly handles error when executing command', (done) => {
-    sinon.stub(mockCommand, 'commandAction').callsFake((logger: Logger, args: CommandArgs, cb: (err?: any) => void) => { cb('Error'); });
+    sinon.stub(mockCommand, 'commandAction').callsFake(() => { throw 'Error'; });
     Cli
       .executeCommand(mockCommand, { options: { _: [] } })
       .then(_ => {
@@ -820,7 +811,7 @@ describe('Cli', () => {
   });
 
   it('correctly handles error when executing command with output', (done) => {
-    sinon.stub(mockCommand, 'commandAction').callsFake((logger: Logger, args: CommandArgs, cb: (err?: any) => void) => { cb('Error'); });
+    sinon.stub(mockCommand, 'commandAction').callsFake(() => { throw 'Error'; });
     Cli
       .executeCommandWithOutput(mockCommand, { options: { _: [] } })
       .then(_ => {

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -782,10 +782,9 @@ export class Cli {
     }
   }
 
-  public static async prompt(options: any): Promise<{ continue: boolean }> {
+  public static async prompt<T>(options: any): Promise<T> {
     const inquirer: Inquirer = require('inquirer');
-    const result = await inquirer.prompt(options);
-    return result as { continue: boolean };
+    return await inquirer.prompt(options) as T;
   }
 
   private static removeShortOptions(args: { options: minimist.ParsedArgs }): { options: minimist.ParsedArgs } {

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -2,7 +2,6 @@ import type * as Chalk from 'chalk';
 import type * as Configstore from 'configstore';
 import * as fs from 'fs';
 import type { Inquirer } from 'inquirer';
-import inquirer = require('inquirer');
 import type * as JMESPath from 'jmespath';
 import * as minimist from 'minimist';
 import * as os from 'os';
@@ -786,11 +785,10 @@ export class Cli {
     }
   }
 
-  public static async prompt(options: any): Promise<inquirer.Answers> {
+  public static async prompt(options: any): Promise<{ continue: boolean }> {
     const inquirer: Inquirer = require('inquirer');
     const result = await inquirer.prompt(options);
-
-    return result;
+    return result as { continue: boolean };
   }
 
   private static removeShortOptions(args: { options: minimist.ParsedArgs }): { options: minimist.ParsedArgs } {

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -181,9 +181,6 @@ export class Cli {
     try {
       await command.action(logger, args as any);
     }
-    catch (err: any) {
-      throw err;
-    }
     finally {
       // restore the original command name
       cli.currentCommandName = parentCommandName;
@@ -242,6 +239,11 @@ export class Cli {
 
     try {
       await command.action(logger, args as any);
+
+      return ({
+        stdout: log.join(os.EOL),
+        stderr: logErr.join(os.EOL)
+      });
     }
     catch (err: any) {
       throw {
@@ -255,11 +257,6 @@ export class Cli {
       // restore the original logger
       request.logger = currentLogger;
     }
-
-    return ({
-      stdout: log.join(os.EOL),
-      stderr: logErr.join(os.EOL)
-    });
   }
 
   public loadAllCommands(): void {

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -2,6 +2,7 @@ import type * as Chalk from 'chalk';
 import type * as Configstore from 'configstore';
 import * as fs from 'fs';
 import type { Inquirer } from 'inquirer';
+import inquirer = require('inquirer');
 import type * as JMESPath from 'jmespath';
 import * as minimist from 'minimist';
 import * as os from 'os';
@@ -158,109 +159,107 @@ export class Cli {
       .then(_ => process.exit(0), err => this.closeWithError(err, optionsWithoutShorts));
   }
 
-  public static executeCommand(command: Command, args: { options: minimist.ParsedArgs }): Promise<void> {
-    return new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
-      const logger: Logger = {
-        log: (message: any): void => {
-          const output: any = Cli.formatOutput(message, args.options);
-          Cli.log(output);
-        },
-        logRaw: (message: any): void => Cli.log(message),
-        logToStderr: (message: any): void => Cli.error(message)
-      };
+  public static async executeCommand(command: Command, args: { options: minimist.ParsedArgs }): Promise<void> {
+    const logger: Logger = {
+      log: (message: any): void => {
+        const output: any = Cli.formatOutput(message, args.options);
+        Cli.log(output);
+      },
+      logRaw: (message: any): void => Cli.log(message),
+      logToStderr: (message: any): void => Cli.error(message)
+    };
 
-      if (args.options.debug) {
-        logger.logToStderr(`Executing command ${command.name} with options ${JSON.stringify(args)}`);
-      }
+    if (args.options.debug) {
+      logger.logToStderr(`Executing command ${command.name} with options ${JSON.stringify(args)}`);
+    }
 
-      // store the current command name, if any and set the name to the name of
-      // the command to execute
-      const cli = Cli.getInstance();
-      const parentCommandName: string | undefined = cli.currentCommandName;
-      cli.currentCommandName = command.getCommandName(cli.currentCommandName);
+    // store the current command name, if any and set the name to the name of
+    // the command to execute
+    const cli = Cli.getInstance();
+    const parentCommandName: string | undefined = cli.currentCommandName;
+    cli.currentCommandName = command.getCommandName(cli.currentCommandName);
 
-      command.action(logger, args as any, (err: any): void => {
-        // restore the original command name
-        cli.currentCommandName = parentCommandName;
+    try {
+      await command.action(logger, args as any);
+    }
+    catch (err: any) {
+      throw err;
+    }
+    finally {
+      // restore the original command name
+      cli.currentCommandName = parentCommandName;
+    }
 
-        if (err) {
-          return reject(err);
-        }
-
-        if (args.options.debug || args.options.verbose) {
-          const chalk: typeof Chalk = require('chalk');
-          logger.logToStderr(chalk.green('DONE'));
-        }
-
-        resolve();
-      });
-    });
+    if (args.options.debug || args.options.verbose) {
+      const chalk: typeof Chalk = require('chalk');
+      logger.logToStderr(chalk.green('DONE'));
+    }
   }
 
-  public static executeCommandWithOutput(command: Command, args: { options: minimist.ParsedArgs }, listener?: {
+  public static async executeCommandWithOutput(command: Command, args: { options: minimist.ParsedArgs }, listener?: {
     stdout?: (message: any) => void,
     stderr?: (message: any) => void
   }): Promise<CommandOutput> {
-    return new Promise((resolve: (result: CommandOutput) => void, reject: (error: any) => void): void => {
-      const log: string[] = [];
-      const logErr: string[] = [];
-      const logger: Logger = {
-        log: (message: any): void => {
-          const formattedMessage = Cli.formatOutput(message, args.options);
-          if (listener && listener.stdout) {
-            listener.stdout(formattedMessage);
-          }
-          log.push(formattedMessage);
-        },
-        logRaw: (message: any): void => {
-          const formattedMessage = Cli.formatOutput(message, args.options);
-          if (listener && listener.stdout) {
-            listener.stdout(formattedMessage);
-          }
-          log.push(formattedMessage);
-        },
-        logToStderr: (message: any): void => {
-          if (listener && listener.stderr) {
-            listener.stderr(message);
-          }
-          logErr.push(message);
+    const log: string[] = [];
+    const logErr: string[] = [];
+    const logger: Logger = {
+      log: (message: any): void => {
+        const formattedMessage = Cli.formatOutput(message, args.options);
+        if (listener && listener.stdout) {
+          listener.stdout(formattedMessage);
         }
-      };
-
-      if (args.options.debug) {
-        const message = `Executing command ${command.name} with options ${JSON.stringify(args)}`;
+        log.push(formattedMessage);
+      },
+      logRaw: (message: any): void => {
+        const formattedMessage = Cli.formatOutput(message, args.options);
+        if (listener && listener.stdout) {
+          listener.stdout(formattedMessage);
+        }
+        log.push(formattedMessage);
+      },
+      logToStderr: (message: any): void => {
         if (listener && listener.stderr) {
           listener.stderr(message);
         }
         logErr.push(message);
       }
+    };
 
-      // store the current command name, if any and set the name to the name of
-      // the command to execute
-      const cli = Cli.getInstance();
-      const parentCommandName: string | undefined = cli.currentCommandName;
-      cli.currentCommandName = command.getCommandName();
-      // store the current logger if any
-      const currentLogger: Logger | undefined = request.logger;
+    if (args.options.debug) {
+      const message = `Executing command ${command.name} with options ${JSON.stringify(args)}`;
+      if (listener && listener.stderr) {
+        listener.stderr(message);
+      }
+      logErr.push(message);
+    }
 
-      command.action(logger, args as any, (err: any): void => {
-        // restore the original command name
-        cli.currentCommandName = parentCommandName;
-        // restore the original logger
-        request.logger = currentLogger;
+    // store the current command name, if any and set the name to the name of
+    // the command to execute
+    const cli = Cli.getInstance();
+    const parentCommandName: string | undefined = cli.currentCommandName;
+    cli.currentCommandName = command.getCommandName();
+    // store the current logger if any
+    const currentLogger: Logger | undefined = request.logger;
 
-        if (err) {
-          return reject({
-            error: err,
-            stderr: logErr.join(os.EOL)
-          });
-        }
+    try {
+      await command.action(logger, args as any);
+    }
+    catch (err: any) {
+      throw {
+        error: err,
+        stderr: logErr.join(os.EOL)
+      };
+    }
+    finally {
+      // restore the original command name
+      cli.currentCommandName = parentCommandName;
+      // restore the original logger
+      request.logger = currentLogger;
+    }
 
-        resolve({
-          stdout: log.join(os.EOL),
-          stderr: logErr.join(os.EOL)
-        });
-      });
+    return ({
+      stdout: log.join(os.EOL),
+      stderr: logErr.join(os.EOL)
     });
   }
 
@@ -787,11 +786,11 @@ export class Cli {
     }
   }
 
-  public static prompt(options: any, cb: (result: any) => void): void {
+  public static async prompt(options: any): Promise<inquirer.Answers> {
     const inquirer: Inquirer = require('inquirer');
-    inquirer
-      .prompt(options)
-      .then(result => cb(result));
+    const result = await inquirer.prompt(options);
+
+    return result;
   }
 
   private static removeShortOptions(args: { options: minimist.ParsedArgs }): { options: minimist.ParsedArgs } {

--- a/src/m365/base/AnonymousCommand.ts
+++ b/src/m365/base/AnonymousCommand.ts
@@ -2,8 +2,8 @@ import { Logger } from '../../cli';
 import Command, { CommandArgs } from '../../Command';
 
 export default abstract class AnonymousCommand extends Command {
-  public action(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+  public async action(logger: Logger, args: CommandArgs): Promise<void> {
     this.initAction(args, logger);
-    this.commandAction(logger, args, cb);
+    await this.commandAction(logger, args);
   }
 }

--- a/src/m365/base/AppCommand.ts
+++ b/src/m365/base/AppCommand.ts
@@ -46,42 +46,42 @@ export default abstract class AppCommand extends Command {
     );
   }
 
-  public action(logger: Logger, args: AppCommandArgs, cb: (err?: any) => void): void {
+  public async action(logger: Logger, args: AppCommandArgs): Promise<void> {
     const m365rcJsonPath: string = '.m365rc.json';
 
     if (!fs.existsSync(m365rcJsonPath)) {
-      return cb(new CommandError(`Could not find file: ${m365rcJsonPath}`));
+      throw new CommandError(`Could not find file: ${m365rcJsonPath}`);
     }
 
     try {
       const m365rcJsonContents: string = fs.readFileSync(m365rcJsonPath, 'utf8');
       if (!m365rcJsonContents) {
-        return cb(new CommandError(`File ${m365rcJsonPath} is empty`));
+        throw new CommandError(`File ${m365rcJsonPath} is empty`);
       }
 
       this.m365rcJson = JSON.parse(m365rcJsonContents) as M365RcJson;
     }
     catch (e) {
-      return cb(new CommandError(`Could not parse file: ${m365rcJsonPath}`));
+      throw new CommandError(`Could not parse file: ${m365rcJsonPath}`);
     }
 
     if (!this.m365rcJson.apps ||
       this.m365rcJson.apps.length === 0) {
-      return cb(new CommandError(`No Azure AD apps found in ${m365rcJsonPath}`));
+      throw new CommandError(`No Azure AD apps found in ${m365rcJsonPath}`);
     }
 
     if (args.options.appId) {
       if (!this.m365rcJson.apps.some(app => app.appId === args.options.appId)) {
-        return cb(new CommandError(`App ${args.options.appId} not found in ${m365rcJsonPath}`));
+        throw new CommandError(`App ${args.options.appId} not found in ${m365rcJsonPath}`);
       }
 
       this.appId = args.options.appId;
-      return super.action(logger, args, cb);
+      return super.action(logger, args);
     }
 
     if (this.m365rcJson.apps.length === 1) {
       this.appId = this.m365rcJson.apps[0].appId;
-      return super.action(logger, args, cb);
+      return super.action(logger, args);
     }
 
     if (this.m365rcJson.apps.length > 1) {
@@ -98,7 +98,7 @@ export default abstract class AppCommand extends Command {
         name: 'appIdIndex'
       }, (result: { appIdIndex: number }): void => {
         this.appId = ((this.m365rcJson as M365RcJson).apps as M365RcJsonApp[])[result.appIdIndex].appId;
-        super.action(logger, args, cb);
+        super.action(logger, args);
       });
     }
   }

--- a/src/m365/base/SpoCommand.ts
+++ b/src/m365/base/SpoCommand.ts
@@ -98,18 +98,18 @@ export default abstract class SpoCommand extends Command {
     return true;
   }
 
-  public action(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
-    auth
-      .restoreAuth()
-      .then((): void => {
-        if (auth.service.connected && AuthType[auth.service.authType] === AuthType[AuthType.Secret]) {
-          cb(new CommandError(`SharePoint does not support authentication using client ID and secret. Please use a different login type to use SharePoint commands.`));
-          return;
-        }
+  public async action(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      await auth.restoreAuth();
+    }
+    catch (error: any) {
+      throw new CommandError(error);
+    }
 
-        super.action(logger, args, cb);
-      }, (error: any): void => {
-        cb(new CommandError(error));
-      });
+    if (auth.service.connected && AuthType[auth.service.authType] === AuthType[AuthType.Secret]) {
+      throw new CommandError(`SharePoint does not support authentication using client ID and secret. Please use a different login type to use SharePoint commands.`);
+    }
+
+    super.action(logger, args);
   }
 }

--- a/src/m365/base/YammerCommand.ts
+++ b/src/m365/base/YammerCommand.ts
@@ -1,4 +1,3 @@
-import { Logger } from "../../cli";
 import Command, { CommandError } from "../../Command";
 
 export default abstract class YammerCommand extends Command {
@@ -6,15 +5,15 @@ export default abstract class YammerCommand extends Command {
     return 'https://www.yammer.com/api';
   }
 
-  protected handleRejectedODataJsonPromise(response: any, logger: Logger, callback: (err?: any) => void): void {
+  protected handleRejectedODataJsonPromise(response: any): void {
     if (response.statusCode === 404) {
-      callback(new CommandError("Not found (404)"));
+      throw new CommandError("Not found (404)");
     }
     else if (response.error && response.error.base) {
-      callback(new CommandError(response.error.base));
+      throw new CommandError(response.error.base);
     }
     else {
-      callback(new CommandError(response));
+      throw new CommandError(response);
     }
   }
 }

--- a/src/m365/cli/commands/cli-consent.ts
+++ b/src/m365/cli/commands/cli-consent.ts
@@ -58,7 +58,7 @@ class CliConsentCommand extends AnonymousCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     let scope = '';
     switch (args.options.service) {
       case 'yammer':
@@ -67,12 +67,11 @@ class CliConsentCommand extends AnonymousCommand {
     }
 
     logger.log(`To consent permissions for executing ${args.options.service} commands, navigate in your web browser to https://login.microsoftonline.com/${config.tenant}/oauth2/v2.0/authorize?client_id=${config.cliAadAppId}&response_type=code&scope=${encodeURIComponent(scope)}`);
-    cb();
   }
 
-  public action(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+  public async action(logger: Logger, args: CommandArgs): Promise<void> {
     this.initAction(args, logger);
-    this.commandAction(logger, args, cb);
+    await this.commandAction(logger, args);
   }
 }
 

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -122,7 +122,7 @@ class LoginCommand extends Command {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     // disconnect before re-connecting
     if (this.debug) {
       logger.logToStderr(`Logging out from Microsoft 365...`);
@@ -130,7 +130,7 @@ class LoginCommand extends Command {
 
     const logout: () => void = (): void => auth.service.logout();
 
-    const login: () => void = (): void => {
+    const login: () => Promise<void> = async (): Promise<void> => {
       if (this.verbose) {
         logger.logToStderr(`Signing in to Microsoft 365...`);
       }
@@ -163,46 +163,48 @@ class LoginCommand extends Command {
           break;
       }
 
-      auth
-        .ensureAccessToken(auth.defaultResource, logger, this.debug)
-        .then((): void => {
-          auth.service.connected = true;
-          cb();
-        }, (rej: Error): void => {
-          if (this.debug) {
-            logger.logToStderr('Error:');
-            logger.logToStderr(rej);
-            logger.logToStderr('');
-          }
+      try {
+        await auth.ensureAccessToken(auth.defaultResource, logger, this.debug);
+        auth.service.connected = true;
 
-          cb(new CommandError(rej.message));
-        });
-    };
-
-    auth
-      .clearConnectionInfo()
-      .then((): void => {
-        logout();
-        login();
-      }, (error: any): void => {
+      }
+      catch(error: any) {
         if (this.debug) {
-          logger.logToStderr(new CommandError(error));
+          logger.logToStderr('Error:');
+          logger.logToStderr(error);
+          logger.logToStderr('');
         }
 
-        logout();
-        login();
-      });
+        throw new CommandError(error.message);
+      }
+    };
+
+    try {
+      await auth.clearConnectionInfo();
+    }
+    catch (error: any) {
+      if (this.debug) {
+        logger.logToStderr(new CommandError(error));
+      }
+
+      logout();
+      await login();
+    }
+
+    logout();
+    await login();
   }
 
-  public action(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
-    auth
-      .restoreAuth()
-      .then((): void => {
-        this.initAction(args, logger);
-        this.commandAction(logger, args, cb);
-      }, (error: any): void => {
-        cb(new CommandError(error));
-      });
+  public async action(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      await auth.restoreAuth();
+    }
+    catch (error: any) {
+      throw new CommandError(error);
+    }
+
+    this.initAction(args, logger);
+    await this.commandAction(logger, args);
   }
 }
 

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -186,13 +186,11 @@ class LoginCommand extends Command {
       if (this.debug) {
         logger.logToStderr(new CommandError(error));
       }
-
+    }
+    finally {
       logout();
       await login();
     }
-
-    logout();
-    await login();
   }
 
   public async action(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/commands/status.ts
+++ b/src/m365/commands/status.ts
@@ -13,7 +13,7 @@ class StatusCommand extends Command {
     return 'Shows Microsoft 365 login status';
   }
 
-  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
+  public async commandAction(logger: Logger): Promise<void> {
     if (auth.service.connected) {
       if (this.debug) {
         logger.logToStderr({
@@ -36,18 +36,18 @@ class StatusCommand extends Command {
         logger.log('Logged out');
       }
     }
-    cb();
   }
 
-  public action(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
-    auth
-      .restoreAuth()
-      .then((): void => {
-        this.initAction(args, logger);
-        this.commandAction(logger, args, cb);
-      }, (error: any): void => {
-        cb(new CommandError(error));
-      });
+  public async action(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      await auth.restoreAuth();
+    }
+    catch (error: any) {
+      throw new CommandError(error);
+    }
+
+    this.initAction(args, logger);
+    this.commandAction(logger);
   }
 }
 

--- a/src/m365/planner/commands/bucket/bucket-add.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.spec.ts
@@ -276,7 +276,7 @@ describe(commands.BUCKET_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('correctly adds planner bucket with name and planId', async (done) => {
+  it('correctly adds planner bucket with name and planId', async () => {
     const options: any = {
       debug: false,
       name: 'My Planner Bucket',
@@ -286,14 +286,13 @@ describe(commands.BUCKET_ADD, () => {
     try {
       await command.action(logger, { options: options } as any);
       assert(loggerLogSpy.calledWith(bucketAddResponse));
-      done();
     }
-    catch (e) {
-      done(e);
+    catch (e: any) {
+      assert.fail(e);
     }
   });
 
-  it('correctly adds planner bucket with name, planTitle, and ownerGroupName', async (done) => {
+  it('correctly adds planner bucket with name, planTitle, and ownerGroupName', async () => {
     const options: any = {
       debug: false,
       name: 'My Planner Bucket',
@@ -304,14 +303,13 @@ describe(commands.BUCKET_ADD, () => {
     try {
       await command.action(logger, { options: options } as any);
       assert(loggerLogSpy.calledWith(bucketAddResponse));
-      done();
     }
-    catch (e) {
-      done(e);
+    catch (e: any) {
+      assert.fail(e);
     }
   });
 
-  it('correctly adds planner bucket with name, deprecated planName, and ownerGroupId', async (done) => {
+  it('correctly adds planner bucket with name, deprecated planName, and ownerGroupId', async () => {
     const options: any = {
       debug: false,
       name: 'My Planner Bucket',
@@ -323,14 +321,13 @@ describe(commands.BUCKET_ADD, () => {
     try {
       await command.action(logger, { options: options } as any);
       assert(loggerLogSpy.calledWith(bucketAddResponse));
-      done();
     }
-    catch (e) {
-      done(e);
+    catch (e: any) {
+      assert.fail(e);
     }
   });
 
-  it('correctly adds planner bucket with name, planTitle, and ownerGroupId', async (done) => {
+  it('correctly adds planner bucket with name, planTitle, and ownerGroupId', async () => {
     const options: any = {
       debug: false,
       name: 'My Planner Bucket',
@@ -342,14 +339,13 @@ describe(commands.BUCKET_ADD, () => {
     try {
       await command.action(logger, { options: options } as any);
       assert(loggerLogSpy.calledWith(bucketAddResponse));
-      done();
     }
-    catch (e) {
-      done(e);
+    catch (e: any) {
+      assert.fail(e);
     }
   });
 
-  it('fails validation when ownerGroupName not found', async (done) => {
+  it('fails validation when ownerGroupName not found', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
@@ -358,56 +354,35 @@ describe(commands.BUCKET_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          debug: false,
-          name: 'My Planner Bucket',
-          planTitle: 'My Planner Plan',
-          ownerGroupName: 'foo'
-        }
-      });
-      done('No exception was thrown.');
-    }
-    catch (err) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group 'foo' does not exist.`)));
-      done();
-    }
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: false,
+        name: 'My Planner Bucket',
+        planTitle: 'My Planner Plan',
+        ownerGroupName: 'foo'
+      }
+    }), new CommandError(`The specified group 'foo' does not exist.`));
   });
 
-  it('fails validation when using app only access token', async (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    try {
-      await command.action(logger, {
-        options: {
-          name: 'My Planner Bucket',
-          planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-        }
-      });
-      done('No exception was thrown.');
-    }
-    catch (err) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-      done();
-    }
+    await assert.rejects(command.action(logger, {
+      options: {
+        name: 'My Planner Bucket',
+        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
+      }
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('correctly handles API OData error', async (done) => {
+  it('correctly handles API OData error', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject("An error has occurred.");
     });
 
-    try {
-      await command.action(logger, { options: { debug: false } } as any);
-      done('No exception was thrown.');
-    }
-    catch (err) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("An error has occurred.")));
-      done();
-    }
+    await assert.rejects(command.action(logger, { options: { debug: false } }), new CommandError("An error has occurred."));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/bucket/bucket-add.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.spec.ts
@@ -276,25 +276,24 @@ describe(commands.BUCKET_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('correctly adds planner bucket with name and planId', (done) => {
+  it('correctly adds planner bucket with name and planId', async (done) => {
     const options: any = {
       debug: false,
       name: 'My Planner Bucket',
       planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(bucketAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, { options: options } as any);
+      assert(loggerLogSpy.calledWith(bucketAddResponse));
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
   });
 
-  it('correctly adds planner bucket with name, planTitle, and ownerGroupName', (done) => {
+  it('correctly adds planner bucket with name, planTitle, and ownerGroupName', async (done) => {
     const options: any = {
       debug: false,
       name: 'My Planner Bucket',
@@ -302,18 +301,17 @@ describe(commands.BUCKET_ADD, () => {
       ownerGroupName: 'My Planner Group'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(bucketAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, { options: options } as any);
+      assert(loggerLogSpy.calledWith(bucketAddResponse));
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
   });
 
-  it('correctly adds planner bucket with name, deprecated planName, and ownerGroupId', (done) => {
+  it('correctly adds planner bucket with name, deprecated planName, and ownerGroupId', async (done) => {
     const options: any = {
       debug: false,
       name: 'My Planner Bucket',
@@ -322,18 +320,17 @@ describe(commands.BUCKET_ADD, () => {
       verbose: true
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(bucketAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, { options: options } as any);
+      assert(loggerLogSpy.calledWith(bucketAddResponse));
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
   });
 
-  it('correctly adds planner bucket with name, planTitle, and ownerGroupId', (done) => {
+  it('correctly adds planner bucket with name, planTitle, and ownerGroupId', async (done) => {
     const options: any = {
       debug: false,
       name: 'My Planner Bucket',
@@ -342,18 +339,17 @@ describe(commands.BUCKET_ADD, () => {
       verbose: true
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(bucketAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, { options: options } as any);
+      assert(loggerLogSpy.calledWith(bucketAddResponse));
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
   });
 
-  it('fails validation when ownerGroupName not found', (done) => {
+  it('fails validation when ownerGroupName not found', async (done) => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
@@ -362,59 +358,56 @@ describe(commands.BUCKET_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, {
-      options: {
-        debug: false,
-        name: 'My Planner Bucket',
-        planTitle: 'My Planner Plan',
-        ownerGroupName: 'foo'
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group 'foo' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          debug: false,
+          name: 'My Planner Bucket',
+          planTitle: 'My Planner Plan',
+          ownerGroupName: 'foo'
+        }
+      });
+      done('No exception was thrown.');
+    }
+    catch (err) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group 'foo' does not exist.`)));
+      done();
+    }
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async (done) => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
-      options: {
-        name: 'My Planner Bucket',
-        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          name: 'My Planner Bucket',
+          planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
+        }
+      });
+      done('No exception was thrown.');
+    }
+    catch (err) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
+      done();
+    }
   });
 
-  it('correctly handles API OData error', (done) => {
+  it('correctly handles API OData error', async (done) => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject("An error has occurred.");
     });
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("An error has occurred.")));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, { options: { debug: false } } as any);
+      done('No exception was thrown.');
+    }
+    catch (err) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("An error has occurred.")));
+      done();
+    }
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/bucket/bucket-add.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.spec.ts
@@ -283,13 +283,8 @@ describe(commands.BUCKET_ADD, () => {
       planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
     };
 
-    try {
-      await command.action(logger, { options: options } as any);
-      assert(loggerLogSpy.calledWith(bucketAddResponse));
-    }
-    catch (e: any) {
-      assert.fail(e);
-    }
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(bucketAddResponse));
   });
 
   it('correctly adds planner bucket with name, planTitle, and ownerGroupName', async () => {
@@ -300,13 +295,8 @@ describe(commands.BUCKET_ADD, () => {
       ownerGroupName: 'My Planner Group'
     };
 
-    try {
-      await command.action(logger, { options: options } as any);
-      assert(loggerLogSpy.calledWith(bucketAddResponse));
-    }
-    catch (e: any) {
-      assert.fail(e);
-    }
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(bucketAddResponse));
   });
 
   it('correctly adds planner bucket with name, deprecated planName, and ownerGroupId', async () => {
@@ -318,13 +308,8 @@ describe(commands.BUCKET_ADD, () => {
       verbose: true
     };
 
-    try {
-      await command.action(logger, { options: options } as any);
-      assert(loggerLogSpy.calledWith(bucketAddResponse));
-    }
-    catch (e: any) {
-      assert.fail(e);
-    }
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(bucketAddResponse));
   });
 
   it('correctly adds planner bucket with name, planTitle, and ownerGroupId', async () => {
@@ -336,13 +321,8 @@ describe(commands.BUCKET_ADD, () => {
       verbose: true
     };
 
-    try {
-      await command.action(logger, { options: options } as any);
-      assert(loggerLogSpy.calledWith(bucketAddResponse));
-    }
-    catch (e: any) {
-      assert.fail(e);
-    }
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(bucketAddResponse));
   });
 
   it('fails validation when ownerGroupName not found', async () => {

--- a/src/m365/planner/commands/bucket/bucket-add.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.ts
@@ -2,6 +2,7 @@ import auth from '../../../../Auth';
 import { Logger } from '../../../../cli';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
+import { AxiosRequestConfig } from 'axios';
 import { accessToken, validation } from '../../../../utils';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -110,7 +111,7 @@ class PlannerBucketAddCommand extends GraphCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (args.options.planName) {
       args.options.planTitle = args.options.planName;
 
@@ -118,32 +119,32 @@ class PlannerBucketAddCommand extends GraphCommand {
     }
 
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
-    this
-      .getPlanId(args)
-      .then((planId: string): Promise<any> => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/buckets`,
-          headers: {
-            'accept': 'application/json;odata.metadata=none'
-          },
-          responseType: 'json',
-          data: {
-            name: args.options.name,
-            planId: planId,
-            orderHint: args.options.orderHint
-          }
-        };
+    try {
+      const planId = await this.getPlanId(args);
 
-        return request.post(requestOptions);
-      })
-      .then((res: any): void => {
-        logger.log(res);
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+      const requestOptions: AxiosRequestConfig = {
+        url: `${this.resource}/v1.0/planner/buckets`,
+        headers: {
+          'accept': 'application/json;odata.metadata=none'
+        },
+        responseType: 'json',
+        data: {
+          name: args.options.name,
+          planId: planId,
+          orderHint: args.options.orderHint
+        }
+      };
+
+      const response = await request.post(requestOptions);
+      logger.log(response);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 
   private getPlanId(args: CommandArgs): Promise<string> {

--- a/src/m365/planner/commands/bucket/bucket-get.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.spec.ts
@@ -260,7 +260,7 @@ describe(commands.BUCKET_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation when no groups found', async (done) => {
+  it('fails validation when no groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve({ "value": [] });
@@ -269,23 +269,16 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          name: validBucketName,
-          planTitle: validPlanTitle,
-          ownerGroupName: validOwnerGroupName
-        }
-      });
-      done('No exception was thrown.');
-    }
-    catch (err) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`)));
-      done();
-    }
+    await assert.rejects(command.action(logger, {
+      options: {
+        name: validBucketName,
+        planTitle: validPlanTitle,
+        ownerGroupName: validOwnerGroupName
+      }
+    }), new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`));
   });
 
-  it('fails validation when multiple groups found', async (done) => {
+  it('fails validation when multiple groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(multipleGroupResponse);
@@ -294,23 +287,16 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          name: validBucketName,
-          planTitle: validPlanTitle,
-          ownerGroupName: validOwnerGroupName
-        }
-      });
-      done('No exception was thrown.');
-    }
-    catch (err) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`)));
-      done();
-    }
+    await assert.rejects(command.action(logger, {
+      options: {
+        name: validBucketName,
+        planTitle: validPlanTitle,
+        ownerGroupName: validOwnerGroupName
+      }
+    }), new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`));
   });
 
-  it('fails validation when no buckets found', async (done) => {
+  it('fails validation when no buckets found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {
         return Promise.resolve({ "value": [] });
@@ -319,22 +305,15 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          name: validBucketName,
-          planId: validPlanId
-        }
-      });
-      done('No exception was thrown.');
-    }
-    catch (err) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified bucket ${validBucketName} does not exist`)));
-      done();
-    }
+    await assert.rejects(command.action(logger, {
+      options: {
+        name: validBucketName,
+        planId: validPlanId
+      }
+    }), new CommandError(`The specified bucket ${validBucketName} does not exist`));
   });
 
-  it('fails validation when multiple buckets found', async (done) => {
+  it('fails validation when multiple buckets found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {
         return Promise.resolve(multipleBucketByNameResponse);
@@ -343,40 +322,26 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          name: validBucketName,
-          planId: validPlanId
-        }
-      });
-      done('No exception was thrown.');
-    }
-    catch (err) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`)));
-      done();
-    }
+    await assert.rejects(command.action(logger, {
+      options: {
+        name: validBucketName,
+        planId: validPlanId
+      }
+    }), new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`));
   });
 
-  it('fails validation when using app only access token', async (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    try {
-      await command.action(logger, {
-        options: {
-          id: validBucketId
-        }
-      });
-      done('No exception was thrown.');
-    }
-    catch (err) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-      done();
-    }
+    await assert.rejects(command.action(logger, {
+      options: {
+        id: validBucketId
+      }
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('Correctly gets bucket by id', async (done) => {
+  it('Correctly gets bucket by id', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}`) {
         return Promise.resolve(singleBucketByIdResponse);
@@ -385,20 +350,14 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          id: validBucketId
-        }
-      });
-      done();
-    }
-    catch (err) {
-      done(err);
-    }
+    await assert.doesNotReject(command.action(logger, {
+      options: {
+        id: validBucketId
+      }
+    }));
   });
 
-  it('Correctly gets bucket by name', async (done) => {
+  it('Correctly gets bucket by name', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(singleGroupResponse);
@@ -416,22 +375,16 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          name: validBucketName,
-          planTitle: validPlanTitle,
-          ownerGroupName: validOwnerGroupName
-        }
-      });
-      done();
-    }
-    catch (err) {
-      done(err);
-    }
+    await assert.doesNotReject(command.action(logger, {
+      options: {
+        name: validBucketName,
+        planTitle: validPlanTitle,
+        ownerGroupName: validOwnerGroupName
+      }
+    }));
   });
 
-  it('Correctly gets bucket by plan title and owner group ID', async (done) => {
+  it('Correctly gets bucket by plan title and owner group ID', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
@@ -446,22 +399,16 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          name: validBucketName,
-          planTitle: validPlanTitle,
-          ownerGroupId: validOwnerGroupId
-        }
-      });
-      done();
-    }
-    catch (err) {
-      done(err);
-    }
+    await assert.doesNotReject(command.action(logger, {
+      options: {
+        name: validBucketName,
+        planTitle: validPlanTitle,
+        ownerGroupId: validOwnerGroupId
+      }
+    }));
   });
 
-  it('Correctly gets bucket by deprecated plan name and owner group ID', async (done) => {
+  it('Correctly gets bucket by deprecated plan name and owner group ID', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
@@ -476,20 +423,14 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, {
-        options: {
-          name: validBucketName,
-          planName: validPlanTitle,
-          ownerGroupId: validOwnerGroupId,
-          verbose: true
-        }
-      });
-      done();
-    }
-    catch (err) {
-      done(err);
-    }
+    await assert.doesNotReject(command.action(logger, {
+      options: {
+        name: validBucketName,
+        planName: validPlanTitle,
+        ownerGroupId: validOwnerGroupId,
+        verbose: true
+      }
+    }));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/bucket/bucket-get.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.spec.ts
@@ -260,7 +260,7 @@ describe(commands.BUCKET_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation when no groups found', (done) => {
+  it('fails validation when no groups found', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve({ "value": [] });
@@ -269,24 +269,23 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          name: validBucketName,
+          planTitle: validPlanTitle,
+          ownerGroupName: validOwnerGroupName
+        }
+      });
+      done('No exception was thrown.');
+    }
+    catch (err) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`)));
+      done();
+    }
   });
 
-  it('fails validation when multiple groups found', (done) => {
+  it('fails validation when multiple groups found', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(multipleGroupResponse);
@@ -295,24 +294,23 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          name: validBucketName,
+          planTitle: validPlanTitle,
+          ownerGroupName: validOwnerGroupName
+        }
+      });
+      done('No exception was thrown.');
+    }
+    catch (err) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`)));
+      done();
+    }
   });
 
-  it('fails validation when no buckets found', (done) => {
+  it('fails validation when no buckets found', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {
         return Promise.resolve({ "value": [] });
@@ -321,23 +319,22 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
-      options: {
-        name: validBucketName,
-        planId: validPlanId
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified bucket ${validBucketName} does not exist`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          name: validBucketName,
+          planId: validPlanId
+        }
+      });
+      done('No exception was thrown.');
+    }
+    catch (err) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified bucket ${validBucketName} does not exist`)));
+      done();
+    }
   });
 
-  it('fails validation when multiple buckets found', (done) => {
+  it('fails validation when multiple buckets found', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {
         return Promise.resolve(multipleBucketByNameResponse);
@@ -346,42 +343,40 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
-      options: {
-        name: validBucketName,
-        planId: validPlanId
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          name: validBucketName,
+          planId: validPlanId
+        }
+      });
+      done('No exception was thrown.');
+    }
+    catch (err) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`)));
+      done();
+    }
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async (done) => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
-      options: {
-        id: validBucketId
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          id: validBucketId
+        }
+      });
+      done('No exception was thrown.');
+    }
+    catch (err) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
+      done();
+    }
   });
 
-  it('Correctly gets bucket by id', (done) => {
+  it('Correctly gets bucket by id', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}`) {
         return Promise.resolve(singleBucketByIdResponse);
@@ -390,22 +385,20 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
-      options: {
-        id: validBucketId
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          id: validBucketId
+        }
+      });
+      done();
+    }
+    catch (err) {
+      done(err);
+    }
   });
 
-  it('Correctly gets bucket by name', (done) => {
+  it('Correctly gets bucket by name', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(singleGroupResponse);
@@ -423,24 +416,22 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          name: validBucketName,
+          planTitle: validPlanTitle,
+          ownerGroupName: validOwnerGroupName
+        }
+      });
+      done();
+    }
+    catch (err) {
+      done(err);
+    }
   });
 
-  it('Correctly gets bucket by plan title and owner group ID', (done) => {
+  it('Correctly gets bucket by plan title and owner group ID', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
@@ -455,24 +446,22 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          name: validBucketName,
+          planTitle: validPlanTitle,
+          ownerGroupId: validOwnerGroupId
+        }
+      });
+      done();
+    }
+    catch (err) {
+      done(err);
+    }
   });
 
-  it('Correctly gets bucket by deprecated plan name and owner group ID', (done) => {
+  it('Correctly gets bucket by deprecated plan name and owner group ID', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
@@ -487,22 +476,20 @@ describe(commands.BUCKET_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
-      options: {
-        name: validBucketName,
-        planName: validPlanTitle,
-        ownerGroupId: validOwnerGroupId,
-        verbose: true
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, {
+        options: {
+          name: validBucketName,
+          planName: validPlanTitle,
+          ownerGroupId: validOwnerGroupId,
+          verbose: true
+        }
+      });
+      done();
+    }
+    catch (err) {
+      done(err);
+    }
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/bucket/bucket-get.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.ts
@@ -132,7 +132,7 @@ class PlannerBucketGetCommand extends GraphCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {    
     if (args.options.planName) {
       args.options.planTitle = args.options.planName;
 
@@ -140,17 +140,18 @@ class PlannerBucketGetCommand extends GraphCommand {
     }
 
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
-    this
-      .getBucketId(args)
-      .then((bucketId: string) => this.getBucketById(bucketId))
-      .then((bucket: PlannerBucket) => {
-        logger.log(bucket);
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+    try {
+      const bucketId = await this.getBucketId(args);
+      const bucket = await this.getBucketById(bucketId);
+      logger.log(bucket);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 
   private getBucketId(args: CommandArgs): Promise<string> {

--- a/src/m365/planner/commands/bucket/bucket-list.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.spec.ts
@@ -271,60 +271,39 @@ describe(commands.BUCKET_LIST, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('correctly lists planner buckets with planId', (done) => {
+  it('correctly lists planner buckets with planId', async () => {
     const options: any = {
       debug: false,
       planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(bucketListResponseValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(bucketListResponseValue));
   });
 
-  it('correctly lists planner buckets with planTitle and ownerGroupName', (done) => {
+  it('correctly lists planner buckets with planTitle and ownerGroupName', async () => {
     const options: any = {
       debug: false,
       planTitle: 'My Planner Plan',
       ownerGroupName: 'My Planner Group'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(bucketListResponseValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(bucketListResponseValue));
   });
 
-  it('correctly lists planner buckets with planTitle and ownerGroupId', (done) => {
+  it('correctly lists planner buckets with planTitle and ownerGroupId', async () => {
     const options: any = {
       debug: false,
       planTitle: 'My Planner Plan',
       ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(bucketListResponseValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(bucketListResponseValue));
   });
 
-  it('correctly lists planner buckets with deprecated planName and ownerGroupId', (done) => {
+  it('correctly lists planner buckets with deprecated planName and ownerGroupId', async () => {
     const options: any = {
       debug: false,
       planName: 'My Planner Plan',
@@ -332,19 +311,12 @@ describe(commands.BUCKET_LIST, () => {
       verbose: true
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(bucketListResponseValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(bucketListResponseValue));
   });
 
 
-  it('fails validation when ownerGroupName not found', (done) => {
+  it('fails validation when ownerGroupName not found', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
@@ -353,57 +325,33 @@ describe(commands.BUCKET_LIST, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         debug: false,
         planTitle: 'My Planner Plan',
         ownerGroupName: 'foo'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group 'foo' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified group 'foo' does not exist.`));
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('correctly handles API OData error', (done) => {
+  it('correctly handles API OData error', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject("An error has occurred.");
     });
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("An error has occurred.")));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError("An error has occurred."));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/bucket/bucket-remove.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.ts
@@ -171,7 +171,7 @@ class PlannerBucketRemoveCommand extends GraphCommand {
       await removeBucket();
     }
     else {
-      const result = await Cli.prompt({
+      const result = await Cli.prompt<{continue: boolean}>({
         type: 'confirm',
         name: 'continue',
         default: false,

--- a/src/m365/planner/commands/bucket/bucket-remove.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.ts
@@ -135,7 +135,7 @@ class PlannerBucketRemoveCommand extends GraphCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (args.options.planName) {
       args.options.planTitle = args.options.planName;
 
@@ -143,45 +143,44 @@ class PlannerBucketRemoveCommand extends GraphCommand {
     }
 
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
-    const removeBucket: () => void = (): void => {
-      this
-        .getBucket(args)
-        .then(bucket => {
-          const requestOptions: AxiosRequestConfig = {
-            url: `${this.resource}/v1.0/planner/buckets/${bucket.id}`,
-            headers: {
-              accept: 'application/json;odata.metadata=none',
-              'if-match': (bucket as any)['@odata.etag']
-            },
-            responseType: 'json'
-          };
+    const removeBucket: () => Promise<void> = async (): Promise<void> => {
+      try {
+        const bucket = await this.getBucket(args);
 
-          return request.delete(requestOptions);
-        })
-        .then(_ => cb(), (err: any) => this.handleRejectedODataJsonPromise(err, logger, cb));
+        const requestOptions: AxiosRequestConfig = {
+          url: `${this.resource}/v1.0/planner/buckets/${bucket.id}`,
+          headers: {
+            accept: 'application/json;odata.metadata=none',
+            'if-match': (bucket as any)['@odata.etag']
+          },
+          responseType: 'json'
+        };
+
+        await request.delete(requestOptions);
+      }
+      catch (err: any) {
+        this.handleRejectedODataJsonPromise(err);
+      }
     };
 
     if (args.options.confirm) {
-      removeBucket();
+      await removeBucket();
     }
     else {
-      Cli.prompt({
+      const result = await Cli.prompt({
         type: 'confirm',
         name: 'continue',
         default: false,
         message: `Are you sure you want to remove the bucket ${args.options.id || args.options.name}?`
-      }, (result: { continue: boolean }): void => {
-        if (!result.continue) {
-          cb();
-        }
-        else {
-          removeBucket();
-        }
       });
+
+      if (result.continue) {
+        await removeBucket();
+      }
     }
   }
 

--- a/src/m365/planner/commands/bucket/bucket-set.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.spec.ts
@@ -259,28 +259,20 @@ describe(commands.BUCKET_SET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         id: validBucketId,
         planId: validPlanId,
         newName: validBucketName
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('fails validation when no groups found', (done) => {
+  it('fails validation when no groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve({ "value": [] });
@@ -289,24 +281,16 @@ describe(commands.BUCKET_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`));
   });
 
-  it('fails validation when multiple groups found', (done) => {
+  it('fails validation when multiple groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(multipleGroupResponse);
@@ -315,24 +299,16 @@ describe(commands.BUCKET_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`));
   });
 
-  it('fails validation when no buckets found', (done) => {
+  it('fails validation when no buckets found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {
         return Promise.resolve({ "value": [] });
@@ -341,23 +317,15 @@ describe(commands.BUCKET_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         name: validBucketName,
         planId: validPlanId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified bucket ${validBucketName} does not exist`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified bucket ${validBucketName} does not exist`));
   });
 
-  it('fails validation when multiple buckets found', (done) => {
+  it('fails validation when multiple buckets found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {
         return Promise.resolve(multipleBucketByNameResponse);
@@ -366,23 +334,15 @@ describe(commands.BUCKET_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         name: validBucketName,
         planId: validPlanId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`));
   });
 
-  it('Correctly updates bucket by id', (done) => {
+  it('Correctly updates bucket by id', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}`) {
         return Promise.resolve(singleBucketByIdResponse);
@@ -398,23 +358,15 @@ describe(commands.BUCKET_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
         id: validBucketId,
         newName: validBucketName
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }));
   });
 
-  it('Correctly updates bucket by name', (done) => {
+  it('Correctly updates bucket by name', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(singleGroupResponse);
@@ -436,7 +388,7 @@ describe(commands.BUCKET_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
         name: validBucketName,
         planTitle: validPlanTitle,
@@ -444,18 +396,10 @@ describe(commands.BUCKET_SET, () => {
         newName: 'New bucket name',
         orderHint: validOrderHint
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }));
   });
 
-  it('Correctly updates bucket by name with group ID', (done) => {
+  it('Correctly updates bucket by name with group ID', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
@@ -474,7 +418,7 @@ describe(commands.BUCKET_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
         name: validBucketName,
         planTitle: validPlanTitle,
@@ -482,18 +426,10 @@ describe(commands.BUCKET_SET, () => {
         newName: 'New bucket name',
         orderHint: validOrderHint
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }));
   });
 
-  it('Correctly updates bucket by name with deprecated planName', (done) => {
+  it('Correctly updates bucket by name with deprecated planName', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
@@ -512,7 +448,7 @@ describe(commands.BUCKET_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
         name: validBucketName,
         planName: validPlanTitle,
@@ -521,15 +457,7 @@ describe(commands.BUCKET_SET, () => {
         orderHint: validOrderHint,
         verbose: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/plan/plan-add.spec.ts
+++ b/src/m365/planner/commands/plan/plan-add.spec.ts
@@ -219,27 +219,19 @@ describe(commands.PLAN_ADD, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTitle,
         ownerGroupId: validOwnerGroupId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('correctly adds planner plan with given title with available ownerGroupId', (done) => {
+  it('correctly adds planner plan with given title with available ownerGroupId', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans`) {
         return Promise.resolve(planResponse);
@@ -248,24 +240,17 @@ describe(commands.PLAN_ADD, () => {
       return Promise.reject(`Invalid request ${opts.url}`);
     });
 
-    const options: any = {
-      debug: false,
-      title: validTitle,
-      ownerGroupId: validOwnerGroupId
-    };
-
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(planResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
+    await command.action(logger, {
+      options: {
+        debug: false,
+        title: validTitle,
+        ownerGroupId: validOwnerGroupId
       }
     });
+    assert(loggerLogSpy.calledWith(planResponse));
   });
 
-  it('correctly adds planner plan with given title with available ownerGroupName', (done) => {
+  it('correctly adds planner plan with given title with available ownerGroupName', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
         return Promise.resolve(singleGroupResponse);
@@ -282,24 +267,18 @@ describe(commands.PLAN_ADD, () => {
       return Promise.reject(`Invalid request ${opts.url}`);
     });
 
-    const options: any = {
-      debug: false,
-      title: validTitle,
-      ownerGroupName: validOwnerGroupName
-    };
-
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(planResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
+    await command.action(logger, {
+      options: {
+        debug: false,
+        title: validTitle,
+        ownerGroupName: validOwnerGroupName
       }
     });
+
+    assert(loggerLogSpy.calledWith(planResponse));
   });
 
-  it('correctly adds planner plan with given title with ownerGroupId and shareWithUserIds', (done) => {
+  it('correctly adds planner plan with given title with ownerGroupId and shareWithUserIds', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validId}/details`) {
         return Promise.resolve(planDetailsEtagResponse);
@@ -324,25 +303,18 @@ describe(commands.PLAN_ADD, () => {
       return Promise.reject(`Invalid request ${opts.url}`);
     });
 
-    const options: any = {
-      debug: false,
-      title: validTitle,
-      ownerGroupId: validOwnerGroupId,
-      shareWithUserIds: validShareWithUserIds
-    };
-
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
+    await command.action(logger, { 
+      options: {
+        debug: false,
+        title: validTitle,
+        ownerGroupId: validOwnerGroupId,
+        shareWithUserIds: validShareWithUserIds
       }
     });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly adds planner plan with given title with ownerGroupId and shareWithUserNames', (done) => {
+  it('correctly adds planner plan with given title with ownerGroupId and shareWithUserNames', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validId}/details`) {
         return Promise.resolve(planDetailsEtagResponse);
@@ -375,25 +347,18 @@ describe(commands.PLAN_ADD, () => {
       return Promise.reject(`Invalid request ${opts.url}`);
     });
 
-    const options: any = {
-      debug: false,
-      title: validTitle,
-      ownerGroupId: validOwnerGroupId,
-      shareWithUserNames: validShareWithUserNames
-    };
-
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
+    await command.action(logger, {
+      options: {
+        debug: false,
+        title: validTitle,
+        ownerGroupId: validOwnerGroupId,
+        shareWithUserNames: validShareWithUserNames
       }
     });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('fails when an invalid user is specified', (done) => {
+  it('fails when an invalid user is specified', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validId}/details`) {
         return Promise.resolve(planDetailsEtagResponse);
@@ -426,38 +391,22 @@ describe(commands.PLAN_ADD, () => {
       return Promise.reject(`Invalid request ${opts.url}`);
     });
 
-    const options: any = {
-      debug: false,
-      title: validTitle,
-      ownerGroupId: validOwnerGroupId,
-      shareWithUserNames: validShareWithUserNames
-    };
-
-    command.action(logger, { options: options } as any, (err: any) => {
-      try {
-        assert.strictEqual(err.message, `Cannot proceed with planner plan creation. The following users provided are invalid : ${user1}`);
-        done();
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: false,
+        title: validTitle,
+        ownerGroupId: validOwnerGroupId,
+        shareWithUserNames: validShareWithUserNames
       }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Cannot proceed with planner plan creation. The following users provided are invalid : ${user1}`));
   });
 
-  it('correctly handles API OData error', (done) => {
+  it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject("An error has occurred.");
     });
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("An error has occurred.")));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } }), new CommandError("An error has occurred."));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/plan/plan-add.ts
+++ b/src/m365/planner/commands/plan/plan-add.ts
@@ -99,34 +99,33 @@ class PlannerPlanAddCommand extends GraphCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
-    this
-      .getGroupId(args)
-      .then((groupId: string): Promise<any> => {
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/plans`,
-          headers: {
-            'accept': 'application/json;odata.metadata=none'
-          },
-          responseType: 'json',
-          data: {
-            owner: groupId,
-            title: args.options.title
-          }
-        };
+    try {
+      const groupId = await this.getGroupId(args);
+      const requestOptions: any = {
+        url: `${this.resource}/v1.0/planner/plans`,
+        headers: {
+          'accept': 'application/json;odata.metadata=none'
+        },
+        responseType: 'json',
+        data: {
+          owner: groupId,
+          title: args.options.title
+        }
+      };
 
-        return request.post(requestOptions);
-      })
-      .then(newPlan => this.updatePlanDetails(args.options, newPlan))
-      .then((res: any): void => {
-        logger.log(res);
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+      const newPlan = await request.post<any>(requestOptions);
+      const result = await this.updatePlanDetails(args.options, newPlan);
+      logger.log(result);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 
   private updatePlanDetails(options: Options, newPlan: PlannerPlan): Promise<PlannerPlan & PlannerPlanDetails> {

--- a/src/m365/planner/commands/plan/plan-get.spec.ts
+++ b/src/m365/planner/commands/plan/plan-get.spec.ts
@@ -230,7 +230,7 @@ describe(commands.PLAN_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('correctly get planner plan with given id', (done) => {
+  it('correctly get planner plan with given id', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validId}`) {
         return Promise.resolve(planResponse);
@@ -243,23 +243,17 @@ describe(commands.PLAN_GET, () => {
       return Promise.reject(`Invalid request ${opts.url}`);
     });
 
-    const options: any = {
-      debug: false,
-      id: validId
-    };
-
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
+    await command.action(logger, { 
+      options: {
+        debug: false,
+        id: validId
       }
     });
+
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly get planner plan with deprecated planId', (done) => {
+  it('correctly get planner plan with deprecated planId', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validId}`) {
         return Promise.resolve(planResponse);
@@ -272,23 +266,16 @@ describe(commands.PLAN_GET, () => {
       return Promise.reject(`Invalid request ${opts.url}`);
     });
 
-    const options: any = {
-      debug: false,
-      planId: validId
-    };
-
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
+    await command.action(logger, {
+      options: {
+        debug: false,
+        planId: validId
       }
     });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly get planner plan with given title and ownerGroupId', (done) => {
+  it('correctly get planner plan with given title and ownerGroupId', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve({
@@ -311,18 +298,11 @@ describe(commands.PLAN_GET, () => {
       ownerGroupId: validOwnerGroupId
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly get planner plan with given ownerGroupId and deprecated planTitle', (done) => {
+  it('correctly get planner plan with given ownerGroupId and deprecated planTitle', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve({
@@ -345,37 +325,22 @@ describe(commands.PLAN_GET, () => {
       ownerGroupId: validOwnerGroupId
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         id: validId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('correctly get planner plan with given title and ownerGroupName', (done) => {
+  it('correctly get planner plan with given title and ownerGroupName', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
         return Promise.resolve(singleGroupResponse);
@@ -402,18 +367,11 @@ describe(commands.PLAN_GET, () => {
       ownerGroupName: validOwnerGroupName
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly handles no plan found with given ownerGroupId', (done) => {
+  it('correctly handles no plan found with given ownerGroupId', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve({ "value": [] });
@@ -428,31 +386,17 @@ describe(commands.PLAN_GET, () => {
       ownerGroupId: validOwnerGroupId
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.notCalled);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.notCalled);
   });
 
-  it('correctly handles API OData error', (done) => {
+  it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').callsFake(() => {
-      return Promise.reject("An error has occurred.");
+      return Promise.reject('An error has occurred.');
     });
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("An error has occurred.")));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+
+    await assert.rejects(command.action(logger, { options: { debug: false } }), new CommandError('An error has occurred.'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/plan/plan-list.spec.ts
+++ b/src/m365/planner/commands/plan/plan-list.spec.ts
@@ -114,7 +114,7 @@ describe(commands.PLAN_LIST, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('correctly list planner plans with given ownerGroupId', (done) => {
+  it('correctly list planner plans with given ownerGroupId', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=ID') > -1) {
         return Promise.resolve({
@@ -205,33 +205,26 @@ describe(commands.PLAN_LIST, () => {
       ownerGroupId: '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith([{
-          "createdDateTime": "2021-03-10T17:39:43.1045549Z",
-          "owner": "233e43d0-dc6a-482e-9b4e-0de7a7bce9b4",
-          "title": "My Planner Plan",
-          "id": "opb7bchfZUiFbVWEPL7jPGUABW7f",
-          "createdBy": {
-            "user": {
-              "displayName": null,
-              "id": "eded3a2a-8f01-40aa-998a-e4f02ec693ba"
-            },
-            "application": {
-              "displayName": null,
-              "id": "31359c7f-bd7e-475c-86db-fdb8c937548e"
-            }
-          }
-        }]));
-        done();
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith([{
+      "createdDateTime": "2021-03-10T17:39:43.1045549Z",
+      "owner": "233e43d0-dc6a-482e-9b4e-0de7a7bce9b4",
+      "title": "My Planner Plan",
+      "id": "opb7bchfZUiFbVWEPL7jPGUABW7f",
+      "createdBy": {
+        "user": {
+          "displayName": null,
+          "id": "eded3a2a-8f01-40aa-998a-e4f02ec693ba"
+        },
+        "application": {
+          "displayName": null,
+          "id": "31359c7f-bd7e-475c-86db-fdb8c937548e"
+        }
       }
-      catch (e) {
-        done(e);
-      }
-    });
+    }]));
   });
 
-  it('correctly list planner plans with given ownerGroupName', (done) => {
+  it('correctly list planner plans with given ownerGroupName', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
         return Promise.resolve({
@@ -322,52 +315,37 @@ describe(commands.PLAN_LIST, () => {
       ownerGroupName: 'spridermvp'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith([{
-          "createdDateTime": "2021-03-10T17:39:43.1045549Z",
-          "owner": "233e43d0-dc6a-482e-9b4e-0de7a7bce9b4",
-          "title": "My Planner Plan",
-          "id": "opb7bchfZUiFbVWEPL7jPGUABW7f",
-          "createdBy": {
-            "user": {
-              "displayName": null,
-              "id": "eded3a2a-8f01-40aa-998a-e4f02ec693ba"
-            },
-            "application": {
-              "displayName": null,
-              "id": "31359c7f-bd7e-475c-86db-fdb8c937548e"
-            }
-          }
-        }]));
-        done();
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith([{
+      "createdDateTime": "2021-03-10T17:39:43.1045549Z",
+      "owner": "233e43d0-dc6a-482e-9b4e-0de7a7bce9b4",
+      "title": "My Planner Plan",
+      "id": "opb7bchfZUiFbVWEPL7jPGUABW7f",
+      "createdBy": {
+        "user": {
+          "displayName": null,
+          "id": "eded3a2a-8f01-40aa-998a-e4f02ec693ba"
+        },
+        "application": {
+          "displayName": null,
+          "id": "31359c7f-bd7e-475c-86db-fdb8c937548e"
+        }
       }
-      catch (e) {
-        done(e);
-      }
-    });
+    }]));
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         ownerGroupId: '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('correctly handles no plan found with given ownerGroupId', (done) => {
+  it('correctly handles no plan found with given ownerGroupId', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=ID') > -1) {
         return Promise.resolve({
@@ -441,31 +419,16 @@ describe(commands.PLAN_LIST, () => {
       ownerGroupId: '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.notCalled);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.notCalled);
   });
 
-  it('correctly handles API OData error', (done) => {
+  it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject("An error has occurred.");
     });
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError("An error has occurred.")));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError("An error has occurred."));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/plan/plan-list.ts
+++ b/src/m365/planner/commands/plan/plan-list.ts
@@ -77,21 +77,20 @@ class PlannerPlanListCommand extends GraphCommand {
     return ['id', 'title', 'createdDateTime', 'owner'];
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
-    this
-      .getGroupId(args)
-      .then((groupId: string) => planner.getPlansByGroupId(groupId))
-      .then((res): void => {
-        if (res && res.length > 0) {
-          logger.log(res);
-        }
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+    try {
+      const groupId = await this.getGroupId(args);
+      const result = await planner.getPlansByGroupId(groupId);
+      logger.log(result);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 
   private getGroupId(args: CommandArgs): Promise<string> {

--- a/src/m365/planner/commands/plan/plan-remove.ts
+++ b/src/m365/planner/commands/plan/plan-remove.ts
@@ -101,9 +101,9 @@ class PlannerPlanRemoveCommand extends GraphCommand {
     this.optionSets.push(['id', 'title']);
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
@@ -121,30 +121,25 @@ class PlannerPlanRemoveCommand extends GraphCommand {
         };
 
         await request.delete(requestOptions);
-        cb();
       }
       catch (err: any) {
-        this.handleRejectedODataJsonPromise(err, logger, cb);
+        this.handleRejectedODataJsonPromise(err);
       }
     };
 
     if (args.options.confirm) {
-      removePlan();
+      await removePlan();
     }
     else {
-      Cli.prompt({
+      const result = await Cli.prompt<{ continue: boolean }>({
         type: 'confirm',
         name: 'continue',
         default: false,
         message: `Are you sure you want to remove the plan ${args.options.id || args.options.title}?`
-      }, (result: { continue: boolean }): void => {
-        if (!result.continue) {
-          cb();
-        }
-        else {
-          removePlan();
-        }
       });
+      if (result.continue) {
+        await removePlan();
+      }
     }
   }
 

--- a/src/m365/planner/commands/task/task-add.spec.ts
+++ b/src/m365/planner/commands/task/task-add.spec.ts
@@ -485,46 +485,31 @@ describe(commands.TASK_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('correctly adds planner task with title, planId, and bucketId', (done) => {
+  it('correctly adds planner task with title, planId, and bucketId', async () => {
     const options: any = {
       title: 'My Planner Task',
       planId: '8QZEH7b3wkS_bGQobscsM5gADCBb',
       bucketId: 'IK8tuFTwQEa5vTonM7ZMRZgAKdno'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponse));
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: 'My Planner Task',
         planId: '8QZEH7b3wkS_bGQobscsM5gADCBb',
         bucketId: 'IK8tuFTwQEa5vTonM7ZMRZgAKdno'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('correctly adds planner bucket with title, bucketId, planTitle, and ownerGroupName', (done) => {
+  it('correctly adds planner bucket with title, bucketId, planTitle, and ownerGroupName', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
@@ -553,18 +538,11 @@ describe(commands.TASK_ADD, () => {
       ownerGroupName: 'My Planner Group'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponse));
   });
 
-  it('correctly adds planner task with title, bucketId, planTitle, and ownerGroupId', (done) => {
+  it('correctly adds planner task with title, bucketId, planTitle, and ownerGroupId', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
@@ -598,18 +576,11 @@ describe(commands.TASK_ADD, () => {
       ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponse));
   });
 
-  it('correctly adds planner task with title, bucketId, deprecated planName, and ownerGroupId', (done) => {
+  it('correctly adds planner task with title, bucketId, deprecated planName, and ownerGroupId', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans`) {
@@ -644,18 +615,11 @@ describe(commands.TASK_ADD, () => {
       verbose: true
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponse));
   });
 
-  it('correctly adds planner task with title, planId, and bucketName', (done) => {
+  it('correctly adds planner task with title, planId, and bucketName', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/8QZEH7b3wkS_bGQobscsM5gADCBb/buckets`) {
@@ -680,18 +644,11 @@ describe(commands.TASK_ADD, () => {
       bucketName: 'My Planner Bucket'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponse));
   });
 
-  it('correctly adds planner task with title, bucketId, planId, and assignedToUserIds', (done) => {
+  it('correctly adds planner task with title, bucketId, planId, and assignedToUserIds', async () => {
     const options: any = {
       title: 'My Planner Task',
       planId: '8QZEH7b3wkS_bGQobscsM5gADCBb',
@@ -699,18 +656,11 @@ describe(commands.TASK_ADD, () => {
       assignedToUserIds: '949b16c1-a032-453e-a8ae-89a52bfc1d8a'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponse));
   });
 
-  it('correctly adds planner task with title, bucketId, planId, assignedToUserNames, and appliedCategories', (done) => {
+  it('correctly adds planner task with title, bucketId, planId, assignedToUserNames, and appliedCategories', async () => {
     sinonUtil.restore(request.get);
     sinonUtil.restore(request.post);
 
@@ -744,18 +694,11 @@ describe(commands.TASK_ADD, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponseWithAssignments));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponseWithAssignments));
   });
 
-  it('correctly adds planner task with title, bucketId, planId, assignedToUserNames, and appliedCategories split with space', (done) => {
+  it('correctly adds planner task with title, bucketId, planId, assignedToUserNames, and appliedCategories split with space', async () => {
     sinonUtil.restore(request.get);
     sinonUtil.restore(request.post);
 
@@ -789,18 +732,11 @@ describe(commands.TASK_ADD, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponseWithAssignments));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponseWithAssignments));
   });
 
-  it('correctly adds planner task with title, bucketId, planId, and description', (done) => {
+  it('correctly adds planner task with title, bucketId, planId, and description', async () => {
     sinonUtil.restore(request.get);
     sinonUtil.restore(request.patch);
 
@@ -839,18 +775,11 @@ describe(commands.TASK_ADD, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskAddResponseWithDetails));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskAddResponseWithDetails));
   });
 
-  it('uses correct value for urgent priority', (done) => {
+  it('uses correct value for urgent priority', async () => {
     sinonUtil.restore(request.post);
     const requestPostStub = sinon.stub(request, 'post');
     requestPostStub.callsFake(() => Promise.resolve(taskAddResponseWithAssignments));
@@ -862,18 +791,11 @@ describe(commands.TASK_ADD, () => {
       priority: 'Urgent'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert.strictEqual(requestPostStub.lastCall.args[0].data.priority, 1);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.priority, 1);
   });
 
-  it('uses correct value for important priority', (done) => {
+  it('uses correct value for important priority', async () => {
     sinonUtil.restore(request.post);
     const requestPostStub = sinon.stub(request, 'post');
     requestPostStub.callsFake(() => Promise.resolve(taskAddResponseWithAssignments));
@@ -885,18 +807,11 @@ describe(commands.TASK_ADD, () => {
       priority: 'Important'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert.strictEqual(requestPostStub.lastCall.args[0].data.priority, 3);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.priority, 3);
   });
 
-  it('uses correct value for medium priority', (done) => {
+  it('uses correct value for medium priority', async () => {
     sinonUtil.restore(request.post);
     const requestPostStub = sinon.stub(request, 'post');
     requestPostStub.callsFake(() => Promise.resolve(taskAddResponseWithAssignments));
@@ -908,18 +823,11 @@ describe(commands.TASK_ADD, () => {
       priority: 'Medium'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert.strictEqual(requestPostStub.lastCall.args[0].data.priority, 5);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.priority, 5);
   });
 
-  it('uses correct value for low priority', (done) => {
+  it('uses correct value for low priority', async () => {
     sinonUtil.restore(request.post);
     const requestPostStub = sinon.stub(request, 'post');
     requestPostStub.callsFake(() => Promise.resolve(taskAddResponseWithAssignments));
@@ -931,18 +839,11 @@ describe(commands.TASK_ADD, () => {
       priority: 'Low'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert.strictEqual(requestPostStub.lastCall.args[0].data.priority, 9);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.priority, 9);
   });
 
-  it('fails when no bucket is found', (done) => {
+  it('fails when no bucket is found', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/8QZEH7b3wkS_bGQobscsM5gADCBb/buckets`) {
@@ -960,18 +861,10 @@ describe(commands.TASK_ADD, () => {
       bucketName: 'My Planner Bucket'
     };
 
-    command.action(logger, { options: options } as any, (err?: any) => {
-      try {
-        assert.strictEqual(err.message, "The specified bucket does not exist");
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('The specified bucket does not exist'));
   });
 
-  it('fails when an invalid user is specified', (done) => {
+  it('fails when an invalid user is specified', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
@@ -1001,18 +894,10 @@ describe(commands.TASK_ADD, () => {
       assignedToUserNames: 'user@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com'
     };
 
-    command.action(logger, { options: options } as any, (err?: any) => {
-      try {
-        assert.strictEqual(err.message, "Cannot proceed with planner task creation. The following users provided are invalid : user2@contoso.onmicrosoft.com");
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('Cannot proceed with planner task creation. The following users provided are invalid : user2@contoso.onmicrosoft.com'));
   });
 
-  it('fails validation when ownerGroupName not found', (done) => {
+  it('fails validation when ownerGroupName not found', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
@@ -1021,25 +906,17 @@ describe(commands.TASK_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         debug: false,
         name: 'My Planner Bucket',
         planTitle: 'My Planner Plan',
         ownerGroupName: 'foo'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group 'foo' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified group 'foo' does not exist.`));
   });
 
-  it('fails validation when task details endpoint fails', (done) => {
+  it('fails validation when task details endpoint fails', async () => {
     sinonUtil.restore(request.get);
 
     sinon.stub(request, 'get').callsFake((opts) => {
@@ -1050,37 +927,21 @@ describe(commands.TASK_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: 'My Planner Task',
         planId: '8QZEH7b3wkS_bGQobscsM5gADCBb',
         bucketId: 'IK8tuFTwQEa5vTonM7ZMRZgAKdno',
         description: 'My Task Description'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Error fetching task details`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Error fetching task details`));
   });
 
-  it('correctly handles random API error', (done) => {
+  it('correctly handles random API error', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/task/task-add.ts
+++ b/src/m365/planner/commands/task/task-add.ts
@@ -193,7 +193,7 @@ class PlannerTaskAddCommand extends GraphCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (args.options.planName) {
       args.options.planTitle = args.options.planName;
 
@@ -201,51 +201,45 @@ class PlannerTaskAddCommand extends GraphCommand {
     }
 
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
-    this
-      .getPlanId(args)
-      .then(planId => {
-        this.planId = planId;
-        return this.getBucketId(args, planId);
-      })
-      .then(bucketId => {
-        this.bucketId = bucketId;
-        return this.generateUserAssignments(args);
-      })
-      .then(assignments => {
-        const appliedCategories = this.generateAppliedCategories(args.options);
+    try {
+      this.planId = await this.getPlanId(args);
+      this.bucketId = await this.getBucketId(args, this.planId);
+      const assignments = await this.generateUserAssignments(args);
 
-        const requestOptions: any = {
-          url: `${this.resource}/v1.0/planner/tasks`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json',
-          data: {
-            planId: this.planId,
-            bucketId: this.bucketId,
-            title: args.options.title,
-            startDateTime: args.options.startDateTime,
-            dueDateTime: args.options.dueDateTime,
-            percentComplete: args.options.percentComplete,
-            assignments: assignments,
-            orderHint: args.options.orderHint,
-            assigneePriority: args.options.assigneePriority,
-            appliedCategories: appliedCategories,
-            priority: taskPriority.getPriorityValue(args.options.priority)
-          }
-        };
+      const appliedCategories = this.generateAppliedCategories(args.options);
 
-        return request.post<PlannerTask>(requestOptions);
-      })
-      .then(newTask => this.updateTaskDetails(args.options, newTask))
-      .then((res: any): void => {
-        logger.log(res);
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+      const requestOptions: any = {
+        url: `${this.resource}/v1.0/planner/tasks`,
+        headers: {
+          accept: 'application/json;odata.metadata=none'
+        },
+        responseType: 'json',
+        data: {
+          planId: this.planId,
+          bucketId: this.bucketId,
+          title: args.options.title,
+          startDateTime: args.options.startDateTime,
+          dueDateTime: args.options.dueDateTime,
+          percentComplete: args.options.percentComplete,
+          assignments: assignments,
+          orderHint: args.options.orderHint,
+          assigneePriority: args.options.assigneePriority,
+          appliedCategories: appliedCategories,
+          priority: taskPriority.getPriorityValue(args.options.priority)
+        }
+      };
+
+      const newTask = await request.post<PlannerTask>(requestOptions);
+      const result = await this.updateTaskDetails(args.options, newTask);
+      logger.log(result);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 
   private getTaskDetailsEtag(taskId: string): Promise<string> {

--- a/src/m365/planner/commands/task/task-checklistitem-list.ts
+++ b/src/m365/planner/commands/task/task-checklistitem-list.ts
@@ -41,9 +41,9 @@ class PlannerTaskChecklistItemListCommand extends GraphCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
@@ -55,20 +55,20 @@ class PlannerTaskChecklistItemListCommand extends GraphCommand {
       responseType: "json"
     };
 
-    request.get(requestOptions).then(
-      (res: any): void => {
-        if (!args.options.output || args.options.output === 'json') {
-          logger.log(res.checklist);
-        }
-        else {
-          //converted to text friendly output
-          const output = Object.getOwnPropertyNames(res.checklist).map(prop => ({ id: prop, ...(res.checklist as any)[prop] }));
-          logger.log(output);
-        }
-        cb();
-      },
-      (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb)
-    );
+    try {
+      const res = await request.get<any>(requestOptions);
+      if (!args.options.output || args.options.output === 'json') {
+        logger.log(res.checklist);
+      }
+      else {
+        //converted to text friendly output
+        const output = Object.getOwnPropertyNames(res.checklist).map(prop => ({ id: prop, ...(res.checklist as any)[prop] }));
+        logger.log(output);
+      }
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 }
 

--- a/src/m365/planner/commands/task/task-checklistitem-remove.spec.ts
+++ b/src/m365/planner/commands/task/task-checklistitem-remove.spec.ts
@@ -58,9 +58,9 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
     };
     promptOptions = undefined;
 
-    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
       promptOptions = options;
-      cb({ continue: true });
+      return { continue: true };
     });
   });
 
@@ -90,33 +90,27 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before removal when confirm option not passed', (done) => {
+  it('prompts before removal when confirm option not passed', async () => {
     sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
       promptOptions = options;
-      cb({ continue: false });
+      return { continue: false };
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         taskId: validTaskId,
         id: validId
       }
-    }, () => {
-      let promptIssued = false;
-
-      if (promptOptions && promptOptions.type === 'confirm') {
-        promptIssued = true;
-      }
-
-      try {
-        assert(promptIssued);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+
+    let promptIssued = false;
+
+    if (promptOptions && promptOptions.type === 'confirm') {
+      promptIssued = true;
+    }
+
+    assert(promptIssued);
   });
 
   it('passes validation when valid options specified', async () => {
@@ -129,7 +123,7 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('correctly deletes checklist item', (done) => {
+  it('correctly deletes checklist item', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details?$select=checklist`) {
         return Promise.resolve({
@@ -145,24 +139,17 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
       }
       return Promise.reject('Invalid Request');
     });
-    command.action(logger, {
+
+    await command.action(logger, {
       options: {
         taskId: validTaskId,
         id: validId,
         confirm: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
   });
 
-  it('fails validation when checklist item does not exists', (done) => {
+  it('fails validation when checklist item does not exists', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details?$select=checklist`) {
         return Promise.resolve({
@@ -174,35 +161,19 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         taskId: validTaskId,
         id: validId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified checklist item with id ${validId} does not exist`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified checklist item with id ${validId} does not exist`));
   });
 
-  it('correctly handles random API error', (done) => {
+  it('correctly handles random API error', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -281,26 +281,18 @@ describe(commands.TASK_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         id: validTaskId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('fails validation when no groups found', (done) => {
+  it('fails validation when no groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve({"value": []});
@@ -309,25 +301,17 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`));
   });
   
-  it('fails validation when multiple groups found', (done) => {
+  it('fails validation when multiple groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(multipleGroupResponse);
@@ -336,25 +320,17 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`));
   });
 
-  it('fails validation when no buckets found', (done) => {
+  it('fails validation when no buckets found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets?$select=id,name`) {
         return Promise.resolve({ "value": [{ "id": "" }] });
@@ -363,24 +339,16 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planId: validPlanId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified bucket ${validBucketName} does not exist`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified bucket ${validBucketName} does not exist`));
   });
 
-  it('fails validation when multiple buckets found', (done) => {
+  it('fails validation when multiple buckets found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets?$select=id,name`) {
         return Promise.resolve(multipleBucketByNameResponse);
@@ -389,24 +357,16 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planId: validPlanId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`));
   });
 
-  it('fails validation when no tasks found', (done) => {
+  it('fails validation when no tasks found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}/tasks?$select=id,title`) {
         return Promise.resolve({ "value": [{ "id": "" }] });
@@ -415,23 +375,15 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketId: validBucketId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified task ${validTaskTitle} does not exist`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified task ${validTaskTitle} does not exist`));
   });
 
-  it('fails validation when multiple tasks found', (done) => {
+  it('fails validation when multiple tasks found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}/tasks?$select=id,title`) {
         return Promise.resolve(multipleTasksByTitleResponse);
@@ -440,23 +392,15 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketId: validBucketId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple tasks with title ${validTaskTitle} found: ${multipleTasksByTitleResponse.value.map(x => x.id)}`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Multiple tasks with title ${validTaskTitle} found: ${multipleTasksByTitleResponse.value.map(x => x.id)}`));
   });
 
-  it('correctly gets task by name', (done) => {
+  it('correctly gets task by name', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(singleGroupResponse);
@@ -480,25 +424,18 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
       }
-    }, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly gets task by name with group ID', (done) => {
+  it('correctly gets task by name with group ID', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
@@ -519,25 +456,18 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupId: validOwnerGroupId
       }
-    }, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('Correctly gets task by name with deprecated planName', (done) => {
+  it('Correctly gets task by name with deprecated planName', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(singleGroupResponse);
@@ -561,25 +491,18 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planName: validPlanTitle,
         ownerGroupName: validOwnerGroupName
       }
-    }, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly gets task by task ID', (done) => {
+  it('correctly gets task by task ID', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}`) {
         return Promise.resolve(taskResponse);
@@ -591,23 +514,16 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         id: validTaskId
       }
-    }, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
   // This test has been added to support task details get alias. Needs to be removed when deprecation is removed. 
-  it('correctly gets task by task ID from task details get', (done) => {
+  it('correctly gets task by task ID from task details get', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}`) {
         return Promise.resolve(taskResponse);
@@ -619,49 +535,26 @@ describe(commands.TASK_GET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         taskId: validTaskId
       }
-    }, () => {
-      try {
-        assert(loggerLogSpy.calledWith(outputResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+    assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly handles item not found', (done) => {
+  it('correctly handles item not found', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => Promise.reject('The requested item is not found.'));
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('The requested item is not found.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError('The requested item is not found.'));
   });
 
-  it('correctly handles random API error', (done) => {
+  it('correctly handles random API error', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/task/task-get.ts
+++ b/src/m365/planner/commands/task/task-get.ts
@@ -120,7 +120,7 @@ class PlannerTaskGetCommand extends GraphCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     this.showDeprecationWarning(logger, commands.TASK_DETAILS_GET, commands.TASK_GET);
     
     if (args.options.planName) {
@@ -130,7 +130,7 @@ class PlannerTaskGetCommand extends GraphCommand {
     }
 
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
@@ -139,14 +139,15 @@ class PlannerTaskGetCommand extends GraphCommand {
       args.options.id = args.options.taskId;
     }
 
-    this
-      .getTaskId(args.options)
-      .then(taskId => this.getTask(taskId))
-      .then(task => this.getTaskDetails(task))
-      .then((res: any): void => {
-        logger.log(res);
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+    try {
+      const taskId = await this.getTaskId(args.options);
+      const task = await this.getTask(taskId);
+      const res = await this.getTaskDetails(task);
+      logger.log(res);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 
   private getTask(taskId: string): Promise<PlannerTask> {

--- a/src/m365/planner/commands/task/task-list.spec.ts
+++ b/src/m365/planner/commands/task/task-list.spec.ts
@@ -501,7 +501,7 @@ describe(commands.TASK_LIST, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation when ownerGroupName not found', (done) => {
+  it('fails validation when ownerGroupName not found', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
@@ -510,44 +510,28 @@ describe(commands.TASK_LIST, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         debug: false,
         planTitle: 'My Planner Plan',
         ownerGroupName: 'foo'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group 'foo' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified group 'foo' does not exist.`));
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         bucketId: 'FtzysDykv0-9s9toWiZhdskAD67z',
         planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('fails validation when bucketName not found', (done) => {
+  it('fails validation when bucketName not found', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent('My Planner Group')}'`) {
@@ -580,91 +564,54 @@ describe(commands.TASK_LIST, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         debug: false,
         bucketName: 'foo',
         planTitle: 'My Planner Plan',
         ownerGroupName: 'My Planner Group'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified bucket does not exist`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified bucket does not exist`));
   });
 
-  it('lists planner tasks of the current logged in user', (done) => {
-    command.action(logger, { options: { debug: false } }, () => {
-      try {
-        assert(loggerLogSpy.called);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+  it('lists planner tasks of the current logged in user', async () => {
+    await command.action(logger, { options: { debug: false } });
+    assert(loggerLogSpy.called);
   });
 
-  it('correctly lists planner tasks with planTitle and ownerGroupId', (done) => {
+  it('correctly lists planner tasks with planTitle and ownerGroupId', async () => {
     const options: any = {
       debug: false,
       planTitle: 'My Planner Plan',
       ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40'
     };
 
-    command.action(logger, { options: options } as any, () => {
-
-      try {
-        assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
   });
 
-  it('correctly lists planner tasks with planTitle and ownerGroupName', (done) => {
+  it('correctly lists planner tasks with planTitle and ownerGroupName', async () => {
     const options: any = {
       debug: false,
       planTitle: 'My Planner Plan',
       ownerGroupName: 'My Planner Group'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
   });
 
-  it('correctly lists planner tasks with bucketId', (done) => {
+  it('correctly lists planner tasks with bucketId', async () => {
     const options: any = {
       debug: false,
       bucketId: 'FtzysDykv0-9s9toWiZhdskAD67z'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
   });
 
-  it('correctly lists planner tasks with bucketName and planId', (done) => {
+  it('correctly lists planner tasks with bucketName and planId', async () => {
 
     const options: any = {
       debug: false,
@@ -672,18 +619,11 @@ describe(commands.TASK_LIST, () => {
       planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
   });
 
-  it('correctly lists planner tasks with bucketName, planTitle, and ownerGroupId', (done) => {
+  it('correctly lists planner tasks with bucketName, planTitle, and ownerGroupId', async () => {
     const options: any = {
       debug: false,
       bucketName: 'Planner Bucket A',
@@ -691,18 +631,11 @@ describe(commands.TASK_LIST, () => {
       ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
   });
 
-  it('correctly lists planner tasks with bucketName, planTitle, and ownerGroupName', (done) => {
+  it('correctly lists planner tasks with bucketName, planTitle, and ownerGroupName', async () => {
     const options: any = {
       debug: false,
       bucketName: 'Planner Bucket A',
@@ -710,18 +643,11 @@ describe(commands.TASK_LIST, () => {
       ownerGroupName: 'My Planner Group'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
   });
 
-  it('correctly lists planner tasks with bucketName, deprecated planName, and ownerGroupName', (done) => {
+  it('correctly lists planner tasks with bucketName, deprecated planName, and ownerGroupName', async () => {
     const options: any = {
       debug: false,
       bucketName: 'Planner Bucket A',
@@ -730,30 +656,15 @@ describe(commands.TASK_LIST, () => {
       verbose: true
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskListResponseBetaValue));
   });
 
-  it('correctly handles random API error', (done) => {
+  it('correctly handles random API error', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/task/task-reference-add.spec.ts
+++ b/src/m365/planner/commands/task/task-reference-add.spec.ts
@@ -106,7 +106,7 @@ describe(commands.TASK_REFERENCE_ADD, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('correctly adds reference', (done) => {
+  it('correctly adds reference', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details`) {
         return Promise.resolve({
@@ -135,18 +135,11 @@ describe(commands.TASK_REFERENCE_ADD, () => {
       url: validUrl
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(referenceResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(referenceResponse));
   });
 
-  it('correctly adds reference with type and alias', (done) => {
+  it('correctly adds reference with type and alias', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent(validTaskId)}/details`) {
         return Promise.resolve({
@@ -177,30 +170,15 @@ describe(commands.TASK_REFERENCE_ADD, () => {
       type: validType
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(referenceResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(referenceResponse));
   });
 
-  it('correctly handles random API error', (done) => {
+  it('correctly handles random API error', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/task/task-reference-list.spec.ts
+++ b/src/m365/planner/commands/task/task-reference-list.spec.ts
@@ -99,26 +99,18 @@ describe(commands.TASK_REFERENCE_LIST, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         taskId: "uBk5fK_MHkeyuPYlCo4OFpcAMowf"
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('successfully handles item found', (done) => {
+  it('successfully handles item found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent("uBk5fK_MHkeyuPYlCo4OFpcAMowf")}/details?$select=references`) {
         return Promise.resolve(references);
@@ -127,19 +119,12 @@ describe(commands.TASK_REFERENCE_LIST, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         taskId: 'uBk5fK_MHkeyuPYlCo4OFpcAMowf'
       }
-    }, () => {
-      try {
-        assert(loggerLogSpy.calledWith(references.references));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+    assert(loggerLogSpy.calledWith(references.references));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/task/task-reference-list.ts
+++ b/src/m365/planner/commands/task/task-reference-list.ts
@@ -37,9 +37,9 @@ class PlannerTaskReferenceListCommand extends GraphCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.', logger, cb);
+      this.handleError('This command does not support application permissions.');
       return;
     }
 
@@ -51,12 +51,13 @@ class PlannerTaskReferenceListCommand extends GraphCommand {
       responseType: 'json'
     };
 
-    request
-      .get(requestOptions)
-      .then((res: any): void => {
-        logger.log(res.references);
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+    try {
+      const res = await request.get<any>(requestOptions);
+      logger.log(res.references);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 }
 

--- a/src/m365/planner/commands/task/task-remove.spec.ts
+++ b/src/m365/planner/commands/task/task-remove.spec.ts
@@ -134,9 +134,9 @@ describe(commands.TASK_REMOVE, () => {
       }
     };
     promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
       promptOptions = options;
-      cb({ continue: false });
+      return { continue: false };
     });
   });
 
@@ -289,7 +289,7 @@ describe(commands.TASK_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation when no groups found', (done) => {
+  it('fails validation when no groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve({ "value": [] });
@@ -298,7 +298,7 @@ describe(commands.TASK_REMOVE, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
@@ -306,18 +306,10 @@ describe(commands.TASK_REMOVE, () => {
         ownerGroupName: validOwnerGroupName,
         confirm: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`));
   });
 
-  it('fails validation when multiple groups found', (done) => {
+  it('fails validation when multiple groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(multipleGroupResponse);
@@ -326,7 +318,7 @@ describe(commands.TASK_REMOVE, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
@@ -334,18 +326,10 @@ describe(commands.TASK_REMOVE, () => {
         ownerGroupName: validOwnerGroupName,
         confirm: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Multiple groups with name '${validOwnerGroupName}' found: ${multipleGroupResponse.value.map(x => x.id)}.`));
   });
 
-  it('fails validation when no buckets found', (done) => {
+  it('fails validation when no buckets found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets?$select=id,name`) {
         return Promise.resolve({ "value": [] });
@@ -354,25 +338,17 @@ describe(commands.TASK_REMOVE, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planId: validPlanId,
         confirm: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified bucket ${validBucketName} does not exist`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified bucket ${validBucketName} does not exist`));
   });
 
-  it('fails validation when multiple buckets found', (done) => {
+  it('fails validation when multiple buckets found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets?$select=id,name`) {
         return Promise.resolve(multipleBucketByNameResponse);
@@ -381,25 +357,17 @@ describe(commands.TASK_REMOVE, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planId: validPlanId,
         confirm: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple buckets with name ${validBucketName} found: Please disambiguate:${os.EOL}${multipleBucketByNameResponse.value.map(f => `- ${f.id}`).join(os.EOL)}`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Multiple buckets with name ${validBucketName} found: Please disambiguate:${os.EOL}${multipleBucketByNameResponse.value.map(f => `- ${f.id}`).join(os.EOL)}`));
   });
 
-  it('fails validation when no tasks found', (done) => {
+  it('fails validation when no tasks found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}/tasks?$select=title,id`) {
         return Promise.resolve({ "value": [] });
@@ -408,24 +376,16 @@ describe(commands.TASK_REMOVE, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketId: validBucketId,
         confirm: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified task ${validTaskTitle} does not exist`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified task ${validTaskTitle} does not exist`));
   });
 
-  it('fails validation when multiple tasks found', (done) => {
+  it('fails validation when multiple tasks found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}/tasks?$select=title,id`) {
         return Promise.resolve(multipleTasksByTitleResponse);
@@ -434,64 +394,44 @@ describe(commands.TASK_REMOVE, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketId: validBucketId,
         confirm: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Multiple tasks with title ${validTaskTitle} found: Please disambiguate: ${os.EOL}${multipleTasksByTitleResponse.value.map(f => `- ${f.id}`).join(os.EOL)}`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Multiple tasks with title ${validTaskTitle} found: Please disambiguate: ${os.EOL}${multipleTasksByTitleResponse.value.map(f => `- ${f.id}`).join(os.EOL)}`));
   });
 
-  it('prompts before removing the specified task when confirm option not passed with id', (done) => {
-    command.action(logger, {
+  it('prompts before removing the specified task when confirm option not passed with id', async () => {
+    await command.action(logger, {
       options: {
         id: validTaskId
       }
-    }, () => {
-      let promptIssued = false;
-
-      if (promptOptions && promptOptions.type === 'confirm') {
-        promptIssued = true;
-      }
-
-      try {
-        assert(promptIssued);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+
+    let promptIssued = false;
+
+    if (promptOptions && promptOptions.type === 'confirm') {
+      promptIssued = true;
+    }
+
+    assert(promptIssued);
   });
 
-  it('aborts removing the specified task when confirm option not passed and prompt not confirmed', (done) => {
+  it('aborts removing the specified task when confirm option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         id: validTaskId
       }
-    }, () => {
-      try {
-        assert(postSpy.notCalled);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+
+    assert(postSpy.notCalled);
   });
 
-  it('correctly deletes task by id', (done) => {
+  it('correctly deletes task by id', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${validTaskId}`) {
         return Promise.resolve(singleTaskByIdResponse);
@@ -508,23 +448,15 @@ describe(commands.TASK_REMOVE, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         id: validTaskId,
         confirm: true
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
   });
 
-  it('correctly deletes task by title with group id', (done) => {
+  it('correctly deletes task by title with group id', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans`) {
         return Promise.resolve(singlePlanResponse);
@@ -550,29 +482,21 @@ describe(commands.TASK_REMOVE, () => {
     });
 
     sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
-      cb({ continue: true });
-    });
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupId: validOwnerGroupId
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
   });
 
-  it('correctly deletes task by title', (done) => {
+  it('correctly deletes task by title', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(validOwnerGroupName)}'`) {
         return Promise.resolve(singleGroupResponse);
@@ -601,24 +525,16 @@ describe(commands.TASK_REMOVE, () => {
     });
 
     sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
-      cb({ continue: true });
-    });
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         title: validTaskTitle,
         bucketName: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
-      }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(typeof err, 'undefined', err?.message);
-        done();
-      }
-      catch (e) {
-        done(e);
       }
     });
   });

--- a/src/m365/planner/commands/task/task-set.spec.ts
+++ b/src/m365/planner/commands/task/task-set.spec.ts
@@ -381,7 +381,7 @@ describe(commands.TASK_SET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('correctly updates planner task with title', (done) => {
+  it('correctly updates planner task with title', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -408,38 +408,23 @@ describe(commands.TASK_SET, () => {
       title: 'My Planner Task'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponse));
   });
 
-  it('fails validation when using app only access token', (done) => {
+  it('fails validation when using app only access token', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         id: 'Z-RLQGfppU6H3663DBzfs5gAMD3o',
         title: 'My Planner Task'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('This command does not support application permissions.')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('This command does not support application permissions.'));
   });
 
-  it('uses correct value for urgent priority', (done) => {
+  it('uses correct value for urgent priority', async () => {
     const requestPatchStub = sinon.stub(request, 'patch');
     requestPatchStub.callsFake(() => Promise.resolve(taskResponse));
 
@@ -458,18 +443,11 @@ describe(commands.TASK_SET, () => {
       priority: 'Urgent'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert.strictEqual(requestPatchStub.lastCall.args[0].data.priority, 1);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert.strictEqual(requestPatchStub.lastCall.args[0].data.priority, 1);
   });
 
-  it('uses correct value for important priority', (done) => {
+  it('uses correct value for important priority', async () => {
     const requestPatchStub = sinon.stub(request, 'patch');
     requestPatchStub.callsFake(() => Promise.resolve(taskResponse));
 
@@ -488,18 +466,11 @@ describe(commands.TASK_SET, () => {
       priority: 'Important'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert.strictEqual(requestPatchStub.lastCall.args[0].data.priority, 3);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert.strictEqual(requestPatchStub.lastCall.args[0].data.priority, 3);
   });
 
-  it('uses correct value for medium priority', (done) => {
+  it('uses correct value for medium priority', async () => {
     const requestPatchStub = sinon.stub(request, 'patch');
     requestPatchStub.callsFake(() => Promise.resolve(taskResponse));
 
@@ -518,18 +489,11 @@ describe(commands.TASK_SET, () => {
       priority: 'Medium'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert.strictEqual(requestPatchStub.lastCall.args[0].data.priority, 5);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert.strictEqual(requestPatchStub.lastCall.args[0].data.priority, 5);
   });
 
-  it('uses correct value for low priority', (done) => {
+  it('uses correct value for low priority', async () => {
     const requestPatchStub = sinon.stub(request, 'patch');
     requestPatchStub.callsFake(() => Promise.resolve(taskResponse));
 
@@ -548,18 +512,11 @@ describe(commands.TASK_SET, () => {
       priority: 'Low'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert.strictEqual(requestPatchStub.lastCall.args[0].data.priority, 9);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert.strictEqual(requestPatchStub.lastCall.args[0].data.priority, 9);
   });
 
-  it('correctly updates planner task to bucket with bucketName, planTitle, and ownerGroupName', (done) => {
+  it('correctly updates planner task to bucket with bucketName, planTitle, and ownerGroupName', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -614,18 +571,11 @@ describe(commands.TASK_SET, () => {
       ownerGroupName: 'My Planner Group'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponse));
   });
 
-  it('correctly updates planner task  to bucket with bucketName, planTitle, and ownerGroupId', (done) => {
+  it('correctly updates planner task  to bucket with bucketName, planTitle, and ownerGroupId', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -676,18 +626,11 @@ describe(commands.TASK_SET, () => {
       ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponse));
   });
 
-  it('correctly updates planner task  to bucket with bucketName, deprecated planName, and ownerGroupId', (done) => {
+  it('correctly updates planner task  to bucket with bucketName, deprecated planName, and ownerGroupId', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -739,18 +682,11 @@ describe(commands.TASK_SET, () => {
       verbose: true
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponse));
   });
 
-  it('correctly updates planner task  to bucket with bucketName, planId', (done) => {
+  it('correctly updates planner task  to bucket with bucketName, planId', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -789,18 +725,11 @@ describe(commands.TASK_SET, () => {
       planId: '8QZEH7b3wkS_bGQobscsM5gADCBb'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponse));
   });
 
-  it('correctly updates planner task with assignedToUserIds', (done) => {
+  it('correctly updates planner task with assignedToUserIds', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponseWithAssignments);
@@ -827,18 +756,11 @@ describe(commands.TASK_SET, () => {
       assignedToUserIds: '949b16c1-a032-453e-a8ae-89a52bfc1d8a'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponseWithAssignments));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponseWithAssignments));
   });
 
-  it('correctly updates planner task with assignedToUserNames', (done) => {
+  it('correctly updates planner task with assignedToUserNames', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponseWithAssignments);
@@ -876,18 +798,11 @@ describe(commands.TASK_SET, () => {
       assignedToUserNames: 'user@contoso.onmicrosoft.com'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponseWithAssignments));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponseWithAssignments));
   });
 
-  it('correctly updates planner task with description', (done) => {
+  it('correctly updates planner task with description', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}/details` &&
         JSON.stringify(opts.headers) === JSON.stringify({
@@ -935,18 +850,11 @@ describe(commands.TASK_SET, () => {
       description: 'My Task Description'
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponseWithDetails));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponseWithDetails));
   });
 
-  it('correctly updates planner task with appliedCategories, bucketId, startDateTime, dueDateTime, percentComplete, assigneePriority, orderHint and priority', (done) => {
+  it('correctly updates planner task with appliedCategories, bucketId, startDateTime, dueDateTime, percentComplete, assigneePriority, orderHint and priority', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -980,18 +888,11 @@ describe(commands.TASK_SET, () => {
       priority: 3
     };
 
-    command.action(logger, { options: options } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(taskResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await command.action(logger, { options: options } as any);
+    assert(loggerLogSpy.calledWith(taskResponse));
   });
 
-  it('fails when no bucket is found', (done) => {
+  it('fails when no bucket is found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${encodeURIComponent('8QZEH7b3wkS_bGQobscsM5gADCBb')}/buckets?$select=id,name`) {
         return Promise.resolve({
@@ -1008,18 +909,10 @@ describe(commands.TASK_SET, () => {
       planId: '8QZEH7b3wkS_bGQobscsM5gADCBb'
     };
 
-    command.action(logger, { options: options } as any, (err?: any) => {
-      try {
-        assert.strictEqual(err.message, "The specified bucket does not exist");
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('The specified bucket does not exist'));
   });
 
-  it('fails when an invalid user is specified', (done) => {
+  it('fails when an invalid user is specified', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'user%40contoso.onmicrosoft.com'&$select=id,userPrincipalName`) {
         return Promise.resolve({
@@ -1046,18 +939,11 @@ describe(commands.TASK_SET, () => {
       assignedToUserNames: 'user@contoso.onmicrosoft.com,user2@contoso.onmicrosoft.com'
     };
 
-    command.action(logger, { options: options } as any, (err?: any) => {
-      try {
-        assert.strictEqual(err.message, "Cannot proceed with planner task update. The following users provided are invalid : user2@contoso.onmicrosoft.com");
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: options } as any)
+      , new CommandError('Cannot proceed with planner task update. The following users provided are invalid : user2@contoso.onmicrosoft.com'));
   });
 
-  it('fails validation when ownerGroupName not found', (done) => {
+  it('fails validation when ownerGroupName not found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
         return Promise.resolve({ value: [] });
@@ -1065,7 +951,7 @@ describe(commands.TASK_SET, () => {
       return Promise.reject('Invalid request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         debug: false,
         id: 'Z-RLQGfppU6H3663DBzfs5gAMD3o',
@@ -1073,18 +959,10 @@ describe(commands.TASK_SET, () => {
         planTitle: 'My Planner Plan',
         ownerGroupName: 'foo'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`The specified group 'foo' does not exist.`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`The specified group 'foo' does not exist.`));
   });
 
-  it('fails validation when task endpoint fails', (done) => {
+  it('fails validation when task endpoint fails', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -1109,23 +987,15 @@ describe(commands.TASK_SET, () => {
     });
 
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         id: 'Z-RLQGfppU6H3663DBzfs5gAMD3o',
         title: 'My Planner Task'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Error fetching task`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Error fetching task`));
   });
 
-  it('fails validation when task details endpoint fails', (done) => {
+  it('fails validation when task details endpoint fails', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks/${encodeURIComponent('Z-RLQGfppU6H3663DBzfs5gAMD3o')}`) {
         return Promise.resolve(taskResponse);
@@ -1152,35 +1022,19 @@ describe(commands.TASK_SET, () => {
     });
 
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         id: 'Z-RLQGfppU6H3663DBzfs5gAMD3o',
         description: 'My Task Description'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(`Error fetching task details`)));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError(`Error fetching task details`));
   });
 
-  it('correctly handles random API error', (done) => {
+  it('correctly handles random API error', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => Promise.reject('An error has occurred'));
 
-    command.action(logger, { options: { debug: false } } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    await assert.rejects(command.action(logger, { options: { debug: false } } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-list.spec.ts
@@ -72,7 +72,7 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['isPlannerAllowed', 'allowCalendarSharing', 'allowTenantMoveWithDataLoss', 'allowTenantMoveWithDataMigration', 'allowRosterCreation', 'allowPlannerMobilePushNotifications']);
   });
 
-  it('successfully lists tenant planner settings', async (done) => {
+  it('successfully lists tenant planner settings', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === 'https://tasks.office.com/taskAPI/tenantAdminSettings/Settings') {
         return Promise.resolve(successReponse);
@@ -81,17 +81,11 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, { options: {} } as any);
-      assert(loggerLogSpy.calledWith(successReponse));
-      done();
-    }
-    catch (e) {
-      done(e);
-    }
+    await command.action(logger, { options: {} } as any);
+    assert(loggerLogSpy.calledWith(successReponse));
   });
 
-  it('correctly handles random API error', async (done) => {
+  it('correctly handles random API error', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === 'https://tasks.office.com/taskAPI/tenantAdminSettings/Settings') {
         return Promise.reject('An error has occurred');
@@ -100,14 +94,7 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
       return Promise.reject('Invalid Request');
     });
 
-    try {
-      await command.action(logger, { options: {} } as any);
-      done('No exception was thrown.');
-    }
-    catch (err: any) {
-      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-      done();
-    }
+    await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-list.spec.ts
@@ -72,7 +72,7 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['isPlannerAllowed', 'allowCalendarSharing', 'allowTenantMoveWithDataLoss', 'allowTenantMoveWithDataMigration', 'allowRosterCreation', 'allowPlannerMobilePushNotifications']);
   });
 
-  it('successfully lists tenant planner settings', (done) => {
+  it('successfully lists tenant planner settings', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === 'https://tasks.office.com/taskAPI/tenantAdminSettings/Settings') {
         return Promise.resolve(successReponse);
@@ -81,18 +81,17 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, { options: {} } as any, () => {
-      try {
-        assert(loggerLogSpy.calledWith(successReponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, { options: {} } as any);
+      assert(loggerLogSpy.calledWith(successReponse));
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
   });
 
-  it('correctly handles random API error', (done) => {
+  it('correctly handles random API error', async (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === 'https://tasks.office.com/taskAPI/tenantAdminSettings/Settings') {
         return Promise.reject('An error has occurred');
@@ -101,15 +100,14 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, { options: {} } as any, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    try {
+      await command.action(logger, { options: {} } as any);
+      done('No exception was thrown.');
+    }
+    catch (err: any) {
+      assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+      done();
+    }
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/tenant/tenant-settings-list.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-list.ts
@@ -17,7 +17,7 @@ class PlannerTenantSettingsListCommand extends PlannerCommand {
     return ['isPlannerAllowed', 'allowCalendarSharing', 'allowTenantMoveWithDataLoss', 'allowTenantMoveWithDataMigration', 'allowRosterCreation', 'allowPlannerMobilePushNotifications'];
   }
 
-  public commandAction(logger: Logger, args: any, cb: (err?: any) => void): void {
+  public async commandAction(logger: Logger): Promise<void> {
     const requestOptions: AxiosRequestConfig = {
       url: `${this.resource}/taskAPI/tenantAdminSettings/Settings`,
       headers: {
@@ -26,12 +26,13 @@ class PlannerTenantSettingsListCommand extends PlannerCommand {
       responseType: 'json'
     };
 
-    request
-      .get(requestOptions)
-      .then((result): void => {
-        logger.log(result);
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+    try {
+      const result = await request.get(requestOptions);
+      logger.log(result);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 }
 

--- a/src/m365/planner/commands/tenant/tenant-settings-set.spec.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-set.spec.ts
@@ -97,7 +97,7 @@ describe(commands.TENANT_SETTINGS_SET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('successfully updates tenant planner settings', (done) => {
+  it('successfully updates tenant planner settings', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === 'https://tasks.office.com/taskAPI/tenantAdminSettings/Settings') {
         return Promise.resolve(successResponse);
@@ -106,22 +106,15 @@ describe(commands.TENANT_SETTINGS_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         isPlannerAllowed: 'true'
       }
-    }, () => {
-      try {
-        assert(loggerLogSpy.calledWith(successResponse));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
     });
+    assert(loggerLogSpy.calledWith(successResponse));
   });
 
-  it('correctly handles random API error', (done) => {
+  it('correctly handles random API error', async () => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (opts.url === 'https://tasks.office.com/taskAPI/tenantAdminSettings/Settings') {
         return Promise.reject('An error has occurred');
@@ -130,19 +123,11 @@ describe(commands.TENANT_SETTINGS_SET, () => {
       return Promise.reject('Invalid Request');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         isPlannerAllowed: 'true'
       }
-    }, (err?: any) => {
-      try {
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
+    }), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/planner/commands/tenant/tenant-settings-set.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-set.ts
@@ -101,7 +101,7 @@ class PlannerTenantSettingsSetCommand extends PlannerCommand {
     );
   }
 
-  public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     const requestOptions: AxiosRequestConfig = {
       url: `${this.resource}/taskAPI/tenantAdminSettings/Settings`,
       headers: {
@@ -119,12 +119,13 @@ class PlannerTenantSettingsSetCommand extends PlannerCommand {
       }
     };
 
-    request
-      .patch(requestOptions)
-      .then((result): void => {
-        logger.log(result);
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+    try {
+      const result = await request.patch(requestOptions);
+      logger.log(result);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
   }
 }
 


### PR DESCRIPTION
This is an temporary PR to see if I'm on the right track.
Linked issue: #3430

I think I've refactored all internal functions already. Refactored all `planner bucket` commands to use async/await in the `commandAction`. These commands can be tested already.

I have already reworked some tests, but have not yet been able to validate whether they actually pass.

With some dedication I think I can get this all done in about 2 weeks. 😃

@waldekmastykarz @martinlingstuyl can you guys check if this is the right way to do it?

Many thanks!