### PR TITLE
Add command to invoke a custom request at a Microsoft 365 API. Closes #3512

### DIFF
--- a/docs/docs/cmd/request.md
+++ b/docs/docs/cmd/request.md
@@ -17,22 +17,23 @@ m365 request [options]
 : The HTTP request method. Accepted values are `get, post, put, patch, delete, head, options`. The default value is `get`.
 
 `-r, --resource [resource]`
-: The resource url for which the CLI should acquire a token from AAD in order to access 
+: The resource uri for which the CLI should acquire a token from AAD in order to access 
 the service.
 
 `-b, --body [body]`
 : The request body. Optionally use `@example.json` to load the body from a file. 
 
-`-a, --accept [accept]`
-: A convenience option to set the `accept` header of the request. The default to `application/json`. 
-
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
-The request will be issued as bare as possible, meaning you are responsible for all request information, such as headers, method and body. The only exception is the `authorization` header. By default, the command will try to retrieve a valid token for the API you are executing a request against based on the `url` option. 
+The request will be issued as bare as possible, meaning you are responsible for most request information, such as headers, method and body. There are a few exceptions: 
 
-If you specify the `resource` option, the CLI will try to retrieve a valid token for the resource instead of determining the resource based on the url. 
+- the command does apply compression and throttling handling as part of the request execution. 
+- The `accept` header is set and defaults to `application/json`. 
+- The `authorization` header is set. By default, the command will try to retrieve a valid token for the API you are executing a request against based on the `url` option. 
+
+If you specify the `resource` option, the CLI will try to retrieve a valid token for the resource instead of determining the resource based on the url. The value doesn't have to be a URL. It can be also a URI like `app://<guid>`.
 
 Specify additional headers by typing them as options, for example: `--content-type "application/json"`, `--if-match "*"`, `--x-requestdigest "somedigest"`
 

--- a/docs/docs/cmd/request.md
+++ b/docs/docs/cmd/request.md
@@ -65,3 +65,9 @@ Call the SharePoint API to update a site title.
 ```sh
 m365 request --method post --url "https://contoso.sharepoint.com/sites/project-x/_api/web" --body '{ "Title": "New title" }' --content-type "application/json" --x-http-method "PATCH"
 ```
+
+Call the Microsoft Graph to get a profile photo.
+
+```sh
+m365 request --url "https://graph.microsoft.com/beta/me/photo/\$value" --filePath ./profile-pic.jpg
+```

--- a/docs/docs/cmd/request.md
+++ b/docs/docs/cmd/request.md
@@ -23,14 +23,17 @@ the service.
 `-b, --body [body]`
 : The request body. Optionally use `@example.json` to load the body from a file. 
 
+`-p, --filePath [filePath]`
+: The file path to save the response to. This option can be used when downloading files.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
 The request will be issued as bare as possible, meaning you are responsible for most request information, such as headers, method and body. There are a few exceptions: 
 
-- the command does apply compression and throttling handling as part of the request execution. 
-- The `accept` header is set and defaults to `application/json`. 
+- The command does apply compression and throttling handling as part of the request execution. 
+- The `accept` header can be set manually, but if you don't, it defaults to `application/json`. 
 - The `authorization` header is set. By default, the command will try to retrieve a valid token for the API you are executing a request against based on the `url` option. 
 
 If you specify the `resource` option, the CLI will try to retrieve a valid token for the resource instead of determining the resource based on the url. The value doesn't have to be a URL. It can be also a URI like `app://<guid>`.

--- a/docs/docs/cmd/request.md
+++ b/docs/docs/cmd/request.md
@@ -1,6 +1,6 @@
 # request
 
-Invoke a custom request at a Microsoft 365 API
+Executes the specified web request using CLI for Microsoft 365
 
 ## Usage
 
@@ -18,35 +18,30 @@ m365 request [options]
 
 `-r, --resource [resource]`
 : The resource url for which the CLI should acquire a token from AAD in order to access 
-the service. The token will be placed in the Authorization header. By default, the CLI can figure this out based on the `--url` argument.
+the service.
 
 `-b, --body [body]`
 : The request body. Optionally use `@example.json` to load the body from a file. 
 
-`-h, --headers [headers]`
-: A JSON string containing optional header values. Optionally use `@example.json` to load the JSON from a 
-file.
-
 `-a, --accept [accept]`
-: A convenience option to set the Accept header of the request.
-
-`-c, --contentType [contentType]`
-: A convenience option to set the Content-Type header of the request.
+: A convenience option to set the `accept` header of the request. The default to `application/json`. 
 
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
-The request will be issued as bare as possible, meaning you are responsible for all request information, such as headers, method and body. The only exception is the `Authorization` header. The command will try to retrieve a valid token for the API you are executing a request against based on the `url` or `resource` options.   
+The request will be issued as bare as possible, meaning you are responsible for all request information, such as headers, method and body. The only exception is the `authorization` header. By default, the command will try to retrieve a valid token for the API you are executing a request against based on the `url` option. 
 
-If the `Accept` value is not set on the option or in the headers, it will default to `application/json`. 
+If you specify the `resource` option, the CLI will try to retrieve a valid token for the resource instead of determining the resource based on the url. 
+
+Specify additional headers by typing them as options, for example: `--content-type "application/json"`, `--if-match "*"`, `--x-requestdigest "somedigest"`
 
 ## Examples
 
 Call the SharePoint Rest API using a GET request with a constructed URL containing expands, filters and selects.
 
 ```sh
-m365 request --url "http://contoso.sharepoint.com/sites/project-x/_api/web/siteusers?$filter=IsShareByEmailGuestUser eq true&$expand=Groups&$select=Title,LoginName,Email,Groups/LoginName" --accept "application/json"
+m365 request --url "https://contoso.sharepoint.com/sites/project-x/_api/web/siteusers?$filter=IsShareByEmailGuestUser eq true&$expand=Groups&$select=Title,LoginName,Email,Groups/LoginName" --accept "application/json;odata=nometadata"
 ```
 
 Call the Microsoft Graph beta endpoint using a GET request.
@@ -58,11 +53,11 @@ m365 request --url "https://graph.microsoft.com/beta/me"
 Call the SharePoint API to retrieve a form digest.
 
 ```sh
-m365 request --method post --url "http://contoso.sharepoint.com/sites/project-x/_api/contextinfo" --accept "application/json"
+m365 request --method post --url "https://contoso.sharepoint.com/sites/project-x/_api/contextinfo"
 ```
 
 Call the SharePoint API to update a site title.
 
 ```sh
-m365 request --method post --url "http://contoso.sharepoint.com/sites/project-x/_api/web" --headers '{"X-HTTP-Method": "PATCH"}' --body '{ "Title": "New title" }' --contentType "application/json"
+m365 request --method post --url "https://contoso.sharepoint.com/sites/project-x/_api/web" --body '{ "Title": "New title" }' --content-type "application/json" --x-http-method "PATCH"
 ```

--- a/docs/docs/cmd/request.md
+++ b/docs/docs/cmd/request.md
@@ -1,0 +1,68 @@
+# request
+
+Invoke a custom request at a Microsoft 365 API
+
+## Usage
+
+```sh
+m365 request [options]
+```
+
+## Options
+
+`-u, --url <url>`
+: The request URL. 
+
+`-m, --method [method]`
+: The HTTP request method. Accepted values are `get, post, put, patch, delete, head, options`. The default value is `get`.
+
+`-r, --resource [resource]`
+: The resource url for which the CLI should acquire a token from AAD in order to access 
+the service. The token will be placed in the Authorization header. By default, the CLI can figure this out based on the `--url` argument.
+
+`-b, --body [body]`
+: The request body. Optionally use `@example.json` to load the body from a file. 
+
+`-h, --headers [headers]`
+: A JSON string containing optional header values. Optionally use `@example.json` to load the JSON from a 
+file.
+
+`-a, --accept [accept]`
+: A convenience option to set the Accept header of the request.
+
+`-c, --contentType [contentType]`
+: A convenience option to set the Content-Type header of the request.
+
+--8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+The request will be issued as bare as possible, meaning you are responsible for all request information, such as headers, method and body. The only exception is the `Authorization` header. The command will try to retrieve a valid token for the API you are executing a request against based on the `url` or `resource` options.   
+
+If the `Accept` value is not set on the option or in the headers, it will default to `application/json`. 
+
+## Examples
+
+Call the SharePoint Rest API using a GET request with a constructed URL containing expands, filters and selects.
+
+```sh
+m365 request --url "http://contoso.sharepoint.com/sites/project-x/_api/web/siteusers?$filter=IsShareByEmailGuestUser eq true&$expand=Groups&$select=Title,LoginName,Email,Groups/LoginName" --accept "application/json"
+```
+
+Call the Microsoft Graph beta endpoint using a GET request.
+
+```sh
+m365 request --url "https://graph.microsoft.com/beta/me"
+```
+
+Call the SharePoint API to retrieve a form digest.
+
+```sh
+m365 request --method post --url "http://contoso.sharepoint.com/sites/project-x/_api/contextinfo" --accept "application/json"
+```
+
+Call the SharePoint API to update a site title.
+
+```sh
+m365 request --method post --url "http://contoso.sharepoint.com/sites/project-x/_api/web" --headers '{"X-HTTP-Method": "PATCH"}' --body '{ "Title": "New title" }' --contentType "application/json"
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - login: 'cmd/login.md'
     - logout: 'cmd/logout.md'
     - status: 'cmd/status.md'
+    - request: 'cmd/request.md'
     - version: 'cmd/version.md'
     - Azure Active Directory (aad):
       - app:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,8 +23,8 @@ nav:
   - Commands:
     - login: 'cmd/login.md'
     - logout: 'cmd/logout.md'
-    - status: 'cmd/status.md'
     - request: 'cmd/request.md'
+    - status: 'cmd/status.md'
     - version: 'cmd/version.md'
     - Azure Active Directory (aad):
       - app:

--- a/src/m365/commands/commands.ts
+++ b/src/m365/commands/commands.ts
@@ -1,6 +1,7 @@
 export default {
   LOGIN: `login`,
   LOGOUT: `logout`,
+  REQUEST: `request`,
   STATUS: `status`,
   VERSION: 'version'
 };

--- a/src/m365/commands/request.spec.ts
+++ b/src/m365/commands/request.spec.ts
@@ -17,7 +17,7 @@ describe(commands.REQUEST, () => {
   let commandInfo: CommandInfo;
 
   //#region 
-  const mockSPOWebJSONResponse = JSON.stringify({ "AllowRssFeeds": true, "AlternateCssUrl": "", "AppInstanceId": "00000000-0000-0000-0000-000000000000", "ClassicWelcomePage": null, "Configuration": 0, "Created": "2020-10-08T07:03:47.907", "CurrentChangeToken": { "StringValue": "1;2;d5f1681e-9480-4636-ac33-094bb75c44ff;637960770683600000;495812642" }, "CustomMasterUrl": "/_catalogs/masterpage/seattle.master", "Description": "", "DesignPackageId": "00000000-0000-0000-0000-000000000000", "DocumentLibraryCalloutOfficeWebAppPreviewersDisabled": false, "EnableMinimalDownload": false, "FooterEmphasis": 0, "FooterEnabled": true, "FooterLayout": 0, "HeaderEmphasis": 0, "HeaderLayout": 0, "HideTitleInHeader": false, "HorizontalQuickLaunch": false, "Id": "d5f1681e-9480-4636-ac33-094bb75c44ff", "IsEduClass": false, "IsEduClassProvisionChecked": false, "IsEduClassProvisionPending": false, "IsHomepageModernized": false, "IsMultilingual": true, "IsRevertHomepageLinkHidden": false, "Language": 1033, "LastItemModifiedDate": "2022-08-14T11:31:56Z", "LastItemUserModifiedDate": "2022-08-14T11:31:56Z", "LogoAlignment": 0, "MasterUrl": "/_catalogs/masterpage/seattle.master", "MegaMenuEnabled": true, "NavAudienceTargetingEnabled": false, "NoCrawl": false, "ObjectCacheEnabled": false, "OverwriteTranslationsOnChange": false, "ResourcePath": { "DecodedUrl": "https://contoso.sharepoint.com" }, "QuickLaunchEnabled": true, "RecycleBinEnabled": true, "SearchScope": 0, "ServerRelativeUrl": "/", "SiteLogoUrl": "/SiteAssets/__sitelogo__logo_240x240.png", "SyndicationEnabled": true, "TenantAdminMembersCanShare": 0, "Title": "Contoso Intranet", "TreeViewEnabled": false, "UIVersion": 15, "UIVersionConfigurationEnabled": false, "Url": "https://contoso.sharepoint.com", "WebTemplate": "SITEPAGEPUBLISHING", "WelcomePage": "SitePages/Home.aspx" });
+  const mockSPOWebJSONResponse = { "AllowRssFeeds": true, "AlternateCssUrl": "", "AppInstanceId": "00000000-0000-0000-0000-000000000000", "ClassicWelcomePage": null, "Configuration": 0, "Created": "2020-10-08T07:03:47.907", "CurrentChangeToken": { "StringValue": "1;2;d5f1681e-9480-4636-ac33-094bb75c44ff;637960770683600000;495812642" }, "CustomMasterUrl": "/_catalogs/masterpage/seattle.master", "Description": "", "DesignPackageId": "00000000-0000-0000-0000-000000000000", "DocumentLibraryCalloutOfficeWebAppPreviewersDisabled": false, "EnableMinimalDownload": false, "FooterEmphasis": 0, "FooterEnabled": true, "FooterLayout": 0, "HeaderEmphasis": 0, "HeaderLayout": 0, "HideTitleInHeader": false, "HorizontalQuickLaunch": false, "Id": "d5f1681e-9480-4636-ac33-094bb75c44ff", "IsEduClass": false, "IsEduClassProvisionChecked": false, "IsEduClassProvisionPending": false, "IsHomepageModernized": false, "IsMultilingual": true, "IsRevertHomepageLinkHidden": false, "Language": 1033, "LastItemModifiedDate": "2022-08-14T11:31:56Z", "LastItemUserModifiedDate": "2022-08-14T11:31:56Z", "LogoAlignment": 0, "MasterUrl": "/_catalogs/masterpage/seattle.master", "MegaMenuEnabled": true, "NavAudienceTargetingEnabled": false, "NoCrawl": false, "ObjectCacheEnabled": false, "OverwriteTranslationsOnChange": false, "ResourcePath": { "DecodedUrl": "https://contoso.sharepoint.com" }, "QuickLaunchEnabled": true, "RecycleBinEnabled": true, "SearchScope": 0, "ServerRelativeUrl": "/", "SiteLogoUrl": "/SiteAssets/__sitelogo__logo_240x240.png", "SyndicationEnabled": true, "TenantAdminMembersCanShare": 0, "Title": "Contoso Intranet", "TreeViewEnabled": false, "UIVersion": 15, "UIVersionConfigurationEnabled": false, "Url": "https://contoso.sharepoint.com", "WebTemplate": "SITEPAGEPUBLISHING", "WelcomePage": "SitePages/Home.aspx" };
   const mockSPOWebXMLResponse = '<?xml version="1.0" encoding="utf-8"?><entry xml:base="https://contoso.sharepoint.com/_api/" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml"><id>https://contoso.sharepoint.com/_api/Web</id><category term="SP.Web" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" /><link rel="edit" href="Web" /><title /><updated>2022-08-14T21:57:35Z</updated><author><name /></author><content type="application/xml"><m:properties><d:Title>Contoso Intranet</d:Title></m:properties></content></entry>';
   //#endregion
 
@@ -70,10 +70,20 @@ describe(commands.REQUEST, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if body is set when contentType is not specified', async () => {
+  it('fails validation if wrong method is set', async () => {
     const actual = await command.validate({ 
       options: { 
-        url: "https://contoso.sharepoint.com/_api/web", 
+        url: 'https://contoso.sharepoint.com/_api/web', 
+        method: 'gett'
+      } 
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if body is set when content-type is not specified', async () => {
+    const actual = await command.validate({ 
+      options: { 
+        url: 'https://contoso.sharepoint.com/_api/web', 
         body: '{ "key": "value" }' ,
         method: 'post'
       } 
@@ -84,22 +94,41 @@ describe(commands.REQUEST, () => {
   it('fails validation if body is set on GET requests', async () => {
     const actual = await command.validate({ 
       options: { 
-        url: "https://contoso.sharepoint.com/_api/web", 
+        url: 'https://contoso.sharepoint.com/_api/web', 
         body: '{ "key": "value" }',
-        contentType: "application/json",
+        'content-type': 'application/json',
         method: 'get' 
       } 
     }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('passes validation with body and contentType on POST request', async () => {
+  it('passes validation with body and content-type on POST request', async () => {
     const actual = await command.validate({ 
       options: { 
-        url: "https://contoso.sharepoint.com/_api/web", 
+        url: 'https://contoso.sharepoint.com/_api/web', 
         body: '{ "key": "value" }',
-        contentType: "application/json",
+        'content-type': 'application/json',
         method: 'post' 
+      } 
+    }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation with correct method set', async () => {
+    const actual = await command.validate({ 
+      options: { 
+        url: 'https://contoso.sharepoint.com/_api/web', 
+        method: 'get'
+      } 
+    }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation with no method set', async () => {
+    const actual = await command.validate({ 
+      options: { 
+        url: 'https://contoso.sharepoint.com/_api/web'
       } 
     }, commandInfo);
     assert.strictEqual(actual, true);
@@ -107,16 +136,16 @@ describe(commands.REQUEST, () => {
 
   it('correctly defaults to a GET request accepting a json response', (done) => {
     sinon.stub(request, 'execute').callsFake((opts) => {
-      if (opts.method === "GET" && opts.headers!.accept === "application/json") {
+      if (opts.method === 'GET' && opts.headers!.accept === 'application/json') {
         return Promise.resolve(mockSPOWebJSONResponse);
       }
 
-      return Promise.reject("Invalid request");
+      return Promise.reject('Invalid request');
     });
 
     command.action(logger, {
       options: {
-        url: "https://contoso.sharepoint.com/_api/web"
+        url: 'https://contoso.sharepoint.com/_api/web'
       }
     }, (err: any) => {
       try {
@@ -131,7 +160,7 @@ describe(commands.REQUEST, () => {
 
   it('successfully executes a GET request to a SharePoint API endpoint', (done) => {
     sinon.stub(request, 'execute').callsFake((opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web') {
         return Promise.resolve(mockSPOWebJSONResponse);
       }
 
@@ -140,12 +169,12 @@ describe(commands.REQUEST, () => {
 
     command.action(logger, {
       options: {
-        url: "https://contoso.sharepoint.com/_api/web",
-        accept: "application/json;odata=nometadata"
+        url: 'https://contoso.sharepoint.com/_api/web',
+        accept: 'application/json;odata=nometadata'
       }
     }, () => {
       try {
-        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        assert(loggerLogSpy.calledWith(mockSPOWebJSONResponse));
         done();
       }
       catch (e) {
@@ -156,7 +185,7 @@ describe(commands.REQUEST, () => {
   
   it('successfully executes a GET request to a SharePoint API endpoint accepting XML', (done) => {
     sinon.stub(request, 'execute').callsFake((opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/_api/web?$select=Title") {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web?$select=Title') {
         return Promise.resolve(mockSPOWebXMLResponse);
       }
 
@@ -165,8 +194,8 @@ describe(commands.REQUEST, () => {
 
     command.action(logger, {
       options: {
-        url: "https://contoso.sharepoint.com/_api/web?$select=Title",
-        accept: "application/xml"
+        url: 'https://contoso.sharepoint.com/_api/web?$select=Title',
+        accept: 'application/xml'
       }
     }, () => {
       try {
@@ -181,7 +210,7 @@ describe(commands.REQUEST, () => {
 
   it('successfully executes a GET request to a SharePoint API endpoint (debug)', (done) => {
     sinon.stub(request, 'execute').callsFake((opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web') {
         return Promise.resolve(mockSPOWebJSONResponse);
       }
 
@@ -190,13 +219,13 @@ describe(commands.REQUEST, () => {
 
     command.action(logger, {
       options: {
-        url: "https://contoso.sharepoint.com/_api/web",
-        accept: "application/json;odata=nometadata",
+        url: 'https://contoso.sharepoint.com/_api/web',
+        accept: 'application/json;odata=nometadata',
         debug: true
       }
     }, () => {
       try {
-        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        assert(loggerLogSpy.calledWith(mockSPOWebJSONResponse));
         done();
       }
       catch (e) {
@@ -207,7 +236,7 @@ describe(commands.REQUEST, () => {
 
   it('successfully executes a POST request to a SharePoint API endpoint', (done) => {
     sinon.stub(request, 'execute').callsFake((opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web') {
         return Promise.resolve(mockSPOWebJSONResponse);
       }
 
@@ -216,15 +245,15 @@ describe(commands.REQUEST, () => {
 
     command.action(logger, {
       options: {
-        url: "https://contoso.sharepoint.com/_api/web",
-        accept: "application/json;odata=nometadata",
-        contentType: "application/json",
-        headers: '{"X-HTTP-Method": "PATCH"}',
-        method: "post"
+        url: 'https://contoso.sharepoint.com/_api/web',
+        accept: 'application/json;odata=nometadata',
+        'content-type': 'application/json',
+        'x-http-method': 'PATCH',
+        method: 'post'
       }
     }, () => {
       try {
-        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        assert(loggerLogSpy.calledWith(mockSPOWebJSONResponse));
         done();
       }
       catch (e) {
@@ -235,7 +264,7 @@ describe(commands.REQUEST, () => {
 
   it('successfully executes a request with a manually specified resource', (done) => {
     sinon.stub(request, 'execute').callsFake((opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web') {
         return Promise.resolve(mockSPOWebJSONResponse);
       }
 
@@ -244,13 +273,13 @@ describe(commands.REQUEST, () => {
 
     command.action(logger, {
       options: {
-        url: "https://contoso.sharepoint.com/_api/web",
-        accept: "application/json;odata=nometadata",
-        resource: "https://contoso.sharepoint.com"
+        url: 'https://contoso.sharepoint.com/_api/web',
+        accept: 'application/json;odata=nometadata',
+        resource: 'https://contoso.sharepoint.com'
       }
     }, () => {
       try {
-        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        assert(loggerLogSpy.calledWith(mockSPOWebJSONResponse));
         done();
       }
       catch (e) {
@@ -261,7 +290,7 @@ describe(commands.REQUEST, () => {
 
   it('successfully executes a request with a manually specified resource (debug)', (done) => {
     sinon.stub(request, 'execute').callsFake((opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web') {
         return Promise.resolve(mockSPOWebJSONResponse);
       }
 
@@ -270,15 +299,15 @@ describe(commands.REQUEST, () => {
 
     command.action(logger, {
       options: {
-        url: "https://contoso.sharepoint.com/_api/web",
-        accept: "application/json;odata=nometadata",
-        resource: "https://contoso.sharepoint.com",
+        url: 'https://contoso.sharepoint.com/_api/web',
+        accept: 'application/json;odata=nometadata',
+        resource: 'https://contoso.sharepoint.com',
         debug: true
       }
     }, () => {
       try {
         assert(loggerLogToStderrSpy.called);
-        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        assert(loggerLogSpy.calledWith(mockSPOWebJSONResponse));
         done();
       }
       catch (e) {
@@ -289,16 +318,16 @@ describe(commands.REQUEST, () => {
 
   it('correctly handles an API exception', (done) => {
     sinon.stub(request, 'execute').callsFake(_ => {
-      return Promise.reject("Invalid request");
+      return Promise.reject('Invalid request');
     });
 
     command.action(logger, {
       options: {
-        url: "https://contoso.sharepoint.com/_api/web"
+        url: 'https://contoso.sharepoint.com/_api/web'
       }
     }, (err: any) => {
       try {
-        assert.deepStrictEqual(err, new CommandError("Invalid request"));
+        assert.deepStrictEqual(err, new CommandError('Invalid request'));
         done();
       }
       catch (e) {

--- a/src/m365/commands/request.spec.ts
+++ b/src/m365/commands/request.spec.ts
@@ -1,0 +1,309 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../appInsights';
+import auth from '../../Auth';
+import { Cli, CommandInfo, Logger } from '../../cli';
+import Command, { CommandError } from '../../Command';
+import request from '../../request';
+import { sinonUtil } from '../../utils';
+import commands from './commands';
+const command: Command = require('./request');
+
+describe(commands.REQUEST, () => {
+  let log: any[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+  let loggerLogToStderrSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+
+  //#region 
+  const mockSPOWebJSONResponse = JSON.stringify({ "AllowRssFeeds": true, "AlternateCssUrl": "", "AppInstanceId": "00000000-0000-0000-0000-000000000000", "ClassicWelcomePage": null, "Configuration": 0, "Created": "2020-10-08T07:03:47.907", "CurrentChangeToken": { "StringValue": "1;2;d5f1681e-9480-4636-ac33-094bb75c44ff;637960770683600000;495812642" }, "CustomMasterUrl": "/_catalogs/masterpage/seattle.master", "Description": "", "DesignPackageId": "00000000-0000-0000-0000-000000000000", "DocumentLibraryCalloutOfficeWebAppPreviewersDisabled": false, "EnableMinimalDownload": false, "FooterEmphasis": 0, "FooterEnabled": true, "FooterLayout": 0, "HeaderEmphasis": 0, "HeaderLayout": 0, "HideTitleInHeader": false, "HorizontalQuickLaunch": false, "Id": "d5f1681e-9480-4636-ac33-094bb75c44ff", "IsEduClass": false, "IsEduClassProvisionChecked": false, "IsEduClassProvisionPending": false, "IsHomepageModernized": false, "IsMultilingual": true, "IsRevertHomepageLinkHidden": false, "Language": 1033, "LastItemModifiedDate": "2022-08-14T11:31:56Z", "LastItemUserModifiedDate": "2022-08-14T11:31:56Z", "LogoAlignment": 0, "MasterUrl": "/_catalogs/masterpage/seattle.master", "MegaMenuEnabled": true, "NavAudienceTargetingEnabled": false, "NoCrawl": false, "ObjectCacheEnabled": false, "OverwriteTranslationsOnChange": false, "ResourcePath": { "DecodedUrl": "https://contoso.sharepoint.com" }, "QuickLaunchEnabled": true, "RecycleBinEnabled": true, "SearchScope": 0, "ServerRelativeUrl": "/", "SiteLogoUrl": "/SiteAssets/__sitelogo__logo_240x240.png", "SyndicationEnabled": true, "TenantAdminMembersCanShare": 0, "Title": "Contoso Intranet", "TreeViewEnabled": false, "UIVersion": 15, "UIVersionConfigurationEnabled": false, "Url": "https://contoso.sharepoint.com", "WebTemplate": "SITEPAGEPUBLISHING", "WelcomePage": "SitePages/Home.aspx" });
+  const mockSPOWebXMLResponse = '<?xml version="1.0" encoding="utf-8"?><entry xml:base="https://contoso.sharepoint.com/_api/" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml"><id>https://contoso.sharepoint.com/_api/Web</id><category term="SP.Web" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" /><link rel="edit" href="Web" /><title /><updated>2022-08-14T21:57:35Z</updated><author><name /></author><content type="application/xml"><m:properties><d:Title>Contoso Intranet</d:Title></m:properties></content></entry>';
+  //#endregion
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve('ABC'));
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.execute
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      auth.ensureAccessToken,
+      appInsights.trackEvent
+    ]);
+    auth.service.accessTokens = {};
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.REQUEST), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if body is set when contentType is not specified', async () => {
+    const actual = await command.validate({ 
+      options: { 
+        url: "https://contoso.sharepoint.com/_api/web", 
+        body: '{ "key": "value" }' ,
+        method: 'post'
+      } 
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if body is set on GET requests', async () => {
+    const actual = await command.validate({ 
+      options: { 
+        url: "https://contoso.sharepoint.com/_api/web", 
+        body: '{ "key": "value" }',
+        contentType: "application/json",
+        method: 'get' 
+      } 
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation with body and contentType on POST request', async () => {
+    const actual = await command.validate({ 
+      options: { 
+        url: "https://contoso.sharepoint.com/_api/web", 
+        body: '{ "key": "value" }',
+        contentType: "application/json",
+        method: 'post' 
+      } 
+    }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('correctly defaults to a GET request accepting a json response', (done) => {
+    sinon.stub(request, 'execute').callsFake((opts) => {
+      if (opts.method === "GET" && opts.headers!.accept === "application/json") {
+        return Promise.resolve(mockSPOWebJSONResponse);
+      }
+
+      return Promise.reject("Invalid request");
+    });
+
+    command.action(logger, {
+      options: {
+        url: "https://contoso.sharepoint.com/_api/web"
+      }
+    }, (err: any) => {
+      try {
+        assert.strictEqual(err, undefined);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('successfully executes a GET request to a SharePoint API endpoint', (done) => {
+    sinon.stub(request, 'execute').callsFake((opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+        return Promise.resolve(mockSPOWebJSONResponse);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        url: "https://contoso.sharepoint.com/_api/web",
+        accept: "application/json;odata=nometadata"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+  
+  it('successfully executes a GET request to a SharePoint API endpoint accepting XML', (done) => {
+    sinon.stub(request, 'execute').callsFake((opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/_api/web?$select=Title") {
+        return Promise.resolve(mockSPOWebXMLResponse);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        url: "https://contoso.sharepoint.com/_api/web?$select=Title",
+        accept: "application/xml"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith(mockSPOWebXMLResponse));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('successfully executes a GET request to a SharePoint API endpoint (debug)', (done) => {
+    sinon.stub(request, 'execute').callsFake((opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+        return Promise.resolve(mockSPOWebJSONResponse);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        url: "https://contoso.sharepoint.com/_api/web",
+        accept: "application/json;odata=nometadata",
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('successfully executes a POST request to a SharePoint API endpoint', (done) => {
+    sinon.stub(request, 'execute').callsFake((opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+        return Promise.resolve(mockSPOWebJSONResponse);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        url: "https://contoso.sharepoint.com/_api/web",
+        accept: "application/json;odata=nometadata",
+        contentType: "application/json",
+        headers: '{"X-HTTP-Method": "PATCH"}',
+        method: "post"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('successfully executes a request with a manually specified resource', (done) => {
+    sinon.stub(request, 'execute').callsFake((opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+        return Promise.resolve(mockSPOWebJSONResponse);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        url: "https://contoso.sharepoint.com/_api/web",
+        accept: "application/json;odata=nometadata",
+        resource: "https://contoso.sharepoint.com"
+      }
+    }, () => {
+      try {
+        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('successfully executes a request with a manually specified resource (debug)', (done) => {
+    sinon.stub(request, 'execute').callsFake((opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/_api/web") {
+        return Promise.resolve(mockSPOWebJSONResponse);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        url: "https://contoso.sharepoint.com/_api/web",
+        accept: "application/json;odata=nometadata",
+        resource: "https://contoso.sharepoint.com",
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(loggerLogToStderrSpy.called);
+        assert(loggerLogSpy.calledWith(JSON.parse(mockSPOWebJSONResponse)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles an API exception', (done) => {
+    sinon.stub(request, 'execute').callsFake(_ => {
+      return Promise.reject("Invalid request");
+    });
+
+    command.action(logger, {
+      options: {
+        url: "https://contoso.sharepoint.com/_api/web"
+      }
+    }, (err: any) => {
+      try {
+        assert.deepStrictEqual(err, new CommandError("Invalid request"));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/m365/commands/request.ts
+++ b/src/m365/commands/request.ts
@@ -1,0 +1,163 @@
+import { AxiosRequestConfig, AxiosRequestHeaders } from 'axios';
+import auth, { Auth } from '../../Auth';
+import { Logger } from '../../cli';
+import Command from '../../Command';
+import GlobalOptions from '../../GlobalOptions';
+import request from '../../request';
+import commands from './commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  url: string;
+  method?: string;
+  resource?: string;
+  body?: string;
+  headers?: string;
+  accept?: string;
+  contentType?: string;
+}
+
+class RequestCommand extends Command {
+  public get name(): string {
+    return commands.REQUEST;
+  }
+
+  public get description(): string {
+    return 'Invoke a custom request at a Microsoft 365 API';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        method: args.options.method || 'get',
+        resource: args.options.resource,
+        accept: args.options.accept || 'application/json',
+        contentType: args.options.contentType,
+        body: typeof args.options.body !== 'undefined',
+        headers: typeof args.options.headers !== 'undefined'
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --url <url>'
+      },
+      {
+        option: '-m, --method [method]',
+        autocomplete: ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']
+      },
+      {
+        option: '-r, --resource [resource]'
+      },
+      {
+        option: '-b, --body [body]'
+      },
+      {
+        option: '-h, --headers [headers]'
+      },
+      {
+        option: '-a, --accept [accept]'
+      },
+      {
+        option: '-c, --contentType [contentType]'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        if (args.options.body && (!args.options.method || args.options.method === "get")) {
+          return "Specify a different method when using body";
+        }
+
+        if (args.options.body && !args.options.contentType) {
+          return "Specify the contentType when using body";
+        }
+
+        return true;
+      }
+    );
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
+    this.getRequestDetails(logger, args)
+      .then(details => this.executeRequest(logger, details))
+      .then(response => {
+        if (response && response !== '') {
+          if (!args.options.accept || args.options.accept.startsWith("application/json")) {
+            logger.log(JSON.parse(response));
+          }
+          else {
+            logger.log(response);
+          }
+        }
+        cb();
+      }, (rawRes: any): void => this.handleRejectedODataJsonPromise(rawRes, logger, cb));
+  }
+
+  private getRequestDetails(logger: Logger, args: CommandArgs): Promise<any> {
+    if (this.verbose) {
+      logger.logToStderr(`Preparing request...`);
+    }
+
+    const headers: AxiosRequestHeaders = args.options.headers ? JSON.parse(args.options.headers) : {};
+    const method = (args.options.method || 'get').toUpperCase();
+
+    if (args.options.accept || !headers['accept']) {
+      headers['accept'] = args.options.accept || "application/json";
+    }
+
+    if (args.options.contentType) {
+      headers['content-type'] = args.options.contentType;
+    }
+
+    const requestDetails: AxiosRequestConfig<string> = {
+      url: args.options.url,
+      headers,
+      method,
+      data: args.options.body
+    };
+
+    if (args.options.resource) {
+      if (this.verbose) {
+        logger.logToStderr(`Retrieving access token for resource...`);
+      }
+
+      const resource: string = Auth.getResourceFromUrl(args.options.resource);
+      return auth
+        .ensureAccessToken(resource, logger as Logger, this.debug)
+        .then(accessToken => {
+          requestDetails.headers!.authorization = `Bearer ${accessToken}`;
+
+          return requestDetails;
+        });
+    }
+    else {
+      return Promise.resolve(requestDetails);
+    }
+  }
+
+  private executeRequest(logger: Logger, options: AxiosRequestConfig): Promise<any> {
+    if (this.verbose) {
+      logger.logToStderr(`Executing request...`);
+    }
+
+    return request.execute(options);
+  }
+}
+
+module.exports = new RequestCommand();

--- a/src/m365/commands/request.ts
+++ b/src/m365/commands/request.ts
@@ -100,7 +100,7 @@ class RequestCommand extends Command {
         }
 
         if (args.options.filePath && !fs.existsSync(path.dirname(args.options.filePath))) {
-          return 'Specified filePath to save the file does not exist';
+          return 'The location specified in the filePath does not exist';
         }
 
         return true;
@@ -109,7 +109,7 @@ class RequestCommand extends Command {
   }
 
   public commandAction(logger: Logger, args: CommandArgs, cb: (err?: any) => void): void {
-    if (this.verbose) {
+    if (this.debug) {
       logger.logToStderr(`Preparing request...`);
     }
 

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -340,25 +340,6 @@ describe('Request', () => {
       });
   });
 
-  it('fails when wrong HTTP verb is used', (done) => {
-    sinon.stub(_request as any, 'req').callsFake((options) => {
-      _options = options;
-      return Promise.resolve({ data: {} });
-    });
-
-    _request
-      .execute({
-        url: 'https://contoso.sharepoint.com/',
-        method: 'GETT'
-      })
-      .then(() => {
-        done('Error expected');
-      }, (err) => {
-        assert.strictEqual(err, 'No valid method set in the request options');
-        done();
-      });
-  });
-
   it('returns response of a successful GET request', (done) => {
     sinon.stub(_request as any, 'req').callsFake((options) => {
       _options = options;

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -313,6 +313,25 @@ describe('Request', () => {
       });
   });
 
+  it('fails when wrong HTTP verb is used', (done) => {
+    sinon.stub(_request as any, 'req').callsFake((options) => {
+      _options = options;
+      return Promise.resolve({ data: {} });
+    });
+
+    _request
+      .execute({
+        url: 'https://contoso.sharepoint.com/',
+        method: 'GETT'
+      })
+      .then(() => {
+        done('Error expected');
+      }, (err) => {
+        assert.strictEqual(err, 'No valid method set in the request options');
+        done();
+      });
+  });
+
   it('returns response of a successful GET request', (done) => {
     sinon.stub(_request as any, 'req').callsFake((options) => {
       _options = options;
@@ -322,6 +341,26 @@ describe('Request', () => {
     _request
       .get({
         url: 'https://contoso.sharepoint.com/'
+      })
+      .then(() => {
+        done();
+      }, (err) => {
+        done(err);
+      });
+  });
+
+  it('returns response of a successful GET request, with overridden authorization', (done) => {
+    sinon.stub(_request as any, 'req').callsFake((options) => {
+      _options = options;
+      return Promise.resolve({ data: {} });
+    });
+
+    _request
+      .get({
+        url: 'https://contoso.sharepoint.com/',
+        headers: {
+          authorization: 'Bearer 123'
+        }
       })
       .then(() => {
         done();

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -175,6 +175,33 @@ describe('Request', () => {
       });
   });
 
+  
+  it(`removes the resource header on distinguished resource requests`, (done) => {
+    sinon.stub(https, 'request').callsFake((options: any) => {
+      _options = options;
+      return new ClientRequest('', () => { });
+    });
+
+    _request
+      .get({
+        url: 'https://contoso.sharepoint.com/',
+        headers: {
+          'x-resource': 'https://contoso.sharepoint.com'
+        }
+      })
+      .then(() => {
+        done('Error expected');
+      }, () => {
+        try {
+          assert.strictEqual(typeof (_options as any).headers['x-resource'], 'undefined');
+          done();
+        }
+        catch (err) {
+          done(err);
+        }
+      });
+  });
+
   it('sets method to GET for a GET request', (done) => {
     sinon.stub(_request as any, 'req').callsFake((options) => {
       _options = options;

--- a/src/request.ts
+++ b/src/request.ts
@@ -145,14 +145,22 @@ class Request {
     return this.execute(options);
   }
 
-  private execute<TResponse>(options: AxiosRequestConfig, resolve?: (res: TResponse) => void, reject?: (error: any) => void): Promise<TResponse> {
+  public execute<TResponse>(options: AxiosRequestConfig, resolve?: (res: TResponse) => void, reject?: (error: any) => void): Promise<TResponse> {
     if (!this._logger) {
       return Promise.reject('Logger not set on the request object');
+    }
+
+    const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+    if (!options.method || methods.indexOf(options.method) === -1 ) {
+      return Promise.reject('No valid method set in the request options');
     }
 
     return new Promise<TResponse>((_resolve: (res: TResponse) => void, _reject: (error: any) => void): void => {
       ((): Promise<string> => {
         if (options.headers && options.headers['x-anonymous']) {
+          return Promise.resolve('');
+        }
+        else if (options.headers?.authorization) {
           return Promise.resolve('');
         }
         else {
@@ -165,7 +173,7 @@ class Request {
             if (options.headers['x-anonymous']) {
               delete options.headers['x-anonymous'];
             }
-            else {
+            else if(accessToken !== '') {
               options.headers.authorization = `Bearer ${accessToken}`;
             }
           }

--- a/src/request.ts
+++ b/src/request.ts
@@ -150,11 +150,6 @@ class Request {
       return Promise.reject('Logger not set on the request object');
     }
 
-    const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
-    if (!options.method || methods.indexOf(options.method) === -1 ) {
-      return Promise.reject('No valid method set in the request options');
-    }
-
     return new Promise<TResponse>((_resolve: (res: TResponse) => void, _reject: (error: any) => void): void => {
       ((): Promise<string> => {
         if (options.headers && options.headers['x-anonymous']) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -160,11 +160,9 @@ class Request {
         if (options.headers && options.headers['x-anonymous']) {
           return Promise.resolve('');
         }
-        else if (options.headers?.authorization) {
-          return Promise.resolve('');
-        }
         else {
-          const resource: string = Auth.getResourceFromUrl(options.url as string);
+          const url = options.headers && options.headers['x-resource'] ? options.headers['x-resource'] : options.url; 
+          const resource: string = Auth.getResourceFromUrl(url as string);
           return auth.ensureAccessToken(resource, this._logger as Logger, this._debug);
         }
       })()
@@ -173,7 +171,10 @@ class Request {
             if (options.headers['x-anonymous']) {
               delete options.headers['x-anonymous'];
             }
-            else if(accessToken !== '') {
+            if (options.headers['x-resource']) {
+              delete options.headers['x-resource'];
+            }
+            if (accessToken !== '') {
               options.headers.authorization = `Bearer ${accessToken}`;
             }
           }


### PR DESCRIPTION
Closes #3512

This PR adds the command to invoke a custom request at a Microsoft 365 API.

To implement the functionality I updated the `Request` class with the following changes:
- Make the `execute` method public to be able to use it to execute a request directly and feed the method from outside. I added some logic to verify that the request method exists and validate it in the tests.
- Added the possibility to override the authorization header from outside the `Request` class. This was necessary to implement the `resource` option. 

I'm open to feedback 👍