### PR TITLE
Add dark theme support for Team page. Closes #3582

### DIFF
--- a/docs/docs/about/team.md
+++ b/docs/docs/about/team.md
@@ -2,7 +2,7 @@
 
 # Meet the Team
 
-Do you want to know the curious and bright minds behind the CLI for M365? Look no further! Below you will find a list of all our hard-working maintainers and brilliant contributors.
+Do you want to know the curious and bright minds behind the CLI for Microsoft 365? Look no further! Below you will find a list of all our hard-working maintainers and brilliant contributors.
 
 ## Maintainers 
 

--- a/docs/docs/css/styles2.css
+++ b/docs/docs/css/styles2.css
@@ -75,6 +75,12 @@
   height: 100%;
 }
 
+[data-md-color-scheme="slate"] .cli-grid-item {
+  border: 1px solid #505050;
+  background-color: #3f3d3d;
+  box-shadow: 0 0 6px 2px rgba(255, 255, 255, 0.02);
+}
+
 #cli-grid-item-template {
   display: none;
 }
@@ -118,10 +124,19 @@
   text-transform: uppercase;
 }
 
+[data-md-color-scheme="slate"] .cli-grid-item-name {
+  color: #fff;
+}
+
+
 .cli-grid-item-company {  
   color: #636e72;
   font-size: 14px;
   line-height: 20px;
+}
+
+[data-md-color-scheme="slate"] .cli-grid-item-company {
+  color: #c5c5c5;
 }
 
 .cli-grid-item-link, .cli-grid-item-link-img {
@@ -145,6 +160,10 @@
   display: inline-block;
 }
 
+[data-md-color-scheme="slate"] .cli-grid-item-link {
+  color: #c5c5c5;
+}
+
 .cli-grid-item-link:hover {  
   opacity: 1;
 }
@@ -153,6 +172,10 @@
   min-height: 24px;
   fill: #636e72;
   display: block;
+}
+
+[data-md-color-scheme="slate"] .cli-grid-item-link-img {
+  filter: invert(1);
 }
 
 @media only screen and (max-width: 76.1875em) {

--- a/docs/docs/css/styles2.css
+++ b/docs/docs/css/styles2.css
@@ -128,7 +128,6 @@
   color: #fff;
 }
 
-
 .cli-grid-item-company {  
   color: #636e72;
   font-size: 14px;


### PR DESCRIPTION
Closes #3582

Preview of the Team page in dark mode:

![afbeelding](https://user-images.githubusercontent.com/38426621/185213121-c82f6dce-715c-4e01-bc20-a68aff659212.png)
