### PR TITLE
Fixed docs `aad app set` and `aad app add` by adding `--appId` in Examples

### DIFF
--- a/docs/docs/cmd/aad/app/app-add.md
+++ b/docs/docs/cmd/aad/app/app-add.md
@@ -176,5 +176,5 @@ m365 aad app add --name 'My AAD app' --save
 Create new Azure AD app registration with a certificate
 
 ```sh
-m365 aad app add --name 'My AAD app' --certificateDisplayName "Some certificate name" --certificateFile c:\temp\some-certificate.cer
+m365 aad app add --name 'My AAD app' --certificateDisplayName "Some certificate name" --certificateFile "c:\temp\some-certificate.cer"
 ```

--- a/docs/docs/cmd/aad/app/app-set.md
+++ b/docs/docs/cmd/aad/app/app-set.md
@@ -85,5 +85,5 @@ m365 aad app set --objectId 95cfe30d-ed44-4f9d-b73d-c66560f72e83 --redirectUris 
 Add a certificate to the app
 
 ```sh
-m365 aad app set --certificateDisplayName "Some certificate name" --certificateFile c:\temp\some-certificate.cer
+m365 aad app set --appId e75be2e1-0204-4f95-857d-51a37cf40be8 --certificateDisplayName "Some certificate name" --certificateFile "c:\temp\some-certificate.cer"
 ```


### PR DESCRIPTION
> ### Fixed docs `aad app set` and `aad app add` by adding `--appId` in Examples
Fixed docs for 'aad app set' and 'aad app add' command by adding `--appId` for the set command. Added " before the certificate path in the both the commands. Closes #3588 

> ### Linked Issue

Closes #3588 