### PR TITLE
New command: spo web roleassignment remove. Closes #3550

### DIFF
--- a/docs/docs/cmd/spo/list/list-roleassignment-remove.md
+++ b/docs/docs/cmd/spo/list/list-roleassignment-remove.md
@@ -31,6 +31,9 @@ m365 spo list roleassignment remove [options]
 `--groupName [groupName]`
 : enter group name of Azure AD or SharePoint group. Specify either groupName or princpialId.
 
+`--confirm`
+: Don't prompt for confirming removing the role assignment
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples

--- a/docs/docs/cmd/spo/web/web-roleassignment-remove.md
+++ b/docs/docs/cmd/spo/web/web-roleassignment-remove.md
@@ -1,0 +1,54 @@
+# spo web roleassignment remove
+
+Removes a role assignment from web permissions.
+
+## Usage
+
+```sh
+m365 spo web roleassignment remove [options]
+```
+
+## Options
+
+`-u, --webUrl <webUrl>`
+: URL of the site
+
+`--principalId [principalId]`
+: SharePoint ID of principal it may be either user id or group id we want to add permissions to. Specify principalId only when upn or groupName are not used.
+
+`--upn [upn]`
+: Upn/email of user to assign role to. Specify upn only when principalId or groupName are not used.
+
+`--groupName [groupName]`
+: Enter group name of Azure AD or SharePoint group. Specify groupName only when principalId or upn are not used.
+
+`--confirm [confirm]`
+: Don't prompt for confirming removing the roleassignment.
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Remove roleassignment from web based on group name
+
+```sh
+m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --groupName "saleGroup"
+```
+
+Remove roleassignment from web based on principal Id
+
+```sh
+m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --principalId 2
+```
+
+Remove roleassignment from web based on upn
+
+```sh
+m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --upn "someaccount@tenant.onmicrosoft.com"
+```
+
+Remove roleassignment from web based on principal Id without prompting for confirmation
+
+```sh
+m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --principalId 2 --confirm
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -572,6 +572,7 @@ nav:
         - web list: 'cmd/spo/web/web-list.md'
         - web reindex: 'cmd/spo/web/web-reindex.md'
         - web remove: 'cmd/spo/web/web-remove.md'
+        - web roleassignment remove: 'cmd/spo/web/web-roleassignment-remove.md'
         - web roleinheritance reset: 'cmd/spo/web/web-roleinheritance-reset.md'
         - web set: 'cmd/spo/web/web-set.md'
     - Teams (teams):

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -269,6 +269,7 @@ export default {
   WEB_LIST: `${prefix} web list`,
   WEB_REINDEX: `${prefix} web reindex`,
   WEB_REMOVE: `${prefix} web remove`,
+  WEB_ROLEASSIGNMENT_REMOVE: `${prefix} web roleassignment remove`,
   WEB_ROLEINHERITANCE_RESET: `${prefix} web roleinheritance reset`,
   WEB_SET: `${prefix} web set`
 };

--- a/src/m365/spo/commands/list/list-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-roleassignment-remove.spec.ts
@@ -140,6 +140,16 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if neither upn nor principalId or groupName is specified', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listTitle: 'Documents' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if neither listId nor listTitle or listUrl is specified', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', upn: 'someaccount@tenant.onmicrosoft.com' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('remove role assignment from list by title', (done) => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf('_api/web/lists/getByTitle(\'test\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {

--- a/src/m365/spo/commands/list/list-roleassignment-remove.ts
+++ b/src/m365/spo/commands/list/list-roleassignment-remove.ts
@@ -106,9 +106,17 @@ class SpoListRoleAssignmentRemoveCommand extends SpoCommand {
           return `Specify either list id or title or list url`;
         }
 
+        if (listOptions.filter(item => item !== undefined).length === 0) {
+          return `Specify at least list id or title or list url`;
+        }
+
         const principalOptions: any[] = [args.options.principalId, args.options.upn, args.options.groupName];
         if (principalOptions.some(item => item !== undefined) && principalOptions.filter(item => item !== undefined).length > 1) {
           return `Specify either principalId id or upn or groupName`;
+        }
+
+        if (principalOptions.filter(item => item !== undefined).length === 0) {
+          return `Specify at least principalId id or upn or groupName`;
         }
 
         return true;

--- a/src/m365/spo/commands/web/web-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/web/web-roleassignment-remove.spec.ts
@@ -1,0 +1,381 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Cli, CommandInfo, Logger } from '../../../../cli';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils';
+import commands from '../../commands';
+import * as SpoUserGetCommand from '../user/user-get';
+import * as SpoGroupGetCommand from '../group/group-get';
+const command: Command = require('./web-roleassignment-remove');
+
+describe(commands.WEB_ROLEASSIGNMENT_REMOVE, () => {
+  let log: any[];
+  let logger: Logger;
+  let commandInfo: CommandInfo;
+  let requests: any[];
+  let promptOptions: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    requests = [];
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      promptOptions = options;
+      cb({ continue: false });
+    });
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.post,
+      Cli.executeCommandWithOutput,
+      Cli.prompt
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.WEB_ROLEASSIGNMENT_REMOVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options;
+    let containsDebugOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsDebugOption = true;
+      }
+    });
+    assert(containsDebugOption);
+  });
+
+  it('fails validation if the url option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'foo', principalId: 11 } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the url option is a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', principalId: 11 } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if the principalId option is not a number', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', principalId: 'abc' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the principalId option is a number', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', principalId: 11 } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if principalId and upn are specified', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', principalId: 11, upn: 'someaccount@tenant.onmicrosoft.com' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if principalId and groupName are specified', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', principalId: 11, groupName: 'someGroup' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if upn and groupName are specified', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', upn: 'someaccount@tenant.onmicrosoft.com', groupName: 'someGroup' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if neither upn nor principalId or groupName is specified', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com'} }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('remove role assignment from web', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('_api/web/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        principalId: 11,
+        confirm: true
+      }
+    }, (err: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('remove role assignment from web get principal id by upn', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command): Promise<any> => {
+      if (command === SpoUserGetCommand) {
+        return Promise.resolve({
+          stdout: '{"Id": 11,"IsHiddenInUI": false,"LoginName": "i:0#.f|membership|someaccount@tenant.onmicrosoft.com","Title": "Some Account","PrincipalType": 1,"Email": "someaccount@tenant.onmicrosoft.com","Expiration": "","IsEmailAuthenticationGuestUser": false,"IsShareByEmailGuestUser": false,"IsSiteAdmin": true,"UserId": {"NameId": "1003200097d06dd6","NameIdIssuer": "urn:federation:microsoftonline"},"UserPrincipalName": "someaccount@tenant.onmicrosoft.com"}'
+        });
+      }
+
+      return Promise.reject(new CommandError('Unknown case'));
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        upn: 'someaccount@tenant.onmicrosoft.com',
+        confirm: true
+      }
+    }, (err: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles error when upn does not exist', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const error = 'no user found';
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command): Promise<any> => {
+      if (command === SpoUserGetCommand) {
+        return Promise.reject(error);
+      }
+
+      return Promise.reject(new CommandError('Unknown case'));
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        upn: 'someaccount@tenant.onmicrosoft.com',
+        confirm: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(error)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('remove role assignment from web get principal id by group name', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command): Promise<any> => {
+      if (command === SpoGroupGetCommand) {
+        return Promise.resolve({
+          stdout: '{"Id": 11,"IsHiddenInUI": false,"LoginName": "otherGroup","Title": "otherGroup","PrincipalType": 8,"AllowMembersEditMembership": false,"AllowRequestToJoinLeave": false,"AutoAcceptRequestToJoinLeave": false,"Description": "","OnlyAllowMembersViewMembership": true,"OwnerTitle": "Some Account","RequestToJoinLeaveEmailSetting": null}'
+        });
+      }
+
+      return Promise.reject(new CommandError('Unknown case'));
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        groupName: 'someGroup',
+        confirm: true
+      }
+    }, (err: any) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles error when group does not exist', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const error = 'no group found';
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command): Promise<any> => {
+      if (command === SpoGroupGetCommand) {
+        return Promise.reject(error);
+      }
+
+      return Promise.reject(new CommandError('Unknown case'));
+    });
+
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        groupName: 'someGroup',
+        confirm: true
+      }
+    }, (err: any) => {
+      try {
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(new CommandError(error)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts removing role assignment when prompt not confirmed', (done) => {
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: false });
+    });
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        groupName: 'someGroup'
+      }
+    }, () => {
+      try {
+        assert(requests.length === 0);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('prompts before removing role assignment when confirmation argument not passed', (done) => {
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        groupName: 'someGroup'
+      }
+    }, () => {
+      let promptIssued = false;
+
+      if (promptOptions && promptOptions.type === 'confirm') {
+        promptIssued = true;
+      }
+
+      try {
+        assert(promptIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('removes role assignment when prompt confirmed', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf('/_api/web/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command): Promise<any> => {
+      if (command === SpoGroupGetCommand) {
+        return Promise.resolve({
+          stdout: '{"Id": 11,"IsHiddenInUI": false,"LoginName": "otherGroup","Title": "otherGroup","PrincipalType": 8,"AllowMembersEditMembership": false,"AllowRequestToJoinLeave": false,"AutoAcceptRequestToJoinLeave": false,"Description": "","OnlyAllowMembersViewMembership": true,"OwnerTitle": "Some Account","RequestToJoinLeaveEmailSetting": null}'
+        });
+      }
+
+      return Promise.reject(new CommandError('Unknown case'));
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake((options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: true });
+    });
+    command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        groupName: 'someGroup'
+      }
+    }, (err) => {
+      try {
+        assert.strictEqual(typeof err, 'undefined');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/m365/spo/commands/web/web-roleassignment-remove.ts
+++ b/src/m365/spo/commands/web/web-roleassignment-remove.ts
@@ -1,0 +1,198 @@
+import { Cli, CommandOutput, Logger } from '../../../../cli';
+import Command, { CommandErrorWithOutput } from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import { validation } from '../../../../utils';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+import * as SpoUserGetCommand from '../user/user-get';
+import { Options as SpoUserGetCommandOptions } from '../user/user-get';
+import * as SpoGroupGetCommand from '../group/group-get';
+import { Options as SpoGroupGetCommandOptions } from '../group/group-get';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  principalId?: number;
+  upn?: string;
+  groupName?: string;
+  confirm?: boolean;
+}
+
+class SpoWebRoleAssignmentRemoveCommand extends SpoCommand {
+  public get name(): string {
+    return commands.WEB_ROLEASSIGNMENT_REMOVE;
+  }
+
+  public get description(): string {
+    return 'Removes a role assignment from web permissions';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        principalId: typeof args.options.principalId !== 'undefined',
+        upn: typeof args.options.upn !== 'undefined',
+        groupName: typeof args.options.groupName !== 'undefined',
+        confirm: (!(!args.options.confirm)).toString()
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '--principalId [principalId]'
+      },
+      {
+        option: '--upn [upn]'
+      },
+      {
+        option: '--groupName [groupName]'
+      },
+      {
+        option: '--confirm'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+        if (isValidSharePointUrl !== true) {
+          return isValidSharePointUrl;
+        }
+
+        if (args.options.principalId && isNaN(args.options.principalId)) {
+          return `Specified principalId ${args.options.principalId} is not a number`;
+        }
+
+        const principalOptions: any[] = [args.options.principalId, args.options.upn, args.options.groupName];
+        if (principalOptions.some(item => item !== undefined) && principalOptions.filter(item => item !== undefined).length > 1) {
+          return `Specify either principalId id or upn or groupName`;
+        }
+
+        if (principalOptions.filter(item => item !== undefined).length === 0) {
+          return `Specify at least principalId id or upn or groupName`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  public commandAction(logger: Logger, args: CommandArgs, cb: () => void): void {
+    const removeRoleAssignment: () => void = (): void => {
+      if (this.verbose) {
+        logger.logToStderr(`Removing role assignment from web ${args.options.webUrl}...`);
+      }
+
+      if (args.options.upn) {
+        this.GetUserPrincipalId(args.options)
+          .then((userPrincipalId: number) => {
+            args.options.principalId = userPrincipalId;
+            this.RemoveRoleAssignment(logger, args.options, cb);
+          }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+      }
+      else if (args.options.groupName) {
+        this.GetGroupPrincipalId(args.options)
+          .then((groupPrincipalId: number) => {
+            args.options.principalId = groupPrincipalId;
+            this.RemoveRoleAssignment(logger, args.options, cb);
+          }, (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+      }
+      else {
+        this.RemoveRoleAssignment(logger, args.options, cb);
+      }
+    };
+
+    if (args.options.confirm) {
+      removeRoleAssignment();
+    }
+    else {
+      Cli.prompt({
+        type: 'confirm',
+        name: 'continue',
+        default: false,
+        message: `Are you sure you want to remove role assignment from web ${args.options.webUrl}?`
+      }, (result: { continue: boolean }): void => {
+        if (!result.continue) {
+          cb();
+        }
+        else {
+          removeRoleAssignment();
+        }
+      });
+    }
+  }
+
+  private RemoveRoleAssignment(logger: Logger, options: Options, cb: () => void): void {
+    const requestOptions: any = {
+      url: `${options.webUrl}/_api/web/roleassignments/removeroleassignment(principalid='${options.principalId}')`,
+      method: 'POST',
+      headers: {
+        'accept': 'application/json;odata=nometadata',
+        'content-type': 'application/json'
+      },
+      responseType: 'json'
+    };
+
+    request
+      .post(requestOptions)
+      .then(_ => cb(), (err: any): void => this.handleRejectedODataJsonPromise(err, logger, cb));
+  }
+
+  private GetGroupPrincipalId(options: Options): Promise<number> {
+    const groupGetCommandOptions: SpoGroupGetCommandOptions = {
+      webUrl: options.webUrl,
+      name: options.groupName,
+      output: 'json',
+      debug: this.debug,
+      verbose: this.verbose
+    };
+
+    return Cli.executeCommandWithOutput(SpoGroupGetCommand as Command, { options: { ...groupGetCommandOptions, _: [] } })
+      .then((output: CommandOutput): Promise<number> => {
+        const getGroupOutput = JSON.parse(output.stdout);
+        return Promise.resolve(getGroupOutput.Id);
+      }, (err: CommandErrorWithOutput) => {
+        return Promise.reject(err);
+      });
+  }
+
+  private GetUserPrincipalId(options: Options): Promise<number> {
+    const userGetCommandOptions: SpoUserGetCommandOptions = {
+      webUrl: options.webUrl,
+      email: options.upn,
+      id: undefined,
+      output: 'json',
+      debug: this.debug,
+      verbose: this.verbose
+    };
+
+    return Cli.executeCommandWithOutput(SpoUserGetCommand as Command, { options: { ...userGetCommandOptions, _: [] } })
+      .then((output: CommandOutput): Promise<number> => {
+        const getUserOutput = JSON.parse(output.stdout);
+        return Promise.resolve(getUserOutput.Id);
+      }, (err: CommandErrorWithOutput) => {
+        return Promise.reject(err);
+      });
+  }
+}
+
+module.exports = new SpoWebRoleAssignmentRemoveCommand();


### PR DESCRIPTION
 ### New command: spo web roleassignment remove. 

- added new command to remove role assginment on web level
- small fixes in list roleassignment remove command along the way (missing --confirm option and additional validation to check for atleast one option to be specified)

 ### Linked Issue

Closes #3550
