### PR TITLE
`planner task get` missing validation. Closes #3433

### DIFF
--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -182,6 +182,16 @@ describe(commands.TASK_GET, () => {
     assert.deepStrictEqual(optionSets, [['id', 'title']]);
   });
 
+  it('fails validation when bucket name is used without id', async () => {
+    const actual = await command.validate({
+      options: {
+        id: validTaskId,
+        bucketName: validBucketName
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('fails validation when title is used without bucket id', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/planner/commands/task/task-get.ts
+++ b/src/m365/planner/commands/task/task-get.ts
@@ -81,6 +81,14 @@ class PlannerTaskGetCommand extends GraphCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
+        if (args.options.id) {
+	      if (args.options.bucketId || args.options.bucketName ||
+          args.options.planId || args.options.planName || args.options.planTitle  || 
+          args.options.ownerGroupId || args.options.ownerGroupName) {
+	        return 'Don\'t specify bucketId, bucketName, planId, planTitle, ownerGroupId or ownerGroupName when using id';
+	      }
+	    }
+
         if (args.options.title && !args.options.bucketId && !args.options.bucketName) {
 	      return 'Specify either bucketId or bucketName when using title';
 	    }


### PR DESCRIPTION
Partially resolves closes #3433

The other part of the issue, missing alias in docs, has already been resolved in another PR (#3494). 