### PR TITLE
Fixes command completion in PowerShell. Closes #3394

### DIFF
--- a/scripts/Register-CLIM365Completion.ps1
+++ b/scripts/Register-CLIM365Completion.ps1
@@ -1,7 +1,7 @@
 function CLIMicrosoft365Completion {
   param($commandName, $wordToComplete, $cursorPosition)
 
-  $commands = Get-Content $(Join-Path $PSScriptRoot ".." "commands.json" -Resolve) | ConvertFrom-Json
+  $commands = Get-Content $(Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "commands.json" -Resolve) | ConvertFrom-Json
   $command = $commands
   $parent = $commands
   $replies = @{ }


### PR DESCRIPTION
Closes #3394

Fixes command completion in PowerShell. 
It appears the `Join-Path` commandlet is not meant to join more than 2 strings together.
It did work in PoSH 7, but failed in PoSH 5.

https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/join-path?view=powershell-7.2

Following the documentation I updated the usage of the `Join-Path` commandlet and piped multiple statements, to ensure we have the full path to the `commands.json` file. 

The command completion now works on my end.