### PR TITLE
Fixes `spo hubsite unregister` typo in command description

### DIFF
--- a/docs/docs/cmd/spo/hubsite/hubsite-unregister.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-unregister.md
@@ -1,6 +1,6 @@
 # spo hubsite unregister
 
-Unregisters the specifies site collection as a hub site
+Unregisters the specified site collection as a hub site
 
 ## Usage
 
@@ -33,7 +33,7 @@ Unregister the site collection with URL _https://contoso.sharepoint.com/sites/sa
 m365 spo hubsite unregister --url https://contoso.sharepoint.com/sites/sales
 ```
 
-Unregister the site collection with URL _https://contoso.sharepoint.com/sites/sales_ as a hub site without prompting for confirmation
+Unregister the site collection with URL _https://contoso.sharepoint.com/sites/sales_ as a hub site without prompting for confirmation.
 
 ```sh
 m365 spo hubsite unregister --url https://contoso.sharepoint.com/sites/sales --confirm

--- a/src/m365/spo/commands/hubsite/hubsite-unregister.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-unregister.ts
@@ -20,7 +20,7 @@ class SpoHubSiteUnregisterCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Unregisters the specifies site collection as a hub site';
+    return 'Unregisters the specified site collection as a hub site';
   }
 
   constructor() {


### PR DESCRIPTION
Seemed a bit overkill to create an issue for this 😊.