### PR TITLE
Remove PowerShell examples from adaptive card docs. Closes #3631

### DIFF
--- a/docs/docs/cmd/adaptivecard/adaptivecard-send.md
+++ b/docs/docs/cmd/adaptivecard/adaptivecard-send.md
@@ -116,23 +116,3 @@ Send custom card with card data
 ```sh
 m365 adaptivecard send --url https://contoso.webhook.office.com/webhookb2/892e8ed3-997c-4b6e-8f8a-7f32728a8a87@f7322380-f203-42ff-93e8-66e266f6d2e4/IncomingWebhook/fcc6565ec7a944928bd43d6fc193b258/4f0482d4-b147-4f67-8a61-11f0a5019547 --card '{"type":"AdaptiveCard","body":[{"type":"TextBlock","size":"Medium","weight":"Bolder","text":"${title}"},{"type":"TextBlock","text":"${description}","wrap":true},{"type":"FactSet","facts":[{"$data":"${properties}","title":"${key}:","value":"${value}"}]}],"actions":[{"type":"Action.OpenUrl","title":"View","url":"${viewUrl}"}],"$schema":"http://adaptivecards.io/schemas/adaptive-card.json","version":"1.2"}' --cardData '{"title":"Publish Adaptive Card Schema","description":"Now that we have defined the main rules and features of the format, we need to produce a schema and publish it to GitHub. The schema will be the starting point of our reference documentation.","creator":{"name":"Matt Hidinger","profileImage":"https://pbs.twimg.com/profile_images/3647943215/d7f12830b3c17a5a9e4afcc370e3a37e_400x400.jpeg"},"createdUtc":"2017-02-14T06:08:39Z","viewUrl":"https://adaptivecards.io","properties":[{"key":"Board","value":"Adaptive Cards"},{"key":"List","value":"Backlog"},{"key":"Assigned to","value":"Matt Hidinger"},{"key":"Due date","value":"Not set"}]}'
 ```
-
-## Examples for PowerShell
-
-Send custom card with all known options merged
-
-```powershell
-m365 adaptivecard send --url https://contoso.webhook.office.com/webhookb2/892e8ed3-997c-4b6e-8f8a-7f32728a8a87@f7322380-f203-42ff-93e8-66e266f6d2e4/IncomingWebhook/fcc6565ec7a944928bd43d6fc193b258/4f0482d4-b147-4f67-8a61-11f0a5019547 --card "{\"type\":\"AdaptiveCard\",\"body\":[{\"type\":\"TextBlock\",\"size\":\"Medium\",\"weight\":\"Bolder\",\"text\":\"${title}\"},{\"type\":\"TextBlock\",\"text\":\"${description}\",\"wrap\":true},{\"type\":\"FactSet\",\"facts\":[{\"$data\":\"${properties}\",\"title\":\"${key}:\",\"value\":\"${value}\"}]}],\"actions\":[{\"type\":\"Action.OpenUrl\",\"title\":\"View\",\"url\":\"${actionUrl}\"}],\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.2\"}" --title "CLI for Microsoft 365 v3.4" --description "New release of CLI for Microsoft 365" --imageUrl "https://contoso.com/image.gif" --actionUrl "https://aka.ms/cli-m365"
-```
-
-Send custom card with unknown option merged
-
-```powershell
-m365 adaptivecard send --url https://contoso.webhook.office.com/webhookb2/892e8ed3-997c-4b6e-8f8a-7f32728a8a87@f7322380-f203-42ff-93e8-66e266f6d2e4/IncomingWebhook/fcc6565ec7a944928bd43d6fc193b258/4f0482d4-b147-4f67-8a61-11f0a5019547 --card "{\"type\":\"AdaptiveCard\",\"body\":[{\"type\":\"TextBlock\",\"size\":\"Medium\",\"weight\":\"Bolder\",\"text\":\"${Title}\"}],\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.2\"}" --Title "CLI for Microsoft 365 v3.4"
-```
-
-Send custom card with card data
-
-```powershell
-m365 adaptivecard send --url https://contoso.webhook.office.com/webhookb2/892e8ed3-997c-4b6e-8f8a-7f32728a8a87@f7322380-f203-42ff-93e8-66e266f6d2e4/IncomingWebhook/fcc6565ec7a944928bd43d6fc193b258/4f0482d4-b147-4f67-8a61-11f0a5019547 --card "{\"type\":\"AdaptiveCard\",\"body\":[{\"type\":\"TextBlock\",\"size\":\"Medium\",\"weight\":\"Bolder\",\"text\":\"${title}\"},{\"type\":\"TextBlock\",\"text\":\"${description}\",\"wrap\":true},{\"type\":\"FactSet\",\"facts\":[{\"$data\":\"${properties}\",\"title\":\"${key}:\",\"value\":\"${value}\"}]}],\"actions\":[{\"type\":\"Action.OpenUrl\",\"title\":\"View\",\"url\":\"${viewUrl}\"}],\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.2\"}" --cardData "{\"title\":\"Publish Adaptive Card Schema\",\"description\":\"Now that we have defined the main rules and features of the format, we need to produce a schema and publish it to GitHub. The schema will be the starting point of our reference documentation.\",\"creator\":{\"name\":\"Matt Hidinger\",\"profileImage\":\"https://pbs.twimg.com/profile_images/3647943215/d7f12830b3c17a5a9e4afcc370e3a37e_400x400.jpeg\"},\"createdUtc\":\"2017-02-14T06:08:39Z\",\"viewUrl\":\"https://adaptivecards.io\",\"properties\":[{\"key\":\"Board\",\"value\":\"Adaptive Cards\"},{\"key\":\"List\",\"value\":\"Backlog\"},{\"key\":\"Assigned to\",\"value\":\"Matt Hidinger\"},{\"key\":\"Due date\",\"value\":\"Not set\"}]}"
-```


### PR DESCRIPTION
Closes #3631

This PR removes PowerShell examples from the adaptive card documentation.