### PR TITLE
Add ability to send emails from a specified account or inbox

### DIFF
--- a/docs/docs/cmd/outlook/mail/mail-send.md
+++ b/docs/docs/cmd/outlook/mail/mail-send.md
@@ -1,6 +1,6 @@
 # outlook sendmail
 
-Sends e-mail on behalf of the current user
+Sends an e-mail
 
 ## Usage
 
@@ -22,6 +22,12 @@ m365 outlook sendmail [options]
 `-t, --to <to>`
 : Comma-separated list of e-mails to send the message to
 
+`--sender [sender]`
+: Optional upn or user id to specify what account to send the message from. Also see the remarks section.
+
+`-m, --mailbox [mailbox]`
+: Specify this option to send the email on behalf of another mailbox, for example a shared mailbox, group or distribution list. The sender needs to be a delegate on the specified mailbox. Also see the remarks section.
+
 `--bodyContents <bodyContents>`
 : String containing the body of the e-mail to send
 
@@ -32,6 +38,24 @@ m365 outlook sendmail [options]
 : Save e-mail in the sent items folder. Default `true`
 
 --8<-- "docs/cmd/_global.md"
+
+## Remarks
+**If you are connected using app only authentication:**
+
+- Always specify a user id or upn in the `--sender` option. The email will be sent as if it came from the specified user, and can optionally be saved in the sent folder of that user account.
+- You can optionally also specify the `--mailbox` option to send mail on behalf of a shared mailbox, group or distribution list. The account used in the `--sender` option, needs to have 'Send on behalf of' permissions on the mailbox in question.
+
+!!! important
+    You need `Mail.Send` application permissions on the Microsoft Graph to be able to send mails using an application identity. 
+
+**If you are connected with a regular user account:**
+
+- Specify the `--mailbox` option if you want to send an email on behalf of another mailbox. This can be a shared mailbox, group or distribution list. It will be visible in the email that the email was sent by you. You need to be assigned `Send on behalf of` permissions on the mailbox in question.  
+- You can specify the `--sender` option if you want to send an email as if you were the other user.
+The sent email can optionally be saved in the sent folder of that user account. You'll need `Read and manage (Full Access)` permissions on the mailbox of the other user. You can combine the `--sender` and `--mailbox` options to let the other user send a mail on behalf of the specified mailbox.
+
+!!! important
+    You need at least `Mail.Send` delegated permissions on the Microsoft Graph to be able to send emails. When specifying another user as sender, you'll need `Mail.Send.Shared` permissions.
 
 ## Examples
 
@@ -57,4 +81,22 @@ Send a text e-mail to the specified e-mail address. Don't store the e-mail in se
 
 ```sh
 m365 outlook mail send --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the team site" --saveToSentItems false
+```
+
+Send an email on behalf of a shared mailbox using the signed in user
+
+```sh
+m365 outlook mail send --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the team site" --mailbox sales@contoso.com
+```
+
+Send an email as another user
+
+```sh
+m365 outlook mail send --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the team site" --sender svc_project@contoso.com
+```
+
+Send an email as another user, on behalf of a shared mailbox
+
+```sh
+m365 outlook mail send --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the team site" --sender svc_project@contoso.com --mailbox sales@contoso.com
 ```


### PR DESCRIPTION
Closes #3589

Add ability to send emails from a specified account or inbox.

This PR adds capabilities to send emails from a specified sender or on behalf of a specified mailbox.
This enables sending on behalf of shared mailboxes, group mailboxes and distribution lists. 

It also enables sending mails within an app only context.