### PR TITLE
Fix typo's in docs. Closes #3652

### DIFF
--- a/docs/docs/cmd/pp/environment/environment-list.md
+++ b/docs/docs/cmd/pp/environment/environment-list.md
@@ -10,7 +10,7 @@ m365 pp environment list [options]
 
 ## Options
 
-`-a, --asAdmin [teamId]`
+`-a, --asAdmin`
 Run the command as admin and retrieve all environments. Lists only environments you have explicitly are assigned permissions to by default.
 
 --8<-- "docs/cmd/_global.md"

--- a/docs/docs/cmd/spo/list/list-roleassignment-add.md
+++ b/docs/docs/cmd/spo/list/list-roleassignment-add.md
@@ -26,10 +26,10 @@ m365 spo list roleassignment add [options]
 : SharePoint ID of principal it may be either user id or group id we want to add permissions to. Specify principalId only when upn or groupName are not used.
 
 `--upn [upn]`
-: Upn/email of user to assign role to. Specify either upn or princpialId
+: Upn/email of user to assign role to. Specify either upn or principalId
 
 `--groupName [groupName]`
-: Enter group name of Azure AD or SharePoint group.. Specify either groupName or princpialId
+: Enter group name of Azure AD or SharePoint group.. Specify either groupName or principalId
 
 `--roleDefinitionId [roleDefinitionId]`
 : ID of role definition. Specify either roleDefinitionId or roleDefinitionName but not both

--- a/docs/docs/cmd/spo/list/list-roleassignment-remove.md
+++ b/docs/docs/cmd/spo/list/list-roleassignment-remove.md
@@ -26,10 +26,10 @@ m365 spo list roleassignment remove [options]
 : SharePoint ID of principal it may be either user id or group id we want to remove permissions Specify principalId only when upn or groupName are not used.
 
 `--upn [upn]`
-: upn/email of user. Specify either upn or princpialId.
+: upn/email of user. Specify either upn or principalId.
 
 `--groupName [groupName]`
-: enter group name of Azure AD or SharePoint group. Specify either groupName or princpialId.
+: enter group name of Azure AD or SharePoint group. Specify either groupName or principalId.
 
 `--confirm`
 : Don't prompt for confirming removing the role assignment

--- a/docs/docs/cmd/spo/listitem/listitem-roleassignment-remove.md
+++ b/docs/docs/cmd/spo/listitem/listitem-roleassignment-remove.md
@@ -29,10 +29,10 @@ m365 spo listitem roleassignment remove [options]
 : SharePoint ID of principal it may be either user id or group id we want to remove permissions Specify principalId only when upn or groupName are not used.
 
 `--upn [upn]`
-: upn/email of user. Specify either upn or princpialId.
+: upn/email of user. Specify either upn or principalId.
 
 `--groupName [groupName]`
-: enter group name of Azure AD or SharePoint group. Specify either groupName or princpialId.
+: enter group name of Azure AD or SharePoint group. Specify either groupName or principalId.
 
 `--confirm`
 : Don't prompt for confirming removing the role assignment

--- a/docs/docs/cmd/spo/web/web-roleassignment-add.md
+++ b/docs/docs/cmd/spo/web/web-roleassignment-add.md
@@ -17,10 +17,10 @@ m365 spo web roleassignment add [options]
 : SharePoint ID of principal it may be either user id or group id we want to add permissions to. Specify principalId only when upn or groupName are not used.
 
 `--upn [upn]`
-: upn/email of user to assign role to. Specify either upn or princpialId
+: upn/email of user to assign role to. Specify either upn or principalId
 
 `--groupName [groupName]`
-: enter group name of Azure AD or SharePoint group.. Specify either groupName or princpialId
+: enter group name of Azure AD or SharePoint group.. Specify either groupName or principalId
 
 `--roleDefinitionId [roleDefinitionId]`
 : ID of role definition. Specify either roleDefinitionId or roleDefinitionName but not both

--- a/src/m365/pp/commands/environment/environment-list.ts
+++ b/src/m365/pp/commands/environment/environment-list.ts
@@ -43,7 +43,7 @@ class PpEnvironmentListCommand extends PowerPlatformCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-a, --asAdmin [teamId]'
+        option: '-a, --asAdmin'
       }
     );
   }


### PR DESCRIPTION
Closes #3652

Fix a series of typo's in the docs and a typo in the `pp environment list` command + doc