### PR TITLE
Replace `recycleFile()` in `spo file copy` and `spo file move`

### DIFF
--- a/src/m365/spo/commands/file/file-copy.spec.ts
+++ b/src/m365/spo/commands/file/file-copy.spec.ts
@@ -222,10 +222,10 @@ describe(commands.FILE_COPY, () => {
           return Promise.resolve();
         }
 
-        return Promise.reject(new CommandError('Invalid URL'));
+        return Promise.reject('Invalid URL');
       }
 
-      return Promise.reject(new CommandError('Unknown case'));
+      return Promise.reject('Unknown case');
     });
 
 
@@ -261,9 +261,9 @@ describe(commands.FILE_COPY, () => {
             }
           });
         }
-        return Promise.reject(new CommandError('Invalid URL'));
+        return Promise.reject('Invalid URL');
       }
-      return Promise.reject(new CommandError('Unknown case'));
+      return Promise.reject('Unknown case');
     });
 
     command.action(logger, {

--- a/src/m365/spo/commands/file/file-copy.spec.ts
+++ b/src/m365/spo/commands/file/file-copy.spec.ts
@@ -222,7 +222,6 @@ describe(commands.FILE_COPY, () => {
       return Promise.reject('Unknown case');
     });
 
-
     command.action(logger, {
       options: {
         debug: true,

--- a/src/m365/spo/commands/file/file-copy.spec.ts
+++ b/src/m365/spo/commands/file/file-copy.spec.ts
@@ -213,16 +213,10 @@ describe(commands.FILE_COPY, () => {
     stubAllGetRequests();
 
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command, args) : Promise<any> => {
-      if (command === fileRemoveCommand) {
-        if (args.options.webUrl === 'https://contoso.sharepoint.com/sites/portal') {
-          return Promise.resolve();
-        }
-
-        if (args.options.url === '/sites/portal/Shared Documents/def.pdf') {
-          return Promise.resolve();
-        }
-
-        return Promise.reject('Invalid URL');
+      if (command === fileRemoveCommand &&
+        args.options.webUrl === 'https://contoso.sharepoint.com/sites/portal' ||
+        args.options.url === '/sites/portal/Shared Documents/def.pdf') {
+        return Promise.resolve();
       }
 
       return Promise.reject('Unknown case');
@@ -253,15 +247,13 @@ describe(commands.FILE_COPY, () => {
     stubAllGetRequests();
 
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command, args): Promise<any> => {
-      if (command === fileRemoveCommand) {
-        if (args.options.webUrl === 'https://contoso.sharepoint.com') {
-          return Promise.reject({
-            error: {
-              message: 'File does not exist'
-            }
-          });
-        }
-        return Promise.reject('Invalid URL');
+      if (command === fileRemoveCommand &&
+        args.options.webUrl === 'https://contoso.sharepoint.com') {
+        return Promise.reject({
+          error: {
+            message: 'File does not exist'
+          }
+        });
       }
       return Promise.reject('Unknown case');
     });

--- a/src/m365/spo/commands/file/file-copy.ts
+++ b/src/m365/spo/commands/file/file-copy.ts
@@ -180,27 +180,27 @@ class SpoFileCopyCommand extends SpoCommand {
     // since the target WebFullUrl is unknown we can use getRequestDigestForSite
     // to get it from target folder absolute url.
     // Similar approach used here Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect
-    return this.getWebFullUrl(targetFolderAbsoluteUrl, logger).then((webFullUrl: string) => {
-      const targetFileServerRelativeUrl: string = `${urlUtil.getServerRelativePath(webFullUrl, targetUrl)}/${filename}`;
-      const removeOptions: SpoFileRemoveOptions = {
-        webUrl: webFullUrl,
-        url: targetFileServerRelativeUrl,
-        recycle: true,
-        confirm: true,
-        debug: this.debug,
-        verbose: this.verbose
-      };
-      
-      return Cli.executeCommandWithOutput(removeCommand as Command, { options: { ...removeOptions, _: [] } })
-        .catch((err: FileDeleteError) => {
-          logger.logToStderr(err);
-          if (err.error !== null && err.error.message !== null && err.error.message.includes('does not exist')) {
-            return Promise.resolve();
-          }
-          return Promise.reject(err);
-        });
-    });
-
+    return this.getWebFullUrl(targetFolderAbsoluteUrl, logger)
+      .then((webFullUrl: string) => {
+        const targetFileServerRelativeUrl: string = `${urlUtil.getServerRelativePath(webFullUrl, targetUrl)}/${filename}`;
+        const removeOptions: SpoFileRemoveOptions = {
+          webUrl: webFullUrl,
+          url: targetFileServerRelativeUrl,
+          recycle: true,
+          confirm: true,
+          debug: this.debug,
+          verbose: this.verbose
+        };
+        
+        return Cli.executeCommandWithOutput(removeCommand as Command, { options: { ...removeOptions, _: [] } })
+          .catch((err: FileDeleteError) => {
+            logger.logToStderr(err);
+            if (err.error !== null && err.error.message !== null && err.error.message.includes('does not exist')) {
+              return Promise.resolve();
+            }
+            return Promise.reject(err);
+          });
+      });
   }
 
   private getWebFullUrl(targetFolderAbsoluteUrl: string, logger: Logger): Promise<string> {

--- a/src/m365/spo/commands/file/file-copy.ts
+++ b/src/m365/spo/commands/file/file-copy.ts
@@ -193,7 +193,7 @@ class SpoFileCopyCommand extends SpoCommand {
       
       return Cli.executeCommandWithOutput(removeCommand as Command, { options: { ...removeOptions, _: [] } })
         .catch((err: FileDeleteError) => {
-          logger.log(err);
+          logger.logToStderr(err);
           if (err.error !== null && err.error.message !== null && err.error.message.includes('does not exist')) {
             return Promise.resolve();
           }

--- a/src/m365/spo/commands/file/file-move.spec.ts
+++ b/src/m365/spo/commands/file/file-move.spec.ts
@@ -215,9 +215,9 @@ describe(commands.FILE_MOVE, () => {
             }
           });
         }
-        return Promise.reject(new CommandError('Invalid URL'));
+        return Promise.reject('Invalid URL');
       }
-      return Promise.reject(new CommandError('Unknown case'));
+      return Promise.reject('Unknown case');
     });
 
     command.action(logger, {

--- a/src/m365/spo/commands/file/file-move.spec.ts
+++ b/src/m365/spo/commands/file/file-move.spec.ts
@@ -207,17 +207,15 @@ describe(commands.FILE_MOVE, () => {
     stubAllPostRequests();
     stubAllGetRequests();
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command, args): Promise<any> => {
-      if (command === fileRemoveCommand) {
-        if (args.options.webUrl === 'https://contoso.sharepoint.com') {
-          return Promise.reject({
-            error: {
-              message: 'File does not exist'
-            }
-          });
-        }
-        return Promise.reject('Invalid URL');
+      if (command === fileRemoveCommand &&
+        args.options.webUrl === 'https://contoso.sharepoint.com') {
+        return Promise.reject({
+          error: {
+            message: 'File does not exist'
+          }
+        });
       }
-      return Promise.reject('Unknown case');
+      return Promise.reject(('Unknown case'));
     });
 
     command.action(logger, {
@@ -310,7 +308,7 @@ describe(commands.FILE_MOVE, () => {
     });
     stubAllPostRequests(null, waitForJobResult);
     stubAllGetRequests();
-    
+
     command.action(logger, {
       options: {
         verbose: true,

--- a/src/m365/spo/commands/file/file-move.spec.ts
+++ b/src/m365/spo/commands/file/file-move.spec.ts
@@ -236,6 +236,7 @@ describe(commands.FILE_MOVE, () => {
       }
     });
   });
+  
   it('should show error when recycleFile rejects with error', (done) => {
     const fileDeleteError: FileDeleteError = {
       error: {

--- a/src/m365/spo/commands/file/file-move.ts
+++ b/src/m365/spo/commands/file/file-move.ts
@@ -181,25 +181,26 @@ class SpoFileMoveCommand extends SpoCommand {
     // since the target WebFullUrl is unknown we can use getRequestDigest
     // to get it from target folder absolute url.
     // Similar approach used here Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect
-    return this.getWebFullUrl(targetFolderAbsoluteUrl, logger).then((webFullUrl: string) => {
-      const targetFileServerRelativeUrl: string = `${urlUtil.getServerRelativePath(webFullUrl, targetUrl)}/${filename}`;
-      const removeOptions: SpoFileRemoveOptions = {
-        webUrl: webFullUrl,
-        url: targetFileServerRelativeUrl,
-        recycle: true,
-        confirm: true,
-        debug: this.debug,
-        verbose: this.verbose
-      };
+    return this.getWebFullUrl(targetFolderAbsoluteUrl, logger)
+      .then((webFullUrl: string) => {
+        const targetFileServerRelativeUrl: string = `${urlUtil.getServerRelativePath(webFullUrl, targetUrl)}/${filename}`;
+        const removeOptions: SpoFileRemoveOptions = {
+          webUrl: webFullUrl,
+          url: targetFileServerRelativeUrl,
+          recycle: true,
+          confirm: true,
+          debug: this.debug,
+          verbose: this.verbose
+        };
 
-      return Cli.executeCommandWithOutput(removeCommand as Command, { options: { ...removeOptions, _: [] } })
-        .catch((err: FileDeleteError) => {
-          if (err.error !== null && err.error.message !== null && err.error.message.includes('does not exist')) {
-            return Promise.resolve();
-          }
-          return Promise.reject(err);
-        });
-    });
+        return Cli.executeCommandWithOutput(removeCommand as Command, { options: { ...removeOptions, _: [] } })
+          .catch((err: FileDeleteError) => {
+            if (err.error !== null && err.error.message !== null && err.error.message.includes('does not exist')) {
+              return Promise.resolve();
+            }
+            return Promise.reject(err);
+          });
+      });
   }
 
   private getWebFullUrl(targetFolderAbsoluteUrl: string, logger: Logger): Promise<string> {

--- a/src/m365/spo/commands/file/file-move.ts
+++ b/src/m365/spo/commands/file/file-move.ts
@@ -1,10 +1,14 @@
 import * as url from 'url';
-import { Logger } from '../../../../cli';
+import { Cli, CommandOutput, Logger } from '../../../../cli';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { ContextInfo, spo, urlUtil, validation } from '../../../../utils';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
+import { Options as SpoFileRemoveOptions } from './file-remove';
+import Command from '../../../../Command';
+import { FileDeleteError } from './file-rename';
+const removeCommand: Command = require('./file-remove');
 
 interface CommandArgs {
   options: Options;
@@ -90,7 +94,7 @@ class SpoFileMoveCommand extends SpoCommand {
     // the user can receive misleading error message.
     this
       .fileExists(tenantUrl, webUrl, args.options.sourceUrl)
-      .then((): Promise<void> => {
+      .then((): Promise<void | CommandOutput> => {
         if (args.options.deleteIfAlreadyExists) {
           // try delete target file, if deleteIfAlreadyExists flag is set
           const filename: string = args.options.sourceUrl.replace(/^.*[\\\/]/, '');
@@ -171,57 +175,41 @@ class SpoFileMoveCommand extends SpoCommand {
   /**
    * Moves file in the site recycle bin
    */
-  private recycleFile(tenantUrl: string, targetUrl: string, filename: string, logger: Logger): Promise<void> {
-    return new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
-      const targetFolderAbsoluteUrl: string = urlUtil.urlCombine(tenantUrl, targetUrl);
+  private recycleFile(tenantUrl: string, targetUrl: string, filename: string, logger: Logger): Promise<void | CommandOutput> {
+    const targetFolderAbsoluteUrl: string = urlUtil.urlCombine(tenantUrl, targetUrl);
 
-      // since the target WebFullUrl is unknown we can use getRequestDigest
-      // to get it from target folder absolute url.
-      // Similar approach used here Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect
-      spo.getRequestDigest(targetFolderAbsoluteUrl)
-        .then((contextResponse: ContextInfo): void => {
-          if (this.debug) {
-            logger.logToStderr(`contextResponse.WebFullUrl: ${contextResponse.WebFullUrl}`);
+    // since the target WebFullUrl is unknown we can use getRequestDigest
+    // to get it from target folder absolute url.
+    // Similar approach used here Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect
+    return this.getWebFullUrl(targetFolderAbsoluteUrl, logger).then((webFullUrl: string) => {
+      const targetFileServerRelativeUrl: string = `${urlUtil.getServerRelativePath(webFullUrl, targetUrl)}/${filename}`;
+      const removeOptions: SpoFileRemoveOptions = {
+        webUrl: webFullUrl,
+        url: targetFileServerRelativeUrl,
+        recycle: true,
+        confirm: true,
+        debug: this.debug,
+        verbose: this.verbose
+      };
+
+      return Cli.executeCommandWithOutput(removeCommand as Command, { options: { ...removeOptions, _: [] } })
+        .catch((err: FileDeleteError) => {
+          if (err.error !== null && err.error.message !== null && err.error.message.includes('does not exist')) {
+            return Promise.resolve();
           }
-
-          if (targetUrl.charAt(0) !== '/') {
-            targetUrl = `/${targetUrl}`;
-          }
-          if (targetUrl.lastIndexOf('/') !== targetUrl.length - 1) {
-            targetUrl = `${targetUrl}/`;
-          }
-
-          const requestUrl: string = `${contextResponse.WebFullUrl}/_api/web/GetFileByServerRelativeUrl('${encodeURIComponent(`${targetUrl}${filename}`)}')/recycle()`;
-          const requestOptions: any = {
-            url: requestUrl,
-            method: 'POST',
-            headers: {
-              'X-HTTP-Method': 'DELETE',
-              'If-Match': '*',
-              'accept': 'application/json;odata=nometadata'
-            },
-            responseType: 'json'
-          };
-
-          request.post(requestOptions)
-            .then((): void => {
-              resolve();
-            })
-            .catch((err: any): any => {
-              if (err.statusCode === 404) {
-                // file does not exist so can proceed
-                return resolve();
-              }
-
-              if (this.debug) {
-                logger.logToStderr(`recycleFile error...`);
-                logger.logToStderr(err);
-              }
-
-              reject(err);
-            });
-        }, (e: any) => reject(e));
+          return Promise.reject(err);
+        });
     });
+  }
+
+  private getWebFullUrl(targetFolderAbsoluteUrl: string, logger: Logger): Promise<string> {
+    return spo.getRequestDigest(targetFolderAbsoluteUrl)
+      .then((contextResponse: ContextInfo): Promise<string> => {
+        if (this.debug) {
+          logger.logToStderr(`contextResponse.WebFullUrl: ${contextResponse.WebFullUrl}`);
+        }
+        return Promise.resolve(contextResponse.WebFullUrl);
+      });
   }
 }
 


### PR DESCRIPTION
Replaces the occurences of the `recycleFile()` command by `Cli.executeCommandWithOutput()`

Closes: #3370 