### PR TITLE
Fixes `spfx project upgrade` missing quotes when upgrading to 1.16.0-beta.1

### DIFF
--- a/docs/docs/about/release-notes.md
+++ b/docs/docs/about/release-notes.md
@@ -40,6 +40,7 @@
 - resolved file creation suggestion for PS and CMD [#3497](https://github.com/pnp/cli-microsoft365/issues/3497)
 - added ability to send emails from a specified account or mailbox [#3589](https://github.com/pnp/cli-microsoft365/issues/3589)
 - fixed rendering code fences in md [#3636](https://github.com/pnp/cli-microsoft365/issues/3636)
+- fixed status command to show correct connection status [#3260](https://github.com/pnp/cli-microsoft365/issues/3260)
 
 ## [v5.7.0](https://github.com/pnp/cli-microsoft365/releases/tag/v5.7.0)
 

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN010008_YORC_nodeVersion.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN010008_YORC_nodeVersion.ts
@@ -23,7 +23,7 @@ export class FN010008_YORC_nodeVersion extends JsonRule {
   get resolution(): string {
     return `{
   "@microsoft/generator-sharepoint": {
-    "nodeVersion": ${process.version.substring(1)}
+    "nodeVersion": "${process.version.substring(1)}"
   }
 }`;
   }


### PR DESCRIPTION
Fixes `spfx project upgrade` missing quotes when upgrading to 1.16.0-beta.1. Closes #3660