### PR TITLE
Updates incorrect command docs titles. Closes #3699

### DIFF
--- a/docs/docs/cmd/aad/o365group/o365group-recyclebinitem-restore.md
+++ b/docs/docs/cmd/aad/o365group/o365group-recyclebinitem-restore.md
@@ -1,4 +1,4 @@
-# aad o365group restore
+# aad o365group recyclebinitem restore
 
 Restores a deleted Microsoft 365 Group
 

--- a/docs/docs/cmd/onedrive/report/report-activityusercounts.md
+++ b/docs/docs/cmd/onedrive/report/report-activityusercounts.md
@@ -1,4 +1,4 @@
-# onerive report activityusercounts
+# onedrive report activityusercounts
 
 Gets the trend in the number of active OneDrive users
 

--- a/docs/docs/cmd/teams/funsettings/funsettings-set.md
+++ b/docs/docs/cmd/teams/funsettings/funsettings-set.md
@@ -1,11 +1,11 @@
-# graph teams funsettings set
+# teams funsettings set
 
 Updates fun settings of a Microsoft Teams team
 
 ## Usage
 
 ```sh
-m365 graph teams funsettings set [options]
+m365 teams funsettings set [options]
 ```
 
 ## Options
@@ -32,23 +32,23 @@ m365 graph teams funsettings set [options]
 Allow giphy usage within a given Microsoft Teams team, setting the content rating for giphy to Moderate
 
 ```sh
-m365 graph teams funsettings set --teamId 83cece1e-938d-44a1-8b86-918cf6151957 --allowGiphy true --giphyContentRating Moderate
+m365 teams funsettings set --teamId 83cece1e-938d-44a1-8b86-918cf6151957 --allowGiphy true --giphyContentRating Moderate
 ```
 
 Disable usage of giphy within a given Microsoft Teams team
 
 ```sh
-m365 graph teams funsettings set --teamId 83cece1e-938d-44a1-8b86-918cf6151957 --allowGiphy false
+m365 teams funsettings set --teamId 83cece1e-938d-44a1-8b86-918cf6151957 --allowGiphy false
 ```
 
 Allow usage of stickers and memes within a given Microsoft Teams team
 
 ```sh
-m365 graph teams funsettings set --teamId 83cece1e-938d-44a1-8b86-918cf6151957 --allowStickersAndMemes true
+m365 teams funsettings set --teamId 83cece1e-938d-44a1-8b86-918cf6151957 --allowStickersAndMemes true
 ```
 
 Disable usage custom memes within a given Microsoft Teams team
 
 ```sh
-m365 graph teams funsettings set --teamId 83cece1e-938d-44a1-8b86-918cf6151957 --allowCustomMemes false
+m365 teams funsettings set --teamId 83cece1e-938d-44a1-8b86-918cf6151957 --allowCustomMemes false
 ```

--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-health-get.md
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-health-get.md
@@ -1,4 +1,4 @@
-# tenant service announcement health get
+# tenant serviceannouncement health get
 
 Get the health report of a specified service for a tenant
 

--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-health-list.md
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-health-list.md
@@ -1,4 +1,4 @@
-# tenant service announcement health list
+# tenant serviceannouncement health list
 
 Gets the health report of all subscribed services for a tenant
 


### PR DESCRIPTION
Closes #3699

This PR fixes incorrect doc titles, command usage syntax and command examples in some docs.

- [x] aad o365group recyclebinitem restore
- [x] onedrive report activityusercounts
- [x] teams funsettings set
- [x] tenant serviceannouncement health get
- [x] tenant serviceannouncement health list