### PR TITLE
Fix: web roleassignment <verb> in docs

### DIFF
--- a/docs/docs/cmd/spo/web/web-roleassignment-add.md
+++ b/docs/docs/cmd/spo/web/web-roleassignment-add.md
@@ -35,23 +35,23 @@ m365 spo web roleassignment add [options]
 add role assignment to site _https://contoso.sharepoint.com/sites/project-x_for principal id _11_ and role definition id _1073741829_
 
 ```sh
-m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --principalId 11 --roleDefinitionId 1073741829
+m365 spo web roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --principalId 11 --roleDefinitionId 1073741829
 ```
 
 add role assignment to site _https://contoso.sharepoint.com/sites/project-x_for upn _someaccount@tenant.onmicrosoft.com_ and role definition id _1073741829_
 
 ```sh
-m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --upn "someaccount@tenant.onmicrosoft.com" --roleDefinitionId 1073741829
+m365 spo web roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --upn "someaccount@tenant.onmicrosoft.com" --roleDefinitionId 1073741829
 ```
 
 add role assignment to site _https://contoso.sharepoint.com/sites/project-x_for group _someGroup_ and role definition id _1073741829_
 
 ```sh
-m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --groupName "someGroup" --roleDefinitionId 1073741829
+m365 spo web roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --groupName "someGroup" --roleDefinitionId 1073741829
 ```
 
 add role assignment to site _https://contoso.sharepoint.com/sites/project-x_for principal id _11_ and role definition name _Full Control_
 
 ```sh
-m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --principalId 11 --roleDefinitionName "Full Control"
+m365 spo web roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --principalId 11 --roleDefinitionName "Full Control"
 ```

--- a/docs/docs/cmd/spo/web/web-roleassignment-remove.md
+++ b/docs/docs/cmd/spo/web/web-roleassignment-remove.md
@@ -32,23 +32,23 @@ m365 spo web roleassignment remove [options]
 Remove roleassignment from web based on group name
 
 ```sh
-m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --groupName "saleGroup"
+m365 spo web roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --groupName "saleGroup"
 ```
 
 Remove roleassignment from web based on principal Id
 
 ```sh
-m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --principalId 2
+m365 spo web roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --principalId 2
 ```
 
 Remove roleassignment from web based on upn
 
 ```sh
-m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --upn "someaccount@tenant.onmicrosoft.com"
+m365 spo web roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --upn "someaccount@tenant.onmicrosoft.com"
 ```
 
 Remove roleassignment from web based on principal Id without prompting for confirmation
 
 ```sh
-m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --principalId 2 --confirm
+m365 spo web roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales"  --principalId 2 --confirm
 ```


### PR DESCRIPTION
 ### Fixed: web roleassignment <verb> in docs

Fixes: Examples for web roleassignment <verb> mention list roleassignment <verb> instead. 
Closes: #3706  

 ### Linked Issue

[Issue Link](https://github.com/pnp/cli-microsoft365/issues/3706)

The examples on the web roleassignment add and web roleassignment remove command documentation were wrongly mentioning list roleassignment add and list roleassignment remove. This Pull request fixes it.