### PR TITLE
Extends 'teams channel list' command with support for filtering shared teams channels. Closes #3690

### DIFF
--- a/docs/docs/cmd/teams/channel/channel-list.md
+++ b/docs/docs/cmd/teams/channel/channel-list.md
@@ -17,7 +17,7 @@ m365 teams channel list [options]
 : The display name of the team to list the channels of. Specify either `teamId` or `teamName` but not both
 
 `--type [type]`
-: Filter the results to only channels of a given type: `standard, private`. By default all channels are listed.
+: Filter the results to only channels of a given type: `standard`, `private`, `shared`. By default all channels are listed.
 
 --8<-- "docs/cmd/_global.md"
 

--- a/src/m365/teams/commands/channel/channel-list.spec.ts
+++ b/src/m365/teams/commands/channel/channel-list.spec.ts
@@ -110,6 +110,12 @@ describe(commands.CHANNEL_LIST, () => {
     assert.strictEqual(actual, true);
   });
 
+  it('rejects invalid channel type', async () => {
+    const type = 'foo';
+    const actual = await command.validate({ options: { teamId: '00000000-0000-0000-0000-000000000000', type: type } }, commandInfo);
+    assert.strictEqual(actual, `${type} is not a valid type value. Allowed values standard|private|shared`);
+  });
+
   it('correctly lists all channels in a Microsoft teams team by team id', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/teams/00000000-0000-0000-0000-000000000000/channels`) {
@@ -480,9 +486,12 @@ describe(commands.CHANNEL_LIST, () => {
       return Promise.reject('An error has occurred');
     });
 
-    await assert.rejects(command.action(logger, { options: {
-      debug: false,
-      teamId: '00000000-0000-0000-0000-000000000000' } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: false,
+        teamId: '00000000-0000-0000-0000-000000000000'
+      }
+    } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/teams/commands/channel/channel-list.ts
+++ b/src/m365/teams/commands/channel/channel-list.ts
@@ -61,7 +61,7 @@ class TeamsChannelListCommand extends GraphCommand {
       },
       {
         option: '--type [type]',
-        autocomplete: ['standard', 'private']
+        autocomplete: ['standard', 'private', 'shared']
       }
     );
   }
@@ -73,8 +73,8 @@ class TeamsChannelListCommand extends GraphCommand {
           return `${args.options.teamId} is not a valid GUID`;
         }
 
-        if (args.options.type && ['standard', 'private'].indexOf(args.options.type.toLowerCase()) === -1) {
-          return `${args.options.type} is not a valid type value. Allowed values standard|private`;
+        if (args.options.type && ['standard', 'private', 'shared'].indexOf(args.options.type.toLowerCase()) === -1) {
+          return `${args.options.type} is not a valid type value. Allowed values standard|private|shared`;
         }
 
         return true;
@@ -106,13 +106,14 @@ class TeamsChannelListCommand extends GraphCommand {
     try {
       const teamId: string = await this.getTeamId(args);
       let endpoint: string = `${this.resource}/v1.0/teams/${teamId}/channels`;
+
       if (args.options.type) {
         endpoint += `?$filter=membershipType eq '${args.options.type}'`;
       }
 
       const items = await odata.getAllItems<Channel>(endpoint);
       logger.log(items);
-    } 
+    }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }


### PR DESCRIPTION
Extends `teams channel list` command with support for filtering shared teams channels. Closes #3690