### PR TITLE
Extends 'teams channel add' command with support for adding shared channels. Closes #3691

### DIFF
--- a/docs/docs/cmd/teams/channel/channel-add.md
+++ b/docs/docs/cmd/teams/channel/channel-add.md
@@ -23,10 +23,10 @@ m365 teams channel add [options]
 : The description of the channel to add
 
 `--type [type]`
-: Type of channel to create: `standard,private`. Default `standard`.
+: Type of channel to create: `standard`, `private`, `shared`. Default `standard`.
 
 `--owner [owner]`
-: User with this ID or UPN will be added as owner of the private channel. This option is required when type is `private`.
+: User with this ID or UPN will be added as owner of the private channel. This option is required when type is `private` or `shared`.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -54,8 +54,8 @@ Add private channel to the specified Microsoft Teams team with owner UPN
 m365 teams channel add --teamName "Team Name" --name climicrosoft365 --type private --owner john.doe@contoso.com
 ```
 
-Add private channel to the specified Microsoft Teams team with owner ID
+Add shared channel to the specified Microsoft Teams team with owner ID
 
 ```sh
-m365 teams channel add --teamId 6703ac8a-c49b-4fd4-8223-28f0ac3a6402 --name climicrosoft365 --type private --owner cc693a7d-4833-4911-a89a-f0fe6e49bf69
+m365 teams channel add --teamId 6703ac8a-c49b-4fd4-8223-28f0ac3a6402 --name climicrosoft365 --type shared --owner cc693a7d-4833-4911-a89a-f0fe6e49bf69
 ```

--- a/docs/docs/cmd/teams/channel/channel-add.md
+++ b/docs/docs/cmd/teams/channel/channel-add.md
@@ -26,7 +26,7 @@ m365 teams channel add [options]
 : Type of channel to create: `standard`, `private`, `shared`. Default `standard`.
 
 `--owner [owner]`
-: User with this ID or UPN will be added as owner of the private channel. This option is required when type is `private` or `shared`.
+: User with this ID or UPN will be added as owner of the channel. This option is required when type is `private` or `shared`.
 
 --8<-- "docs/cmd/_global.md"
 

--- a/src/m365/teams/commands/channel/channel-add.ts
+++ b/src/m365/teams/commands/channel/channel-add.ts
@@ -81,7 +81,7 @@ class TeamsChannelAddCommand extends GraphCommand {
         }
 
         if (args.options.type && ['standard', 'private', 'shared'].indexOf(args.options.type) === -1) {
-          return `${args.options.type} is not a valid type value. Allowed values standard|private.`;
+          return `${args.options.type} is not a valid type value. Allowed values standard|private|shared.`;
         }
 
         if ((args.options.type === 'private' || args.options.type === 'shared') && !args.options.owner) {
@@ -89,7 +89,7 @@ class TeamsChannelAddCommand extends GraphCommand {
         }
 
         if ((args.options.type !== 'private' && args.options.type !== 'shared') && args.options.owner) {
-          return `Specify owner only when creating a ${args.options.type} channel.`;
+          return `Specify owner only when creating a private or shared channel.`;
         }
 
         return true;

--- a/src/m365/teams/commands/channel/channel-add.ts
+++ b/src/m365/teams/commands/channel/channel-add.ts
@@ -65,7 +65,7 @@ class TeamsChannelAddCommand extends GraphCommand {
       },
       {
         option: '--type [type]',
-        autocomplete: ['standard', 'private']
+        autocomplete: ['standard', 'private', 'shared']
       },
       {
         option: '--owner [owner]'
@@ -80,16 +80,16 @@ class TeamsChannelAddCommand extends GraphCommand {
           return `${args.options.teamId} is not a valid GUID`;
         }
 
-        if (args.options.type && ['standard', 'private'].indexOf(args.options.type) === -1) {
+        if (args.options.type && ['standard', 'private', 'shared'].indexOf(args.options.type) === -1) {
           return `${args.options.type} is not a valid type value. Allowed values standard|private.`;
         }
 
-        if (args.options.type === 'private' && !args.options.owner) {
-          return 'Specify owner when creating a private channel.';
+        if ((args.options.type === 'private' || args.options.type === 'shared') && !args.options.owner) {
+          return `Specify owner when creating a ${args.options.type} channel.`;
         }
 
-        if (args.options.type !== 'private' && args.options.owner) {
-          return 'Specify owner only when creating a private channel.';
+        if ((args.options.type !== 'private' && args.options.type !== 'shared') && args.options.owner) {
+          return `Specify owner only when creating a ${args.options.type} channel.`;
         }
 
         return true;
@@ -147,8 +147,8 @@ class TeamsChannelAddCommand extends GraphCommand {
       responseType: 'json'
     };
 
-    if (args.options.type === 'private') {
-      // Private channels must have at least 1 owner
+    if (args.options.type === 'private' || args.options.type === 'shared') {
+      // Private and Shared channels must have at least 1 owner
       requestOptions.data.members = [
         {
           '@odata.type': '#microsoft.graph.aadUserConversationMember',
@@ -166,7 +166,7 @@ class TeamsChannelAddCommand extends GraphCommand {
       const teamId: string = await this.getTeamId(args);
       const res: any = await this.createChannel(args, teamId);
       logger.log(res);
-    } 
+    }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }


### PR DESCRIPTION
Extends `teams channel add` command with support for adding shared channels. Closes #3691