### PR TITLE
Replace `recycleFile()` in `spo file copy` and `spo file move`, closes: #3370

### DIFF
--- a/src/m365/spo/commands/file/file-copy.spec.ts
+++ b/src/m365/spo/commands/file/file-copy.spec.ts
@@ -206,11 +206,8 @@ describe(commands.FILE_COPY, () => {
     stubAllPostRequests();
     stubAllGetRequests();
 
-    const fileDeleteError: any = {
-      error: {
-        message: 'does not exist'
-      },
-      stderr: ''
+    const fileDeleteError = {
+      message: 'File does not exist'
     };
 
     sinon.stub(Cli, 'executeCommand').returns(Promise.reject(fileDeleteError));

--- a/src/m365/spo/commands/file/file-copy.ts
+++ b/src/m365/spo/commands/file/file-copy.ts
@@ -1,12 +1,16 @@
 import * as url from 'url';
+import Command from '../../../../Command';
 import { Logger } from '../../../../cli/Logger';
+import { Cli } from '../../../../cli/Cli';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { ContextInfo, spo } from '../../../../utils/spo';
+import { spo } from '../../../../utils/spo';
 import { urlUtil } from '../../../../utils/urlUtil';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
+import { Options as SpoFileRemoveOptions } from './file-remove';
 import commands from '../../commands';
+const removeCommand: Command = require('./file-remove');
 
 interface CommandArgs {
   options: Options;
@@ -169,58 +173,40 @@ class SpoFileCopyCommand extends SpoCommand {
   /**
    * Moves file in the site recycle bin
    */
-  private recycleFile(tenantUrl: string, targetUrl: string, filename: string, logger: Logger): Promise<void> {
-    return new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
-      const targetFolderAbsoluteUrl: string = urlUtil.urlCombine(tenantUrl, targetUrl);
+  private async recycleFile(tenantUrl: string, targetUrl: string, filename: string, logger: Logger) {
+    const targetFolderAbsoluteUrl: string = urlUtil.urlCombine(tenantUrl, targetUrl);
 
-      // since the target WebFullUrl is unknown we can use getRequestDigestForSite
-      // to get it from target folder absolute url.
-      // Similar approach used here Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect
-      spo
-        .getRequestDigest(targetFolderAbsoluteUrl)
-        .then((contextResponse: ContextInfo): void => {
-          if (this.debug) {
-            logger.logToStderr(`contextResponse.WebFullUrl: ${contextResponse.WebFullUrl}`);
-          }
+    // since the target WebFullUrl is unknown we can use getRequestDigest
+    // to get it from target folder absolute url.
+    // Similar approach used here Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect
+    const contextResponse = await spo.getRequestDigest(targetFolderAbsoluteUrl);
 
-          if (targetUrl.charAt(0) !== '/') {
-            targetUrl = `/${targetUrl}`;
-          }
-          if (targetUrl.lastIndexOf('/') !== targetUrl.length - 1) {
-            targetUrl = `${targetUrl}/`;
-          }
+    if (this.debug) {
+      logger.logToStderr(`contextResponse.WebFullUrl: ${contextResponse.WebFullUrl}`);
+    }
 
-          const requestUrl: string = `${contextResponse.WebFullUrl}/_api/web/GetFileByServerRelativeUrl('${encodeURIComponent(`${targetUrl}${filename}`)}')/recycle()`;
-          const requestOptions: any = {
-            url: requestUrl,
-            method: 'POST',
-            headers: {
-              'X-HTTP-Method': 'DELETE',
-              'If-Match': '*',
-              'accept': 'application/json;odata=nometadata'
-            },
-            responseType: 'json'
-          };
+    const targetFileServerRelativeUrl: string = `${urlUtil.getServerRelativePath(contextResponse.WebFullUrl, targetUrl)}/${filename}`;
 
-          request.post(requestOptions)
-            .then((): void => {
-              resolve();
-            })
-            .catch((err: any): any => {
-              if (err.statusCode === 404) {
-                // file does not exist so can proceed
-                return resolve();
-              }
+    const removeOptions: SpoFileRemoveOptions = {
+      webUrl: contextResponse.WebFullUrl,
+      url: targetFileServerRelativeUrl,
+      recycle: true,
+      confirm: true,
+      debug: this.debug,
+      verbose: this.verbose
+    };
 
-              if (this.debug) {
-                logger.logToStderr(`recycleFile error...`);
-                logger.logToStderr(err);
-              }
-
-              reject(err);
-            });
-        }, (e: any) => reject(e));
-    });
+    try {
+      await Cli.executeCommand(removeCommand as Command, { options: { ...removeOptions, _: [] } });
+    }
+    catch (err: any) {
+      if (err.error !== undefined && err.error.message !== undefined && err.error.message.includes('does not exist')) {
+        
+      } 
+      else {
+        throw err;
+      }
+    }
   }
 }
 

--- a/src/m365/spo/commands/file/file-copy.ts
+++ b/src/m365/spo/commands/file/file-copy.ts
@@ -96,7 +96,7 @@ class SpoFileCopyCommand extends SpoCommand {
       // then there are edge cases when deleteIfAlreadyExists flag is set
       // the user can receive misleading error message.
       await this.fileExists(tenantUrl, webUrl, args.options.sourceUrl);
-
+      
       if (args.options.deleteIfAlreadyExists) {
         // try delete target file, if deleteIfAlreadyExists flag is set
         const filename = args.options.sourceUrl.replace(/^.*[\\\/]/, '');
@@ -200,11 +200,8 @@ class SpoFileCopyCommand extends SpoCommand {
       await Cli.executeCommand(removeCommand as Command, { options: { ...removeOptions, _: [] } });
     }
     catch (err: any) {
-      if (err.error !== undefined && err.error.message !== undefined && err.error.message.includes('does not exist')) {
-        
-      } 
-      else {
-        throw err;
+      if (!(err !== undefined && err.message !== undefined && err.message.includes('does not exist'))) {
+        throw err;        
       }
     }
   }

--- a/src/m365/spo/commands/file/file-move.spec.ts
+++ b/src/m365/spo/commands/file/file-move.spec.ts
@@ -19,18 +19,10 @@ describe(commands.FILE_MOVE, () => {
   let commandInfo: CommandInfo;
 
   const stubAllPostRequests: any = (
-    recycleFile: any = null,
     createCopyJobs: any = null,
     waitForJobResult: any = null
   ) => {
     return sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/recycle()') > -1) {
-        if (recycleFile) {
-          return recycleFile;
-        }
-        return Promise.resolve();
-      }
-
       if ((opts.url as string).indexOf('/_api/site/CreateCopyJobs') > -1) {
         if (createCopyJobs) {
           return createCopyJobs;
@@ -100,6 +92,7 @@ describe(commands.FILE_MOVE, () => {
 
   afterEach(() => {
     sinonUtil.restore([
+      Cli.executeCommand,
       request.post,
       request.get
     ]);
@@ -177,11 +170,16 @@ describe(commands.FILE_MOVE, () => {
   });
 
   it('should succeed when run with option --deleteIfAlreadyExists and response 404', async () => {
-    const recycleFile404 = new Promise<any>((resolve, reject) => {
-      return reject({ statusCode: 404 });
-    });
-    stubAllPostRequests(recycleFile404);
+    stubAllPostRequests();
     stubAllGetRequests();
+    const fileDeleteError: any = {
+      error: {
+        message: 'does not exist'
+      },
+      stderr: ''
+    };
+
+    sinon.stub(Cli, 'executeCommand').returns(Promise.reject(fileDeleteError));
 
     await command.action(logger, {
       options: {
@@ -194,11 +192,17 @@ describe(commands.FILE_MOVE, () => {
     });
   });
   it('should show error when recycleFile rejects with error', async () => {
-    const recycleFile = new Promise<any>((resolve, reject) => {
-      return reject('abc');
-    });
-    stubAllPostRequests(recycleFile);
+    stubAllPostRequests();
     stubAllGetRequests();
+
+    const fileDeleteError: any = {
+      error: {
+        message: 'Locked for use'
+      },
+      stderr: ''
+    };
+
+    sinon.stub(Cli, 'executeCommand').returns(Promise.reject(fileDeleteError));
 
     await assert.rejects(command.action(logger, {
       options: {
@@ -207,16 +211,13 @@ describe(commands.FILE_MOVE, () => {
         targetUrl: 'abc',
         deleteIfAlreadyExists: true
       }
-    } as any), new CommandError('abc'));
+    }), new CommandError(fileDeleteError.error.message));
   });
 
   it('should recycleFile format target url', async () => {
-    const recycleFile = new Promise<any>((resolve, reject) => {
-      return reject('abc');
-    });
-    stubAllPostRequests(recycleFile);
+    stubAllPostRequests();
     stubAllGetRequests();
-
+    sinon.stub(Cli, 'executeCommand').returns(Promise.reject('abc'));
     await assert.rejects(command.action(logger, {
       options: {
         debug: true,
@@ -231,6 +232,7 @@ describe(commands.FILE_MOVE, () => {
   it('should show error when getRequestDigestForSite rejects with error', async () => {
     stubAllPostRequests();
     stubAllGetRequests();
+    sinon.stub(Cli, 'executeCommand');
     sinonUtil.restore(spo.getRequestDigest);
     sinon.stub(spo, 'getRequestDigest').callsFake(() => Promise.reject('error'));
 
@@ -261,9 +263,9 @@ describe(commands.FILE_MOVE, () => {
       const log = JSON.stringify({ Event: 'JobError', Message: 'error1' });
       return resolve({ Logs: [log] });
     });
-    stubAllPostRequests(null, null, waitForJobResult);
+    stubAllPostRequests(null, waitForJobResult);
     stubAllGetRequests();
-
+    sinon.stub(Cli, 'executeCommand');
     await assert.rejects(command.action(logger, {
       options: {
         verbose: true,
@@ -280,9 +282,9 @@ describe(commands.FILE_MOVE, () => {
       const log = JSON.stringify({ Event: 'JobFatalError', Message: 'error2' });
       return resolve({ JobState: 0, Logs: [log] });
     });
-    stubAllPostRequests(null, null, waitForJobResult);
+    stubAllPostRequests(null, waitForJobResult);
     stubAllGetRequests();
-
+    sinon.stub(Cli, 'executeCommand');
     await assert.rejects(command.action(logger, {
       options: {
         debug: true,

--- a/src/m365/spo/commands/file/file-move.spec.ts
+++ b/src/m365/spo/commands/file/file-move.spec.ts
@@ -172,11 +172,8 @@ describe(commands.FILE_MOVE, () => {
   it('should succeed when run with option --deleteIfAlreadyExists and response 404', async () => {
     stubAllPostRequests();
     stubAllGetRequests();
-    const fileDeleteError: any = {
-      error: {
-        message: 'does not exist'
-      },
-      stderr: ''
+    const fileDeleteError = {
+      message: 'File does not exist'
     };
 
     sinon.stub(Cli, 'executeCommand').returns(Promise.reject(fileDeleteError));

--- a/src/m365/spo/commands/file/file-move.ts
+++ b/src/m365/spo/commands/file/file-move.ts
@@ -201,11 +201,8 @@ class SpoFileMoveCommand extends SpoCommand {
       await Cli.executeCommand(removeCommand as Command, { options: { ...removeOptions, _: [] } });
     } 
     catch (err: any) {
-      if (err.error !== undefined && err.error.message !== undefined && err.error.message.includes('does not exist')) {
-        
-      }
-      else {
-        throw err;
+      if (!(err !== undefined && err.message !== undefined && err.message.includes('does not exist'))) {
+        throw err;        
       }
     }
   }

--- a/src/m365/spo/commands/file/file-rename.spec.ts
+++ b/src/m365/spo/commands/file/file-rename.spec.ts
@@ -58,7 +58,7 @@ describe(commands.FILE_RENAME, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get, 
+      request.get,
       request.post,
       Cli.executeCommand
     ]);
@@ -107,13 +107,15 @@ describe(commands.FILE_RENAME, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: 
-      { 
-        webUrl: 'https://contoso.sharepoint.com/sites/portal', 
+    await command.action(logger, {
+      options:
+      {
+        webUrl: 'https://contoso.sharepoint.com/sites/portal',
         sourceUrl: '/Shared Documents/abc.pdf',
         force: true,
         targetFileName: 'def.pdf'
-      } });
+      }
+    });
     assert(loggerLogSpy.calledWith(renameResponseJson));
   });
 
@@ -145,9 +147,7 @@ describe(commands.FILE_RENAME, () => {
 
   it('continues if file cannot be recycled because it does not exist', async () => {
     const fileDeleteError = {
-      error: {
-        message: 'File does not exist'
-      }
+      message: 'File does not exist'
     };
     sinon.stub(Cli, 'executeCommand').returns(Promise.reject(fileDeleteError));
 

--- a/src/m365/spo/commands/file/file-rename.spec.ts
+++ b/src/m365/spo/commands/file/file-rename.spec.ts
@@ -9,9 +9,7 @@ import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
-import { FileDeleteError } from './file-rename';
 const command: Command = require('./file-rename');
-const fileRemoveCommand: Command = require('./file-remove');
 
 describe(commands.FILE_RENAME, () => {
   let log: any[];
@@ -62,7 +60,7 @@ describe(commands.FILE_RENAME, () => {
     sinonUtil.restore([
       request.get, 
       request.post,
-      Cli.executeCommandWithOutput
+      Cli.executeCommand
     ]);
   });
 
@@ -93,21 +91,7 @@ describe(commands.FILE_RENAME, () => {
   });
 
   it('forcefully renames file from a non-root site in the root folder of a document library when a file with the same name exists (or it doesn\'t?)', async () => {
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command, args) : Promise<any> => {
-      if (command === fileRemoveCommand) {
-        if (args.options.webUrl === 'https://contoso.sharepoint.com/sites/portal') {
-          return Promise.resolve();
-        }
-
-        if (args.options.url === '/sites/portal/Shared Documents/def.pdf') {
-          return Promise.resolve();
-        }
-
-        return Promise.reject(new CommandError('Invalid URL'));
-      }
-
-      return Promise.reject(new CommandError('Unknown case'));
-    });
+    sinon.stub(Cli, 'executeCommand');
 
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')/ListItemAllFields/ValidateUpdateListItem()') {
@@ -160,19 +144,12 @@ describe(commands.FILE_RENAME, () => {
   });
 
   it('continues if file cannot be recycled because it does not exist', async () => {
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake((command, args): Promise<any> => {
-      if (command === fileRemoveCommand) {
-        if (args.options.webUrl === 'https://contoso.sharepoint.com/sites/portal') {
-          return Promise.reject({
-            error: {
-              message: 'File does not exist'
-            }
-          });
-        }
-        return Promise.reject(new CommandError('Invalid URL'));
+    const fileDeleteError = {
+      error: {
+        message: 'File does not exist'
       }
-      return Promise.reject(new CommandError('Unknown case'));
-    });
+    };
+    sinon.stub(Cli, 'executeCommand').returns(Promise.reject(fileDeleteError));
 
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')/ListItemAllFields/ValidateUpdateListItem()') {
@@ -201,14 +178,14 @@ describe(commands.FILE_RENAME, () => {
   });
 
   it('throws error if file cannot be recycled', async () => {
-    const fileDeleteError: FileDeleteError = {
+    const fileDeleteError = {
       error: {
         message: 'Locked for use'
       },
       stderr: ''
     };
 
-    sinon.stub(Cli, 'executeCommandWithOutput').returns(Promise.reject(fileDeleteError));
+    sinon.stub(Cli, 'executeCommand').returns(Promise.reject(fileDeleteError));
 
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string) === `https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf')?$select=UniqueId`) {

--- a/src/m365/spo/commands/file/file-rename.ts
+++ b/src/m365/spo/commands/file/file-rename.ts
@@ -145,11 +145,8 @@ class SpoFileRenameCommand extends SpoCommand {
       await Cli.executeCommand(removeCommand as Command, { options: { ...removeOptions, _: [] } });
     } 
     catch (err: any) {
-      if (err.error !== undefined && err.error.message !== undefined && err.error.message.includes('does not exist')) {
-        
-      }
-      else {
-        throw err;
+      if (!(err !== undefined && err.message !== undefined && err.message.includes('does not exist'))) {
+        throw err;        
       }
     }
   }


### PR DESCRIPTION
Replaces the occurences of the `recycleFile()` command by `Cli.executeCommandWithOutput()`

Closes: #3370 