### PR TITLE
Adds command `spo folder roleinheritance break`, closes #3598

### DIFF
--- a/docs/docs/cmd/spo/folder/folder-roleinheritance-break.md
+++ b/docs/docs/cmd/spo/folder/folder-roleinheritance-break.md
@@ -17,7 +17,7 @@ m365 spo folder roleinheritance break [options]
 : The site-relative URL or server-relative URL of the folder.
 
 `-c, --clearExistingPermissions`
-: Set to clear existing roles from the list item
+: Clear all existing permissions from the folder.
 
 `--confirm`
 : Don't prompt for confirmation to breaking role inheritance of the folder.
@@ -26,14 +26,14 @@ m365 spo folder roleinheritance break [options]
 
 ## Examples
 
-Breaks inheritance of folder with site-relative url _Shared Documents/TestFolder_ located in site _https://contoso.sharepoint.com/sites/project-x_ keeping the existing permissions of the folder.
+Break the inheritance of a folder with a specified site-relative URL.
 
 ```sh
 m365 spo folder roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "Shared Documents/TestFolder"
 ```
 
-Breaks inheritance of folder with server-relative url _/sites/project-x/Shared Documents/TestFolder_ located in site _https://contoso.sharepoint.com/sites/project-x_. It will **not** prompt for confirmation before breaking the inheritance.
+Break the inheritance of a folder with a specified server-relative URL. It will clear the existing permissions of the folder. It will **not** prompt for confirmation before breaking the inheritance.
 
 ```sh
-m365 spo folder roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "/sites/project-x/Shared Documents/TestFolder" --confirm
+m365 spo folder roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "/sites/project-x/Shared Documents/TestFolder" --clearExistingPermissions --confirm
 ```

--- a/docs/docs/cmd/spo/folder/folder-roleinheritance-break.md
+++ b/docs/docs/cmd/spo/folder/folder-roleinheritance-break.md
@@ -1,0 +1,39 @@
+# spo folder roleinheritance break
+
+Breaks the role inheritance of a folder.
+
+## Usage
+
+```sh
+m365 spo folder roleinheritance break [options]
+```
+
+## Options
+
+`-u, --webUrl <webUrl>`
+: URL of the site where the folder is located.
+
+`-f, --folderUrl <folderUrl>`
+: The site-relative URL or server-relative URL of the folder.
+
+`-c, --clearExistingPermissions`
+: Set to clear existing roles from the list item
+
+`--confirm`
+: Don't prompt for confirmation to breaking role inheritance of the folder.
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Breaks inheritance of folder with site-relative url _Shared Documents/TestFolder_ located in site _https://contoso.sharepoint.com/sites/project-x_ keeping the existing permissions of the folder.
+
+```sh
+m365 spo folder roleinheritance reset --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "Shared Documents/TestFolder"
+```
+
+Reset inheritance of folder with server-relative url _/sites/project-x/Shared Documents/TestFolder_ located in site _https://contoso.sharepoint.com/sites/project-x_. It will **not** prompt for confirmation before resetting.
+
+```sh
+m365 spo folder roleinheritance reset --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "/sites/project-x/Shared Documents/TestFolder" --confirm
+```

--- a/docs/docs/cmd/spo/folder/folder-roleinheritance-break.md
+++ b/docs/docs/cmd/spo/folder/folder-roleinheritance-break.md
@@ -29,11 +29,11 @@ m365 spo folder roleinheritance break [options]
 Breaks inheritance of folder with site-relative url _Shared Documents/TestFolder_ located in site _https://contoso.sharepoint.com/sites/project-x_ keeping the existing permissions of the folder.
 
 ```sh
-m365 spo folder roleinheritance reset --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "Shared Documents/TestFolder"
+m365 spo folder roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "Shared Documents/TestFolder"
 ```
 
-Reset inheritance of folder with server-relative url _/sites/project-x/Shared Documents/TestFolder_ located in site _https://contoso.sharepoint.com/sites/project-x_. It will **not** prompt for confirmation before resetting.
+Breaks inheritance of folder with server-relative url _/sites/project-x/Shared Documents/TestFolder_ located in site _https://contoso.sharepoint.com/sites/project-x_. It will **not** prompt for confirmation before breaking the inheritance.
 
 ```sh
-m365 spo folder roleinheritance reset --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "/sites/project-x/Shared Documents/TestFolder" --confirm
+m365 spo folder roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --folderUrl "/sites/project-x/Shared Documents/TestFolder" --confirm
 ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -362,6 +362,7 @@ nav:
         - folder move: 'cmd/spo/folder/folder-move.md'
         - folder remove: 'cmd/spo/folder/folder-remove.md'
         - folder rename: 'cmd/spo/folder/folder-rename.md'
+        - folder roleinheritance break: 'cmd/spo/folder/folder-roleinheritance-break.md'
         - folder roleinheritance reset: 'cmd/spo/folder/folder-roleinheritance-reset.md'
       - group:
         - group add: 'cmd/spo/group/group-add.md'

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -64,6 +64,7 @@ export default {
   FOLDER_MOVE: `${prefix} folder move`,
   FOLDER_REMOVE: `${prefix} folder remove`,
   FOLDER_RENAME: `${prefix} folder rename`,
+  FOLDER_ROLEINHERITANCE_BREAK: `${prefix} folder roleinheritance break`,
   FOLDER_ROLEINHERITANCE_RESET: `${prefix} folder roleinheritance reset`,
   GET: `${prefix} get`,
   GROUP_ADD: `${prefix} group add`,

--- a/src/m365/spo/commands/folder/folder-roleinheritance-break.spec.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-break.spec.ts
@@ -1,0 +1,202 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { formatting } from '../../../../utils/formatting';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+const command: Command = require('./folder-roleinheritance-break');
+
+describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
+  const webUrl = 'https://contoso.sharepoint.com/sites/project-x';
+  const folderUrl = '/Shared Documents/TestFolder';
+
+  let log: any[];
+  let logger: Logger;
+  let commandInfo: CommandInfo;
+  let promptOptions: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
+      promptOptions = options;
+      return { continue: false };
+    });
+    promptOptions = undefined;
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      Cli.prompt,
+      request.post
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.FOLDER_ROLEINHERITANCE_BREAK), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'foo', folderUrl: folderUrl, confirm: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if webUrl and folderUrl are valid', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, folderUrl: folderUrl, confirm: true } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('prompts before breaking role inheritance for the folder when confirm option not passed', async () => {
+    await command.action(logger, {
+      options: {
+        webUrl: webUrl,
+        folderUrl: folderUrl
+      }
+    });
+
+    let promptIssued = false;
+
+    if (promptOptions && promptOptions.type === 'confirm') {
+      promptIssued = true;
+    }
+
+    assert(promptIssued);
+  });
+
+  it('aborts breaking role inheritance for the folder when confirm option is not passed and prompt not confirmed', async () => {
+    const postSpy = sinon.spy(request, 'post');
+
+    await command.action(logger, {
+      options: {
+        webUrl: webUrl,
+        folderUrl: folderUrl
+      }
+    });
+
+    assert(postSpy.notCalled);
+  });
+
+  it('breaks role inheritance on folder by site-relative URL (debug)', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: webUrl,
+        folderUrl: folderUrl,
+        confirm: true
+      }
+    });
+  });
+
+  it('breaks role inheritance on folder by site-relative URL when prompt confirmed', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
+
+    await command.action(logger, {
+      options: {
+        webUrl: webUrl,
+        folderUrl: folderUrl
+      }
+    });
+  });
+
+  it('breaks role inheritance and clears existing scopes on folder by site-relative URL when prompt confirmed', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderUrl)}')/ListItemAllFields/breakroleinheritance(false)`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
+
+    await command.action(logger, {
+      options: {
+        webUrl: webUrl,
+        folderUrl: folderUrl,
+        clearExistingPermissions: true
+      }
+    });
+  });
+
+  it('correctly handles error when breaking folder role inheritance', async () => {
+    const errorMessage = 'request rejected';
+    sinon.stub(request, 'post').callsFake(async () => { throw errorMessage; });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: webUrl,
+        folderUrl: folderUrl,
+        confirm: true
+      }
+    }), new CommandError(errorMessage));
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options;
+    let containsDebugOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsDebugOption = true;
+      }
+    });
+    assert(containsDebugOption);
+  });
+});

--- a/src/m365/spo/commands/folder/folder-roleinheritance-break.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-break.ts
@@ -25,7 +25,7 @@ class SpoFolderRoleInheritanceBreakCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Breaks the role inheritance of a folder';
+    return 'Breaks the role inheritance of a folder. Keeping existing permissions is the default behavior.';
   }
 
   constructor() {
@@ -39,6 +39,7 @@ class SpoFolderRoleInheritanceBreakCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
+        clearExistingPermissions: !!args.options.clearExistingPermissions,
         confirm: !!args.options.confirm
       });
     });
@@ -68,17 +69,14 @@ class SpoFolderRoleInheritanceBreakCommand extends SpoCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    let keepExistingPermissions: boolean = true;
-    if (args.options.clearExistingPermissions) {
-      keepExistingPermissions = !args.options.clearExistingPermissions;
-    }
+    const keepExistingPermissions: boolean = !args.options.clearExistingPermissions;
 
     const breakFolderRoleInheritance: () => Promise<void> = async (): Promise<void> => {
       try {
         const requestOptions: AxiosRequestConfig = {
           url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(args.options.folderUrl)}')/ListItemAllFields/breakroleinheritance(${keepExistingPermissions})`,
           headers: {
-            accept: 'application/json;odata.metadata=none'
+            accept: 'application/json'
           },
           responseType: 'json'
         };

--- a/src/m365/spo/commands/folder/folder-roleinheritance-break.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-break.ts
@@ -1,0 +1,110 @@
+import { Cli } from '../../../../cli/Cli';
+import { Logger } from '../../../../cli/Logger';
+import { AxiosRequestConfig } from 'axios';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import { formatting } from '../../../../utils/formatting';
+import { validation } from '../../../../utils/validation';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  folderUrl: string;
+  clearExistingPermissions?: boolean;
+  confirm?: boolean;
+}
+
+class SpoFolderRoleInheritanceBreakCommand extends SpoCommand {
+  public get name(): string {
+    return commands.FOLDER_ROLEINHERITANCE_BREAK;
+  }
+
+  public get description(): string {
+    return 'Breaks the role inheritance of a folder';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        confirm: !!args.options.confirm
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-f, --folderUrl <folderUrl>'
+      },
+      {
+        option: '-c, --clearExistingPermissions'
+      },
+      {
+        option: '--confirm'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => validation.isValidSharePointUrl(args.options.webUrl)
+    );
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    let keepExistingPermissions: boolean = true;
+    if (args.options.clearExistingPermissions) {
+      keepExistingPermissions = !args.options.clearExistingPermissions;
+    }
+
+    const breakFolderRoleInheritance: () => Promise<void> = async (): Promise<void> => {
+      try {
+        const requestOptions: AxiosRequestConfig = {
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(args.options.folderUrl)}')/ListItemAllFields/breakroleinheritance(${keepExistingPermissions})`,
+          headers: {
+            accept: 'application/json;odata.metadata=none'
+          },
+          responseType: 'json'
+        };
+        await request.post(requestOptions);
+      }
+      catch (err: any) {
+        this.handleRejectedODataJsonPromise(err);
+      }
+    };
+
+    if (args.options.confirm) {
+      await breakFolderRoleInheritance();
+    }
+    else {
+      const result = await Cli.prompt<{ continue: boolean }>({
+        type: 'confirm',
+        name: 'continue',
+        default: false,
+        message: `Are you sure you want to break the role inheritance of folder ${args.options.folderUrl} located in site ${args.options.webUrl}?`
+      });
+
+      if (result.continue) {
+        await breakFolderRoleInheritance();
+      }
+    }
+  }
+}
+
+module.exports = new SpoFolderRoleInheritanceBreakCommand();


### PR DESCRIPTION
This PR adds the command `spo folder roleinheritance break`.

Closes #3598 