### PR TITLE
Adds command `pp tenant settings list`, closes #3657 

### DIFF
--- a/docs/docs/cmd/pp/tenant/tenant-settings-list.md
+++ b/docs/docs/cmd/pp/tenant/tenant-settings-list.md
@@ -1,6 +1,6 @@
 # pp tenant settings list
 
-Lists the global power platform tenant settings
+Lists the global Power Platform tenant settings
 
 ## Usage
 

--- a/docs/docs/cmd/pp/tenant/tenant-settings-list.md
+++ b/docs/docs/cmd/pp/tenant/tenant-settings-list.md
@@ -1,0 +1,26 @@
+# pp tenant settings list
+
+Lists the global power platform tenant settings
+
+## Usage
+
+```sh
+m365 pp tenant settings list [options]
+```
+
+## Options
+
+--8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+!!! attention
+    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
+
+## Examples
+
+Lists the global power platform settings of the tenant
+
+```sh
+m365 pp tenant settings list
+```

--- a/docs/docs/cmd/pp/tenant/tenant-settings-list.md
+++ b/docs/docs/cmd/pp/tenant/tenant-settings-list.md
@@ -19,7 +19,7 @@ m365 pp tenant settings list [options]
 
 ## Examples
 
-Lists the global power platform settings of the tenant
+Lists the global Power Platform settings of the tenant
 
 ```sh
 m365 pp tenant settings list

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -263,6 +263,8 @@ nav:
       - managementapp:
         - managementapp add: 'cmd/pp/managementapp/managementapp-add.md'
         - managementapp list: 'cmd/pp/managementapp/managementapp-list.md'
+      - tenant:
+        - tenant settings list: 'cmd/pp/tenant/tenant-settings-list.md'
     - Search (search):
       - externalconnection:
         - externalconnection add: 'cmd/search/externalconnection/externalconnection-add.md'

--- a/src/m365/pp/commands.ts
+++ b/src/m365/pp/commands.ts
@@ -4,5 +4,6 @@ export default {
   ENVIRONMENT_LIST: `${prefix} environment list`,
   GATEWAY_LIST: `${prefix} gateway list`,
   MANAGEMENTAPP_ADD: `${prefix} managementapp add`,
-  MANAGEMENTAPP_LIST: `${prefix} managementapp list`
+  MANAGEMENTAPP_LIST: `${prefix} managementapp list`,
+  TENANT_SETTINGS_LIST: `${prefix} tenant settings list`
 };

--- a/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
@@ -1,0 +1,127 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+const command: Command = require('./tenant-settings-list');
+
+describe(commands.TENANT_SETTINGS_LIST, () => {
+  const successResponse = {
+    walkMeOptOut: false,
+    disableNPSCommentsReachout: false,
+    disableNewsletterSendout: false,
+    disableEnvironmentCreationByNonAdminUsers: false,
+    disablePortalsCreationByNonAdminUsers: false,
+    disableSurveyFeedback: false,
+    disableTrialEnvironmentCreationByNonAdminUsers: false,
+    isableCapacityAllocationByEnvironmentAdmins: false,
+    disableSupportTicketsVisibleByAllUsers: false,
+    powerPlatform: {
+      search: {
+        disableDocsSearch: false,
+        disableCommunitySearch: false,
+        disableBingVideoSearch: false
+      },
+      teamsIntegration: {
+        shareWithColleaguesUserLimit: 10000
+      },
+      powerApps: {
+        disableShareWithEveryone: false,
+        enableGuestsToMake: false,
+        disableMembersIndicator: false
+      },
+      environments: {},
+      governance: {
+        disableAdminDigest: false
+      },
+      licensing: {
+        disableBillingPolicyCreationByNonAdminUsers: false
+      },
+      powerPages: {}
+    }
+  };
+
+
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.post
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.TENANT_SETTINGS_LIST), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('successfully retrieves tenant settings', async () => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/listtenantsettings?api-version=2020-10-01") {
+        return Promise.resolve(successResponse);
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, { options: {} } as any);
+    assert(loggerLogSpy.calledWith(successResponse));
+  });
+
+  it('handles error correctly', async () => {
+    sinon.stub(request, 'post').callsFake(() => {
+      return Promise.reject('An error has occurred');
+    });
+
+    await assert.rejects(command.action(logger, { options: { } } as any), new CommandError('An error has occurred'));
+  });
+
+  it('supports debug mode', () => {
+    const options = command.options;
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+});

--- a/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
@@ -94,6 +94,10 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['disableCapacityAllocationByEnvironmentAdmins', 'disableEnvironmentCreationByNonAdminUsers', 'disableNPSCommentsReachout', 'disablePortalsCreationByNonAdminUsers', 'disableSupportTicketsVisibleByAllUsers', 'disableSurveyFeedback', 'disableTrialEnvironmentCreationByNonAdminUsers', 'walkMeOptOut']);
+  });
+
   it('successfully retrieves tenant settings', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/listtenantsettings?api-version=2020-10-01") {

--- a/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
@@ -95,11 +95,11 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
   });
 
   it('successfully retrieves tenant settings', async () => {
-    sinon.stub(request, 'post').callsFake((opts) => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/listtenantsettings?api-version=2020-10-01") {
-        return Promise.resolve(successResponse);
+        return successResponse;
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: {} } as any);
@@ -107,11 +107,11 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
   });
 
   it('handles error correctly', async () => {
-    sinon.stub(request, 'post').callsFake(() => {
-      return Promise.reject('An error has occurred');
+    sinon.stub(request, 'post').callsFake(async () => {
+      throw 'An error has occurred';
     });
 
-    await assert.rejects(command.action(logger, { options: { } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('An error has occurred'));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/pp/commands/tenant/tenant-settings-list.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-list.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli/Logger';
 import request from '../../../../request';
 import PowerPlatformCommand from '../../../base/PowerPlatformCommand';
@@ -9,11 +10,11 @@ class PpTenantSettingsListCommand extends PowerPlatformCommand {
   }
 
   public get description(): string {
-    return 'Lists the global power platform tenant settings';
+    return 'Lists the global Power Platform tenant settings';
   }
 
   public async commandAction(logger: Logger): Promise<void> {
-    const requestOptions: any = {
+    const requestOptions: AxiosRequestConfig  = {
       url: `${this.resource}/providers/Microsoft.BusinessAppPlatform/listtenantsettings?api-version=2020-10-01`,
       headers: {
         accept: 'application/json'

--- a/src/m365/pp/commands/tenant/tenant-settings-list.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-list.ts
@@ -13,6 +13,10 @@ class PpTenantSettingsListCommand extends PowerPlatformCommand {
     return 'Lists the global Power Platform tenant settings';
   }
 
+  public defaultProperties(): string[] | undefined {
+    return ['disableCapacityAllocationByEnvironmentAdmins', 'disableEnvironmentCreationByNonAdminUsers', 'disableNPSCommentsReachout', 'disablePortalsCreationByNonAdminUsers', 'disableSupportTicketsVisibleByAllUsers', 'disableSurveyFeedback', 'disableTrialEnvironmentCreationByNonAdminUsers', 'walkMeOptOut'];
+  }
+
   public async commandAction(logger: Logger): Promise<void> {
     const requestOptions: AxiosRequestConfig  = {
       url: `${this.resource}/providers/Microsoft.BusinessAppPlatform/listtenantsettings?api-version=2020-10-01`,

--- a/src/m365/pp/commands/tenant/tenant-settings-list.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-list.ts
@@ -1,0 +1,34 @@
+import { Logger } from '../../../../cli/Logger';
+import request from '../../../../request';
+import PowerPlatformCommand from '../../../base/PowerPlatformCommand';
+import commands from '../../commands';
+
+class PpTenantSettingsListCommand extends PowerPlatformCommand {
+  public get name(): string {
+    return commands.TENANT_SETTINGS_LIST;
+  }
+
+  public get description(): string {
+    return 'Lists the global power platform tenant settings';
+  }
+
+  public async commandAction(logger: Logger): Promise<void> {
+    const requestOptions: any = {
+      url: `${this.resource}/providers/Microsoft.BusinessAppPlatform/listtenantsettings?api-version=2020-10-01`,
+      headers: {
+        accept: 'application/json'
+      },
+      responseType: 'json'
+    };
+    
+    try {
+      const res = await request.post<any>(requestOptions);
+      logger.log(res);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+}
+
+module.exports = new PpTenantSettingsListCommand();


### PR DESCRIPTION
This PR adds the command `pp tenant settings list`.

Closes #3657 

Minor remark: However, the documentation stated that this was a GET-request, after doing some research on why the call was not working, me and @milanholemans found out that it's actually a POST-request.