### PR TITLE
Extends "teams channel" commands with extra options. Closes #3688

### DIFF
--- a/docs/docs/cmd/teams/channel/channel-remove.md
+++ b/docs/docs/cmd/teams/channel/channel-remove.md
@@ -11,13 +11,16 @@ m365 teams channel remove [options]
 ## Options
 
 `-c, --channelId [channelId]`
-: The ID of the channel to remove
+: The ID of the channel to remove. Specify either `channelId` or `channelName` but not both
 
 `-n, --channelName [channelName]`
-: The name of the channel to remove. Specify channelId or channelName but not both
+: The name of the channel to remove. Specify either `channelId` or `channelName` but not both
 
-`-i, --teamId <teamId>`
-: The ID of the team to which the channel to remove belongs
+`-i, --teamId [teamId]`
+: The ID of the team to which the channel to remove belongs. Specify either `teamId` or `teamName` but not both
+
+`--teamName [teamName]`
+: The display name of the team to which the channel to remove belongs to. Specify either `teamId` or `teamName` but not both
 
 `--confirm`
 : Don't prompt for confirmation
@@ -45,15 +48,16 @@ m365 teams channel remove --channelId 19:f3dcbb1674574677abcae89cb626f1e6@thread
 Remove the specified Microsoft Teams channel by Name
 
 ```sh
-m365 teams channel remove --channelName 'channelName' --teamId d66b8110-fcad-49e8-8159-0d488ddb7656
+m365 teams channel remove --channelName 'channelName' --teamName "Team Name"
 ```
 
 Remove the specified Microsoft Teams channel by Name without confirmation
 
 ```sh
-m365 teams channel remove --channelName 'channelName' --teamId d66b8110-fcad-49e8-8159-0d488ddb7656 --confirm 
+m365 teams channel remove --channelName 'channelName' --teamName "Team Name" --confirm 
 ```
 
 ## More information
 
 - directory resource type (deleted items): [https://docs.microsoft.com/en-us/graph/api/resources/directory?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/directory?view=graph-rest-1.0)
+

--- a/docs/docs/cmd/teams/channel/channel-set.md
+++ b/docs/docs/cmd/teams/channel/channel-set.md
@@ -10,11 +10,17 @@ m365 teams channel set [options]
 
 ## Options
 
-`-i, --teamId <teamId>`
-: The ID of the team where the channel to update is located
+`-i, --teamId [teamId]`
+: The ID of the team where the channel to update is located. Specify either `teamId` or `teamName` but not both
 
-`--channelName <channelName>`
-: The name of the channel to update
+`--teamName [teamName]`
+: The display name of the team where the channel to update is located. Specify either `teamId` or `teamName` but not both
+
+`-c, --channelId [channelId]`
+: The ID of the channel to update. Specify either `channelId` or `channelName` but not both
+
+`-n, --channelName [channelName]`
+: The name of the channel to update. Specify either `channelId` or `channelName` but not both
 
 `--newChannelName [newChannelName]`
 : The new name of the channel
@@ -26,14 +32,15 @@ m365 teams channel set [options]
 
 ## Examples
   
-Set new description and display name for the specified channel in the given Microsoft Teams team
+Set new description and display name for the channel with id
 
 ```sh
-m365 teams channel set --teamId "00000000-0000-0000-0000-000000000000" --channelName Reviews --newChannelName Projects --description "Channel for new projects"
+m365 teams channel set --teamId "00000000-0000-0000-0000-000000000000" --channelId 19:f3dcbb1674574677abcae89cb626f1e6@thread.skype --newChannelName Projects --description "Channel for new projects"
 ```
 
-Set new display name for the specified channel in the given Microsoft Teams team
+Set new display name for the channel with name
 
 ```sh
-m365 teams channel set --teamId "00000000-0000-0000-0000-000000000000" --channelName Reviews --newChannelName Projects
+m365 teams channel set --teamName "Team Name" --channelName Reviews --newChannelName Projects
 ```
+

--- a/src/m365/teams/commands/channel/channel-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-remove.spec.ts
@@ -7,12 +7,16 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
 const command: Command = require('./channel-remove');
 
 describe(commands.CHANNEL_REMOVE, () => {
+  const channelId = '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype';
+  const channelName = 'channelName';
+  const teamId = 'd66b8110-fcad-49e8-8159-0d488ddb7656';
+  const teamName = 'Team Name';
+
   let log: string[];
   let logger: Logger;
   let promptOptions: any;
@@ -21,7 +25,6 @@ describe(commands.CHANNEL_REMOVE, () => {
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
     sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -39,11 +42,11 @@ describe(commands.CHANNEL_REMOVE, () => {
         log.push(msg);
       }
     };
-    promptOptions = undefined;
     sinon.stub(Cli, 'prompt').callsFake(async (options) => {
       promptOptions = options;
       return { continue: false };
     });
+    promptOptions = undefined;
   });
 
   afterEach(() => {
@@ -57,8 +60,7 @@ describe(commands.CHANNEL_REMOVE, () => {
   after(() => {
     sinonUtil.restore([
       auth.restoreAuth,
-      appInsights.trackEvent,
-      pid.getProcessName
+      appInsights.trackEvent
     ]);
     auth.service.connected = false;
   });
@@ -74,36 +76,35 @@ describe(commands.CHANNEL_REMOVE, () => {
   it('passes validation when valid channelId & teamId is specified', async () => {
     const actual = await command.validate({
       options: {
-        channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656'
+        channelId: channelId,
+        teamId: teamId
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation when channelName & teamId is specified', async () => {
+  it('passes validation when channelName & teamName is specified', async () => {
     const actual = await command.validate({
       options: {
-        channelName: 'Channel Name',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656'
+        channelName: channelName,
+        teamName: teamName
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation if the channelId and channelName are not provided', async () => {
-    const actual = await command.validate({
-      options: {
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets;
+    assert.deepStrictEqual(optionSets, [
+      ['channelId', 'channelName'],
+      ['teamId', 'teamName']
+    ]);
   });
 
   it('fails validation if the channelId is not valid channelId', async () => {
     const actual = await command.validate({
       options: {
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656',
+        teamId: teamId,
         channelId: 'invalid'
       }
     }, commandInfo);
@@ -114,62 +115,38 @@ describe(commands.CHANNEL_REMOVE, () => {
     const actual = await command.validate({
       options: {
         teamId: 'invalid',
-        channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if both channelName and channelId are provided', async () => {
-    const actual = await command.validate({
-      options: {
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656',
-        channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype',
-        channelName: 'channelname'
+        channelId: channelId
       }
     }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails to remove channel when channel does not exists', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`channels?$filter=displayName eq 'channelName'`) > -1) {
-        return Promise.resolve({ value: [] });
+    const errorMessage = 'The specified channel does not exist in the Microsoft Teams team';
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels?$filter=displayName eq '${encodeURIComponent(channelName)}'`) {
+        return { value: [] };
       }
-      return Promise.reject('Invalid request');
+
+      throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: {
-      debug: true,
-      teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656',
-      channelName: 'channelName',
-      confirm: true } } as any), new CommandError('The specified channel does not exist in the Microsoft Teams team'));
-  });
-
-  it('prompts before removing the specified channel when confirm option not passed', async () => {
-    await command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
-        debug: false,
-        channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656'
+        debug: true,
+        teamId: teamId,
+        channelName: channelName,
+        confirm: true
       }
-    });
-
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-
-    assert(promptIssued);
+    }), new CommandError(errorMessage));
   });
 
   it('prompts before removing the specified channel when confirm option not passed (debug)', async () => {
     await command.action(logger, {
       options: {
         debug: true,
-        channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656'
+        channelId: channelId,
+        teamId: teamId
       }
     });
 
@@ -184,28 +161,44 @@ describe(commands.CHANNEL_REMOVE, () => {
 
   it('aborts removing the specified channel when confirm option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
+
     await command.action(logger, {
       options: {
         debug: true,
-        channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656'
+        channelId: channelId,
+        teamId: teamId
       }
     });
 
     assert(postSpy.notCalled);
   });
 
-  it('aborts removing the specified channel when confirm option not passed and prompt not confirmed (debug)', async () => {
-    const postSpy = sinon.spy(request, 'delete');
-    await command.action(logger, {
-      options: {
-        debug: true,
-        channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656'
+  it('fails when team name does not exist', async () => {
+    const errorMessage = 'The specified team does not exist in the Microsoft Teams';
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(teamName)}'`) {
+        return {
+          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
+          "@odata.count": 1,
+          "value": [
+            {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "resourceProvisioningOptions": []
+            }
+          ]
+        };
       }
+
+      throw 'Invalid request';
     });
 
-    assert(postSpy.notCalled);
+    await assert.rejects(command.action(logger, {
+      options: {
+        channelId: channelId,
+        teamName: teamName,
+        confirm: true
+      }
+    }), new CommandError(errorMessage));
   });
 
   it('removes specified channel when channelId is passed with confirm option', async () => {
@@ -213,37 +206,38 @@ describe(commands.CHANNEL_REMOVE, () => {
 
     await command.action(logger, {
       options: {
-        channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656',
+        channelId: channelId,
+        teamId: teamId,
         confirm: true
       }
     });
   });
 
   it('removes the specified channel by name when prompt confirmed (debug)', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`channels?$filter=displayName eq 'channelName'`) > -1) {
-        return Promise.resolve({
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels?$filter=displayName eq '${encodeURIComponent(channelName)}'`) {
+        return {
           value: [
             {
-              "id": "19:f3dcbb1674574677abcae89cb626f1e6@thread.skype",
-              "displayName": "channelName",
+              "id": channelId,
+              "displayName": channelName,
               "description": null,
               "email": "",
               "webUrl": "https://teams.microsoft.com/l/channel/19:f3dcbb1674574677abcae89cb626f1e6%40thread.skype/%F0%9F%92%A1+Ideas?groupId=d66b8110-fcad-49e8-8159-0d488ddb7656&tenantId=eff8592e-e14a-4ae8-8771-d96d5c549e1c"
             }
           ]
-        });
+        };
       }
-      return Promise.reject('Invalid request');
+
+      throw 'Invalid request';
     });
 
-    sinon.stub(request, 'delete').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/teams/d66b8110-fcad-49e8-8159-0d488ddb7656/channels/19%3Af3dcbb1674574677abcae89cb626f1e6%40thread.skype`) {
-        return Promise.resolve();
+    sinon.stub(request, 'delete').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(channelId)}`) {
+        return;
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     sinonUtil.restore(Cli.prompt);
@@ -254,74 +248,73 @@ describe(commands.CHANNEL_REMOVE, () => {
     await command.action(logger, {
       options: {
         debug: true,
-        channelName: 'channelName',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656'
+        channelName: channelName,
+        teamId: teamId
       }
     });
   });
 
   it('removes the specified channel by name without prompt', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`channels?$filter=displayName eq 'channelName'`) > -1) {
-        return Promise.resolve({
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(teamName)}'`) {
+        return {
           value: [
             {
-              "id": "19:f3dcbb1674574677abcae89cb626f1e6@thread.skype",
-              "displayName": "channelName",
+              "id": teamId,
+              "displayName": teamName,
+              "resourceProvisioningOptions": ["Team"]
+            }
+          ]
+        };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels?$filter=displayName eq '${encodeURIComponent(channelName)}'`) {
+        return {
+          value: [
+            {
+              "id": channelId,
+              "displayName": channelName,
               "description": null,
               "email": "",
               "webUrl": "https://teams.microsoft.com/l/channel/19:f3dcbb1674574677abcae89cb626f1e6%40thread.skype/%F0%9F%92%A1+Ideas?groupId=d66b8110-fcad-49e8-8159-0d488ddb7656&tenantId=eff8592e-e14a-4ae8-8771-d96d5c549e1c"
             }
           ]
-        });
+        };
       }
-      return Promise.reject('Invalid request');
+
+      throw 'Invalid request';
     });
 
-    sinon.stub(request, 'delete').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/teams/d66b8110-fcad-49e8-8159-0d488ddb7656/channels/19%3Af3dcbb1674574677abcae89cb626f1e6%40thread.skype`) {
+    sinon.stub(request, 'delete').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(channelId)}`) {
         return Promise.resolve();
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, {
       options: {
         debug: true,
-        channelName: 'channelName',
-        teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656',
+        channelName: channelName,
+        teamName: teamName,
         confirm: true
       }
     });
   });
 
-  it('should handle Microsoft graph error response', async () => {
-    sinon.stub(request, 'delete').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/teams/d66b8110-fcad-49e8-8159-0d488ddb7656/channels/19%3Af3dcbb1674574677abcae89cb626f1e6%40thread.skype`) {
-        return Promise.reject({
-          "error": {
-            "code": "ItemNotFound",
-            "message": "Failed to execute Skype backend request GetThreadS2SRequest.",
-            "innerError": {
-              "request-id": "5a563fc6-6df2-4cd9-b0b8-9810f1110714",
-              "date": "2019-08-28T19:18:30"
-            }
-          }
-        });
+  it('correctly handles Microsoft graph error response', async () => {
+    const errorMessage = 'UnknownError';
+    sinon.stub(request, 'delete').callsFake(async () => { throw errorMessage; });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: true,
+        channelId: channelId,
+        teamId: teamId,
+        confirm: true
       }
-
-      return Promise.reject('Invalid request');
-    });
-
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
-
-    await assert.rejects(command.action(logger, { options: {
-      channelId: '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype',
-      teamId: 'd66b8110-fcad-49e8-8159-0d488ddb7656' } } as any), new CommandError('Failed to execute Skype backend request GetThreadS2SRequest.'));
+    }), new CommandError(errorMessage));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/teams/commands/channel/channel-remove.ts
+++ b/src/m365/teams/commands/channel/channel-remove.ts
@@ -1,11 +1,17 @@
+import { Group } from '@microsoft/microsoft-graph-types';
 import { Cli } from '../../../../cli/Cli';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils/validation';
+import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import { Channel } from '../../Channel';
 import commands from '../../commands';
+
+interface ExtendedGroup extends Group {
+  resourceProvisioningOptions: string[];
+}
 
 interface CommandArgs {
   options: Options;
@@ -14,11 +20,14 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   channelId?: string;
   channelName?: string;
-  teamId: string;
+  teamId?: string;
+  teamName?: string;
   confirm?: boolean;
 }
 
 class TeamsChannelRemoveCommand extends GraphCommand {
+  private teamId: string = "";
+
   public get name(): string {
     return commands.CHANNEL_REMOVE;
   }
@@ -41,6 +50,8 @@ class TeamsChannelRemoveCommand extends GraphCommand {
       Object.assign(this.telemetryProperties, {
         channelId: typeof args.options.channelId !== 'undefined',
         channelName: typeof args.options.channelName !== 'undefined',
+        teamId: typeof args.options.teamId !== 'undefined',
+        teamName: typeof args.options.teamName !== 'undefined',
         confirm: (!(!args.options.confirm)).toString()
       });
     });
@@ -55,7 +66,10 @@ class TeamsChannelRemoveCommand extends GraphCommand {
         option: '-n, --channelName [channelName]'
       },
       {
-        option: '-i, --teamId <teamId>'
+        option: '-i, --teamId [teamId]'
+      },
+      {
+        option: '--teamName [teamName]'
       },
       {
         option: '--confirm'
@@ -80,52 +94,27 @@ class TeamsChannelRemoveCommand extends GraphCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push(['channelId', 'channelName']);
+    this.optionSets.push(
+      ['channelId', 'channelName'],
+      ['teamId', 'teamName']
+    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     const removeChannel: () => Promise<void> = async (): Promise<void> => {
       try {
-        if (args.options.channelName) {
-          const requestOptions: any = {
-            url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.teamId)}/channels?$filter=displayName eq '${encodeURIComponent(args.options.channelName)}'`,
-            headers: {
-              accept: 'application/json;odata.metadata=none'
-            },
-            responseType: 'json'
-          };
-  
-          const res: { value: Channel[] } = await request.get<{ value: Channel[] }>(requestOptions);
-          const channelItem: Channel | undefined = res.value[0];
+        this.teamId = await this.getTeamId(args);
+        const channelId: string = await this.getChannelId(args);
 
-          if (!channelItem) {
-            return Promise.reject(`The specified channel does not exist in the Microsoft Teams team`);
-          }
+        const requestOptionsDelete: any = {
+          url: `${this.resource}/v1.0/teams/${encodeURIComponent(this.teamId)}/channels/${encodeURIComponent(channelId)}`,
+          headers: {
+            accept: 'application/json;odata.metadata=none'
+          },
+          responseType: 'json'
+        };
 
-          const channelId: string = res.value[0].id;
-
-          const requestOptionsDelete: any = {
-            url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.teamId)}/channels/${encodeURIComponent(channelId)}`,
-            headers: {
-              accept: 'application/json;odata.metadata=none'
-            },
-            responseType: 'json'
-          };
-
-          await request.delete(requestOptionsDelete);
-        }
-  
-        if (args.options.channelId) {
-          const requestOptions: any = {
-            url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.teamId)}/channels/${encodeURIComponent(args.options.channelId)}`,
-            headers: {
-              accept: 'application/json;odata.metadata=none'
-            },
-            responseType: 'json'
-          };
-  
-          await request.delete(requestOptions);
-        }
+        await request.delete(requestOptionsDelete);
       }
       catch (err: any) {
         this.handleRejectedODataJsonPromise(err);
@@ -141,13 +130,51 @@ class TeamsChannelRemoveCommand extends GraphCommand {
         type: 'confirm',
         name: 'continue',
         default: false,
-        message: `Are you sure you want to remove the channel ${channelName} from team ${args.options.teamId}?`
+        message: `Are you sure you want to remove the channel ${channelName}?`
       });
-      
+
       if (result.continue) {
         await removeChannel();
       }
     }
+  }
+
+  private async getTeamId(args: CommandArgs): Promise<string> {
+    if (args.options.teamId) {
+      return args.options.teamId;
+    }
+
+    const group: Group = await aadGroup.getGroupByDisplayName(args.options.teamName!);
+
+    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
+      throw 'The specified team does not exist in the Microsoft Teams';
+    }
+    else {
+      return group.id!;
+    }
+  }
+
+  private async getChannelId(args: CommandArgs): Promise<string> {
+    if (args.options.channelId) {
+      return args.options.channelId;
+    }
+
+    const channelRequestOptions: any = {
+      url: `${this.resource}/v1.0/teams/${encodeURIComponent(this.teamId)}/channels?$filter=displayName eq '${encodeURIComponent(args.options.channelName as string)}'`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    const res: { value: Channel[] } = await request.get<{ value: Channel[] }>(channelRequestOptions);
+    const channelItem: Channel | undefined = res.value[0];
+
+    if (!channelItem) {
+      throw `The specified channel does not exist in the Microsoft Teams team`;
+    }
+
+    return channelItem.id;
   }
 }
 

--- a/src/m365/teams/commands/channel/channel-set.spec.ts
+++ b/src/m365/teams/commands/channel/channel-set.spec.ts
@@ -7,19 +7,25 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
 const command: Command = require('./channel-set');
 
 describe(commands.CHANNEL_SET, () => {
+  const channelId = '19:f3dcbb1674574677abcae89cb626f1e6@thread.skype';
+  const channelName = 'channelName';
+  const teamId = 'd66b8110-fcad-49e8-8159-0d488ddb7656';
+  const teamName = 'Team Name';
+  const newChannelName = 'New Review';
+  const description = 'This is a new description';
+
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -50,8 +56,7 @@ describe(commands.CHANNEL_SET, () => {
   after(() => {
     sinonUtil.restore([
       auth.restoreAuth,
-      appInsights.trackEvent,
-      pid.getProcessName
+      appInsights.trackEvent
     ]);
     auth.service.connected = false;
   });
@@ -67,10 +72,10 @@ describe(commands.CHANNEL_SET, () => {
   it('correctly validates the arguments', async () => {
     const actual = await command.validate({
       options: {
-        teamId: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402',
-        channelName: 'Reviews',
-        newChannelName: 'Gen',
-        description: 'this is a new description'
+        teamId: teamId,
+        channelName: channelName,
+        newChannelName: newChannelName,
+        description: description
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
@@ -80,9 +85,21 @@ describe(commands.CHANNEL_SET, () => {
     const actual = await command.validate({
       options: {
         teamId: 'invalid',
-        channelName: 'Reviews',
-        newChannelName: 'Gen',
-        description: 'this is a new description'
+        channelName: channelId,
+        newChannelName: newChannelName,
+        description: description
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the channelId is not valid channelId', async () => {
+    const actual = await command.validate({
+      options: {
+        teamId: teamId,
+        channelId: 'invalid',
+        newChannelName: newChannelName,
+        description: description
       }
     }, commandInfo);
     assert.notStrictEqual(actual, true);
@@ -91,64 +108,146 @@ describe(commands.CHANNEL_SET, () => {
   it('fails validation when channelName is General', async () => {
     const actual = await command.validate({
       options: {
-        teamId: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402',
+        teamId: teamId,
         channelName: 'General',
-        newChannelName: 'Reviews',
-        description: 'this is a new description'
+        newChannelName: newChannelName,
+        description: description
       }
     }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails to patch channel updates for the Microsoft Teams team when channel does not exists', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`channels?$filter=displayName eq 'Latest'`) > -1) {
-        return Promise.resolve({ value: [] });
-      }
-      return Promise.reject('Invalid request');
-    });
-
-    await assert.rejects(command.action(logger, { options: {
-      debug: true,
-      teamId: '00000000-0000-0000-0000-000000000000',
-      channelName: 'Latest',
-      newChannelName: 'New Review',
-      description: 'New Review' } } as any), new CommandError('The specified channel does not exist in the Microsoft Teams team'));
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets;
+    assert.deepStrictEqual(optionSets, [
+      ['channelId', 'channelName'],
+      ['teamId', 'teamName']
+    ]);
   });
 
-  it('correctly patches channel updates for the Microsoft Teams team', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`channels?$filter=displayName eq 'Review'`) > -1) {
-        return Promise.resolve({
+  it('fails to patch channel when channel does not exists', async () => {
+    const errorMessage = 'The specified channel does not exist in the Microsoft Teams team';
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels?$filter=displayName eq '${encodeURIComponent(channelName)}'`) {
+        return { value: [] };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: true,
+        teamId: teamId,
+        channelName: channelName,
+        newChannelName: newChannelName,
+        description: description
+      }
+    }), new CommandError(errorMessage));
+  });
+
+  it('correctly patches channel updates for the Microsoft Teams team by teamId and channelName', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels?$filter=displayName eq '${encodeURIComponent(channelName)}'`) {
+        return {
           value:
             [
               {
-                "id": "19:8a53185a51ac44a3aef27397c3dfebfc@thread.skype",
+                "id": channelId,
                 "displayName": "Review",
                 "description": "Updated by CLI"
               }]
-        });
+        };
       }
-      return Promise.reject('Invalid request');
+
+      throw 'Invalid request';
     });
-    sinon.stub(request, 'patch').callsFake((opts) => {
-      if (((opts.url as string).indexOf(`channels/19:8a53185a51ac44a3aef27397c3dfebfc@thread.skype`) > -1) &&
-        JSON.stringify(opts.data) === JSON.stringify({ displayName: "New Review", description: "New Review" })
+
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if ((opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(channelId)}`) &&
+        JSON.stringify(opts.data) === JSON.stringify({ displayName: newChannelName, description: description })
       ) {
-        return Promise.resolve({});
+        return;
       }
-      return Promise.reject('Invalid request');
+
+      throw 'Invalid request';
     });
 
     await command.action(logger, {
       options: {
         debug: false,
-        teamId: '00000000-0000-0000-0000-000000000000',
-        channelName: 'Review',
-        newChannelName: 'New Review',
-        description: 'New Review'
+        teamId: teamId,
+        channelName: channelName,
+        newChannelName: newChannelName,
+        description: description
       }
-    } as any);
+    });
+  });
+
+  it('correctly patches channel updates for the Microsoft Teams team by teamName and channelId', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(teamName)}'`) {
+        return {
+          value: [
+            {
+              "id": teamId,
+              "displayName": teamName,
+              "resourceProvisioningOptions": ["Team"]
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if ((opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(channelId)}`) &&
+        JSON.stringify(opts.data) === JSON.stringify({ displayName: newChannelName, description: description })
+      ) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: false,
+        teamName: teamName,
+        channelId: channelId,
+        newChannelName: newChannelName,
+        description: description
+      }
+    });
+  });
+
+  it('fails when team name does not exist', async () => {
+    const errorMessage = 'The specified team does not exist in the Microsoft Teams';
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(teamName)}'`) {
+        return {
+          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
+          "@odata.count": 1,
+          "value": [
+            {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "resourceProvisioningOptions": []
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        channelId: channelId,
+        teamName: teamName,
+        confirm: true
+      }
+    }), new CommandError(errorMessage));
   });
 
   it('supports debug mode', () => {

--- a/src/m365/teams/commands/channel/channel-set.ts
+++ b/src/m365/teams/commands/channel/channel-set.ts
@@ -1,23 +1,33 @@
+import { Group } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { validation } from '../../../../utils/validation';
+import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import { Channel } from '../../Channel';
 import commands from '../../commands';
+
+interface ExtendedGroup extends Group {
+  resourceProvisioningOptions: string[];
+}
 
 interface CommandArgs {
   options: Options;
 }
 
 interface Options extends GlobalOptions {
-  channelName: string;
+  channelId?: string;
+  channelName?: string;
+  teamId?: string;
+  teamName?: string;
   description?: string
   newChannelName?: string;
-  teamId: string;
 }
 
 class TeamsChannelSetCommand extends GraphCommand {
+  private teamId: string = "";
+
   public get name(): string {
     return commands.CHANNEL_SET;
   }
@@ -31,11 +41,16 @@ class TeamsChannelSetCommand extends GraphCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
+        channelId: typeof args.options.channelId !== 'undefined',
+        channelName: typeof args.options.channelName !== 'undefined',
+        teamId: typeof args.options.teamId !== 'undefined',
+        teamName: typeof args.options.teamName !== 'undefined',
         newChannelName: typeof args.options.newChannelName !== 'undefined',
         description: typeof args.options.description !== 'undefined'
       });
@@ -45,10 +60,16 @@ class TeamsChannelSetCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-i, --teamId <teamId>'
+        option: '-c, --channelId [channelId]'
       },
       {
-        option: '--channelName <channelName>'
+        option: '-n, --channelName [channelName]'
+      },
+      {
+        option: '-i, --teamId [teamId]'
+      },
+      {
+        option: '--teamName [teamName]'
       },
       {
         option: '--newChannelName [newChannelName]'
@@ -62,12 +83,16 @@ class TeamsChannelSetCommand extends GraphCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.teamId)) {
+        if (args.options.teamId && !validation.isValidGuid(args.options.teamId)) {
           return `${args.options.teamId} is not a valid GUID`;
         }
 
-        if (args.options.channelName.toLowerCase() === "general") {
+        if (args.options.channelName && args.options.channelName.toLowerCase() === "general") {
           return 'General channel cannot be updated';
+        }
+
+        if (args.options.channelId && !validation.isValidTeamsChannelId(args.options.channelId)) {
+          return `${args.options.channelId} is not a valid Teams Channel Id`;
         }
 
         return true;
@@ -75,27 +100,21 @@ class TeamsChannelSetCommand extends GraphCommand {
     );
   }
 
+  #initOptionSets(): void {
+    this.optionSets.push(
+      ['channelId', 'channelName'],
+      ['teamId', 'teamName']
+    );
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    const requestOptions: any = {
-      url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.teamId)}/channels?$filter=displayName eq '${encodeURIComponent(args.options.channelName)}'`,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
-    
     try {
-      const res: { value: Channel[] } = await request.get<{ value: Channel[] }>(requestOptions);
-      const channelItem: Channel | undefined = res.value[0];
+      this.teamId = await this.getTeamId(args);
+      const channelId: string = await this.getChannelId(args);
 
-      if (!channelItem) {
-        throw `The specified channel does not exist in the Microsoft Teams team`;
-      }
-
-      const channelId: string = res.value[0].id;
       const data: any = this.mapRequestBody(args.options);
       const requestOptionsPatch: any = {
-        url: `${this.resource}/v1.0/teams/${encodeURIComponent(args.options.teamId)}/channels/${channelId}`,
+        url: `${this.resource}/v1.0/teams/${encodeURIComponent(this.teamId)}/channels/${encodeURIComponent(channelId)}`,
         headers: {
           'accept': 'application/json;odata.metadata=none'
         },
@@ -104,7 +123,7 @@ class TeamsChannelSetCommand extends GraphCommand {
       };
 
       await request.patch(requestOptionsPatch);
-    } 
+    }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
@@ -122,6 +141,44 @@ class TeamsChannelSetCommand extends GraphCommand {
     }
 
     return requestBody;
+  }
+
+  private async getTeamId(args: CommandArgs): Promise<string> {
+    if (args.options.teamId) {
+      return args.options.teamId;
+    }
+
+    const group: Group = await aadGroup.getGroupByDisplayName(args.options.teamName!);
+
+    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
+      throw 'The specified team does not exist in the Microsoft Teams';
+    }
+    else {
+      return group.id!;
+    }
+  }
+
+  private async getChannelId(args: CommandArgs): Promise<string> {
+    if (args.options.channelId) {
+      return args.options.channelId;
+    }
+
+    const channelRequestOptions: any = {
+      url: `${this.resource}/v1.0/teams/${encodeURIComponent(this.teamId)}/channels?$filter=displayName eq '${encodeURIComponent(args.options.channelName as string)}'`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    const res: { value: Channel[] } = await request.get<{ value: Channel[] }>(channelRequestOptions);
+    const channelItem: Channel | undefined = res.value[0];
+
+    if (!channelItem) {
+      throw `The specified channel does not exist in the Microsoft Teams team`;
+    }
+
+    return channelItem.id;
   }
 }
 


### PR DESCRIPTION
Extends "teams channel" commands with extra options. Closes https://github.com/pnp/cli-microsoft365/issues/3688

Extends below commands to support option sets of teamId, temName and channelId, channelName:

1. teams channel remove
2. teams channel set