### PR TITLE
Fixes odata from output for `planner bucket get`

### DIFF
--- a/src/m365/planner/commands/bucket/bucket-get.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.ts
@@ -206,7 +206,7 @@ class PlannerBucketGetCommand extends GraphCommand {
     const requestOptions: AxiosRequestConfig = {
       url: `${this.resource}/v1.0/planner/buckets/${id}`,
       headers: {
-        accept: 'application/json'
+        accept: 'application/json;odata.metadata=none'
       },
       responseType: 'json'
     };


### PR DESCRIPTION
Closes #3825 
