### PR TITLE
Extend `m365 status command` with appId and appTenant

### DIFF
--- a/src/m365/commands/status.spec.ts
+++ b/src/m365/commands/status.spec.ts
@@ -105,17 +105,25 @@ describe(commands.STATUS, () => {
     };
 
     auth.service.connected = true;
+    auth.service.authType = AuthType.DeviceCode;
+    auth.service.appId = '8dd76117-ab8e-472c-b5c1-a50e13b457cd';
+    auth.service.tenant = 'common';
     sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve(''));
     sinon.stub(accessToken, 'getUserNameFromAccessToken').callsFake(() => { return 'admin@contoso.onmicrosoft.com'; });
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
-      connectedAs: 'admin@contoso.onmicrosoft.com'
+      connectedAs: 'admin@contoso.onmicrosoft.com',
+      authType: 'DeviceCode',
+      appId: '8dd76117-ab8e-472c-b5c1-a50e13b457cd',
+      appTenant: 'common'
     }));
   });
 
   it('correctly reports access token', async () => {
     auth.service.connected = true;
     auth.service.authType = AuthType.DeviceCode;
+    auth.service.appId = '8dd76117-ab8e-472c-b5c1-a50e13b457cd';
+    auth.service.tenant = 'common';
     sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve(''));
     sinon.stub(accessToken, 'getUserNameFromAccessToken').callsFake(() => { return 'admin@contoso.onmicrosoft.com'; });
     auth.service.accessTokens = {
@@ -128,6 +136,8 @@ describe(commands.STATUS, () => {
     assert(loggerLogToStderrSpy.calledWith({
       connectedAs: 'admin@contoso.onmicrosoft.com',
       authType: 'DeviceCode',
+      appId: '8dd76117-ab8e-472c-b5c1-a50e13b457cd',
+      appTenant: 'common',
       accessTokens: '{\n  "https://graph.microsoft.com": {\n    "expiresOn": "123",\n    "accessToken": "abc"\n  }\n}'
     }));
   });
@@ -135,6 +145,8 @@ describe(commands.STATUS, () => {
   it('correctly reports access token - no user', async () => {
     auth.service.connected = true;
     auth.service.authType = AuthType.DeviceCode;
+    auth.service.appId = '8dd76117-ab8e-472c-b5c1-a50e13b457cd';
+    auth.service.tenant = 'common';
     sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve(''));
     auth.service.accessTokens = {
       'https://graph.microsoft.com': {
@@ -147,6 +159,8 @@ describe(commands.STATUS, () => {
     assert(loggerLogToStderrSpy.calledWith({
       connectedAs: '',
       authType: 'DeviceCode',
+      appId: '8dd76117-ab8e-472c-b5c1-a50e13b457cd',
+      appTenant: 'common',
       accessTokens: '{\n  "https://graph.microsoft.com": {\n    "expiresOn": "123",\n    "accessToken": "abc"\n  }\n}'
     }));
   });

--- a/src/m365/commands/status.ts
+++ b/src/m365/commands/status.ts
@@ -31,12 +31,17 @@ class StatusCommand extends Command {
         logger.logToStderr({
           connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
           authType: AuthType[auth.service.authType],
+          appId: auth.service.appId,
+          appTenant: auth.service.tenant,
           accessTokens: JSON.stringify(auth.service.accessTokens, null, 2)
         });
       }
       else {
         logger.log({
-          connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken)
+          connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
+          authType: AuthType[auth.service.authType],
+          appId: auth.service.appId,
+          appTenant: auth.service.tenant
         });
       }
     }


### PR DESCRIPTION
Extend `m365 status command` with appId and tenantId. Closes #3818