### PR TITLE
Expands the user guide with info about escaping in PowerShell. Closes #3638

### DIFF
--- a/docs/docs/cmd/adaptivecard/adaptivecard-send.md
+++ b/docs/docs/cmd/adaptivecard/adaptivecard-send.md
@@ -43,6 +43,9 @@ The predefined card is automatically adjusted based on which options have been s
 
 If your custom card is a card template (card with placeholders like `${title}`), you can fill it with data either by specifying the complete data object using the `cardData` option, or by passing any number of arbitrary options that will be mapped onto the card. The arbitrary properties should not match any of the global options like `output`, `query`, `debug`, etc. Data options like `title`, `description`, `imageUrl` and `actionUrl` will be mapped onto the card as well.
 
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--card` and `--cardData` options it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
+
 ## Examples
 
 Send a predefined adaptive card with just title

--- a/docs/docs/cmd/graph/schemaextension/schemaextension-add.md
+++ b/docs/docs/cmd/graph/schemaextension/schemaextension-add.md
@@ -43,26 +43,19 @@ The schema extension owner is the ID of the Azure AD application that is the own
 
 The target types are the set of Microsoft Graph resource types (that support schema extensions) that this schema extension definition can be applied to. This option is specified as a comma-separated list
 
-When specifying the JSON string of properties on Windows, you have to escape double quotes in a specific way. Considering the following value for the _properties_ option: `{"Foo":"Bar"}`,
-you should specify the value as <code>\`"{""Foo"":""Bar""}"\`</code>.
-In addition, when using PowerShell, you should use the `--%` argument.
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--properties` option it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
 
 ## Examples
 
 Create a schema extension
 
 ```sh
-m365 graph schemaextension add --id MySchemaExtension --description "My Schema Extension" --targetTypes Group --owner 62375ab9-6b52-47ed-826b-58e47e0e304b --properties \`"[{""name"":""myProp1"",""type"":""Integer""},{""name"":""myProp2"",""type"":""String""}]\`
+m365 graph schemaextension add --id MySchemaExtension --description "My Schema Extension" --targetTypes Group --owner 62375ab9-6b52-47ed-826b-58e47e0e304b --properties '[{"name":"myProp1","type":"Integer"},{"name":"myProp2","type":"String"}]'
 ```
 
 Create a schema extension with a verified domain
 
 ```sh
-m365 graph schemaextension add --id contoso_MySchemaExtension --description "My Schema Extension" --targetTypes Group --owner 62375ab9-6b52-47ed-826b-58e47e0e304b --properties \`"[{""name"":""myProp1"",""type"":""Integer""},{""name"":""myProp2"",""type"":""String""}]\`
-```
-
-Create a schema extension in PowerShell
-
-```PowerShell
-graph schemaextension add --id contoso_MySchemaExtension --description "My Schema Extension" --targetTypes Group --owner "62375ab9-6b52-47ed-826b-58e47e0e304b" --properties --% \`"[{""name"":""myProp1"",""type"":""Integer""},{""name"":""myProp2"",""type"":""String""}]\`
+m365 graph schemaextension add --id contoso_MySchemaExtension --description "My Schema Extension" --targetTypes Group --owner 62375ab9-6b52-47ed-826b-58e47e0e304b --properties '[{"name":"myProp1","type":"Integer"},{"name":"myProp2","type":"String"}]'
 ```

--- a/docs/docs/cmd/graph/schemaextension/schemaextension-set.md
+++ b/docs/docs/cmd/graph/schemaextension/schemaextension-set.md
@@ -35,9 +35,9 @@ m365 graph schemaextension set [options]
 The lifecycle state of the schema extension. The initial state upon creation is `InDevelopment`.
 Possible states transitions are from `InDevelopment` to `Available` and `Available` to `Deprecated`.
 The target types are the set of Microsoft Graph resource types (that support schema extensions) that this schema extension definition can be applied to. This option is specified as a comma-separated list.
-When specifying the JSON string of properties on Windows, you have to escape double quotes in a specific way. Considering the following value for the _properties_ option: `{"Foo":"Bar"}`,
-you should specify the value as <code>\`"{""Foo"":""Bar""}"\`</code>.
-In addition, when using PowerShell, you should use the `--%` argument.
+
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--properties` option it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
 
 ## Examples
 
@@ -50,13 +50,7 @@ m365 graph schemaextension set --id MySchemaExtension --owner 62375ab9-6b52-47ed
 Update the target types and properties of a schema extension
 
 ```sh
-m365 graph schemaextension set --id contoso_MySchemaExtension --owner 62375ab9-6b52-47ed-826b-58e47e0e304b --targetTypes "Group,User" --properties \`"[{""name"":""myProp1"",""type"":""Integer""},{""name"":""myProp2"",""type"":""String""}]\`
-```
-
-Update the properties of a schema extension in PowerShell
-
-```PowerShell
-graph schemaextension set --id contoso_MySchemaExtension --owner 62375ab9-6b52-47ed-826b-58e47e0e304b --properties --% \`"[{""name"":""myProp1"",""type"":""Integer""},{""name"":""myProp2"",""type"":""String""}]\`
+m365 graph schemaextension set --id contoso_MySchemaExtension --owner 62375ab9-6b52-47ed-826b-58e47e0e304b --targetTypes "Group,User" --properties '[{"name":"myProp1","type":"Integer"},{"name":"myProp2","type":"String"}]'
 ```
 
 Change the status of a schema extension to 'Available'

--- a/docs/docs/cmd/spo/customaction/customaction-add.md
+++ b/docs/docs/cmd/spo/customaction/customaction-add.md
@@ -78,6 +78,9 @@ Note, how the clientSideComponentProperties option (-p) has escaped double quote
 
 The `--rights` option accepts **case sensitive** values.
 
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--clientSideComponentProperties` option it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
+
 ## Examples
 
 Adds tenant-wide SharePoint Framework Application Customizer extension in site _https://contoso.sharepoint.com/sites/test_

--- a/docs/docs/cmd/spo/customaction/customaction-set.md
+++ b/docs/docs/cmd/spo/customaction/customaction-set.md
@@ -77,11 +77,12 @@ Running this command from the Windows Command Shell (cmd.exe) or PowerShell for 
 m365 spo customaction set --url https://contoso.sharepoint.com/sites/test --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --clientSideComponentProperties '{\"testMessage\":\"Test message\"}'
 ```
 
-Note, how the `clientSideComponentProperties` option (-p) has escaped double quotes `'{\"testMessage\":\"Test message\"}'` compared to execution from bash `'{"testMessage":"Test message"}'`.
-
 The `--rights` option accepts **case-sensitive** values.
 
 Note, specifying the scope option might speed up the execution of the command, but would not update the scope. If the scope has to be changed, then the existing custom action should be removed and new should be added with different scope.
+
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--clientSideComponentProperties` option it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
 
 ## Examples
 

--- a/docs/docs/cmd/spo/field/field-set.md
+++ b/docs/docs/cmd/spo/field/field-set.md
@@ -37,6 +37,9 @@ m365 spo field set [options]
 
 Specify properties to update using their names, eg. `--Title 'New Title' --JSLink jslink.js`.
 
+!!! warning "Escaping JSON in PowerShell"
+    When updating column formatting for a field with the `--CustomFormatter` option, it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
+
 ## Examples
 
 Update the title of the site column specified by its internal name and push changes to existing lists
@@ -54,5 +57,5 @@ m365 spo field set --webUrl https://contoso.sharepoint.com/sites/project-x --lis
 Update column formatting of the specified list column
 
 ```sh
-m365 spo field set --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'My List' --title 'MyColumn' --CustomFormatter '`{"schema":"https://developer.microsoft.com/json-schemas/sp/column-formatting.schema.json", "elmType": "div", "txtContent": "@currentField"}`'
+m365 spo field set --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'My List' --title 'MyColumn' --CustomFormatter '{"schema":"https://developer.microsoft.com/json-schemas/sp/column-formatting.schema.json", "elmType": "div", "txtContent": "@currentField"}'
 ```

--- a/docs/docs/cmd/spo/list/list-view-set.md
+++ b/docs/docs/cmd/spo/list/list-view-set.md
@@ -33,6 +33,9 @@ Specify properties to update using their names, eg. `--Title 'New Title' --JSLin
 
 When updating list formatting, the value of the CustomFormatter property must be XML-escaped, eg. `&lt;` instead of `<`.
 
+!!! warning "Escaping JSON in PowerShell"
+    When updating list view formatting for a view with the `--CustomFormatter` option, it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
+
 ## Examples
 
 Update the title of the list view specified by its name
@@ -49,6 +52,14 @@ m365 spo list view set --webUrl https://contoso.sharepoint.com/sites/project-x -
 
 Update view formatting of the specified list view
 
-```sh
-m365 spo list view set --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'My List' --viewTitle 'All items' --CustomFormatter '`{"schema":"https://developer.microsoft.com/json-schemas/sp/view-formatting.schema.json","additionalRowClass": "=if([$DueDate] &lt;= @now, 'sp-field-severity--severeWarning', '')"}`'
-```
+=== "PowerShell"
+
+    ```sh
+    m365 spo list view set --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'My List' --viewTitle 'All items' --CustomFormatter '{\"schema\":\"https://developer.microsoft.com/json-schemas/sp/view-formatting.schema.json\",\"additionalRowClass\": \"=if([$DueDate] &lt;= @now, ''sp-field-severity--severeWarning'', '''')\"}'
+    ```
+
+=== "Bash"
+
+    ```sh
+    m365 spo list view set --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'My List' --viewTitle 'All items' --CustomFormatter "{\"schema\":\"https://developer.microsoft.com/json-schemas/sp/view-formatting.schema.json\",\"additionalRowClass\": \"=if([$DueDate] &lt;= @now, 'sp-field-severity--severeWarning', '')\"}"
+    ```

--- a/docs/docs/cmd/spo/page/page-clientsidewebpart-add.md
+++ b/docs/docs/cmd/spo/page/page-clientsidewebpart-add.md
@@ -45,7 +45,8 @@ If the specified `pageName` doesn't refer to an existing modern page, you will g
 
 To add a standard web part to the page, specify one of the following values: _ContentRollup, BingMap, ContentEmbed, DocumentEmbed, Image, ImageGallery, LinkPreview, NewsFeed, NewsReel, PowerBIReportEmbed, QuickChart, SiteActivity, VideoEmbed, YammerEmbed, Events, GroupCalendar, Hero, List, PageTitle, People, QuickLinks, CustomMessageRegion, Divider, MicrosoftForms, Spacer_.
 
-When specifying the JSON string with web part properties on Windows, you have to escape double quotes in a specific way. Considering the following value for the _webPartProperties_ option: `{"Foo":"Bar"}`, you should specify the value as \`"{""Foo"":""Bar""}"\`. In addition, when using PowerShell, you should use the `--%` argument.
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--webPartProperties` option it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
 
 ## Examples
 
@@ -67,20 +68,14 @@ Add a custom web part to the modern page
 m365 spo page clientsidewebpart add --webUrl https://contoso.sharepoint.com/sites/a-team --pageName page.aspx --webPartId 3ede60d3-dc2c-438b-b5bf-cc40bb2351e1
 ```
 
-Using PowerShell, add the standard Bing Map web part with the specific properties to a modern page
-
-```PowerShell
-m365 --% spo page clientsidewebpart add --webUrl https://contoso.sharepoint.com/sites/a-team --pageName page.aspx --standardWebPart BingMap --webPartProperties `"{""Title"":""Foo location""}"`
-```
-
-Using Windows command line, add the standard Bing Map web part with the specific properties to a modern page
+Add the standard Bing Map web part with the specific properties to a modern page
 
 ```sh
-m365 spo page clientsidewebpart add --webUrl https://contoso.sharepoint.com/sites/a-team --pageName page.aspx --standardWebPart BingMap --webPartProperties `"{""Title"":""Foo location""}"`
+m365 spo page clientsidewebpart add --webUrl https://contoso.sharepoint.com/sites/a-team --pageName page.aspx --standardWebPart BingMap --webPartProperties '{"Title":"Foo location"}'
 ```
 
 Add the standard Image web part with the preconfigured image
 
 ```sh
-m365 spo page clientsidewebpart add --webUrl https://contoso.sharepoint.com/sites/a-team --pageName page.aspx --standardWebPart Image --webPartData '`{ "dataVersion": "1.8", "serverProcessedContent": {"htmlStrings":{},"searchablePlainTexts":{"captionText":""},"imageSources":{"imageSource":"/sites/team-a/SiteAssets/work-life-balance.png"},"links":{}}, "properties": {"imageSourceType":2,"altText":"a group of people on a beach","overlayText":"Work life balance","fileName":"48146-OFF12_Justice_01.png","siteId":"27664b85-067d-4be9-a7d7-89b2e804d09f","webId":"a7664b85-067d-4be9-a7d7-89b2e804d09f","listId":"37664b85-067d-4be9-a7d7-89b2e804d09f","uniqueId":"67664b85-067d-4be9-a7d7-89b2e804d09f","imgWidth":650,"imgHeight":433,"fixAspectRatio":false,"isOverlayTextEnabled":true}}`'
+m365 spo page clientsidewebpart add --webUrl https://contoso.sharepoint.com/sites/a-team --pageName page.aspx --standardWebPart Image --webPartData '{ "dataVersion": "1.8", "serverProcessedContent": {"htmlStrings":{},"searchablePlainTexts":{"captionText":""},"imageSources":{"imageSource":"/sites/team-a/SiteAssets/work-life-balance.png"},"links":{}}, "properties": {"imageSourceType":2,"altText":"a group of people on a beach","overlayText":"Work life balance","fileName":"48146-OFF12_Justice_01.png","siteId":"27664b85-067d-4be9-a7d7-89b2e804d09f","webId":"a7664b85-067d-4be9-a7d7-89b2e804d09f","listId":"37664b85-067d-4be9-a7d7-89b2e804d09f","uniqueId":"67664b85-067d-4be9-a7d7-89b2e804d09f","imgWidth":650,"imgHeight":433,"fixAspectRatio":false,"isOverlayTextEnabled":true}}'
 ```

--- a/docs/docs/cmd/spo/page/page-control-set.md
+++ b/docs/docs/cmd/spo/page/page-control-set.md
@@ -31,7 +31,8 @@ m365 spo page control set [options]
 
 If the specified `name` doesn't refer to an existing modern page, you will get a `File doesn't exists` error.
 
-When specifying the JSON string with web part properties on Windows, you have to escape double quotes in a specific way. Considering the following value for the _webPartProperties_ option: `{"Foo":"Bar"}`, you should specify the value as \`"{""Foo"":""Bar""}"\`. In addition, when using PowerShell, you should use the `--%` argument.
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--webPartProperties` option it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
 
 ## Examples
 

--- a/docs/docs/cmd/spo/term/term-add.md
+++ b/docs/docs/cmd/spo/term/term-add.md
@@ -45,6 +45,11 @@ m365 spo term add [options]
 !!! important
     To use this command you have to have permissions to access the tenant admin site.
 
+## Remarks
+
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--customProperties` and/or `--localCustomProperties` options it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
+
 ## Examples
 
 Add taxonomy term with the specified name to the term group and term set specified by their names

--- a/docs/docs/cmd/spo/term/term-set-add.md
+++ b/docs/docs/cmd/spo/term/term-set-add.md
@@ -33,6 +33,11 @@ m365 spo term set add [options]
 !!! important
     To use this command you have to have permissions to access the tenant admin site.
 
+## Remarks
+
+!!! warning "Escaping JSON in PowerShell"
+    When using the `--customProperties` option it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
+
 ## Examples
 
 Add taxonomy term set to the term group specified by ID
@@ -56,5 +61,5 @@ m365 spo term set add --name PnP-Organizations --termGroupId 0e8f395e-ff58-4d45-
 Add taxonomy term set and set its custom properties
 
 ```sh
-m365 spo term set add --name PnP-Organizations --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb --customProperties '`{"Property":"Value"}`'
+m365 spo term set add --name PnP-Organizations --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb --customProperties '{"Property":"Value"}'
 ```

--- a/docs/docs/user-guide/using-cli.md
+++ b/docs/docs/user-guide/using-cli.md
@@ -91,6 +91,37 @@ You can use the `@` token in any command, with any option that accepts a value.
 m365 spo sitescript add --title "Contoso" --description "Contoso theme script" --content `@themeScript.json
 ```
 
+## Escaping double quotes in PowerShell
+
+PowerShell Versions 5 to 7.2 have an [issue with escaping double quotes](https://github.com/PowerShell/PowerShell/issues/1995). Command arguments are being parsed twice for tools like the CLI. Once by PowerShell and once by the CLI for Microsoft 365 executable that's being called by PowerShell. The result is that you need to escape quotes twice. The issue should be resolved from version 7.3.
+
+As an example, see the following code: 
+
+```PowerShell
+m365 spo listitem set --webUrl "<some-url>" --id 1 --listTitle somelist --SomeField "{ `"test1`": `"test2`" }"
+```
+
+While correctly escaped, it would result in the following being saved to sharepoint: `{ test1: test2 }`. The double quotes are missing.
+
+The following two methods resolve this:
+
+### Method 1: Escaping twice
+Escape the double quotes twice. Once for powershell using the backtick (`) and once for the executable, using a backslash.
+
+```PowerShell
+m365 spo listitem set --webUrl "<some-url>" --id 1 --listTitle somelist --SomeField "{ \`"test1\`": \`"test2\`" }"
+```
+
+### Method 2: Using verbatim strings with single quotes
+Use single quotes to start a verbatim string. The double quotes need not be escaped for powershell using the backtick. However, they do need to be escaped for the executable, using a backslash.
+
+```PowerShell
+m365 spo listitem set --webUrl "<some-url>" --id 1 --listTitle somelist --SomeField '{ \"test1\": \"test2\" }'
+```
+
+!!! info
+    Remember, instead of escaping, it's also possible to [feed complex content from a file](./using-cli.md#passing-complex-content-into-cli-options). 
+
 ## `@meId` and `@meUserName` tokens
 
 CLI for Microsoft 365 contains a number of commands that require you to provide a user ID or username. If you want to pass these values for the current user, instead of looking them up, you can use the built-in tokens. With the `@meId` token you can specify the ID of the current user. Using the `@meUserName` token you can specify the username of the current user.


### PR DESCRIPTION
Closes #3638

Expands the user guide with info about escaping in PowerShell. 

👉 I added a central section in the user guide to explain what's going on.

👉 I added a warning note on all the command md files that allow JSON strings in command options. 
   
👉 I updated all examples with JSON in them to strings with single quotes. This is the most consistent string that's the same for posh and bash and therefore handy to use here. 

👉 A few commands already had explanations about escaping in PoSH. These where different ways to do it than I have written about in the user guide. I tried these methods, but I couldn't get them to work. There were also some slight variations in details between these explanations. In the end I swapped these notes with my own note and updated the examples. I also removed some powershell specific examples.

👉 Two commands docs kind of took me longer:
- `spo list view set` had a very specific example with a view formatter that contained single as well as double quotes. I could not merge this in a single quotes string that made sense for bash AND posh, so I added a tabbed structure there. Let me know what you think.
- `m365 spo page clientsidewebpart add` - I could not get this one to work in PoSH 5 and Bash. I did get it to work in PoSH 7 though. I tried it with every possible method i knew, including what the original author wrote, but it didn't work. In PoSH 5, it shows the help section. In bash it executes, but does not POST the JSON. I've let it be for now.  