### PR TITLE
updated documentation for `pp card get`. Closes #3890

### DIFF
--- a/docs/docs/cmd/pp/card/card-get.md
+++ b/docs/docs/cmd/pp/card/card-get.md
@@ -14,7 +14,7 @@ pp card get [options]
 : The name of the environment.
 
 `-i, --id [id]`
-: The id of the card.
+: The id of the card. Specify either `id` or `name` but not both.
 
 `-n, --name [name]`
 : The name of the card. Specify either `id` or `name` but not both.


### PR DESCRIPTION
adds `Specify either id or name but not both.` for the `id` parameter.

Closes #3890 