### PR TITLE
Extends 'spo list' commands to have all available list options. Closes #3808

### DIFF
--- a/docs/docs/about/generate-team-cards.js
+++ b/docs/docs/about/generate-team-cards.js
@@ -582,7 +582,7 @@ const contributors = [
     name: 'Smita Nachan',
     company: '',
     github: 'SmitaNachan',
-    twitter: 'mitanachan'
+    twitter: 'smitanachan'
   },
   {
     name: 'Stefan Bauer',

--- a/docs/docs/cmd/spo/list/list-get.md
+++ b/docs/docs/cmd/spo/list/list-get.md
@@ -14,10 +14,13 @@ m365 spo list get [options]
 : URL of the site where the list to retrieve is located
 
 `-i, --id [id]`
-: ID of the list to retrieve information for. Specify either `id` or `title` but not both
+: ID of the list to retrieve information for. Specify either `id`, `title` or `url` but not multiple.
 
 `-t, --title [title]`
-: Title of the list to retrieve information for. Specify either `id` or `title` but not both
+: Title of the list to retrieve information for. Specify either `id`, `title` or `url` but not multiple.
+
+`--url [url]`
+: Server- or site-relative URL of the list. Specify either `id`, `title` or `url` but not multiple.
 
 `-p, --properties [properties]`
 : Comma-separated list of properties to retrieve from the list. Will retrieve all properties possible from default response, if not specified.
@@ -29,16 +32,28 @@ m365 spo list get [options]
 
 ## Examples
 
-Return information about a list with ID _0cd891ef-afce-4e55-b836-fce03286cccf_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get information about a list with ID _0cd891ef-afce-4e55-b836-fce03286cccf_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 m365 spo list get --id 0cd891ef-afce-4e55-b836-fce03286cccf --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Return information about a list with title _Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get information about a list with title _Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x
+```
+
+Get information about a list with server relative url _sites/project-x/Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents'
+```
+
+Get information about a list with site-relative URL _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents'
 ```
 
 Get information about a list returning the specified list properties
@@ -56,3 +71,4 @@ m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/site
 ## More information
 
 - List REST API resources: [https://msdn.microsoft.com/en-us/library/office/dn531433.aspx#bk_ListEndpoint](https://msdn.microsoft.com/en-us/library/office/dn531433.aspx#bk_ListEndpoint)
+

--- a/docs/docs/cmd/spo/list/list-get.md
+++ b/docs/docs/cmd/spo/list/list-get.md
@@ -32,37 +32,37 @@ m365 spo list get [options]
 
 ## Examples
 
-Get information about a list with ID _0cd891ef-afce-4e55-b836-fce03286cccf_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get information about a list with specified ID located in the specified site.
 
 ```sh
 m365 spo list get --id 0cd891ef-afce-4e55-b836-fce03286cccf --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Get information about a list with title _Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get information about a list with specified title located in the specified site.
 
 ```sh
 m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Get information about a list with server relative url _sites/project-x/Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get information about a list with specified server relative url located in the specified site.
 
 ```sh
-m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents'
+m365 spo list get --url 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Get information about a list with site-relative URL _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get information about a list with specified site-relative URL located in the specified site.
 
 ```sh
-m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents'
+m365 spo list get --url 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Get information about a list returning the specified list properties
+Get information about a list returning the specified list properties.
 
 ```sh
 m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --properties "Title,Id,HasUniqueRoleAssignments,AllowContentTypes"
 ```
 
-Get information about a list along with the roles and permissions
+Get information about a list along with the roles and permissions.
 
 ```sh
 m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/sites/project-x --withPermissions

--- a/docs/docs/cmd/spo/list/list-label-get.md
+++ b/docs/docs/cmd/spo/list/list-label-get.md
@@ -11,13 +11,16 @@ m365 spo list label get  [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: URL of the site where the list to get the label from is located
+: URL of the site where the list to get the label from is located.
 
 `-l, --listId [listId]`
-: ID of the list to get the label from. Specify either `listId` or `listTitle` but not both
+: ID of the list to get the label from. Specify either `listId`, `title` or `listTitle` but not multiple.
 
 `-t, --listTitle [listTitle]`
-: Title of the list to get the label from. Specify either `listId` or `listTitle` but not both
+: Title of the list to get the label from. Specify either `listId`, `title` or `listTitle` but not multiple.
+
+`--listUrl [listUrl]`
+: Server- or site-relative URL of the list. Specify either `listId`, `title` or `listTitle` but not multiple.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -34,3 +37,15 @@ Gets label set on the list with id _cc27a922-8224-4296-90a5-ebbc54da2e85_ locate
 ```sh
 m365 spo list label get  --webUrl https://contoso.sharepoint.com/sites/project-x --listId cc27a922-8224-4296-90a5-ebbc54da2e85
 ```
+
+Gets label set on the list with server relative url _sites/project-x/Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+m365 spo list label get  --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents'
+```
+
+Gets label set on the list with site-relative URL _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+m365 spo list label get  --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents'
+

--- a/docs/docs/cmd/spo/list/list-label-get.md
+++ b/docs/docs/cmd/spo/list/list-label-get.md
@@ -14,38 +14,39 @@ m365 spo list label get  [options]
 : URL of the site where the list to get the label from is located.
 
 `-l, --listId [listId]`
-: ID of the list to get the label from. Specify either `listId`, `title` or `listTitle` but not multiple.
+: ID of the list to get the label from. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
 
 `-t, --listTitle [listTitle]`
-: Title of the list to get the label from. Specify either `listId`, `title` or `listTitle` but not multiple.
+: Title of the list to get the label from. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listId`, `title` or `listTitle` but not multiple.
+: Server- or site-relative URL of the list. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Gets label set on the list with title _ContosoList_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Gets label set on the list with specified title located in the specified site.
 
 ```sh
-m365 spo list label get  --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle ContosoList
+m365 spo list label get --listTitle ContosoList --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Gets label set on the list with id _cc27a922-8224-4296-90a5-ebbc54da2e85_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Gets label set on the list with specified id located in the specified site.
 
 ```sh
-m365 spo list label get  --webUrl https://contoso.sharepoint.com/sites/project-x --listId cc27a922-8224-4296-90a5-ebbc54da2e85
+m365 spo list label get --listId cc27a922-8224-4296-90a5-ebbc54da2e85 --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Gets label set on the list with server relative url _sites/project-x/Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Gets label set on the list with specified server relative url located in the specified site.
 
 ```sh
-m365 spo list label get  --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents'
+m365 spo list label get --listUrl 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Gets label set on the list with site-relative URL _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Gets label set on the list with specified site-relative URL located in the specified site.
 
 ```sh
-m365 spo list label get  --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents'
+m365 spo list label get --listUrl 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x
+```
 

--- a/docs/docs/cmd/spo/list/list-sitescript-get.md
+++ b/docs/docs/cmd/spo/list/list-sitescript-get.md
@@ -11,45 +11,42 @@ m365 spo list sitescript get [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: URL of the site where the list to extract the site script from is located
+: URL of the site where the list to extract the site script from is located.
 
 `-l, --listId [listId]`
-: ID of the list to extract the site script from. Specify either `listId`, `title` or `listTitle` but not multiple.
+: ID of the list to extract the site script from. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
 
 `-t, --listTitle [listTitle]`
-: Title of the list to extract the site script from. Specify either `listId`, `title` or `listTitle` but not multiple.
+: Title of the list to extract the site script from. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listId`, `title` or `listTitle` but not multiple.
+: Server- or site-relative URL of the list. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Extract a site script from an existing SharePoint list with title _ContosoList_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Extract a site script from an existing SharePoint list with specified title located in the specified site.
 
 ```sh
-m365 spo list sitescript get --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle ContosoList
+m365 spo list sitescript get --listTitle ContosoList --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Extract a site script from an existing SharePoint list with id _cc27a922-8224-4296-90a5-ebbc54da2e85_
-located in site _https://contoso.sharepoint.com/sites/project-x_
+Extract a site script from an existing SharePoint list with specified id located in the specified site.
 
 ```sh
-m365 spo list sitescript get --webUrl https://contoso.sharepoint.com/sites/project-x --listId cc27a922-8224-4296-90a5-ebbc54da2e85
+m365 spo list sitescript get --listId cc27a922-8224-4296-90a5-ebbc54da2e85 --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Extract a site script from an existing SharePoint list with server relative url _sites/project-x/Documents_
-located in site _https://contoso.sharepoint.com/sites/project-x_
+Extract a site script from an existing SharePoint list with specified server relative url located in the specified site.
 
 ```sh
-m365 spo list sitescript get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents'
+m365 spo list sitescript get --listUrl 'sites/project-x/Documents' --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Extract a site script from an existing SharePoint list with site-relative URL _Shared Documents_
-located in site _https://contoso.sharepoint.com/sites/project-x_
+Extract a site script from an existing SharePoint list with specified site-relative URL located in the specified site.
 
 ```sh
-m365 spo list sitescript get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents'
+m365 spo list sitescript get --listUrl 'Shared Documents' --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 

--- a/docs/docs/cmd/spo/list/list-sitescript-get.md
+++ b/docs/docs/cmd/spo/list/list-sitescript-get.md
@@ -14,10 +14,13 @@ m365 spo list sitescript get [options]
 : URL of the site where the list to extract the site script from is located
 
 `-l, --listId [listId]`
-: ID of the list to extract the site script from. Specify either `listId` or `listTitle` but not both
+: ID of the list to extract the site script from. Specify either `listId`, `title` or `listTitle` but not multiple.
 
 `-t, --listTitle [listTitle]`
-: Title of the list to extract the site script from. Specify either `listId` or `listTitle` but not both
+: Title of the list to extract the site script from. Specify either `listId`, `title` or `listTitle` but not multiple.
+
+`--listUrl [listUrl]`
+: Server- or site-relative URL of the list. Specify either `listId`, `title` or `listTitle` but not multiple.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -35,3 +38,18 @@ located in site _https://contoso.sharepoint.com/sites/project-x_
 ```sh
 m365 spo list sitescript get --webUrl https://contoso.sharepoint.com/sites/project-x --listId cc27a922-8224-4296-90a5-ebbc54da2e85
 ```
+
+Extract a site script from an existing SharePoint list with server relative url _sites/project-x/Documents_
+located in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+m365 spo list sitescript get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents'
+```
+
+Extract a site script from an existing SharePoint list with site-relative URL _Shared Documents_
+located in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+m365 spo list sitescript get --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents'
+```
+

--- a/src/m365/spo/commands/list/list-get.spec.ts
+++ b/src/m365/spo/commands/list/list-get.spec.ts
@@ -184,7 +184,7 @@ describe(commands.LIST_GET, () => {
     }));
   });
 
-  it('retrieves details of list if title and properties option is passed', async () => {
+  it('retrieves details of list if title and properties option is passed (debug)', async () => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.resolve(
         {
@@ -199,7 +199,7 @@ describe(commands.LIST_GET, () => {
         debug: true,
         title: 'Documents',
         webUrl: 'https://contoso.sharepoint.com',
-        properties:'Title,Id'
+        properties: 'Title,Id'
       }
     });
     assert(loggerLogSpy.calledWith({
@@ -208,8 +208,7 @@ describe(commands.LIST_GET, () => {
     }));
   });
 
-
-  it('retrieves details of list if list id and properties option is passed', async () => {
+  it('retrieves details of list if list id and properties option is passed (debug)', async () => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.resolve(
         {
@@ -224,7 +223,31 @@ describe(commands.LIST_GET, () => {
         debug: true,
         id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
         webUrl: 'https://contoso.sharepoint.com',
-        properties:'Title,Id'
+        properties: 'Title,Id'
+      }
+    });
+    assert(loggerLogSpy.calledWith({
+      Id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
+      Title: 'Documents'
+    }));
+  });
+
+  it('retrieves details of list if url and properties option is passed (debug)', async () => {
+    sinon.stub(request, 'get').callsFake(() => {
+      return Promise.resolve(
+        {
+          "Id": "14b2b6ed-0885-4814-bfd6-594737cc3ae3",
+          "Title": "Documents"
+        }
+      );
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: true,
+        url: 'Shared Documents',
+        webUrl: 'https://contoso.sharepoint.com',
+        properties: 'Title,Id'
       }
     });
     assert(loggerLogSpy.calledWith({
@@ -771,7 +794,7 @@ describe(commands.LIST_GET, () => {
         debug: false,
         id: '14b2b6ed-0885-4814-bfd6-594737cc3ae3',
         webUrl: 'https://contoso.sharepoint.com',
-        properties:'Title,Id',
+        properties: 'Title,Id',
         withPermissions: true
       }
     });
@@ -1064,7 +1087,7 @@ describe(commands.LIST_GET, () => {
         debug: false,
         title: 'Documents',
         webUrl: 'https://contoso.sharepoint.com',
-        properties:'Title,Id',
+        properties: 'Title,Id',
         withPermissions: true
       }
     });
@@ -1282,12 +1305,6 @@ describe(commands.LIST_GET, () => {
     assert(containsTypeOption);
   });
 
-  
-  it('fails validation if both id and title options are not passed', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('fails validation if the url option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', id: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF' } }, commandInfo);
     assert.notStrictEqual(actual, true);
@@ -1308,8 +1325,8 @@ describe(commands.LIST_GET, () => {
     assert(actual);
   });
 
-  it('fails validation if both id and title options are passed', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', title: 'Documents' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets;
+    assert.deepStrictEqual(optionSets, [['id', 'title', 'url']]);
   });
 });

--- a/src/m365/spo/commands/list/list-get.ts
+++ b/src/m365/spo/commands/list/list-get.ts
@@ -103,17 +103,17 @@ class SpoListGetCommand extends SpoCommand {
       logger.logToStderr(`Retrieving information for list in site at ${args.options.webUrl}...`);
     }
 
-    let requestUrl: string = '';
+    let requestUrl: string = `${args.options.webUrl}/_api/web/`;
 
     if (args.options.id) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.id)}')`;
+      requestUrl += `lists(guid'${formatting.encodeQueryParameter(args.options.id)}')`;
     }
     else if (args.options.title) {
-      requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.title as string)}')`;
+      requestUrl += `lists/GetByTitle('${formatting.encodeQueryParameter(args.options.title as string)}')`;
     }
     else if (args.options.url) {
       const listServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.url);
-      requestUrl = `${args.options.webUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
+      requestUrl += `GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
     }
 
     let propertiesSelect: string = args.options.properties ? `?$select=${encodeURIComponent(args.options.properties)}` : ``;

--- a/src/m365/spo/commands/list/list-get.ts
+++ b/src/m365/spo/commands/list/list-get.ts
@@ -2,6 +2,7 @@ import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { formatting } from '../../../../utils/formatting';
+import { urlUtil } from '../../../../utils/urlUtil';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
@@ -16,6 +17,7 @@ interface Options extends GlobalOptions {
   webUrl: string;
   id?: string;
   title?: string;
+  url?: string;
   properties?: string;
   withPermissions?: boolean;
 }
@@ -43,6 +45,7 @@ class SpoListGetCommand extends SpoCommand {
       Object.assign(this.telemetryProperties, {
         id: (!(!args.options.id)).toString(),
         title: (!(!args.options.title)).toString(),
+        url: (!(!args.options.url)).toString(),
         properties: (!(!args.options.properties)).toString(),
         withPermissions: typeof args.options.withPermissions !== 'undefined'
       });
@@ -59,6 +62,9 @@ class SpoListGetCommand extends SpoCommand {
       },
       {
         option: '-t, --title [title]'
+      },
+      {
+        option: '--url [url]'
       },
       {
         option: '-p, --properties [properties]'
@@ -89,7 +95,7 @@ class SpoListGetCommand extends SpoCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push(['id', 'title']);
+    this.optionSets.push(['id', 'title', 'url']);
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -102,8 +108,12 @@ class SpoListGetCommand extends SpoCommand {
     if (args.options.id) {
       requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.id)}')`;
     }
-    else {
+    else if (args.options.title) {
       requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.title as string)}')`;
+    }
+    else if (args.options.url) {
+      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.url);
+      requestUrl = `${args.options.webUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
     }
 
     let propertiesSelect: string = args.options.properties ? `?$select=${encodeURIComponent(args.options.properties)}` : ``;

--- a/src/m365/spo/commands/list/list-label-get.spec.ts
+++ b/src/m365/spo/commands/list/list-label-get.spec.ts
@@ -382,15 +382,6 @@ describe(commands.LIST_LABEL_GET, () => {
       return Promise.reject('Invalid request');
     });
 
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/web/GetList(\'%2Fsites%2Fteam1%2Fdocuments\')`) > -1) {
-        return Promise.resolve({ "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } }
-        );
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
     await command.action(logger, {
       options: {
         debug: true,

--- a/src/m365/spo/commands/list/list-label-get.ts
+++ b/src/m365/spo/commands/list/list-label-get.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
@@ -93,23 +94,6 @@ class SpoListLabelGetCommand extends SpoCommand {
         logger.logToStderr(`Getting label set on the list ${args.options.listId || args.options.listTitle || args.options.listUrl} in site at ${args.options.webUrl}...`);
       }
 
-      let requestUrl: string = `${args.options.webUrl}/_api/web/`;
-
-      if (args.options.listId) {
-        if (this.debug) {
-          logger.logToStderr(`Retrieving List from Id '${args.options.listId}'...`);
-        }
-
-        requestUrl += `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')?$expand=RootFolder&$select=RootFolder`;
-      }
-      else if (args.options.listTitle) {
-        if (this.debug) {
-          logger.logToStderr(`Retrieving List from Title '${args.options.listTitle}'...`);
-        }
-
-        requestUrl += `lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')?$expand=RootFolder&$select=RootFolder`;
-      }
-
       let listServerRelativeUrl: string = '';
 
       if (args.options.listUrl) {
@@ -120,7 +104,24 @@ class SpoListLabelGetCommand extends SpoCommand {
         listServerRelativeUrl = urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
       }
       else {
-        const requestOptions: any = {
+        let requestUrl: string = `${args.options.webUrl}/_api/web/`;
+
+        if (args.options.listId) {
+          if (this.debug) {
+            logger.logToStderr(`Retrieving List from Id '${args.options.listId}'...`);
+          }
+
+          requestUrl += `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')?$expand=RootFolder&$select=RootFolder`;
+        }
+        else if (args.options.listTitle) {
+          if (this.debug) {
+            logger.logToStderr(`Retrieving List from Title '${args.options.listTitle}'...`);
+          }
+
+          requestUrl += `lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')?$expand=RootFolder&$select=RootFolder`;
+        }
+
+        const requestOptions: AxiosRequestConfig = {
           url: requestUrl,
           headers: {
             'accept': 'application/json;odata=nometadata'
@@ -133,7 +134,7 @@ class SpoListLabelGetCommand extends SpoCommand {
       }
 
       const listAbsoluteUrl: string = urlUtil.getAbsoluteUrl(args.options.webUrl, listServerRelativeUrl);
-      const reqOptions: any = {
+      const reqOptions: AxiosRequestConfig = {
         url: `${args.options.webUrl}/_api/SP_CompliancePolicy_SPPolicyStoreProxy_GetListComplianceTag`,
         headers: {
           'accept': 'application/json;odata=nometadata',

--- a/src/m365/spo/commands/list/list-sitescript-get.spec.ts
+++ b/src/m365/spo/commands/list/list-sitescript-get.spec.ts
@@ -19,7 +19,7 @@ describe(commands.LIST_SITESCRIPT_GET, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -733,6 +733,175 @@ describe(commands.LIST_SITESCRIPT_GET, () => {
     assert.strictEqual(JSON.stringify(actual), JSON.stringify(expected));
   });
 
+  it('extracts the site script from the given list if url option is passed (debug)', async () => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/Microsoft_SharePoint_Utilities_WebTemplateExtensions_SiteScriptUtility_GetSiteScriptFromList`) > -1) {
+        return Promise.resolve({
+          value: {
+            "actions": [
+              {
+                "verb": "createSPList",
+                "listName": "MyLibrary",
+                "templateType": 101,
+                "subactions": [
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field ID=\"{47b1b86f-9f8a-4dbe-a75e-ca5d9b0f566c}\" Type=\"URL\" Name=\"_ShortcutUrl\" DisplayName=\"Shortcut URL\" DisplaceOnUpgrade=\"TRUE\" Indexed=\"FALSE\" Required=\"FALSE\" Hidden=\"TRUE\" ReadOnlyField=\"TRUE\" ShowInEditForm=\"FALSE\" ShowInDisplayForm=\"FALSE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"_ShortcutUrl\" />"
+                  },
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field ID=\"{2662ad77-2410-4938-b01c-e5e43321bad4}\" Type=\"Guid\" Name=\"_ShortcutSiteId\" DisplayName=\"Shortcut Site Id\" DisplaceOnUpgrade=\"TRUE\" Indexed=\"FALSE\" Required=\"FALSE\" Hidden=\"TRUE\" ReadOnlyField=\"TRUE\" ShowInEditForm=\"FALSE\" ShowInDisplayForm=\"FALSE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"_ShortcutSiteId\" />"
+                  },
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field ID=\"{e2a3861f-c216-47d7-820f-7cb638862ab2}\" Type=\"Guid\" Name=\"_ShortcutWebId\" DisplayName=\"Shortcut Web Id\" DisplaceOnUpgrade=\"TRUE\" Indexed=\"FALSE\" Required=\"FALSE\" Hidden=\"TRUE\" ReadOnlyField=\"TRUE\" ShowInEditForm=\"FALSE\" ShowInDisplayForm=\"FALSE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"_ShortcutWebId\" />"
+                  },
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field ID=\"{e8fea999-553d-4f45-be52-d941627e9fe5}\" Type=\"Guid\" Name=\"_ShortcutUniqueId\" DisplayName=\"Shortcut Unique Id\" DisplaceOnUpgrade=\"TRUE\" Indexed=\"FALSE\" Required=\"FALSE\" Hidden=\"TRUE\" ReadOnlyField=\"TRUE\" ShowInEditForm=\"FALSE\" ShowInDisplayForm=\"FALSE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"_ShortcutUniqueId\" />"
+                  },
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field DisplayName=\"MyText\" Format=\"Dropdown\" MaxLength=\"255\" Title=\"MyText\" Type=\"Text\" ID=\"{dbd0f8fa-5131-44ed-b7a1-23bfffc50ac8}\" StaticName=\"MyText\" Name=\"MyText\" />"
+                  },
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field DisplayName=\"MyDate\" FriendlyDisplayFormat=\"Disabled\" Format=\"DateTime\" Title=\"MyDate\" Type=\"DateTime\" ID=\"{f98a4e28-5fb3-4737-9a24-3ad533552bf5}\" StaticName=\"MyDate\" Name=\"MyDate\"><Default>[today]</Default></Field>"
+                  },
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field Decimals=\"2\" DisplayName=\"MyNumber\" Format=\"Dropdown\" Percentage=\"FALSE\" Title=\"MyNumber\" Type=\"Number\" ID=\"{496aa48c-0cf7-4990-be49-d373aa327e0c}\" StaticName=\"MyNumber\" Name=\"MyNumber\"><Default>100</Default></Field>"
+                  },
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field ID=\"{e52012a0-51eb-4c0c-8dfb-9b8a0ebedcb6}\" ReadOnly=\"TRUE\" Type=\"Computed\" Name=\"Combine\" DisplaceOnUpgrade=\"TRUE\" DisplayName=\"Merge\" Filterable=\"FALSE\" Sortable=\"FALSE\" Hidden=\"TRUE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"Combine\"><FieldRefs><FieldRef Name=\"FSObjType\" Key=\"Primary\" /><FieldRef Name=\"EncodedAbsUrl\" /><FieldRef Name=\"TemplateUrl\" /></FieldRefs><DisplayPattern><IfEqual><Expr1><Field Name=\"FSObjType\" /></Expr1><Expr2>0</Expr2><Then><HTML><![CDATA[<input id=\"chkCombine\" type=\"CHECKBOX\" title=\"Merge]]\" href=\"]]></HTML><Field Name=\"EncodedAbsUrl\" /><HTML><![CDATA[\">]]></HTML><HTML><![CDATA[<input id=\"chkUrl\" type=\"HIDDEN\" href=\"]]></HTML><Column Name=\"TemplateUrl\" HTMLEncode=\"TRUE\" /><HTML><![CDATA[\">]]></HTML><HTML><![CDATA[<input id=\"chkProgID\" type=\"HIDDEN\" href=\"]]></HTML><MapToControl><HTML>|</HTML><GetFileExtension><Column Name=\"TemplateUrl\" HTMLEncode=\"TRUE\" /></GetFileExtension></MapToControl><HTML><![CDATA[\">]]></HTML></Then></IfEqual></DisplayPattern></Field>"
+                  },
+                  {
+                    "verb": "addSPFieldXml",
+                    "schemaXml": "<Field ID=\"{5d36727b-bcb2-47d2-a231-1f0bc63b7439}\" ReadOnly=\"TRUE\" Type=\"Computed\" Name=\"RepairDocument\" DisplaceOnUpgrade=\"TRUE\" DisplayName=\"Relink\" Filterable=\"FALSE\" Sortable=\"FALSE\" Hidden=\"TRUE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"RepairDocument\"><FieldRefs><FieldRef Name=\"FSObjType\" Key=\"Primary\" /><FieldRef Name=\"ID\" /></FieldRefs><DisplayPattern><IfEqual><Expr1><Field Name=\"FSObjType\" /></Expr1><Expr2>0</Expr2><Then><HTML><![CDATA[<input id=\"chkRepair\" type=\"CHECKBOX\" title=\"Relink\" docid=\"]]></HTML><Field Name=\"ID\" /><HTML><![CDATA[\">]]></HTML></Then></IfEqual></DisplayPattern></Field>"
+                  },
+                  {
+                    "verb": "addSPView",
+                    "name": "All Documents",
+                    "viewFields": [
+                      "DocIcon",
+                      "LinkFilename",
+                      "MyText",
+                      "MyDate",
+                      "MyNumber"
+                    ],
+                    "query": "<OrderBy><FieldRef Name=\"FileLeafRef\" /></OrderBy>",
+                    "rowLimit": 30,
+                    "isPaged": true,
+                    "makeDefault": true,
+                    "formatterJSON": ""
+                  }
+                ]
+              },
+              {
+                "verb": "addNavLink",
+                "url": "MyLibrary/Forms/AllItems.aspx",
+                "displayName": "MyLibrary",
+                "isWebRelative": true
+              }
+            ]
+          }
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/web/GetList(\'%2Fsites%2Fteam1%2FMyLibrary\')`) > -1) {
+        return Promise.resolve({ "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" }, "AllowContentTypes": true, "BaseTemplate": 101, "BaseType": 1, "ContentTypesEnabled": false, "CrawlNonDefaultViews": false, "Created": "2019-01-11T10:03:19Z", "CurrentChangeToken": { "StringValue": "1;3;fb4b0cf8-c006-4802-a1ea-57e0e4852188;636827981522200000;96826061" }, "CustomActionElements": { "Items": [{ "ClientSideComponentId": "00000000-0000-0000-0000-000000000000", "ClientSideComponentProperties": "", "CommandUIExtension": null, "Id": "vwaViewAsWebAccessFromEcb", "EnabledScript": null, "ImageUrl": null, "Location": "EditControlBlock", "RegistrationId": "vdw", "RegistrationType": 4, "RequireSiteAdministrator": false, "Rights": { "High": "0", "Low": "1" }, "Title": "View in Web Browser", "UrlAction": "~site/_layouts/15/VisioWebAccess/VisioWebAccess.aspx?listguid={ListId}&itemid={ItemId}&DefaultItemOpen=1" }, { "ClientSideComponentId": "00000000-0000-0000-0000-000000000000", "ClientSideComponentProperties": "", "CommandUIExtension": null, "Id": "vwaViewAsWebAccessVsdxFromEcb", "EnabledScript": null, "ImageUrl": null, "Location": "EditControlBlock", "RegistrationId": "vsdx", "RegistrationType": 4, "RequireSiteAdministrator": false, "Rights": { "High": "0", "Low": "1" }, "Title": "View in Web Browser", "UrlAction": "~site/_layouts/15/VisioWebAccess/VisioWebAccess.aspx?listguid={ListId}&itemid={ItemId}&DefaultItemOpen=1" }, { "ClientSideComponentId": "00000000-0000-0000-0000-000000000000", "ClientSideComponentProperties": "", "CommandUIExtension": null, "Id": "vwaViewAsWebAccessVsdmFromEcb", "EnabledScript": null, "ImageUrl": null, "Location": "EditControlBlock", "RegistrationId": "vsdm", "RegistrationType": 4, "RequireSiteAdministrator": false, "Rights": { "High": "0", "Low": "1" }, "Title": "View in Web Browser", "UrlAction": "~site/_layouts/15/VisioWebAccess/VisioWebAccess.aspx?listguid={ListId}&itemid={ItemId}&DefaultItemOpen=1" }, { "ClientSideComponentId": "00000000-0000-0000-0000-000000000000", "ClientSideComponentProperties": "", "CommandUIExtension": null, "Id": "FormServerEcbItemOpenXsn", "EnabledScript": null, "ImageUrl": "/_layouts/15/images/icxddoc.gif?rev=45", "Location": "EditControlBlock", "RegistrationId": "xsn", "RegistrationType": 4, "RequireSiteAdministrator": false, "Rights": { "High": "0", "Low": "1" }, "Title": "Edit in Browser", "UrlAction": "~site/_layouts/15/formserver.aspx?XsnLocation={ItemUrl}&OpenIn=Browser&Source={Source}" }, { "ClientSideComponentId": "00000000-0000-0000-0000-000000000000", "ClientSideComponentProperties": "", "CommandUIExtension": null, "Id": "FormServerEcbItemOpenInfoPathDocument", "EnabledScript": null, "ImageUrl": "/_layouts/15/images/icxddoc.gif?rev=45", "Location": "EditControlBlock", "RegistrationId": "InfoPath.Document", "RegistrationType": 3, "RequireSiteAdministrator": false, "Rights": { "High": "0", "Low": "1" }, "Title": "Edit in Browser", "UrlAction": "~site/_layouts/15/formserver.aspx?XmlLocation={ItemUrl}&OpenIn=Browser&Source={Source}" }, { "ClientSideComponentId": "00000000-0000-0000-0000-000000000000", "ClientSideComponentProperties": "", "CommandUIExtension": null, "Id": "FormServerEcbItemOpenInfoPathDocument2", "EnabledScript": null, "ImageUrl": "/_layouts/15/images/icxddoc.gif?rev=45", "Location": "EditControlBlock", "RegistrationId": "InfoPath.Document.2", "RegistrationType": 3, "RequireSiteAdministrator": false, "Rights": { "High": "0", "Low": "1" }, "Title": "Edit in Browser", "UrlAction": "~site/_layouts/15/formserver.aspx?XmlLocation={ItemUrl}&OpenIn=Browser&Source={Source}" }, { "ClientSideComponentId": "00000000-0000-0000-0000-000000000000", "ClientSideComponentProperties": "", "CommandUIExtension": null, "Id": "FormServerEcbItemOpenInfoPathDocument3", "EnabledScript": null, "ImageUrl": "/_layouts/15/images/icxddoc.gif?rev=45", "Location": "EditControlBlock", "RegistrationId": "InfoPath.Document.3", "RegistrationType": 3, "RequireSiteAdministrator": false, "Rights": { "High": "0", "Low": "1" }, "Title": "Edit in Browser", "UrlAction": "~site/_layouts/15/formserver.aspx?XmlLocation={ItemUrl}&OpenIn=Browser&Source={Source}" }, { "ClientSideComponentId": "00000000-0000-0000-0000-000000000000", "ClientSideComponentProperties": "", "CommandUIExtension": null, "Id": "FormServerEcbItemOpenInfoPathDocument4", "EnabledScript": null, "ImageUrl": "/_layouts/15/images/icxddoc.gif?rev=45", "Location": "EditControlBlock", "RegistrationId": "InfoPath.Document.4", "RegistrationType": 3, "RequireSiteAdministrator": false, "Rights": { "High": "0", "Low": "1" }, "Title": "Edit in Browser", "UrlAction": "~site/_layouts/15/formserver.aspx?XmlLocation={ItemUrl}&OpenIn=Browser&Source={Source}" }] }, "DefaultContentApprovalWorkflowId": "00000000-0000-0000-0000-000000000000", "DefaultItemOpenUseListSetting": false, "Description": "", "Direction": "none", "DisableGridEditing": false, "DocumentTemplateUrl": "/sites/team1/MyLibrary/Forms/template.dotx", "DraftVersionVisibility": 0, "EnableAttachments": false, "EnableFolderCreation": true, "EnableMinorVersions": false, "EnableModeration": false, "EnableRequestSignOff": true, "EnableVersioning": true, "EntityTypeName": "MyLibrary", "ExemptFromBlockDownloadOfNonViewableFiles": false, "FileSavePostProcessingEnabled": false, "ForceCheckout": false, "HasExternalDataSource": false, "Hidden": false, "Id": "fb4b0cf8-c006-4802-a1ea-57e0e4852188", "ImagePath": { "DecodedUrl": "/_layouts/15/images/itdl.png?rev=45" }, "ImageUrl": "/_layouts/15/images/itdl.png?rev=45", "IrmEnabled": false, "IrmExpire": false, "IrmReject": false, "IsApplicationList": false, "IsCatalog": false, "IsPrivate": false, "ItemCount": 0, "LastItemDeletedDate": "2019-01-11T10:03:19Z", "LastItemModifiedDate": "2019-01-11T10:04:15Z", "LastItemUserModifiedDate": "2019-01-11T10:03:19Z", "ListExperienceOptions": 0, "ListItemEntityTypeFullName": "SP.Data.MyLibraryItem", "MajorVersionLimit": 500, "MajorWithMinorVersionsLimit": 0, "MultipleDataList": false, "NoCrawl": false, "ParentWebPath": { "DecodedUrl": "/sites/team1" }, "ParentWebUrl": "/sites/team1", "ParserDisabled": false, "ServerTemplateCanCreateFolders": true, "TemplateFeatureId": "00bfea71-e717-4e80-aa17-d0c71b360101", "Title": "MyLibrary" }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listUrl: 'sites/team1/MyLibrary'
+      }
+    });
+
+    const expected = {
+      "actions": [
+        {
+          "verb": "createSPList",
+          "listName": "MyLibrary",
+          "templateType": 101,
+          "subactions": [
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field ID=\"{47b1b86f-9f8a-4dbe-a75e-ca5d9b0f566c}\" Type=\"URL\" Name=\"_ShortcutUrl\" DisplayName=\"Shortcut URL\" DisplaceOnUpgrade=\"TRUE\" Indexed=\"FALSE\" Required=\"FALSE\" Hidden=\"TRUE\" ReadOnlyField=\"TRUE\" ShowInEditForm=\"FALSE\" ShowInDisplayForm=\"FALSE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"_ShortcutUrl\" />"
+            },
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field ID=\"{2662ad77-2410-4938-b01c-e5e43321bad4}\" Type=\"Guid\" Name=\"_ShortcutSiteId\" DisplayName=\"Shortcut Site Id\" DisplaceOnUpgrade=\"TRUE\" Indexed=\"FALSE\" Required=\"FALSE\" Hidden=\"TRUE\" ReadOnlyField=\"TRUE\" ShowInEditForm=\"FALSE\" ShowInDisplayForm=\"FALSE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"_ShortcutSiteId\" />"
+            },
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field ID=\"{e2a3861f-c216-47d7-820f-7cb638862ab2}\" Type=\"Guid\" Name=\"_ShortcutWebId\" DisplayName=\"Shortcut Web Id\" DisplaceOnUpgrade=\"TRUE\" Indexed=\"FALSE\" Required=\"FALSE\" Hidden=\"TRUE\" ReadOnlyField=\"TRUE\" ShowInEditForm=\"FALSE\" ShowInDisplayForm=\"FALSE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"_ShortcutWebId\" />"
+            },
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field ID=\"{e8fea999-553d-4f45-be52-d941627e9fe5}\" Type=\"Guid\" Name=\"_ShortcutUniqueId\" DisplayName=\"Shortcut Unique Id\" DisplaceOnUpgrade=\"TRUE\" Indexed=\"FALSE\" Required=\"FALSE\" Hidden=\"TRUE\" ReadOnlyField=\"TRUE\" ShowInEditForm=\"FALSE\" ShowInDisplayForm=\"FALSE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"_ShortcutUniqueId\" />"
+            },
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field DisplayName=\"MyText\" Format=\"Dropdown\" MaxLength=\"255\" Title=\"MyText\" Type=\"Text\" ID=\"{dbd0f8fa-5131-44ed-b7a1-23bfffc50ac8}\" StaticName=\"MyText\" Name=\"MyText\" />"
+            },
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field DisplayName=\"MyDate\" FriendlyDisplayFormat=\"Disabled\" Format=\"DateTime\" Title=\"MyDate\" Type=\"DateTime\" ID=\"{f98a4e28-5fb3-4737-9a24-3ad533552bf5}\" StaticName=\"MyDate\" Name=\"MyDate\"><Default>[today]</Default></Field>"
+            },
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field Decimals=\"2\" DisplayName=\"MyNumber\" Format=\"Dropdown\" Percentage=\"FALSE\" Title=\"MyNumber\" Type=\"Number\" ID=\"{496aa48c-0cf7-4990-be49-d373aa327e0c}\" StaticName=\"MyNumber\" Name=\"MyNumber\"><Default>100</Default></Field>"
+            },
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field ID=\"{e52012a0-51eb-4c0c-8dfb-9b8a0ebedcb6}\" ReadOnly=\"TRUE\" Type=\"Computed\" Name=\"Combine\" DisplaceOnUpgrade=\"TRUE\" DisplayName=\"Merge\" Filterable=\"FALSE\" Sortable=\"FALSE\" Hidden=\"TRUE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"Combine\"><FieldRefs><FieldRef Name=\"FSObjType\" Key=\"Primary\" /><FieldRef Name=\"EncodedAbsUrl\" /><FieldRef Name=\"TemplateUrl\" /></FieldRefs><DisplayPattern><IfEqual><Expr1><Field Name=\"FSObjType\" /></Expr1><Expr2>0</Expr2><Then><HTML><![CDATA[<input id=\"chkCombine\" type=\"CHECKBOX\" title=\"Merge]]\" href=\"]]></HTML><Field Name=\"EncodedAbsUrl\" /><HTML><![CDATA[\">]]></HTML><HTML><![CDATA[<input id=\"chkUrl\" type=\"HIDDEN\" href=\"]]></HTML><Column Name=\"TemplateUrl\" HTMLEncode=\"TRUE\" /><HTML><![CDATA[\">]]></HTML><HTML><![CDATA[<input id=\"chkProgID\" type=\"HIDDEN\" href=\"]]></HTML><MapToControl><HTML>|</HTML><GetFileExtension><Column Name=\"TemplateUrl\" HTMLEncode=\"TRUE\" /></GetFileExtension></MapToControl><HTML><![CDATA[\">]]></HTML></Then></IfEqual></DisplayPattern></Field>"
+            },
+            {
+              "verb": "addSPFieldXml",
+              "schemaXml": "<Field ID=\"{5d36727b-bcb2-47d2-a231-1f0bc63b7439}\" ReadOnly=\"TRUE\" Type=\"Computed\" Name=\"RepairDocument\" DisplaceOnUpgrade=\"TRUE\" DisplayName=\"Relink\" Filterable=\"FALSE\" Sortable=\"FALSE\" Hidden=\"TRUE\" SourceID=\"http://schemas.microsoft.com/sharepoint/v3\" StaticName=\"RepairDocument\"><FieldRefs><FieldRef Name=\"FSObjType\" Key=\"Primary\" /><FieldRef Name=\"ID\" /></FieldRefs><DisplayPattern><IfEqual><Expr1><Field Name=\"FSObjType\" /></Expr1><Expr2>0</Expr2><Then><HTML><![CDATA[<input id=\"chkRepair\" type=\"CHECKBOX\" title=\"Relink\" docid=\"]]></HTML><Field Name=\"ID\" /><HTML><![CDATA[\">]]></HTML></Then></IfEqual></DisplayPattern></Field>"
+            },
+            {
+              "verb": "addSPView",
+              "name": "All Documents",
+              "viewFields": [
+                "DocIcon",
+                "LinkFilename",
+                "MyText",
+                "MyDate",
+                "MyNumber"
+              ],
+              "query": "<OrderBy><FieldRef Name=\"FileLeafRef\" /></OrderBy>",
+              "rowLimit": 30,
+              "isPaged": true,
+              "makeDefault": true,
+              "formatterJSON": ""
+            }
+          ]
+        },
+        {
+          "verb": "addNavLink",
+          "url": "MyLibrary/Forms/AllItems.aspx",
+          "displayName": "MyLibrary",
+          "isWebRelative": true
+        }
+      ]
+    };
+    const actual = log[log.length - 1];
+    assert.strictEqual(JSON.stringify(actual), JSON.stringify(expected));
+  });
+
   it('correctly handles error when trying to extract site script if the server did not return generated site script (using listId)', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/Microsoft_SharePoint_Utilities_WebTemplateExtensions_SiteScriptUtility_GetSiteScriptFromList`) > -1) {
@@ -827,7 +996,7 @@ describe(commands.LIST_SITESCRIPT_GET, () => {
 
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/Microsoft_SharePoint_Utilities_WebTemplateExtensions_SiteScriptUtility_GetSiteScriptFromList`) > -1) {
-        return Promise.resolve({value: "SiteScript"});
+        return Promise.resolve({ value: "SiteScript" });
       }
 
       return Promise.reject('Invalid request');
@@ -863,14 +1032,9 @@ describe(commands.LIST_SITESCRIPT_GET, () => {
     assert(actual);
   });
 
-  it('fails validation if both listId and listTitle options are passed', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: 'cc27a922-8224-4296-90a5-ebbc54da2e85', listTitle: 'Documents' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if both listId and listTitle options are not passed', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets;
+    assert.deepStrictEqual(optionSets, [['listId', 'listTitle', 'listUrl']]);
   });
 
   it('supports debug mode', () => {

--- a/src/m365/spo/commands/list/list-sitescript-get.ts
+++ b/src/m365/spo/commands/list/list-sitescript-get.ts
@@ -93,19 +93,19 @@ class SpoListSiteScriptGetCommand extends SpoCommand {
         logger.logToStderr(`Extracting Site Script from list ${args.options.listId || args.options.listTitle || args.options.listUrl} in site at ${args.options.webUrl}...`);
       }
 
-      let requestUrl: string = '';
+      let requestUrl: string = `${args.options.webUrl}/_api/web/`;
 
       if (args.options.listId) {
         if (this.debug) {
           logger.logToStderr(`Retrieving List from Id '${args.options.listId}'...`);
         }
-        requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')?$expand=RootFolder`;
+        requestUrl += `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')?$expand=RootFolder`;
       }
       else if (args.options.listTitle) {
         if (this.debug) {
           logger.logToStderr(`Retrieving List from Title '${args.options.listTitle}'...`);
         }
-        requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')?$expand=RootFolder`;
+        requestUrl += `lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')?$expand=RootFolder`;
       }
       else if (args.options.listUrl) {
         if (this.debug) {
@@ -113,7 +113,7 @@ class SpoListSiteScriptGetCommand extends SpoCommand {
         }
 
         const listServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
-        requestUrl = `${args.options.webUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
+        requestUrl += `GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
       }
 
       let requestOptions: any = {

--- a/src/m365/spo/commands/list/list-sitescript-get.ts
+++ b/src/m365/spo/commands/list/list-sitescript-get.ts
@@ -119,7 +119,7 @@ class SpoListSiteScriptGetCommand extends SpoCommand {
           requestUrl += `lists/GetByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')?$expand=RootFolder`;
         }
 
-        let requestOptions: AxiosRequestConfig = {
+        const requestOptions: AxiosRequestConfig = {
           url: requestUrl,
           headers: {
             'accept': 'application/json;odata=nometadata'


### PR DESCRIPTION
Extends `spo list` commands to have all available list options. Closes #3808

Added below missing options:

Command | Options added
-- | --
spo list get | --url
spo list label get | --listUrl
spo list sitescript get | --listUrl
