### PR TITLE
Enhances parsing of boolean arguments. Closes #3914

### DIFF
--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -1749,7 +1749,7 @@ describe('Cli', () => {
     (cli as any).printAvailableCommands();
 
     try {
-      assert(cliLogStub.calledWith('  cli *  6 commands'));
+      assert(cliLogStub.calledWith('  cli *  7 commands'));
       done();
     }
     catch (e) {
@@ -1789,7 +1789,7 @@ describe('Cli', () => {
     (cli as any).printAvailableCommands();
 
     try {
-      assert(cliLogStub.calledWith('  cli *  6 commands'));
+      assert(cliLogStub.calledWith('  cli *  7 commands'));
       done();
     }
     catch (e) {

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -212,7 +212,6 @@ describe('Cli', () => {
   let mockCommandWithAlias: Command;
   let mockCommandWithValidation: Command;
   let log: string[] = [];
-  let mockCommandWithBooleanCuration: Command;
   let mockCommandWithBooleanRewrite: Command;
 
   before(() => {
@@ -551,11 +550,11 @@ describe('Cli', () => {
 
   it(`succeeds running with truthy/falsy values 'true' and 'false'`, (done) => {
     cli
-      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'true', '--booleanParameterY', 'false'])
+      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'true', '--booleanParameterY', 'false', '--output', 'text'])
       .then(_ => {
         try {
-          assert(cliLogStub.calledWith(`"booleanParameterX: true"`));
-          assert(cliLogStub.calledWith(`"booleanParameterY: false"`));
+          assert(cliLogStub.calledWith(`booleanParameterX: true`));
+          assert(cliLogStub.calledWith(`booleanParameterY: false`));
           done();
         }
         catch (e) {
@@ -566,11 +565,11 @@ describe('Cli', () => {
 
   it(`rewrites a truthy/falsy values '1' and '0' to 'true' and 'false' respectively`, (done) => {
     cli
-      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', '1', '--booleanParameterY', '0'])
+      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', '1', '--booleanParameterY', '0', '--output', 'text'])
       .then(_ => {
         try {
-          assert(cliLogStub.calledWith(`"booleanParameterX: true"`));
-          assert(cliLogStub.calledWith(`"booleanParameterY: false"`));
+          assert(cliLogStub.calledWith(`booleanParameterX: true`));
+          assert(cliLogStub.calledWith(`booleanParameterY: false`));
           done();
         }
         catch (e) {
@@ -581,11 +580,11 @@ describe('Cli', () => {
 
   it(`rewrites a truthy/falsy values 'on' and 'off' to 'true' and 'false' respectively`, (done) => {
     cli
-      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'on', '--booleanParameterY', 'off'])
+      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'on', '--booleanParameterY', 'off', '--output', 'text'])
       .then(_ => {
         try {
-          assert(cliLogStub.calledWith(`"booleanParameterX: true"`));
-          assert(cliLogStub.calledWith(`"booleanParameterY: false"`));
+          assert(cliLogStub.calledWith(`booleanParameterX: true`));
+          assert(cliLogStub.calledWith(`booleanParameterY: false`));
           done();
         }
         catch (e) {
@@ -596,11 +595,11 @@ describe('Cli', () => {
 
   it(`rewrites a truthy/falsy values 'yes' and 'no' to 'true' and 'false' respectively`, (done) => {
     cli
-      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'yes', '--booleanParameterY', 'no'])
+      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'yes', '--booleanParameterY', 'no', '--output', 'text'])
       .then(_ => {
         try {
-          assert(cliLogStub.calledWith(`"booleanParameterX: true"`));
-          assert(cliLogStub.calledWith(`"booleanParameterY: false"`));
+          assert(cliLogStub.calledWith(`booleanParameterX: true`));
+          assert(cliLogStub.calledWith(`booleanParameterY: false`));
           done();
         }
         catch (e) {
@@ -611,11 +610,11 @@ describe('Cli', () => {
 
   it(`rewrites a truthy/falsy values 'True' and 'False' to 'true' and 'false' respectively`, (done) => {
     cli
-      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'True', '--booleanParameterY', 'False'])
+      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'True', '--booleanParameterY', 'False', '--output', 'text'])
       .then(_ => {
         try {
-          assert(cliLogStub.calledWith(`"booleanParameterX: true"`));
-          assert(cliLogStub.calledWith(`"booleanParameterY: false"`));
+          assert(cliLogStub.calledWith(`booleanParameterX: true`));
+          assert(cliLogStub.calledWith(`booleanParameterY: false`));
           done();
         }
         catch (e) {
@@ -626,11 +625,11 @@ describe('Cli', () => {
 
   it(`rewrites a truthy/falsy values 'yes' and 'no' to 'true' and 'false' respectively (using shorts)`, (done) => {
     cli
-      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '-x', 'yes', '-y', 'no'])
+      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '-x', 'yes', '-y', 'no', '--output', 'text'])
       .then(_ => {
         try {
-          assert(cliLogStub.calledWith(`"booleanParameterX: true"`));
-          assert(cliLogStub.calledWith(`"booleanParameterY: false"`));
+          assert(cliLogStub.calledWith(`booleanParameterX: true`));
+          assert(cliLogStub.calledWith(`booleanParameterY: false`));
           done();
         }
         catch (e) {

--- a/src/m365/planner/commands/tenant/tenant-settings-set.spec.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-set.spec.ts
@@ -82,14 +82,6 @@ describe(commands.TENANT_SETTINGS_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation when invalid boolean is passed as option', async () => {
-    const actual = await command.validate({
-      options: {
-        isPlannerAllowed: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
 
   it('passes validation when valid options specified', async () => {
     const actual = await command.validate({

--- a/src/m365/planner/commands/tenant/tenant-settings-set.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-set.ts
@@ -2,7 +2,6 @@ import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { validation } from '../../../../utils/validation';
 import PlannerCommand from '../../../base/PlannerCommand';
 import commands from '../../commands';
 
@@ -33,6 +32,7 @@ class PlannerTenantSettingsSetCommand extends PlannerCommand {
 
     this.#initTelemetry();
     this.#initOptions();
+    this.#initTypes();
     this.#initValidators();
   }
 
@@ -78,6 +78,15 @@ class PlannerTenantSettingsSetCommand extends PlannerCommand {
     );
   }
 
+  #initTypes(): void {
+    this.types.boolean.push('isPlannerAllowed');
+    this.types.boolean.push('allowCalendarSharing');
+    this.types.boolean.push('allowTenantMoveWithDataLoss');
+    this.types.boolean.push('allowTenantMoveWithDataMigration');
+    this.types.boolean.push('allowRosterCreation');
+    this.types.boolean.push('allowPlannerMobilePushNotifications');
+  }
+
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
@@ -88,12 +97,6 @@ class PlannerTenantSettingsSetCommand extends PlannerCommand {
 
         if (optionsArray.every(o => typeof o === 'undefined')) {
           return 'You must specify at least one option';
-        }
-
-        for (const option of optionsArray) {
-          if (typeof option !== 'undefined' && !validation.isValidBoolean(option as any)) {
-            return `Value '${option}' is not a valid boolean`;
-          }
         }
 
         return true;

--- a/src/m365/planner/commands/tenant/tenant-settings-set.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-set.ts
@@ -79,12 +79,7 @@ class PlannerTenantSettingsSetCommand extends PlannerCommand {
   }
 
   #initTypes(): void {
-    this.types.boolean.push('isPlannerAllowed');
-    this.types.boolean.push('allowCalendarSharing');
-    this.types.boolean.push('allowTenantMoveWithDataLoss');
-    this.types.boolean.push('allowTenantMoveWithDataMigration');
-    this.types.boolean.push('allowRosterCreation');
-    this.types.boolean.push('allowPlannerMobilePushNotifications');
+    this.types.boolean.push('isPlannerAllowed', 'allowCalendarSharing', 'allowTenantMoveWithDataLoss', 'allowTenantMoveWithDataMigration', 'allowRosterCreation', 'allowPlannerMobilePushNotifications');
   }
 
   #initValidators(): void {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -84,5 +84,31 @@ export const formatting = {
       .replace(/:/g, '%3A')
       .replace(/@/g, '%40')
       .replace(/#/g, '%23');
+  },
+
+  /**
+   * Rewrites boolean values according to the definition:
+   * Booleans are case-insensitive, and are represented by the following values.
+   *   True: 1, yes, true, on
+   *   False: 0, no, false, off
+   * @value Stringied Boolean value to rewrite
+   * @returns A stringified boolean with the value 'true' or 'false'. Returns the original value if it does not comply with the definition. 
+   */
+  rewriteBooleanValue(value: string): string {
+    const argValue = value.toLowerCase();
+    switch (argValue) {
+      case '1':
+      case 'true':
+      case 'yes':
+      case 'on':
+        return 'true';
+      case '0':
+      case 'false':
+      case 'no':
+      case 'off':
+        return 'false';
+      default:
+        return value;
+    }
   }
 };

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -91,7 +91,7 @@ export const formatting = {
    * Booleans are case-insensitive, and are represented by the following values.
    *   True: 1, yes, true, on
    *   False: 0, no, false, off
-   * @value Stringied Boolean value to rewrite
+   * @value Stringified Boolean value to rewrite
    * @returns A stringified boolean with the value 'true' or 'false'. Returns the original value if it does not comply with the definition. 
    */
   rewriteBooleanValue(value: string): string {


### PR DESCRIPTION
Closes #3914

Enhances parsing of boolean arguments. 

This PR fixes the following:
- Curate boolean arguments if they agree to a set definition of truthy and falsy values.
- Shows how this works in an example setup with a single planner command.

To make this work I updated passing the `this.types.boolean` array to minimist with a filter. We should only pass options that are actually used as arguments, otherwise these options will default to `false`.