### PR TITLE
Update VS Code settings. Closes #3892

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,9 @@
 {
   "editor.tabSize": 2,
-  "editor.renderFinalNewline": false,
   "files.insertFinalNewline": false,
   "editor.insertSpaces": true,
   "editor.detectIndentation": false,
   "editor.inlineSuggest.enabled": true,
-  "editor.formatOnSave": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "docker.commands.runInteractive": [
     {
@@ -20,5 +18,9 @@
   ],
   "[markdown]": {
     "files.insertFinalNewline": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features",
+    "editor.formatOnSave": true
   }
 }


### PR DESCRIPTION
Closes #3892

Modified the `editor.formatOnSave` setting to only apply to typescript files and to use the default VS Code formatter.