### PR TITLE
Updates `m365 teams channel remove`, closes #4004

### DIFF
--- a/src/m365/teams/commands/channel/channel-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-remove.spec.ts
@@ -240,6 +240,45 @@ describe(commands.CHANNEL_REMOVE, () => {
 
   it('removes the specified channel by name when prompt confirmed (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${encodeURIComponent(teamName)}'`) {
+        return {
+          value: [
+            {
+              "id": teamId,
+              "displayName": teamName,
+              "resourceProvisioningOptions": ["Team"]
+            }
+          ]
+        };
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'delete').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels/${encodeURIComponent(id)}`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
+
+    await command.action(logger, {
+      options: {
+        debug: true,
+        id: id,
+        teamName: teamName
+      }
+    });
+  });
+
+
+  it('removes the specified channel by name when prompt confirmed (debug)', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/teams/${encodeURIComponent(teamId)}/channels?$filter=displayName eq '${encodeURIComponent(name)}'`) {
         return {
           value: [

--- a/src/m365/teams/commands/channel/channel-remove.ts
+++ b/src/m365/teams/commands/channel/channel-remove.ts
@@ -130,7 +130,7 @@ class TeamsChannelRemoveCommand extends GraphCommand {
         type: 'confirm',
         name: 'continue',
         default: false,
-        message: `Are you sure you want to remove the channel ${channel} from team ${args.options.teamId}?`
+        message: `Are you sure you want to remove the channel ${channel} from team ${args.options.teamId || args.options.teamName}?`
       });
 
       if (result.continue) {


### PR DESCRIPTION
Modified the `m365 teams channel remove` command so the confirmation message displays the teamName when the parameter `teamName` is given.

Closes #4004 