### PR TITLE
Introduce finally in executeCommandWithOutput

### DIFF
--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -242,28 +242,23 @@ export class Cli {
     try {
       await command.action(logger, args as any);
 
-      // restoring the command and logger is done here instead of in a 'finally' because there were issues with the code coverage tool
-      // restore the original command name
-      cli.currentCommandName = parentCommandName;
-      // restore the original logger
-      request.logger = currentLogger;
-
       return ({
         stdout: log.join(os.EOL),
         stderr: logErr.join(os.EOL)
       });
     }
     catch (err: any) {
-      // restoring the command and logger is done here instead of in a 'finally' because there were issues with the code coverage tool
-      // restore the original command name
-      cli.currentCommandName = parentCommandName;
-      // restore the original logger
-      request.logger = currentLogger;
-      
       throw {
         error: err,
         stderr: logErr.join(os.EOL)
       };
+    }
+    /* c8 ignore next */
+    finally {
+      // restore the original command name
+      cli.currentCommandName = parentCommandName;
+      // restore the original logger
+      request.logger = currentLogger;
     }
   }
 


### PR DESCRIPTION
Did not create an issue for this since I thought it was a bit overkill and this PR is maybe not worth it to add to the release notes.

### Context
When we stepped away from promise/then and introduced async/await, we had to refactor a `.finally(...)` to a finally block `finally { }`.
But there was a problem, because we threw an exception in the `catch` block, our code coverage tool did not hit the word `finally` (everything in the finally block was hit like you should expect, only the word 'finally' didn't). We agreed to just ditch the `finally` and put the code in both `try` and `catch`.
Now we have a slightly better way of fixing it. We can use the `finally` block like we intended and just tell our code coverage tool to ignore the line with `finally` on it.