### PR TITLE
Fixes `prompt` issue when `false`. Closes #4020

### DIFF
--- a/src/m365/cli/commands/config/config-set.spec.ts
+++ b/src/m365/cli/commands/config/config-set.spec.ts
@@ -40,7 +40,7 @@ describe(commands.CONFIG_SET, () => {
   afterEach(() => {
     sinonUtil.restore(Cli.getInstance().config.set);
   });
-  
+
   after(() => {
     sinonUtil.restore([
       appInsights.trackEvent,
@@ -161,6 +161,17 @@ describe(commands.CONFIG_SET, () => {
     assert.strictEqual(actualValue, false, 'Invalid value');
   });
 
+  it(`sets ${settingsNames.prompt} property`, async () => {
+    const config = Cli.getInstance().config;
+    let actualKey: string = '', actualValue: any;
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+    await command.action(logger, { options: { key: settingsNames.prompt, value: false } });
+    assert.strictEqual(actualKey, settingsNames.prompt, 'Invalid key');
+    assert.strictEqual(actualValue, false, 'Invalid value');
+  });
 
   it('supports specifying key and value', () => {
     const options = command.options;

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -57,19 +57,19 @@ class CliConfigSetCommand extends AnonymousCommand {
         if (CliConfigSetCommand.optionNames.indexOf(args.options.key) < 0) {
           return `${args.options.key} is not a valid setting. Allowed values: ${CliConfigSetCommand.optionNames.join(', ')}`;
         }
-    
+
         const allowedOutputs = ['text', 'json', 'csv'];
         if (args.options.key === settingsNames.output &&
           allowedOutputs.indexOf(args.options.value) === -1) {
           return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${allowedOutputs.join(', ')}`;
         }
-    
+
         const allowedErrorOutputs = ['stdout', 'stderr'];
         if (args.options.key === settingsNames.errorOutput &&
           allowedErrorOutputs.indexOf(args.options.value) === -1) {
           return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${allowedErrorOutputs.join(', ')}`;
         }
-    
+
         return true;
       }
     );
@@ -85,6 +85,7 @@ class CliConfigSetCommand extends AnonymousCommand {
       case settingsNames.csvQuoted:
       case settingsNames.csvQuotedEmpty:
       case settingsNames.printErrorsAsPlainText:
+      case settingsNames.prompt:
       case settingsNames.showHelpOnFailure:
         value = args.options.value === 'true';
         break;


### PR DESCRIPTION
### Pull Request Title

- Fixes prompting of the mandatory parameter eventhough `prompt` config setting is `false`. Closes #4020

### Linked Issue

Closes #4020

