### PR TITLE
Extend `spo page set` with option to demote news

### DIFF
--- a/docs/docs/cmd/spo/page/page-set.md
+++ b/docs/docs/cmd/spo/page/page-set.md
@@ -22,6 +22,9 @@ m365 spo page set [options]
 `-p, --promoteAs [promoteAs]`
 : Update the page purpose. Allowed values `HomePage`, `NewsPage`, `Template`
 
+`--demoteFrom [demoteFrom]`
+: Update the page purpose. Allowed values `newspage`
+
 `--commentsEnabled [commentsEnabled]`
 : Set to `true`, to enable comments on the page. Allowed values `true`, `false`
 
@@ -65,6 +68,12 @@ Promote the existing article page as a template
 m365 spo page set --name page.aspx --webUrl https://contoso.sharepoint.com/sites/a-team --promoteAs Template
 ```
 
+Demote the existing newspage
+
+```sh
+m365 spo page set --name page.aspx --webUrl https://contoso.sharepoint.com/sites/a-team --demoteFrom newspage
+```
+
 Change the page's layout to Home and set it as the site's home page
 
 ```sh
@@ -88,3 +97,7 @@ Set page description
 ```sh
 m365 spo page set --name page.aspx --webUrl https://contoso.sharepoint.com/sites/a-team --description "Description to add for the page"
 ```
+
+## Response
+
+The command won't return a response on success.

--- a/src/m365/spo/commands/listitem/listitem-set.ts
+++ b/src/m365/spo/commands/listitem/listitem-set.ts
@@ -15,7 +15,7 @@ interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
+export interface Options extends GlobalOptions {
   webUrl: string;
   listId?: string;
   listTitle?: string;

--- a/src/m365/spo/commands/page/page-set.spec.ts
+++ b/src/m365/spo/commands/page/page-set.spec.ts
@@ -12,6 +12,8 @@ import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import { spo } from '../../../../utils/spo';
 import commands from '../../commands';
+import * as spoFileGetCommand from '../file/file-get';
+import * as spoListItemSetCommand from '../listitem/listitem-set';
 const command: Command = require('./page-set');
 
 describe(commands.PAGE_SET, () => {
@@ -94,7 +96,9 @@ describe(commands.PAGE_SET, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.post
+      request.post,
+      Cli.executeCommand,
+      Cli.executeCommandWithOutput
     ]);
   });
 
@@ -329,6 +333,30 @@ describe(commands.PAGE_SET, () => {
 
     await command.action(logger, { options: { debug: false, name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', commentsEnabled: 'false' } });
     assert(loggerLogSpy.notCalled);
+  });
+
+  it('demotes news page to a regular page', async () => {
+    sinonUtil.restore([request.post]);
+
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === spoFileGetCommand) {
+        return { 'stdout': '{\"FileSystemObjectType\":0,\"Id\":6,\"ServerRedirectedEmbedUri\":null,\"ServerRedirectedEmbedUrl\":\"\",\"ContentTypeId\":\"0x0101009D1CB255DA76424F860D91F20E6C411800E2DAFA6353688E488147257C551A63BD\",\"ComplianceAssetId\":null,\"WikiField\":null,\"Title\":\"zzzz\",\"CanvasContent1\":\"<div><div data-sp-canvascontrol=\\\"\\\" data-sp-canvasdataversion=\\\"1.0\\\" data-sp-controldata=\\\"&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;0&#125;&#125;\\\"><\/div><\/div>\",\"BannerImageUrl\":{\"Description\":\"https:\/\/mathijsdev2.sharepoint.com\/_layouts\/15\/images\/sitepagethumbnail.png\",\"Url\":\"https:\/\/mathijsdev2.sharepoint.com\/_layouts\/15\/images\/sitepagethumbnail.png\"},\"Description\":null,\"PromotedState\":0,\"FirstPublishedDate\":\"2022-11-11T15:48:15\",\"LayoutWebpartsContent\":\"<div><div data-sp-canvascontrol=\\\"\\\" data-sp-canvasdataversion=\\\"1.4\\\" data-sp-controldata=\\\"&#123;&quot;id&quot;&#58;&quot;cbe7b0a9-3504-44dd-a3a3-0e5cacd07788&quot;,&quot;instanceId&quot;&#58;&quot;cbe7b0a9-3504-44dd-a3a3-0e5cacd07788&quot;,&quot;title&quot;&#58;&quot;Title area&quot;,&quot;description&quot;&#58;&quot;Title Region Description&quot;,&quot;audiences&quot;&#58;[],&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.4&quot;,&quot;properties&quot;&#58;&#123;&quot;title&quot;&#58;&quot;zzzz&quot;,&quot;imageSourceType&quot;&#58;4,&quot;layoutType&quot;&#58;&quot;FullWidthImage&quot;,&quot;textAlignment&quot;&#58;&quot;Left&quot;,&quot;showTopicHeader&quot;&#58;false,&quot;showPublishDate&quot;&#58;false,&quot;topicHeader&quot;&#58;&quot;&quot;,&quot;enableGradientEffect&quot;&#58;true,&quot;authors&quot;&#58;[&#123;&quot;id&quot;&#58;&quot;i&#58;0#.f|membership|mathijs@mathijsdev2.onmicrosoft.com&quot;,&quot;upn&quot;&#58;&quot;mathijs@mathijsdev2.onmicrosoft.com&quot;,&quot;email&quot;&#58;&quot;mathijs@mathijsdev2.onmicrosoft.com&quot;,&quot;name&quot;&#58;&quot;Mathijs Verbeeck&quot;,&quot;role&quot;&#58;&quot;&quot;&#125;],&quot;authorByline&quot;&#58;[&quot;i&#58;0#.f|membership|mathijs@mathijsdev2.onmicrosoft.com&quot;]&#125;,&quot;reservedHeight&quot;&#58;228&#125;\\\"><\/div><\/div>\",\"OData__AuthorBylineId\":[9],\"_AuthorBylineStringId\":[\"9\"],\"OData__TopicHeader\":null,\"OData__SPSitePageFlags\":null,\"OData__SPCallToAction\":null,\"OData__OriginalSourceUrl\":null,\"OData__OriginalSourceSiteId\":null,\"OData__OriginalSourceWebId\":null,\"OData__OriginalSourceListId\":null,\"OData__OriginalSourceItemId\":null,\"ID\":6,\"Created\":\"2022-11-11T15:48:00\",\"AuthorId\":9,\"Modified\":\"2022-11-12T02:03:12\",\"EditorId\":9,\"OData__CopySource\":null,\"CheckoutUserId\":9,\"OData__UIVersionString\":\"2.19\",\"GUID\":\"9a94cb88-019b-4a66-abd6-be7f5337f659\"}' };
+      }
+      if (command === spoListItemSetCommand) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/checkoutpage`) {
+        return {};
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { verbose: true, name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', demoteFrom: 'newspage' } });
   });
 
   it('updates page title', async () => {
@@ -632,6 +660,11 @@ describe(commands.PAGE_SET, () => {
   it('passes validation if layout type is Topic', async () => {
     const actual = await command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', layoutType: 'Topic' } }, commandInfo);
     assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if demote type is invalid', async () => {
+    const actual = await command.validate({ options: { name: 'page.aspx', webUrl: 'https://contoso.sharepoint.com', demoteFrom: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if promote type is invalid', async () => {

--- a/src/m365/spo/commands/page/page-set.ts
+++ b/src/m365/spo/commands/page/page-set.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from 'axios';
 import { Auth } from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
@@ -9,6 +10,12 @@ import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { Page, supportedPageLayouts, supportedPromoteAs } from './Page';
+import { Options as spoFileGetOptions } from '../file/file-get';
+import { Options as spoListItemSetOptions } from '../listitem/listitem-set';
+import * as spoFileGetCommand from '../file/file-get';
+import * as spoListItemSetCommand from '../listitem/listitem-set';
+import { Cli, CommandOutput } from '../../../../cli/Cli';
+import Command from '../../../../Command';
 
 interface CommandArgs {
   options: Options;
@@ -24,6 +31,7 @@ interface Options extends GlobalOptions {
   publishMessage?: string;
   description?: string;
   title?: string;
+  demoteFrom?: string;
 }
 
 class SpoPageSetCommand extends SpoCommand {
@@ -52,7 +60,8 @@ class SpoPageSetCommand extends SpoCommand {
         publish: args.options.publish || false,
         publishMessage: typeof args.options.publishMessage !== 'undefined',
         description: typeof args.options.description !== 'undefined',
-        title: typeof args.options.title !== 'undefined'
+        title: typeof args.options.title !== 'undefined',
+        demotefrom: typeof args.options.demoteFrom !== 'undefined'
       });
     });
   }
@@ -88,6 +97,10 @@ class SpoPageSetCommand extends SpoCommand {
       },
       {
         option: '--title [title]'
+      },
+      {
+        option: '--demoteFrom [demoteFrom]',
+        autocomplete: ['newspage']
       }
     );
   }
@@ -108,6 +121,11 @@ class SpoPageSetCommand extends SpoCommand {
         if (args.options.promoteAs &&
           supportedPromoteAs.indexOf(args.options.promoteAs) < 0) {
           return `${args.options.promoteAs} is not a valid option for promoteAs. Allowed values ${supportedPromoteAs.join(', ')}`;
+        }
+
+        if (args.options.demoteFrom &&
+          args.options.demoteFrom !== 'newspage') {
+          return `${args.options.demoteFrom} is not a valid option for demoteFrom. The only allowed value is 'newspage'`;
         }
 
         if (args.options.promoteAs === 'HomePage' && args.options.layoutType !== 'Home') {
@@ -146,7 +164,8 @@ class SpoPageSetCommand extends SpoCommand {
     if (!pageName.endsWith('.aspx')) {
       pageName += '.aspx';
     }
-    const serverRelativeFileUrl: string = `${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/sitepages/${pageName}`;
+    const listServerRelativeUrl = `${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/sitepages`;
+    const serverRelativeFileUrl: string = `${listServerRelativeUrl}/${pageName}`;
     const needsToSavePage = !!args.options.title || !!args.options.description;
 
     try {
@@ -167,7 +186,7 @@ class SpoPageSetCommand extends SpoCommand {
       }
 
       if (args.options.layoutType) {
-        const requestOptions: any = {
+        const requestOptions: AxiosRequestConfig = {
           url: `${args.options.webUrl}/_api/web/getfilebyserverrelativeurl('${serverRelativeFileUrl}')/ListItemAllFields`,
           headers: {
             'X-RequestDigest': requestDigest,
@@ -194,7 +213,7 @@ class SpoPageSetCommand extends SpoCommand {
       }
 
       if (args.options.promoteAs) {
-        const requestOptions: any = {
+        const requestOptions: AxiosRequestConfig = {
           responseType: 'json'
         };
 
@@ -237,9 +256,8 @@ class SpoPageSetCommand extends SpoCommand {
         }
 
         const pageRes = await request.post<{ Id: string }>(requestOptions);
-
         if (args.options.promoteAs === 'Template') {
-          const requestOptions: any = {
+          const requestOptions: AxiosRequestConfig = {
             responseType: 'json',
             url: `${args.options.webUrl}/_api/SitePages/Pages(${pageRes.Id})/SavePageAsTemplate`,
             headers: {
@@ -296,7 +314,7 @@ class SpoPageSetCommand extends SpoCommand {
       }
 
       if (needsToSavePage) {
-        const requestOptions: any = {
+        const requestOptions: AxiosRequestConfig = {
           responseType: 'json',
           url: `${args.options.webUrl}/_api/SitePages/Pages(${pageId})/SavePage`,
           headers: {
@@ -313,7 +331,7 @@ class SpoPageSetCommand extends SpoCommand {
       }
 
       if (args.options.promoteAs === 'Template') {
-        const requestOptions: any = {
+        const requestOptions: AxiosRequestConfig = {
           responseType: 'json',
           url: `${args.options.webUrl}/_api/SitePages/Pages(${pageId})/SavePageAsDraft`,
           headers: {
@@ -330,7 +348,7 @@ class SpoPageSetCommand extends SpoCommand {
       }
 
       if (typeof args.options.commentsEnabled !== 'undefined') {
-        const requestOptions: any = {
+        const requestOptions: AxiosRequestConfig = {
           url: `${args.options.webUrl}/_api/web/getfilebyserverrelativeurl('${serverRelativeFileUrl}')/ListItemAllFields/SetCommentsDisabled(${args.options.commentsEnabled === 'false'})`,
           headers: {
             'X-RequestDigest': requestDigest,
@@ -343,7 +361,29 @@ class SpoPageSetCommand extends SpoCommand {
         await request.post(requestOptions);
       }
 
-      let requestOptions: any;
+      if (args.options.demoteFrom) {
+        const fileGetOptions: spoFileGetOptions = {
+          webUrl: args.options.webUrl,
+          url: serverRelativeFileUrl,
+          asListItem: true,
+          verbose: this.verbose,
+          debug: this.debug
+        };
+        const fileGetOutput: CommandOutput = await Cli.executeCommandWithOutput(spoFileGetCommand as Command, { options: { ...fileGetOptions, _: [] } });
+        const fileGetOutputJson = JSON.parse(fileGetOutput.stdout);
+        const listItemSetOptions: spoListItemSetOptions = {
+          webUrl: args.options.webUrl,
+          listUrl: listServerRelativeUrl,
+          id: fileGetOutputJson.Id,
+          systemUpdate: true,
+          PromotedState: 0,
+          verbose: this.verbose,
+          debug: this.debug
+        };
+        await Cli.executeCommandWithOutput(spoListItemSetCommand as Command, { options: { ...listItemSetOptions, _: [] } });
+      }
+
+      let requestOptions: AxiosRequestConfig;
 
       if (!args.options.publish) {
         if (args.options.promoteAs === 'Template' || !pageId) {


### PR DESCRIPTION
Closes #2226 

A bit unsure about the autocomplete value used in `demoteFrom` `newspage` which I took from the specs in the issue as in the options `promoteAs`, this is `NewsPage. Should I change this?