### PR TITLE
Adds command `spo listitem batch add`

### DIFF
--- a/docs/docs/cmd/spo/listitem/listitem-batch-add.md
+++ b/docs/docs/cmd/spo/listitem/listitem-batch-add.md
@@ -1,0 +1,61 @@
+# spo listitem batch add
+
+Creates list items in a batch
+
+## Usage
+
+```sh
+m365 spo listitem batch add [options]
+```
+
+## Options
+
+`-p, --filePath <filePath>`
+: The absolute or relative path to a flat file containing the list items
+
+`-u, --webUrl <webUrl>`
+: URL of the site
+
+`-l, --listId [listId]`
+: ID of the list. Specify either `listTitle`, `listId` or `listUrl`
+
+`-t, --listTitle [listTitle]`
+: Title of the list. Specify either `listTitle`, `listId` or `listUrl`
+
+`--listUrl [listUrl]`
+: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Add a batch of items to a list retrieved by title in a specific site
+
+```sh
+m365 spo listitem batch add --filePath "C:\Path\To\Csv\CsvFile.csv" --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle "Demo List"
+```
+
+Add a batch of items to a list retrieved by Id in a specific site
+
+```sh
+m365 spo listitem batch add --filePath "C:\Path\To\Csv\CsvFile.csv" --webUrl https://contoso.sharepoint.com/sites/project-x --listId fe54c47b-22e4-4cab-8a10-3fc54003fb4c
+```
+
+Add a batch of items to a list defined by server-relative URL in a specific site
+
+```sh
+m365 spo listitem batch add --filePath "C:\Path\To\Csv\CsvFile.csv" --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl "/sites/project-x/lists/Demo List"
+```
+
+## Remarks
+
+A sample CSV can be found below. The first line of the CSV-file should contain the internal column names that you wish to set.
+
+```csv
+ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField
+Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",5
+```
+
+## Response
+
+The command won't return a response on success.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -461,6 +461,7 @@ nav:
       - listitem:
         - listitem add: cmd/spo/listitem/listitem-add.md
         - listitem attachment list: cmd/spo/listitem/listitem-attachment-list.md
+        - listitem batch add: cmd/spo/listitem/listitem-batch-add.md
         - listitem get: cmd/spo/listitem/listitem-get.md
         - listitem isrecord: cmd/spo/listitem/listitem-isrecord.md
         - listitem list: cmd/spo/listitem/listitem-list.md

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -135,6 +135,7 @@ export default {
   LIST_WEBHOOK_SET: `${prefix} list webhook set`,
   LISTITEM_ADD: `${prefix} listitem add`,
   LISTITEM_ATTACHMENT_LIST: `${prefix} listitem attachment list`,
+  LISTITEM_BATCH_ADD: `${prefix} listitem batch add`,
   LISTITEM_GET: `${prefix} listitem get`,
   LISTITEM_ISRECORD: `${prefix} listitem isrecord`,
   LISTITEM_LIST: `${prefix} listitem list`,

--- a/src/m365/spo/commands/listitem/listitem-batch-add.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-add.spec.ts
@@ -1,0 +1,156 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { pid } from '../../../../utils/pid';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import request from '../../../../request';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import Command, { CommandError } from '../../../../Command';
+import commands from '../../commands';
+import { Logger } from '../../../../cli/Logger';
+const command: Command = require('./listitem-batch-add');
+
+describe(commands.LISTITEM_BATCH_ADD, () => {
+  const filePath = 'C:\\Path\\To\\CSV\\CsvFile.csv';
+  const webUrl = 'https://contoso.sharepoint.com/sites/project-x';
+  const listId = 'f2978459-4e2a-4307-b57c-0c90eb4e5d6a';
+  const listTitle = 'Random List';
+  const listUrl = '/sites/project-x/lists/random-list';
+  const csvContentHeaders = `ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField`;
+  const csvContentLine = `Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",5`;
+  const csvContent = `${csvContentHeaders}\n${csvContentLine}`;
+
+  let commandInfo: CommandInfo;
+  let log: any[];
+  let logger: Logger;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.post,
+      fs.existsSync,
+      fs.readFileSync
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent,
+      pid.getProcessName
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.LISTITEM_BATCH_ADD);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('adds items in batch to a sharepoint list retrieved by id', async () => {
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, verbose: true } } as any);
+  });
+
+  it('adds items in batch to a sharepoint list retrieved by title', async () => {
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listTitle: listTitle, verbose: true } } as any);
+  });
+
+  it('adds 150 items in batch to a sharepoint list retrieved by url', async () => {
+    let csvContent150Items = csvContent;
+    for (let i = 1; i < 150; i++) {
+      csvContent150Items += `\n${csvContentLine}`;
+    }
+    let amountOfRequestsInBody = 0;
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent150Items);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        amountOfRequestsInBody += opts.data.match(/POST/g).length;
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, verbose: true } } as any);
+    assert.strictEqual(amountOfRequestsInBody, 150);
+  });
+
+  it('throws an error when batch api URL fails', async () => {
+    const errorMessage = 'SharePoint REST Service Exception';
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        throw errorMessage;
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, verbose: true } } as any), new CommandError(errorMessage));
+  });
+
+  it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'foo', filePath: filePath, listId: listId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if listId option is not a valid GUID', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: 'foo' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if csv file does not exist', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(_ => false);
+    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: listId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if filePath exists and listId is a valid guid', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: listId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+});

--- a/src/m365/spo/commands/listitem/listitem-batch-add.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-add.ts
@@ -1,0 +1,223 @@
+import { AxiosRequestConfig } from 'axios';
+import * as fs from 'fs';
+import { Logger } from '../../../../cli/Logger';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import { v4 } from 'uuid';
+import { formatting } from '../../../../utils/formatting';
+import { urlUtil } from '../../../../utils/urlUtil';
+import { validation } from '../../../../utils/validation';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  filePath: string;
+  webUrl: string;
+  listId?: string;
+  listTitle?: string;
+  listUrl?: string;
+}
+
+interface FormValues {
+  FieldName: string;
+  FieldValue: string;
+}
+
+class SpoListItemBatchAddCommand extends SpoCommand {
+  public allowUnknownOptions(): boolean | undefined {
+    return true;
+  }
+
+  public get name(): string {
+    return commands.LISTITEM_BATCH_ADD;
+  }
+
+  public get description(): string {
+    return 'Creates list items in a batch';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initTypes();
+    this.#initOptionSets();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        listId: typeof args.options.listId !== 'undefined',
+        listTitle: typeof args.options.listTitle !== 'undefined',
+        listUrl: typeof args.options.listUrl !== 'undefined'
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-p, --filePath <filePath>'
+      },
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-l, --listId [listId]'
+      },
+      {
+        option: '-t, --listTitle [listTitle]'
+      },
+      {
+        option: '--listUrl [listUrl]'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+        if (isValidSharePointUrl !== true) {
+          return isValidSharePointUrl;
+        }
+
+        if (args.options.listId &&
+          !validation.isValidGuid(args.options.listId)) {
+          return `${args.options.listId} in option listId is not a valid GUID`;
+        }
+
+        if (!fs.existsSync(args.options.filePath)) {
+          return `File with path ${args.options.filePath} does not exist`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  #initTypes(): void {
+    this.types.string.push(
+      'webUrl',
+      'filePath',
+      'listId',
+      'listTitle',
+      'listUrl'
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push(['listId', 'listTitle', 'listUrl']);
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      if (this.verbose) {
+        logger.logToStderr(`Starting to create batch items from csv at path ${args.options.filePath}`);
+      }
+      const csvContent = fs.readFileSync(args.options.filePath, 'utf8');
+      const jsonContent = formatting.parseCsvToJson(csvContent);
+      await this.addItemsAsBatch(jsonContent, args.options, logger);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+
+  private async addItemsAsBatch(rows: any[], options: Options, logger: Logger): Promise<void> {
+    const requestUrl = this.getRequestUrl(options);
+    let itemsToAdd: FormValues[][] = [];
+
+    for await (const [index, row] of rows.entries()) {
+      itemsToAdd.push(this.getSingleItemRequestBody(row));
+      if (itemsToAdd.length === 100) {
+        if (this.verbose) {
+          logger.logToStderr(`Writing away batch of items, currently at: ${index + 1}/${rows.length}.`);
+        }
+        await this.postBatchData(itemsToAdd, options.webUrl, requestUrl);
+        itemsToAdd = [];
+      }
+    }
+    if (itemsToAdd.length) {
+      if (this.verbose) {
+        logger.logToStderr(`Writing away ${itemsToAdd.length} items.`);
+      }
+      await this.postBatchData(itemsToAdd, options.webUrl, requestUrl);
+    }
+  }
+
+  private async postBatchData(itemsToAdd: FormValues[][], webUrl: string, requestUrl: string): Promise<void> {
+    const batchId = v4();
+    const requestBody = this.parseBatchRequestBody(itemsToAdd, batchId, requestUrl);
+    const requestOptions: AxiosRequestConfig = {
+      url: `${webUrl}/_api/$batch`,
+      headers: {
+        'Content-Type': `multipart/mixed; boundary=batch_${batchId}`,
+        'Accept': 'application/json;odata=verbose'
+      },
+      data: requestBody.join('')
+    };
+    await request.post(requestOptions);
+  }
+
+  private parseBatchRequestBody(items: FormValues[][], batchId: string, requestUrl: string): string[] {
+    const changeSetId = v4();
+    const batchBody: string[] = [];
+
+    // add default batch body headers
+    batchBody.push(`--batch_${batchId}\n`);
+    batchBody.push(`Content-Type: multipart/mixed; boundary="changeset_${changeSetId}"\n\n`);
+    batchBody.push('Content-Transfer-Encoding: binary\n\n');
+
+    items.forEach((item) => {
+      batchBody.push(`--changeset_${changeSetId}\n`);
+      batchBody.push('Content-Type: application/http\n');
+      batchBody.push('Content-Transfer-Encoding: binary\n\n');
+      batchBody.push(`POST ${requestUrl} HTTP/1.1\n`);
+      batchBody.push(`Accept: application/json;odata=nometadata\n`);
+      batchBody.push(`Content-Type: application/json;odata=verbose\n`);
+      batchBody.push(`If-Match: *\n\n`);
+      batchBody.push(`{\n"formValues": ${JSON.stringify(item)}\n}`);
+    });
+
+    // close batch body
+    batchBody.push(`\n\n`);
+    batchBody.push(`--changeset_${changeSetId}--\n\n`);
+    batchBody.push(`--batch_${batchId}--\n`);
+
+    return batchBody;
+  }
+
+  private getSingleItemRequestBody(row: any): FormValues[] {
+    const requestBody: FormValues[] = [];
+    Object.keys(row).forEach(key => {
+      // have to do 'toString()' or the API will complain when entering a numeric field
+      requestBody.push({ FieldName: key, FieldValue: (<any>row)[key].toString() });
+    });
+    return requestBody;
+  }
+
+  private getRequestUrl(options: Options): string {
+    let listUrl = `${options.webUrl}/_api/web`;
+    if (options.listId) {
+      listUrl += `/lists(guid'${formatting.encodeQueryParameter(options.listId)}')`;
+    }
+    else if (options.listTitle) {
+      listUrl += `/lists/getByTitle('${formatting.encodeQueryParameter(options.listTitle)}')`;
+    }
+    else if (options.listUrl) {
+      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(options.webUrl, options.listUrl);
+      listUrl += `/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
+    }
+
+    return `${listUrl}/AddValidateUpdateItemUsingPath`;
+  }
+}
+
+module.exports = new SpoListItemBatchAddCommand();

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -42,23 +42,24 @@ export const formatting = {
       }, {});
   },
 
-  parseCsvToJson(s: string): any {
-    const rows: string[] = s.split('\n');
-    const jsonObj: any = [];
-    const headers: string[] = rows[0].split(',');
+  parseCsvToJson(s: string, quoteChar: string = '"', delimiter: string = ','): any {
+    const regex = new RegExp(`\\s*(${quoteChar})?(.*?)\\1\\s*(?:${delimiter}|$)`, 'gs');
+    const lines: string[] = s.split('\n');
 
-    for (let i = 1; i < rows.length; i++) {
-      const data: string[] = rows[i].split(',');
-      const obj: any = {};
-      for (let j = 0; j < data.length; j++) {
-        const value = data[j].trim();
-        const numValue = parseInt(value);
-        obj[headers[j].trim()] = isNaN(numValue) || numValue.toString() !== value ? value : numValue;
-      }
-      jsonObj.push(obj);
-    }
+    const match = (line: string): string[] => [...line.matchAll(regex)]
+      .map(m => m[2])  // we only want the second capture group
+      .slice(0, -1);   // cut off blank match at the end
 
-    return jsonObj;
+    const heads = match(lines[0]);
+
+    return lines.slice(1).map(line => {
+      return match(line).reduce((acc, cur, i) => {
+        const val = cur;
+        const numValue = parseInt(val);
+        const key = heads[i];
+        return { ...acc, [key]: isNaN(numValue) || numValue.toString() !== val ? val : numValue };
+      }, {});
+    });
   },
 
   encodeQueryParameter(value: string): string {


### PR DESCRIPTION
Closes #2029 

I've added a sample-csv to the remarks section of the docs file. In the listitem-add command, all the different field types are explained in an example, but that seems like a bit weird in this case.

I also reworked `formatting.parseCsvToJson` to keep track of double quotes in the values. This is required for when we use a ',' in a value in the CSV, for example for setting a hyperlink value `https://bing.com, URL`, we specify a comma in the value as this is required, so in the CSV, we should put double quotes around the value.
