### PR TITLE
Added template option value for page promotion

### DIFF
--- a/docs/docs/cmd/spo/page/page-add.md
+++ b/docs/docs/cmd/spo/page/page-add.md
@@ -20,10 +20,10 @@ m365 spo page add [options]
 : Title of the page to create. If not specified, will use the page name as its title
 
 `-l, --layoutType [layoutType]`
-: Layout of the page. Allowed values `Article`, `Home`, `SingleWebPartAppPage`, `RepostPage`,`HeaderlessSearchResults`, `Spaces`, `Topic`. Default `Article`
+: Layout of the page. Allowed values `Article`, `Home`, `SingleWebPartAppPage`, `RepostPage`, `HeaderlessSearchResults`, `Spaces`, `Topic`. Default `Article`
 
 `-p, --promoteAs [promoteAs]`
-: Create the page for a specific purpose. Allowed values `HomePage`, `NewsPage`
+: Create the page for a specific purpose. Allowed values `HomePage`, `NewsPage`, `Template`
 
 `--commentsEnabled`
 : Set to enable comments on the page

--- a/docs/docs/cmd/spo/page/page-set.md
+++ b/docs/docs/cmd/spo/page/page-set.md
@@ -17,10 +17,10 @@ m365 spo page set [options]
 : URL of the site where the page to update is located
 
 `-l, --layoutType [layoutType]`
-: Layout of the page. Allowed values `Article`, `Home`, `SingleWebPartAppPage`, `RepostPage`,`HeaderlessSearchResults`, `Spaces`, `Topic`
+: Layout of the page. Allowed values `Article`, `Home`, `SingleWebPartAppPage`, `RepostPage`, `HeaderlessSearchResults`, `Spaces`, `Topic`
 
 `-p, --promoteAs [promoteAs]`
-: Update the page purpose. Allowed values `HomePage`, `NewsPage`
+: Update the page purpose. Allowed values `HomePage`, `NewsPage`, `Template`
 
 `--commentsEnabled [commentsEnabled]`
 : Set to `true`, to enable comments on the page. Allowed values `true`, `false`


### PR DESCRIPTION
Not related to an issue.

Added a missing option value to the docs. For the SPO page commands `add` and `set` there are three different promotion values but the docs only mentioned two of them. 