### PR TITLE
Updates 'spo contenttype set' with a flag to push updates to child content types. Closes #3792

### DIFF
--- a/docs/docs/cmd/spo/contenttype/contenttype-set.md
+++ b/docs/docs/cmd/spo/contenttype/contenttype-set.md
@@ -1,6 +1,6 @@
 # spo contenttype set
 
-Update existing content type
+Update an existing content type
 
 ## Usage
 
@@ -28,7 +28,15 @@ m365 spo contenttype set [options]
 `--listUrl [listUrl]`
 : URL of the list if you want to update a list content type. Specify either `listTitle`, `listId` or `listUrl`.
 
+`--updateChildren`
+: Specify if you want to push updates to child content types.
+
 --8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+!!! important "Updating child content types"
+    When specifying the `--updateChildren` flag, SharePoint will only propagate the changes that are made in the current request. If you want to know more about updating a content type and propagating changes to child content types, be sure to [read more here](https://learn.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ms442695(v=office.14)#considerations-when-updating-child-content-types). 
 
 ## Examples
 
@@ -42,4 +50,10 @@ Rename list content type
 
 ```sh
 m365 spo contenttype set --name "My old item" --webUrl https://contoso.sharepoint.com --listTitle "My list" --Name "My item"
+```
+
+Configure a form customizer with manifest ID _19890cce-15d8-4af9-bfcb-72da06d13ed8_ on a site content type and push changes to child content types.
+
+```sh
+m365 spo contenttype set --name "My content type" --webUrl https://contoso.sharepoint.com --DisplayFormClientSideComponentId "19890cce-15d8-4af9-bfcb-72da06d13ed8" --EditFormClientSideComponentId "19890cce-15d8-4af9-bfcb-72da06d13ed8" --NewFormClientSideComponentId "19890cce-15d8-4af9-bfcb-72da06d13ed8" --updateChildren
 ```

--- a/src/m365/spo/commands/contenttype/contenttype-set.spec.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-set.spec.ts
@@ -6,6 +6,7 @@ import { Cli } from '../../../../cli/Cli';
 import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
+import config from '../../../../config';
 import request from '../../../../request';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
@@ -15,6 +16,8 @@ const command: Command = require('./contenttype-set');
 
 describe(commands.CONTENTTYPE_SET, () => {
   const webUrl = 'https://contoso.sharepoint.com';
+  const siteId = 'c119e182-eabc-4454-8f1e-6b39551586a7';
+  const webId = '5d50a096-7973-4838-85bd-ead8e9a75f2f';
   const listId = '00000000-0000-0000-0000-000000000000';
   const listTitle = 'Assets';
   const listUrl = '/sites/project-x/Lists/Assets';
@@ -36,6 +39,7 @@ describe(commands.CONTENTTYPE_SET, () => {
 
   let log: any[];
   let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -59,12 +63,13 @@ describe(commands.CONTENTTYPE_SET, () => {
         log.push(msg);
       }
     };
+    loggerLogSpy = sinon.spy(logger, 'log');
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.patch
+      request.post
     ]);
   });
 
@@ -136,66 +141,235 @@ describe(commands.CONTENTTYPE_SET, () => {
   });
 
   it('correctly updates content type with id', async () => {
-    const patchStub = sinon.stub(request, 'patch').callsFake(() => Promise.resolve());
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
+        return Promise.resolve({ Id: siteId });
+      }
+      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
+        return Promise.resolve({ Id: webId });
+      }
+
+      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return Promise.resolve(`[
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.7911.1206",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
+          }
+        ]`);
+      }
+
+      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+    });
 
     await command.action(logger, { options: { webUrl: webUrl, id: id, Name: newName } } as any);
-    assert.strictEqual(patchStub.lastCall.args[0].url, `${webUrl}/_api/Web/ContentTypes/GetById('${id}')`);
+    assert(loggerLogSpy.notCalled);
   });
 
   it('correctly updates content type with name', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `${webUrl}/_api/Web/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
+      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
+        return Promise.resolve({ Id: siteId });
+      }
+      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
+        return Promise.resolve({ Id: webId });
+      }
+      else if (opts.url === `${webUrl}/_api/Web/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
         return Promise.resolve(contentTypesResponse);
       }
 
-      return Promise.reject('Invalid request url: ' + opts.url);
+      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
     });
-    const patchStub = sinon.stub(request, 'patch').callsFake(() => Promise.resolve());
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return Promise.resolve(`[
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.7911.1206",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
+          }
+        ]`);
+      }
+
+      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+    });
 
     await command.action(logger, { options: { webUrl: webUrl, name: name, Name: newName } } as any);
-    assert.strictEqual(patchStub.lastCall.args[0].url, `${webUrl}/_api/Web/ContentTypes/GetById('${contentTypesResponse.value[0].Id.StringValue}')`);
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('correctly updates content type with name (Debug)', async () => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
+        return Promise.resolve({ Id: siteId });
+      }
+      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
+        return Promise.resolve({ Id: webId });
+      }
+      else if (opts.url === `${webUrl}/_api/Web/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
+        return Promise.resolve(contentTypesResponse);
+      }
+
+      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return Promise.resolve(`[
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.7911.1206",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
+          }
+        ]`);
+      }
+
+      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, name: name, Name: newName, debug: true } } as any);
+    assert(loggerLogSpy.notCalled);
   });
 
   it('correctly updates content type with name and listId', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `${webUrl}/_api/Web/Lists/GetById('${formatting.encodeQueryParameter(listId)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
+      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
+        return Promise.resolve({ Id: siteId });
+      }
+      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
+        return Promise.resolve({ Id: webId });
+      }
+      else if (opts.url === `${webUrl}/_api/Web/Lists/GetById('${formatting.encodeQueryParameter(listId)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
         return Promise.resolve(contentTypesResponse);
       }
 
-      return Promise.reject('Invalid request url: ' + opts.url);
+      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
     });
-    const patchStub = sinon.stub(request, 'patch').callsFake(() => Promise.resolve());
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return Promise.resolve(`[
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.7911.1206",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
+          }
+        ]`);
+      }
+
+      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+    });
 
     await command.action(logger, { options: { webUrl: webUrl, name: name, listId: listId, Name: newName } } as any);
-    assert.strictEqual(patchStub.lastCall.args[0].url, `${webUrl}/_api/Web/Lists/GetById('${formatting.encodeQueryParameter(listId)}')/ContentTypes/GetById('${contentTypesResponse.value[0].Id.StringValue}')`);
+    assert(loggerLogSpy.notCalled);
   });
 
   it('correctly updates content type with name and listTitle', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `${webUrl}/_api/Web/Lists/GetByTitle('${formatting.encodeQueryParameter(listTitle)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
+      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
+        return Promise.resolve({ Id: siteId });
+      }
+      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
+        return Promise.resolve({ Id: webId });
+      }
+      else if (opts.url === `${webUrl}/_api/Web/Lists/GetByTitle('${formatting.encodeQueryParameter(listTitle)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
         return Promise.resolve(contentTypesResponse);
       }
 
-      return Promise.reject('Invalid request url: ' + opts.url);
+      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
     });
-    const patchStub = sinon.stub(request, 'patch').callsFake(() => Promise.resolve());
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return Promise.resolve(`[
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.7911.1206",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
+          }
+        ]`);
+      }
+
+      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+    });
 
     await command.action(logger, { options: { webUrl: webUrl, name: name, listTitle: listTitle, Name: newName } } as any);
-    assert.strictEqual(patchStub.lastCall.args[0].url, `${webUrl}/_api/Web/Lists/GetByTitle('${formatting.encodeQueryParameter(listTitle)}')/ContentTypes/GetById('${contentTypesResponse.value[0].Id.StringValue}')`);
+    assert(loggerLogSpy.notCalled);
   });
 
   it('correctly updates content type with name and listUrl', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `${webUrl}/_api/Web/GetList('${formatting.encodeQueryParameter(listUrl)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
+      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
+        return Promise.resolve({ Id: siteId });
+      }
+      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
+        return Promise.resolve({ Id: webId });
+      }
+      else if (opts.url === `${webUrl}/_api/Web/GetList('${formatting.encodeQueryParameter(listUrl)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
         return Promise.resolve(contentTypesResponse);
       }
 
-      return Promise.reject('Invalid request url: ' + opts.url);
+      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
     });
-    const patchStub = sinon.stub(request, 'patch').callsFake(() => Promise.resolve());
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return Promise.resolve(`[
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.7911.1206",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
+          }
+        ]`);
+      }
+
+      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+    });
 
     await command.action(logger, { options: { webUrl: webUrl, name: name, listUrl: listUrl, Name: newName } } as any);
-    assert.strictEqual(patchStub.lastCall.args[0].url, `${webUrl}/_api/Web/GetList('${formatting.encodeQueryParameter(listUrl)}')/ContentTypes/GetById('${contentTypesResponse.value[0].Id.StringValue}')`);
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('correctly updates content type with id and pushing changes to children', async () => {
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
+        return Promise.resolve({ Id: siteId });
+      }
+      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
+        return Promise.resolve({ Id: webId });
+      }
+
+      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty><Method Name="Update" Id="13" ObjectPathId="9"><Parameters><Parameter Type="Boolean">true</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return Promise.resolve(`[
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.7911.1206",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
+          }
+        ]`);
+      }
+
+      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, id: id, Name: newName, updateChildren: true } } as any);
+    assert(loggerLogSpy.notCalled);
   });
 
   it('fails to update content type with name and listUrl when content type does not exist', async () => {
@@ -213,9 +387,36 @@ describe(commands.CONTENTTYPE_SET, () => {
   });
 
   it('correctly handles random API error', async () => {
-    sinon.stub(request, 'patch').callsFake(() => Promise.reject('An error has occurred'));
+    sinon.stub(request, 'get').callsFake(opts => {
+      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
+        return Promise.resolve({ Id: siteId });
+      }
+      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
+        return Promise.resolve({ Id: webId });
+      }
 
-    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, id: id, Name: newName } } as any), new CommandError('An error has occurred'));
+      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+    });
+    sinon.stub(request, 'post').callsFake(opts => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        //&& opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="CLI for Microsoft 365 v6.0.0" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${id}" /></ObjectPaths></Request>`) {
+        return Promise.resolve(`[
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.7911.1206",
+            "ErrorInfo": {
+              "ErrorMessage": "Unknown Error", "ErrorValue": null, "TraceCorrelationId": "b33c489e-009b-5000-8240-a8c28e5fd8b4", "ErrorCode": -1, "ErrorTypeName": "Microsoft.SharePoint.Client.UnknownError"
+            },
+            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
+          }
+        ]`);
+      }
+
+      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, id: id, Name: newName } } as any), new CommandError('Unknown Error'));
   });
 
   it('supports debug mode', () => {


### PR DESCRIPTION
Closes #3792

Updates 'spo contenttype set' with a flag to push updates to child content types. 

To get this functionality implemented I had to change the update request to use the older `client.svc/ProcessQuery` API.