### PR TITLE
Extend `teams cache remove` to check on Teams PID

### DIFF
--- a/src/m365/teams/commands/cache/cache-remove.spec.ts
+++ b/src/m365/teams/commands/cache/cache-remove.spec.ts
@@ -7,13 +7,16 @@ import { Cli } from '../../../../cli/Cli';
 import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
-import request from '../../../../request';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
 const command: Command = require('./cache-remove');
 
 describe(commands.CACHE_REMOVE, () => {
+  const processOutput = `ProcessId
+  6456
+  14196
+  11352`;
   let log: string[];
   let logger: Logger;
   let promptOptions: any;
@@ -134,7 +137,7 @@ describe(commands.CACHE_REMOVE, () => {
     sinon.stub(fs, 'existsSync').callsFake(() => true);
     const error = new Error('random error');
     sinon.stub(command, 'exec' as any).callsFake(async (opts) => {
-      if (opts === 'taskkill /IM "Teams.exe" /F') {
+      if (opts === 'wmic process where caption="Teams.exe" get ProcessId') {
         throw error;
       }
       throw 'Invalid request';
@@ -145,12 +148,12 @@ describe(commands.CACHE_REMOVE, () => {
   it('fails to remove teams cache when exec fails randomly when removing cache folder', async () => {
     sinon.stub(process, 'platform').value('win32');
     sinon.stub(process, 'env').value({ 'CLIMICROSOFT365_ENV': '', APPDATA: 'C:\\Users\\Administrator\\AppData\\Roaming' });
-
+    sinon.stub(process, 'kill' as any).returns(null);
     sinon.stub(fs, 'existsSync').callsFake(() => true);
     const error = new Error('random error');
     sinon.stub(command, 'exec' as any).callsFake(async (opts) => {
-      if (opts === 'taskkill /IM "Teams.exe" /F') {
-        return { stdout: '' };
+      if (opts === 'wmic process where caption="Teams.exe" get ProcessId') {
+        return { stdout: processOutput };
       }
       if (opts === 'rmdir /s /q "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Teams"') {
         throw error;
@@ -179,19 +182,17 @@ describe(commands.CACHE_REMOVE, () => {
   it('removes teams cache when teams is currently not active', async () => {
     sinon.stub(process, 'platform').value('win32');
     sinon.stub(process, 'env').value({ 'CLIMICROSOFT365_ENV': '', APPDATA: 'C:\\Users\\Administrator\\AppData\\Roaming' });
-
-    sinon.stub(fs, 'existsSync').callsFake(() => true);
-    const error = new Error('ERROR: The process "Teams.exe" not found.');
     sinon.stub(process, 'kill' as any).returns(null);
     sinon.stub(command, 'exec' as any).callsFake(async (opts) => {
-      if (opts === 'taskkill /IM "Teams.exe" /F') {
-        throw error;
+      if (opts === 'wmic process where caption="Teams.exe" get ProcessId') {
+        return { stdout: 'No Instance(s) Available.' };
       }
       if (opts === 'rmdir /s /q "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Teams"') {
         return;
       }
       throw 'Invalid request';
     });
+    sinon.stub(fs, 'existsSync').callsFake(() => true);
 
     await command.action(logger, {
       options: {
@@ -204,10 +205,18 @@ describe(commands.CACHE_REMOVE, () => {
 
   it('removes Teams cache from win32 platform without prompting.', async () => {
     sinon.stub(process, 'platform').value('win32');
-    sinon.stub(process, 'env').value({ 'CLIMICROSOFT365_ENV': '' });
-    sinon.stub(command, 'exec' as any).returns({ stdout: '' });
+    sinon.stub(process, 'env').value({ 'CLIMICROSOFT365_ENV': '', APPDATA: 'C:\\Users\\Administrator\\AppData\\Roaming' });
+    sinon.stub(process, 'kill' as any).returns(null);
+    sinon.stub(command, 'exec' as any).callsFake(async (opts) => {
+      if (opts === 'wmic process where caption="Teams.exe" get ProcessId') {
+        return { stdout: processOutput };
+      }
+      if (opts === 'rmdir /s /q "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Teams"') {
+        return;
+      }
+      throw 'Invalid request';
+    });
     sinon.stub(fs, 'existsSync').callsFake(() => true);
-
     await command.action(logger, {
       options: {
         confirm: true,
@@ -236,7 +245,6 @@ describe(commands.CACHE_REMOVE, () => {
     sinon.stub(process, 'platform').value('darwin');
     sinon.stub(process, 'env').value({ 'CLIMICROSOFT365_ENV': '' });
     sinon.stub(fs, 'existsSync').callsFake(() => false);
-
     await command.action(logger, {
       options: {
         verbose: true
@@ -245,17 +253,17 @@ describe(commands.CACHE_REMOVE, () => {
   });
 
   it('aborts cache clearing from Teams when prompt not confirmed', async () => {
+    const execStub = sinon.stub(command, 'exec' as any);
     sinon.stub(process, 'platform').value('darwin');
     sinon.stub(process, 'env').value({ 'CLIMICROSOFT365_ENV': '' });
 
-    const postSpy = sinon.spy(request, 'delete');
     sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinon.stub(Cli, 'prompt').callsFake(async () => {
+      return { continue: false };
+    });
 
     await command.action(logger, { options: {} });
-    assert(postSpy.notCalled);
+    assert(execStub.notCalled);
   });
 
 


### PR DESCRIPTION
Closes #3448 

I've also removed the try catch statements around every specific method as they were pretty pointless in my opinion and changed the error method from `handleRejectedODataJsonPromise` to a regular `handleError` as we aren't doing any OData calls in the command. 