### PR TITLE
Extend `aad user set` with capabilities to change or reset a password

### DIFF
--- a/docs/docs/cmd/aad/user/user-set.md
+++ b/docs/docs/cmd/aad/user/user-set.md
@@ -11,13 +11,25 @@ m365 aad user set [options]
 ## Options
 
 `-i, --objectId [objectId]`
-: The object ID of the user to update. Specify `objectId` or `userPrincipalName` but not both
+: The object ID of the user to update. Specify `objectId` or `userPrincipalName` but not both.
 
 `-n, --userPrincipalName [userPrincipalName]`
-: User principal name of the user to update. Specify `objectId` or `userPrincipalName` but not both
+: User principal name of the user to update. Specify `objectId` or `userPrincipalName` but not both.
 
 `--accountEnabled [accountEnabled]`
-: Boolean value specifying whether the account is enabled. Valid values are `true,false`
+: Boolean value specifying whether the account is enabled. Valid values are `true` or `false`.
+
+`--resetPassword`
+: If specified, the password of the user will be reset. This will make the parameter `newPassword` required.
+
+`--forceChangePasswordNextSignIn`
+: If specified, the user will have to change his password the next time they log in. Can only be set in combination with `resetPassword`.
+
+`--currentPassword [currentPassword]`
+: Current password of the user that is signed in. If this parameter is set, `newPassword` is mandatory. Can't be combined with `resetPassword`.
+
+`--newPassword [newPassword]`
+: New password to be set. Must be set when specifying either `resetPassword` or `currentPassword`.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -58,3 +70,19 @@ Enable user with id _1caf7dcd-7e83-4c3a-94f7-932a1299c844_
 ```sh
 m365 aad user set --objectId 1caf7dcd-7e83-4c3a-94f7-932a1299c844 --accountEnabled true
 ```
+
+Reset password of a given user by userPrincipalName and require the user to change his password the next time he logs in
+
+```sh
+m365 aad user set --userPrincipalName steve@contoso.onmicrosoft.com --resetPassword --password 6NLUId79Lc24 --forceChangePasswordNextSignIn
+```
+
+Change password of currently logged in user
+
+```sh
+m365 aad user set --objectId 1caf7dcd-7e83-4c3a-94f7-932a1299c844 --currentPassword SLBF5gnRtyYc --newPassword 6NLUId79Lc24
+```
+
+### Response
+
+The command won't return a response on success.

--- a/src/m365/aad/commands/user/user-get.spec.ts
+++ b/src/m365/aad/commands/user/user-get.spec.ts
@@ -29,6 +29,12 @@ describe(commands.USER_GET, () => {
     sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
     auth.service.connected = true;
+    if (!auth.service.accessTokens[auth.defaultResource]) {
+      auth.service.accessTokens[auth.defaultResource] = {
+        expiresOn: '123',
+        accessToken: 'abc'
+      };
+    }
     commandInfo = Cli.getCommandInfo(command);
   });
 
@@ -51,7 +57,9 @@ describe(commands.USER_GET, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get
+      request.get,
+      accessToken.getUserIdFromAccessToken,
+      accessToken.getUserNameFromAccessToken
     ]);
   });
 
@@ -95,13 +103,6 @@ describe(commands.USER_GET, () => {
     });
 
     sinon.stub(accessToken, 'getUserIdFromAccessToken').callsFake(() => { return userId; });
-    auth.service.connected = true;
-    if (!auth.service.accessTokens[auth.defaultResource]) {
-      auth.service.accessTokens[auth.defaultResource] = {
-        expiresOn: '123',
-        accessToken: 'abc'
-      };
-    }
 
     await command.action(logger, { options: { id: '@meid' } });
     assert(loggerLogSpy.calledWith(resultValue));
@@ -143,13 +144,6 @@ describe(commands.USER_GET, () => {
     });
 
     sinon.stub(accessToken, 'getUserNameFromAccessToken').callsFake(() => { return userName; });
-    auth.service.connected = true;
-    if (!auth.service.accessTokens[auth.defaultResource]) {
-      auth.service.accessTokens[auth.defaultResource] = {
-        expiresOn: '123',
-        accessToken: 'abc'
-      };
-    }
 
     await command.action(logger, { options: { userName: '@meusername' } });
     assert(loggerLogSpy.calledWith(resultValue));

--- a/src/m365/aad/commands/user/user-set.spec.ts
+++ b/src/m365/aad/commands/user/user-set.spec.ts
@@ -9,10 +9,16 @@ import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
+import { accessToken } from '../../../../utils/accessToken';
 import commands from '../../commands';
+import { formatting } from '../../../../utils/formatting';
 const command: Command = require('./user-set');
 
 describe(commands.USER_SET, () => {
+  const currentPassword = '9%9OLUg6p@Ra';
+  const newPassword = 'iO$99OVj386i';
+  const objectId = '1caf7dcd-7e83-4c3a-94f7-932a1299c844';
+  const userPrincipalName = 'steve@contoso.onmicrosoft.com';
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -23,6 +29,12 @@ describe(commands.USER_SET, () => {
     sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
     auth.service.connected = true;
+    if (!auth.service.accessTokens[auth.defaultResource]) {
+      auth.service.accessTokens[auth.defaultResource] = {
+        expiresOn: '123',
+        accessToken: 'abc'
+      };
+    }
     commandInfo = Cli.getCommandInfo(command);
   });
 
@@ -45,7 +57,10 @@ describe(commands.USER_SET, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.patch
+      request.patch,
+      request.post,
+      accessToken.getUserNameFromAccessToken,
+      accessToken.getUserIdFromAccessToken
     ]);
   });
 
@@ -72,7 +87,7 @@ describe(commands.USER_SET, () => {
   });
 
   it('fails validation if both the objectId and the userPrincipalName are specified', async () => {
-    const actual = await command.validate({ options: { objectId: '1caf7dcd-7e83-4c3a-94f7-932a1299c844', userPrincipalName: 'steve@contoso.onmicrosoft.com' } }, commandInfo);
+    const actual = await command.validate({ options: { objectId: objectId, userPrincipalName: userPrincipalName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
@@ -81,8 +96,33 @@ describe(commands.USER_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if currentPassword is set without newPassword', async () => {
+    const actual = await command.validate({ options: { objectId: objectId, currentPassword: currentPassword } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if newPassword is set without currentPassword', async () => {
+    const actual = await command.validate({ options: { objectId: objectId, newPassword: newPassword } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if resetPassword is set without a password', async () => {
+    const actual = await command.validate({ options: { objectId: objectId, resetPassword: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if resetPassword and password is set and currentPassword is also set', async () => {
+    const actual = await command.validate({ options: { objectId: objectId, resetPassword: true, password: newPassword, currentPassword: currentPassword } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if resetPassword and password is set and newPassword is also set', async () => {
+    const actual = await command.validate({ options: { objectId: objectId, resetPassword: true, password: newPassword, newPassword: newPassword } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('passes validation if the objectId is a valid GUID', async () => {
-    const actual = await command.validate({ options: { objectId: '1caf7dcd-7e83-4c3a-94f7-932a1299c844' } }, commandInfo);
+    const actual = await command.validate({ options: { objectId: objectId } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
@@ -91,9 +131,21 @@ describe(commands.USER_SET, () => {
     assert.strictEqual(allowUnknownOptions, true);
   });
 
+  it('throws error when objectId is not equal to current signed in objectId in Cli when passing both the options currentPassword and newPassword', async () => {
+    sinon.stub(accessToken, 'getUserIdFromAccessToken').callsFake(() => { return '7c47b08e-e7b3-427a-9eba-b679815148e9'; });
+    await assert.rejects(command.action(logger, { options: { verbose: true, debug: false, objectId: objectId, newPassword: newPassword, currentPassword: currentPassword } } as any),
+      new CommandError(`You can only change your own password. Please use --objectId @meId to reference to your own userId`));
+  });
+
+  it('throws error when userPrincipalName is not equal to current signed in userPrincipalName in Cli when passing both the options currentPassword and newPassword', async () => {
+    sinon.stub(accessToken, 'getUserNameFromAccessToken').callsFake(() => { return 'john@contoso.com'; });
+    await assert.rejects(command.action(logger, { options: { verbose: true, debug: false, userPrincipalName: userPrincipalName, newPassword: newPassword, currentPassword: currentPassword } } as any),
+      new CommandError(`You can only change your own password. Please use --userPrincipalName @meUserName to reference to your own userPrincipalName`));
+  });
+
   it('correctly handles user or property not found', async () => {
-    sinon.stub(request, 'patch').callsFake(() => {
-      return Promise.reject({
+    sinon.stub(request, 'patch').callsFake(async () => {
+      throw {
         "error": {
           "code": "Request_ResourceNotFound",
           "message": "Resource '1caf7dcd-7e83-4c3a-94f7-932a1299c844' does not exist or one of its queried reference-property objects are not present.",
@@ -102,24 +154,26 @@ describe(commands.USER_SET, () => {
             "date": "2018-04-24T18:56:48"
           }
         }
-      });
+      };
     });
 
-    await assert.rejects(command.action(logger, { options: { objectId: '1caf7dcd-7e83-4c3a-94f7-932a1299c844', NonExistingProperty: 'Value' } } as any),
+    await assert.rejects(command.action(logger, { options: { verbose: true, objectId: objectId, NonExistingProperty: 'Value' } } as any),
       new CommandError(`Resource '1caf7dcd-7e83-4c3a-94f7-932a1299c844' does not exist or one of its queried reference-property objects are not present.`));
   });
 
   it('correctly updates information about the specified user', async () => {
-    sinon.stub(request, 'patch').callsFake((opts) => {
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/v1.0/users/`) > -1) {
-        return Promise.resolve({});
+        return;
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, {
       options: {
-        objectId: '1caf7dcd-7e83-4c3a-94f7-932a1299c844',
+        verbose: true,
+        debug: false,
+        objectId: objectId,
         Department: 'Sales & Marketing',
         CompanyName: 'Contoso'
       }
@@ -127,17 +181,110 @@ describe(commands.USER_SET, () => {
     assert(loggerLogSpy.notCalled);
   });
 
-  it('correctly enables the specified user', async () => {
-    sinon.stub(request, 'patch').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/users/`) > -1) {
-        return Promise.resolve({});
+  it('correctly resets password for a specified user by objectId', async () => {
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${objectId}`
+        && opts.data.passwordProfile !== undefined
+        && opts.data.passwordProfile.password === newPassword
+        && opts.data.passwordProfile.forceChangePasswordNextSignIn === true) {
+        return;
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, {
       options: {
-        userPrincipalName: 'steve@contoso.onmicrosoft.com',
+        verbose: true,
+        objectId: objectId,
+        resetPassword: true,
+        password: newPassword,
+        forceChangePasswordNextSignIn: true
+      }
+    } as any);
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('correctly resets password for a specified user by userPrincipalName', async () => {
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userPrincipalName)}`
+        && opts.data.passwordProfile !== undefined
+        && opts.data.passwordProfile.password === newPassword
+        && opts.data.passwordProfile.forceChangePasswordNextSignIn === false) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        userPrincipalName: userPrincipalName,
+        resetPassword: true,
+        password: newPassword
+      }
+    } as any);
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('correctly changes password for current user retrieved by userPrincipalName', async () => {
+    sinon.stub(accessToken, 'getUserNameFromAccessToken').callsFake(() => { return userPrincipalName; });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userPrincipalName)}/changePassword`
+        && opts.data !== undefined
+        && opts.data.currentPassword === currentPassword
+        && opts.data.newPassword === newPassword) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        userPrincipalName: userPrincipalName,
+        currentPassword: currentPassword,
+        newPassword: newPassword
+      }
+    } as any);
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('correctly changes password for current user retrieved by objectId', async () => {
+    sinon.stub(accessToken, 'getUserIdFromAccessToken').callsFake(() => { return objectId; });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${objectId}/changePassword`
+        && opts.data !== undefined
+        && opts.data.currentPassword === currentPassword
+        && opts.data.newPassword === newPassword) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        objectId: objectId,
+        currentPassword: currentPassword,
+        newPassword: newPassword
+      }
+    } as any);
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('correctly enables the specified user', async () => {
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/v1.0/users/`) > -1) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        debug: false,
+        userPrincipalName: userPrincipalName,
         accountEnabled: true
       }
     } as any);

--- a/src/m365/aad/commands/user/user-set.spec.ts
+++ b/src/m365/aad/commands/user/user-set.spec.ts
@@ -116,11 +116,6 @@ describe(commands.USER_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if resetPassword and password is set and newPassword is also set', async () => {
-    const actual = await command.validate({ options: { objectId: objectId, resetPassword: true, password: newPassword, newPassword: newPassword } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('passes validation if the objectId is a valid GUID', async () => {
     const actual = await command.validate({ options: { objectId: objectId } }, commandInfo);
     assert.strictEqual(actual, true);
@@ -133,13 +128,13 @@ describe(commands.USER_SET, () => {
 
   it('throws error when objectId is not equal to current signed in objectId in Cli when passing both the options currentPassword and newPassword', async () => {
     sinon.stub(accessToken, 'getUserIdFromAccessToken').callsFake(() => { return '7c47b08e-e7b3-427a-9eba-b679815148e9'; });
-    await assert.rejects(command.action(logger, { options: { verbose: true, debug: false, objectId: objectId, newPassword: newPassword, currentPassword: currentPassword } } as any),
+    await assert.rejects(command.action(logger, { options: { verbose: true, objectId: objectId, newPassword: newPassword, currentPassword: currentPassword } } as any),
       new CommandError(`You can only change your own password. Please use --objectId @meId to reference to your own userId`));
   });
 
   it('throws error when userPrincipalName is not equal to current signed in userPrincipalName in Cli when passing both the options currentPassword and newPassword', async () => {
     sinon.stub(accessToken, 'getUserNameFromAccessToken').callsFake(() => { return 'john@contoso.com'; });
-    await assert.rejects(command.action(logger, { options: { verbose: true, debug: false, userPrincipalName: userPrincipalName, newPassword: newPassword, currentPassword: currentPassword } } as any),
+    await assert.rejects(command.action(logger, { options: { verbose: true, userPrincipalName: userPrincipalName, newPassword: newPassword, currentPassword: currentPassword } } as any),
       new CommandError(`You can only change your own password. Please use --userPrincipalName @meUserName to reference to your own userPrincipalName`));
   });
 
@@ -172,7 +167,6 @@ describe(commands.USER_SET, () => {
     await command.action(logger, {
       options: {
         verbose: true,
-        debug: false,
         objectId: objectId,
         Department: 'Sales & Marketing',
         CompanyName: 'Contoso'
@@ -197,7 +191,7 @@ describe(commands.USER_SET, () => {
         verbose: true,
         objectId: objectId,
         resetPassword: true,
-        password: newPassword,
+        newPassword: newPassword,
         forceChangePasswordNextSignIn: true
       }
     } as any);
@@ -220,7 +214,7 @@ describe(commands.USER_SET, () => {
         verbose: true,
         userPrincipalName: userPrincipalName,
         resetPassword: true,
-        password: newPassword
+        newPassword: newPassword
       }
     } as any);
     assert(loggerLogSpy.notCalled);
@@ -283,7 +277,6 @@ describe(commands.USER_SET, () => {
     await command.action(logger, {
       options: {
         verbose: true,
-        debug: false,
         userPrincipalName: userPrincipalName,
         accountEnabled: true
       }


### PR DESCRIPTION
Closes #2852 

A 'short' summary of what I've changed / added:
**New options:**
|Name|Description|
|-|-|
resetPassword|Has to be specified if we want to reset the password of a user. Can not be used in combination with `currentPassword` or `newPassword`
password|Has to be specified if `resetPassword` is specified. Can not be combined with `currentPassword` or `newPassword`
forceChangePasswordNextSignIn|If set, we will force the user to change his password on the next login after resetting. If not set, false will be used in requestbody
currentPassword|Used for changing the password of the current logged in user. If set, `newPassword` is also required
newPassword|Used for changing the password of the current logged in user. If set, `currentPassword` is also required.

To accomplish this, I've extended the requestBody for updating the properties so that if the parameter `resetPassword` is specified, we will add an object named `passwordProfile` to the request body as this can be done in the same 'patch' call. I've also added a check to see if any keys are available in the requestBody, as now it is possible that we call the command to just set the password for the currently signed in user, in which case we would not need to send a `patch` call as the body will be empty.

Finally I've added the `changePassword` method to change the password for the currently signed in user.