### PR TITLE
Reworked `spo file copy` with new options

### DIFF
--- a/docs/docs/cmd/spo/file/file-copy.md
+++ b/docs/docs/cmd/spo/file/file-copy.md
@@ -11,50 +11,60 @@ m365 spo file copy [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: The URL of the site where the file is located
+: The URL of the site where the file is located.
 
 `-s, --sourceUrl <sourceUrl>`
-: Site-relative URL of the file to copy
+: Server-relative or absolute URL of the file.
 
 `-t, --targetUrl <targetUrl>`
-: Server-relative URL where to copy the file
+: Server-relative or absolute URL of the location.
 
-`--deleteIfAlreadyExists`
-: If a file already exists at the targetUrl, it will be moved to the recycle bin. If omitted, the copy operation will be canceled if the file already exists at the targetUrl location
+`--newName [newName]`
+: New name of the destination file.
 
-`--allowSchemaMismatch`
-: Ignores any missing fields in the target document library and copies the file anyway
+`--nameConflictBehavior [nameConflictBehavior]`
+: Behavior when a document with the same name is already present at the destination. Possible values: `fail`, `replace`, `rename`. Default is `fail`.
+
+`--bypassSharedLock`
+: This indicates whether a file with a share lock can still be copied. Use this option to copy a file that is locked.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
-When you copy a file using the `spo file copy` command, only the latest version of the file is copied.
+!!! important
+    The required URLs `webUrl`, `sourceUrl` and `targetUrl` cannot be encoded. When you do so, you will get a `File Not Found` error.
+
+When you specify a value for `nameConflictBehavior`, consider the following:
+
+- `fail` will throw an error when the destination file already exists.
+- `replace` will replace the destination file if it already exists.
+- `rename` will add a suffix (e.g. Document1.pdf) when the destination file already exists.
 
 ## Examples
 
-Copy file to a document library in another site collection
+Copy a file to a document library in another site collection with server relative URLs
 
 ```sh
-m365 spo file copy --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/sp1.pdf --targetUrl /sites/test2/Shared%20Documents/
+m365 spo file copy --webUrl https://contoso.sharepoint.com/sites/project --sourceUrl /sites/project/Shared Documents/Document.pdf --targetUrl /sites/IT/Shared Documents
 ```
 
-Copy file to a document library in the same site collection
+Copy a file to a document library in another site collection with absolute URLs
 
 ```sh
-m365 spo file copy --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/sp1.pdf --targetUrl /sites/test1/HRDocuments/
+m365 spo file copy --webUrl https://contoso.sharepoint.com/sites/project --sourceUrl https://contoso.sharepoint.com/sites/project/Shared Documents/Document.pdf --targetUrl https://contoso.sharepoint.com/sites/IT/Shared Documents
 ```
 
-Copy file to a document library in another site collection. If a file with the same name already exists in the target document library, move it to the recycle bin
+Copy file to a document library in another site collection with a new name
 
 ```sh
-m365 spo file copy --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/sp1.pdf --targetUrl /sites/test2/Shared%20Documents/ --deleteIfAlreadyExists
+m365 spo file copy --webUrl https://contoso.sharepoint.com/sites/project --sourceUrl /sites/project/Shared Documents/Document.pdf --targetUrl /sites/IT/Shared Documents --newName "Report.pdf"
 ```
 
-Copy file to a document library in another site collection. Will ignore any missing fields in the target destination and copy anyway
+Copy file to a document library in another site collection with a new name, rename the file if it already exists
 
 ```sh
-m365 spo file copy --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/sp1.pdf --targetUrl /sites/test2/Shared%20Documents/ --allowSchemaMismatch
+m365 spo file copy --webUrl https://contoso.sharepoint.com/sites/project --sourceUrl /sites/project/Shared Documents/Document.pdf --targetUrl /sites/IT/Shared Documents --newName "Report.pdf" --nameConflictBehavior rename
 ```
 
 ## More information

--- a/docs/docs/v6-upgrade-guidance.md
+++ b/docs/docs/v6-upgrade-guidance.md
@@ -80,6 +80,33 @@ If you have configured the `autoOpenBrowserOnLogin` key, you'll now need to conf
 m365 cli config set --key autoOpenLinksInBrowser --value true
 ```
 
+## Updated `spo file copy` options
+
+The command [spo file copy](./cmd/spo/file/file-copy.md) has been updated under the hood. This rework gives us more flexibility while copying files, right now it's even possible to copy files over 2GB. This rework comes with some changes. When you specify an URL for options `webUrl`, `sourceUrl` and `targetUrl`, make sure that you specify a decoded URL. Specifying an encoded URL will result in a `File Not Found` error. For example, `/sites/IT/Shared%20Documents/Document.pdf` will not work while `/sites/IT/Shared Documents/Document.pdf` will work just fine.
+
+Because of this rework, we were able to add new options, but we also removed existing ones.
+
+**Removed options:**
+
+- `--deleteIfAlreadyExists`
+- `--allowSchemaMismatch`
+
+**New options:**
+
+Option | Description
+--- | ---
+`--nameConflictBehavior [nameConflictBehavior]` | Behavior when a document with the same name is already present at the destination. Possible values: `fail`, `replace`, `rename`. Default is `fail`.
+`--newName [newName]` | New name of the destination file.
+`--bypassSharedLock` | This indicates whether a file with a share lock can still be copied. Use this option to copy a file that is locked.
+
+### What action do I need to take?
+
+Update your scripts with the following:
+
+- Ensure all the URLs you provide are **decoded**.
+- Remove the option `--allowSchemaMismatch`.
+- Replace option `--deleteIfAlreadyExists` with `--nameConflictBehavior replace`.
+
 ## In `teams channel` commands, changed short options
 
 In the following commands we've changed some shorts:
@@ -160,7 +187,7 @@ Update your scripts to expect a single object instead of an array.
 
 ## Updated `spo group user <verb>` commands
 
-We've renamed the `spo group user <verb>` commands to `spo group member <verb>` to better cover all possibly scenario's. In the near future we'll be adding support to add Azure AD Groups as group member. Using `spo group member` better fits the intended situation of adding either users or Azure AD groups.
+We've renamed the `spo group user <verb>` commands to `spo group member <verb>` to better cover all possible scenarios. In the near future we'll be adding support to add Azure AD Groups as group member. Using `spo group member` better fits the intended situation of adding either users or Azure AD groups.
 
 As a side issue, we've also updated the response output of the `spo group member list` command in JSON output mode. This returned a member array within a parent `value` object. In the new situation, the command returns the array without the parent `value` object.
 

--- a/src/m365/spo/commands/eventreceiver/eventreceiver-remove.spec.ts
+++ b/src/m365/spo/commands/eventreceiver/eventreceiver-remove.spec.ts
@@ -7,6 +7,7 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
+import { pid } from '../../../../utils/pid';
 import { formatting } from '../../../../utils/formatting';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
@@ -34,6 +35,7 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
     sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -72,7 +74,8 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
   after(() => {
     sinonUtil.restore([
       appInsights.trackEvent,
-      auth.restoreAuth
+      auth.restoreAuth,
+      pid.getProcessName
     ]);
     auth.service.connected = false;
   });

--- a/src/m365/spo/commands/file/file-copy.spec.ts
+++ b/src/m365/spo/commands/file/file-copy.spec.ts
@@ -9,69 +9,26 @@ import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
-import { spo } from '../../../../utils/spo';
 import commands from '../../commands';
 const command: Command = require('./file-copy');
 
 describe(commands.FILE_COPY, () => {
+  const webUrl = 'https://contoso.sharepoint.com/sites/project';
+  const documentName = 'Document.pdf';
+  const relSourceUrl = '/sites/project/Documents/' + documentName;
+  const absoluteSourceUrl = 'https://contoso.sharepoint.com/sites/project/Documents/' + documentName;
+  const relTargetUrl = '/sites/IT/Documents';
+  const absoluteTargetUrl = 'https://contoso.sharepoint.com/sites/IT/Documents';
+
   let log: any[];
   let logger: Logger;
-  let loggerLogToStderrSpy: sinon.SinonSpy;
+  let requestPostStub: sinon.SinonStub;
   let commandInfo: CommandInfo;
-
-  const stubAllPostRequests: any = (
-    createCopyJobs: any = null,
-    waitForJobResult: any = null
-  ) => {
-    return sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/site/CreateCopyJobs') > -1) {
-        if (createCopyJobs) {
-          return createCopyJobs;
-        }
-        return Promise.resolve({ value: [{ "EncryptionKey": "6G35dpTMegtzqT3rsZ/av6agpsqx/SUyaAHBs9fJE6A=", "JobId": "cee65dc5-8d05-41cc-8657-92a12d213f76", "JobQueueUri": "https://spobn1sn1m001pr.queue.core.windows.net:443/1246pq20180429-5305d83990eb483bb93e7356252715b4?sv=2014-02-14&sig=JUwFF1B0KVC2h0o5qieHPUG%2BQE%2BEhJHNpbzFf8QmCGc%3D&st=2018-04-28T07%3A00%3A00Z&se=2018-05-20T07%3A00%3A00Z&sp=rap" }] });
-      }
-
-      if ((opts.url as string).indexOf('/_api/site/GetCopyJobProgress') > -1) {
-        if (waitForJobResult) {
-          return waitForJobResult;
-        }
-        return Promise.resolve({
-          JobState: 0,
-          Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Copy\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-  };
-
-  const stubAllGetRequests: any = (fileExists: any = null) => {
-    return sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf('GetFileByServerRelativeUrl') > -1) {
-        if (fileExists) {
-          return fileExists;
-        }
-        return Promise.resolve({});
-      }
-
-      return Promise.reject('Invalid request');
-    });
-  };
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
     sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(spo, 'getRequestDigest').callsFake(() => Promise.resolve({
-      FormDigestValue: 'abc',
-      FormDigestTimeoutSeconds: 1800,
-      FormDigestExpiresAt: new Date(),
-      WebFullUrl: 'https://contoso.sharepoint.com'
-    }));
-    sinon.stub(global, 'setTimeout').callsFake((fn) => {
-      fn();
-      return {} as any;
-    });
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -89,24 +46,27 @@ describe(commands.FILE_COPY, () => {
         log.push(msg);
       }
     };
-    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
+
+    requestPostStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/SP.MoveCopyUtil.CopyFileByPath`) {
+        return;
+      }
+
+      throw 'Invalid request URL: ' + opts.url;
+    });
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      request.post,
-      request.get,
-      Cli.executeCommand
+      request.post
     ]);
   });
 
   after(() => {
     sinonUtil.restore([
-      auth.restoreAuth,
-      spo.getRequestDigest,
       appInsights.trackEvent,
-      pid.getProcessName,
-      global.setTimeout
+      auth.restoreAuth,
+      pid.getProcessName
     ]);
     auth.service.connected = false;
   });
@@ -119,247 +79,185 @@ describe(commands.FILE_COPY, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('excludes options from URL processing', () => {
-    assert.deepStrictEqual((command as any).getExcludedOptionsWithUrls(), ['targetUrl']);
+  it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'foo', sourceUrl: absoluteSourceUrl, targetUrl: absoluteTargetUrl } }, commandInfo);
+    assert.notStrictEqual(actual, true);
   });
 
-  it('should command complete successfully', async () => {
-    stubAllPostRequests();
-    stubAllGetRequests();
+  it('fails validation if nameConflictBehavior has an invalid value', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, sourceUrl: absoluteSourceUrl, targetUrl: absoluteTargetUrl, nameConflictBehavior: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
 
+  it('passes validation if all required properties are provided', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, sourceUrl: absoluteSourceUrl, targetUrl: absoluteTargetUrl } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('copies file successfully when absolute URLs are provided', async () => {
     await command.action(logger, {
       options: {
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: 'abc'
+        verbose: true,
+        webUrl: webUrl,
+        sourceUrl: absoluteSourceUrl,
+        targetUrl: absoluteTargetUrl
       }
     });
-  });
 
-  it('should complete successfully in 4 tries', async () => {
-    let counter = 4;
-    sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/recycle()') > -1) {
-        return Promise.resolve();
-      }
-
-      if ((opts.url as string).indexOf('/_api/site/CreateCopyJobs') > -1) {
-        return Promise.resolve({ value: [{ "EncryptionKey": "6G35dpTMegtzqT3rsZ/av6agpsqx/SUyaAHBs9fJE6A=", "JobId": "cee65dc5-8d05-41cc-8657-92a12d213f76", "JobQueueUri": "https://spobn1sn1m001pr.queue.core.windows.net:443/1246pq20180429-5305d83990eb483bb93e7356252715b4?sv=2014-02-14&sig=JUwFF1B0KVC2h0o5qieHPUG%2BQE%2BEhJHNpbzFf8QmCGc%3D&st=2018-04-28T07%3A00%3A00Z&se=2018-05-20T07%3A00%3A00Z&sp=rap" }] });
-      }
-
-      if ((opts.url as string).indexOf('/_api/site/GetCopyJobProgress') > -1) {
-        // substract jobstate untill we hit jobstate = 0 (success)
-        counter = (counter - 1);
-
-        return Promise.resolve({
-          JobState: counter,
-          Logs: ["{\r\n  \"Event\": \"JobEnd\",\r\n  \"JobId\": \"cee65dc5-8d05-41cc-8657-92a12d213f76\",\r\n  \"Time\": \"04/29/2018 22:00:08.370\",\r\n  \"FilesCreated\": \"1\",\r\n  \"BytesProcessed\": \"4860914\",\r\n  \"ObjectsProcessed\": \"2\",\r\n  \"TotalExpectedSPObjects\": \"2\",\r\n  \"TotalErrors\": \"0\",\r\n  \"TotalWarnings\": \"0\",\r\n  \"TotalRetryCount\": \"0\",\r\n  \"MigrationType\": \"Move\",\r\n  \"MigrationDirection\": \"Import\",\r\n  \"CreatedOrUpdatedFileStatsBySize\": \"{\\\"1-10M\\\":{\\\"Count\\\":1,\\\"TotalSize\\\":4860914,\\\"TotalDownloadTime\\\":24,\\\"TotalCreationTime\\\":2824}}\",\r\n  \"ObjectsStatsByType\": \"{\\\"SPUser\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":0,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPFile\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":3184,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0},\\\"SPListItem\\\":{\\\"Count\\\":1,\\\"TotalTime\\\":360,\\\"AccumulatedVersions\\\":0,\\\"ObjectsWithVersions\\\":0}}\",\r\n  \"TotalExpectedBytes\": \"4860914\",\r\n  \"CorrelationId\": \"8559629e-0036-5000-c38d-80b698e0cd79\"\r\n}"]
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    stubAllGetRequests();
-
-    await command.action(logger, {
-      options: {
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: 'abc'
-      }
-    });
-  });
-
-  it('should fail if source file not found', async () => {
-    stubAllPostRequests();
-    const rejectFileExists = new Promise<any>((resolve, reject) => {
-      return reject('File not found.');
-    });
-    stubAllGetRequests(rejectFileExists);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        debug: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: 'abc'
-      }
-    } as any), new CommandError('File not found.'));
-  });
-
-  it('should succeed when run with option --deleteIfAlreadyExists', async () => {
-    stubAllPostRequests();
-    stubAllGetRequests();
-    sinon.stub(Cli, 'executeCommand');
-
-    await command.action(logger, {
-      options: {
-        debug: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: 'abc',
-        deleteIfAlreadyExists: true
-      }
-    });
-    assert(loggerLogToStderrSpy.called);
-  });
-
-  it('should succeed when run with option --deleteIfAlreadyExists and response 404', async () => {
-    stubAllPostRequests();
-    stubAllGetRequests();
-
-    const fileDeleteError: any = {
-      error: {
-        message: 'does not exist'
+    const response = {
+      srcPath: {
+        DecodedUrl: absoluteSourceUrl
       },
-      stderr: ''
+      destPath: {
+        DecodedUrl: absoluteTargetUrl + `/${documentName}`
+      },
+      overwrite: false,
+      options: {
+        KeepBoth: false,
+        ShouldBypassSharedLocks: false
+      }
     };
 
-    sinon.stub(Cli, 'executeCommand').returns(Promise.reject(fileDeleteError));
+    assert.deepStrictEqual(requestPostStub.lastCall.args[0].data, response);
+  });
 
+  it('copies file successfully when server relative URLs are provided', async () => {
     await command.action(logger, {
       options: {
-        debug: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: 'abc',
-        deleteIfAlreadyExists: true
+        verbose: true,
+        webUrl: webUrl,
+        sourceUrl: relSourceUrl,
+        targetUrl: relTargetUrl
       }
     });
-    assert(loggerLogToStderrSpy.called);
-  });
 
-  it('should show error when recycleFile rejects with error', async () => {
-    
-    stubAllPostRequests();
-    stubAllGetRequests();
-    sinon.stub(Cli, 'executeCommand').returns(Promise.reject('abc'));
-    await assert.rejects(command.action(logger, {
+    const response = {
+      srcPath: {
+        DecodedUrl: absoluteSourceUrl
+      },
+      destPath: {
+        DecodedUrl: absoluteTargetUrl + `/${documentName}`
+      },
+      overwrite: false,
       options: {
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: 'abc',
-        deleteIfAlreadyExists: true
+        KeepBoth: false,
+        ShouldBypassSharedLocks: false
       }
-    } as any), new CommandError('abc'));
+    };
+
+    assert.deepStrictEqual(requestPostStub.lastCall.args[0].data, response);
   });
 
-  it('should recycleFile format target url', async () => {
-    stubAllPostRequests();
-    stubAllGetRequests();
-
-    sinon.stub(Cli, 'executeCommand').returns(Promise.reject('abc'));
-
-    await assert.rejects(command.action(logger, {
+  it('copies file successfully with a new name', async () => {
+    await command.action(logger, {
       options: {
-        debug: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: '/abc/',
-        deleteIfAlreadyExists: true
+        verbose: true,
+        webUrl: webUrl,
+        sourceUrl: relSourceUrl,
+        targetUrl: relTargetUrl,
+        newName: 'Document-renamed.pdf'
       }
-    } as any), new CommandError('abc'));
+    });
+
+    const response = {
+      srcPath: {
+        DecodedUrl: absoluteSourceUrl
+      },
+      destPath: {
+        DecodedUrl: absoluteTargetUrl + '/Document-renamed.pdf'
+      },
+      overwrite: false,
+      options: {
+        KeepBoth: false,
+        ShouldBypassSharedLocks: false
+      }
+    };
+
+    assert.deepStrictEqual(requestPostStub.lastCall.args[0].data, response);
   });
 
-  it('should show error when getRequestDigest rejects with error', async () => {
-    stubAllPostRequests();
-    stubAllGetRequests();
-    sinonUtil.restore(spo.getRequestDigest);
-    sinon.stub(spo, 'getRequestDigest').callsFake(() => Promise.reject('error'));
+  it('copies file successfully with nameConflictBehavior fail', async () => {
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        webUrl: webUrl,
+        sourceUrl: relSourceUrl,
+        targetUrl: relTargetUrl,
+        nameConflictBehavior: 'fail'
+      }
+    });
 
-    try {
-      await assert.rejects(command.action(logger, {
-        options: {
-          debug: true,
-          webUrl: 'https://contoso.sharepoint.com',
-          sourceUrl: 'abc/abc.pdf',
-          targetUrl: 'abc',
-          deleteIfAlreadyExists: true
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.overwrite, false, 'Overwite option is not false');
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.options.KeepBoth, false, 'KeepBoth option is not false');
+  });
+
+  it('copies file successfully with nameConflictBehavior replace', async () => {
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        webUrl: webUrl,
+        sourceUrl: relSourceUrl,
+        targetUrl: relTargetUrl,
+        nameConflictBehavior: 'replace'
+      }
+    });
+
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.overwrite, true, 'Overwite option is not true');
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.options.KeepBoth, false, 'KeepBoth option is not false');
+  });
+
+  it('copies file successfully with nameConflictBehavior rename', async () => {
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        webUrl: webUrl,
+        sourceUrl: relSourceUrl,
+        targetUrl: relTargetUrl,
+        nameConflictBehavior: 'rename'
+      }
+    });
+
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.overwrite, false, 'Overwite option is not false');
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.options.KeepBoth, true, 'KeepBoth option is not true');
+  });
+
+  it('copies file successfully with with bypassSharedLock option', async () => {
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        webUrl: webUrl,
+        sourceUrl: relSourceUrl,
+        targetUrl: relTargetUrl,
+        bypassSharedLock: true
+      }
+    });
+
+    assert.strictEqual(requestPostStub.lastCall.args[0].data.options.ShouldBypassSharedLocks, true);
+  });
+
+  it('handles file not found error correctly', async () => {
+    const errorMessage = 'File Not Found.';
+    requestPostStub.restore();
+    sinon.stub(request, 'post').callsFake(async () => {
+      throw {
+        error: {
+          'odata.error': {
+            message: {
+              lang: 'en-US',
+              value: errorMessage
+            }
+          }
         }
-      } as any), new CommandError('error'));
-    }
-    finally {
-      sinonUtil.restore(spo.getRequestDigest);
-      sinon.stub(spo, 'getRequestDigest').callsFake(() => Promise.resolve({
-        FormDigestValue: 'abc',
-        FormDigestTimeoutSeconds: 1800,
-        FormDigestExpiresAt: new Date(),
-        WebFullUrl: 'https://contoso.sharepoint.com'
-      }));
-    }
-  });
-
-  it('should show error when waitForJobResult rejects with JobError', async () => {
-    const waitForJobResult = new Promise<any>((resolve) => {
-      const log = JSON.stringify({ Event: 'JobError', Message: 'error1' });
-      return resolve({ Logs: [log] });
+      };
     });
-    stubAllPostRequests(null, waitForJobResult);
-    stubAllGetRequests();
-
-    sinon.stub(Cli, 'executeCommand');
 
     await assert.rejects(command.action(logger, {
       options: {
         verbose: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: 'abc',
-        deleteIfAlreadyExists: true
+        webUrl: webUrl,
+        sourceUrl: relSourceUrl,
+        targetUrl: relTargetUrl
       }
-    } as any), new CommandError('error1'));
-  });
-
-  it('should show error when waitForJobResult rejects with JobFatalError', async () => {
-    const waitForJobResult = new Promise<any>((resolve) => {
-      const log = JSON.stringify({ Event: 'JobFatalError', Message: 'error2' });
-      return resolve({ JobState: 0, Logs: [log] });
-    });
-    stubAllPostRequests(null, waitForJobResult);
-    stubAllGetRequests();
-    sinon.stub(Cli, 'executeCommand');
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        debug: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: 'abc/abc.pdf',
-        targetUrl: 'abc',
-        deleteIfAlreadyExists: true
-      }
-    } as any), new CommandError('error2'));
-  });
-
-  it('supports debug mode', () => {
-    const options = command.options;
-    let containsDebugOption = false;
-    options.forEach(o => {
-      if (o.option === '--debug') {
-        containsDebugOption = true;
-      }
-    });
-    assert(containsDebugOption);
-  });
-
-  it('supports specifying URL', () => {
-    const options = command.options;
-    let containsTypeOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('<webUrl>') > -1) {
-        containsTypeOption = true;
-      }
-    });
-    assert(containsTypeOption);
-  });
-
-  it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
-    const actual = await command.validate({ options: { webUrl: 'foo', sourceUrl: 'abc', targetUrl: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('passes validation if the webUrl option is a valid SharePoint site URL', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', sourceUrl: 'abc', targetUrl: 'abc' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    }), new CommandError(errorMessage));
   });
 });

--- a/src/m365/spo/commands/file/file-copy.ts
+++ b/src/m365/spo/commands/file/file-copy.ts
@@ -1,17 +1,11 @@
-import * as url from 'url';
-import Command from '../../../../Command';
 import { Logger } from '../../../../cli/Logger';
-import { Cli } from '../../../../cli/Cli';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { spo } from '../../../../utils/spo';
-import { urlUtil } from '../../../../utils/urlUtil';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
-import { Options as SpoFileRemoveOptions } from './file-remove';
 import commands from '../../commands';
-import { formatting } from '../../../../utils/formatting';
-const removeCommand: Command = require('./file-remove');
+import { AxiosRequestConfig } from 'axios';
+import { urlUtil } from '../../../../utils/urlUtil';
 
 interface CommandArgs {
   options: Options;
@@ -21,13 +15,12 @@ interface Options extends GlobalOptions {
   webUrl: string;
   sourceUrl: string;
   targetUrl: string;
-  deleteIfAlreadyExists?: boolean;
-  allowSchemaMismatch: boolean;
+  newName?: string;
+  nameConflictBehavior?: string;
+  bypassSharedLock?: boolean;
 }
 
 class SpoFileCopyCommand extends SpoCommand {
-  private dots?: string;
-
   public get name(): string {
     return commands.FILE_COPY;
   }
@@ -47,12 +40,14 @@ class SpoFileCopyCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        deleteIfAlreadyExists: args.options.deleteIfAlreadyExists || false,
-        allowSchemaMismatch: args.options.allowSchemaMismatch || false
+        newName: typeof args.options.newName !== 'undefined',
+        nameConflictBehavior: args.options.nameConflictBehavior || false,
+        bypassSharedLock: !!args.options.bypassSharedLock
       });
     });
   }
 
+  private readonly nameConflictBehaviorOptions = ['fail', 'replace', 'rename'];
   #initOptions(): void {
     this.options.unshift(
       {
@@ -65,149 +60,83 @@ class SpoFileCopyCommand extends SpoCommand {
         option: '-t, --targetUrl <targetUrl>'
       },
       {
-        option: '--deleteIfAlreadyExists'
+        option: '--newName [newName]'
       },
       {
-        option: '--allowSchemaMismatch'
+        option: '--nameConflictBehavior [nameConflictBehavior]',
+        autocomplete: this.nameConflictBehaviorOptions
+      },
+      {
+        option: '--bypassSharedLock'
       }
     );
   }
 
   #initValidators(): void {
     this.validators.push(
-      async (args: CommandArgs) => validation.isValidSharePointUrl(args.options.webUrl)
+      async (args: CommandArgs) => {
+        const isValidSharePointUrl = validation.isValidSharePointUrl(args.options.webUrl);
+        if (isValidSharePointUrl !== true) {
+          return isValidSharePointUrl;
+        }
+
+        if (args.options.nameConflictBehavior && this.nameConflictBehaviorOptions.indexOf(args.options.nameConflictBehavior) === -1) {
+          return `${args.options.nameConflictBehavior} is not a valid nameConflictBehavior value. Allowed values: ${this.nameConflictBehaviorOptions.join('|')}`;
+        }
+
+        return true;
+      }
     );
   }
 
-  protected getExcludedOptionsWithUrls(): string[] | undefined {
-    return ['targetUrl'];
-  }
-
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    const webUrl = args.options.webUrl;
-    const parsedUrl: url.UrlWithStringQuery = url.parse(webUrl);
-    const tenantUrl: string = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
-
     try {
-      // Check if the source file exists.
-      // Called on purpose, we explicitly check if user specified file
-      // in the sourceUrl option.
-      // The CreateCopyJobs endpoint accepts file, folder or batch from both.
-      // A user might enter folder instead of file as source url by mistake
-      // then there are edge cases when deleteIfAlreadyExists flag is set
-      // the user can receive misleading error message.
-      await this.fileExists(tenantUrl, webUrl, args.options.sourceUrl);
-
-      if (args.options.deleteIfAlreadyExists) {
-        // try delete target file, if deleteIfAlreadyExists flag is set
-        const filename = args.options.sourceUrl.replace(/^.*[\\\/]/, '');
-        await this.recycleFile(tenantUrl, args.options.targetUrl, filename, logger);
+      if (this.verbose) {
+        logger.logToStderr(`Copying file '${args.options.sourceUrl}' to '${args.options.targetUrl}'.`);
       }
 
-      // all preconditions met, now create copy job
-      const sourceAbsoluteUrl = urlUtil.urlCombine(webUrl, args.options.sourceUrl);
-      const allowSchemaMismatch: boolean = args.options.allowSchemaMismatch || false;
-      const requestUrl: string = urlUtil.urlCombine(webUrl, '/_api/site/CreateCopyJobs');
-      const requestOptions: any = {
-        url: requestUrl,
+      const sourcePath = this.getAbsoluteUrl(args.options, args.options.sourceUrl);
+      let destinationPath = this.getAbsoluteUrl(args.options, args.options.targetUrl) + '/';
+
+      if (args.options.newName) {
+        destinationPath += args.options.newName;
+      }
+      else {
+        // Keep the original file name
+        destinationPath += sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
+      }
+
+      const requestOptions: AxiosRequestConfig = {
+        url: `${args.options.webUrl}/_api/SP.MoveCopyUtil.CopyFileByPath`,
         headers: {
-          'accept': 'application/json;odata=nometadata'
+          accept: 'application/json;odata=nometadata'
         },
+        responseType: 'json',
         data: {
-          exportObjectUris: [sourceAbsoluteUrl],
-          destinationUri: urlUtil.urlCombine(tenantUrl, args.options.targetUrl),
+          srcPath: {
+            DecodedUrl: sourcePath
+          },
+          destPath: {
+            DecodedUrl: destinationPath
+          },
+          overwrite: args.options.nameConflictBehavior === 'replace',
           options: {
-            "AllowSchemaMismatch": allowSchemaMismatch,
-            "IgnoreVersionHistory": true
+            KeepBoth: args.options.nameConflictBehavior === 'rename',
+            ShouldBypassSharedLocks: !!args.options.bypassSharedLock
           }
-        },
-        responseType: 'json'
+        }
       };
 
-      const jobInfo = await request.post<any>(requestOptions);
-
-      await new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
-        this.dots = '';
-        const copyJobInfo: any = jobInfo.value[0];
-        const progressPollInterval: number = 30 * 60; //used previously implemented interval. The API does not provide guidance on what value should be used.
-
-        setTimeout(() => {
-          spo.waitUntilCopyJobFinished({
-            copyJobInfo,
-            siteUrl: webUrl,
-            pollingInterval: progressPollInterval,
-            resolve,
-            reject,
-            logger,
-            dots: this.dots,
-            debug: this.debug,
-            verbose: this.verbose
-          });
-        }, progressPollInterval);
-      });
+      await request.post(requestOptions);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
   }
 
-  /**
-   * Checks if a file exists on the server relative url
-   */
-  private fileExists(tenantUrl: string, webUrl: string, sourceUrl: string): Promise<void> {
-    const webServerRelativeUrl: string = webUrl.replace(tenantUrl, '');
-    const fileServerRelativeUrl: string = `${webServerRelativeUrl}${sourceUrl}`;
-
-    const requestUrl = `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileServerRelativeUrl)}')/`;
-    const requestOptions: any = {
-      url: requestUrl,
-      method: 'GET',
-      headers: {
-        'accept': 'application/json;odata=nometadata'
-      },
-      responseType: 'json'
-    };
-
-    return request.get(requestOptions);
-  }
-
-  /**
-   * Moves file in the site recycle bin
-   */
-  private async recycleFile(tenantUrl: string, targetUrl: string, filename: string, logger: Logger): Promise<void> {
-    const targetFolderAbsoluteUrl: string = urlUtil.urlCombine(tenantUrl, targetUrl);
-
-    // since the target WebFullUrl is unknown we can use getRequestDigest
-    // to get it from target folder absolute url.
-    // Similar approach used here Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect
-    const contextResponse = await spo.getRequestDigest(targetFolderAbsoluteUrl);
-
-    if (this.debug) {
-      logger.logToStderr(`contextResponse.WebFullUrl: ${contextResponse.WebFullUrl}`);
-    }
-
-    const targetFileServerRelativeUrl: string = `${urlUtil.getServerRelativePath(contextResponse.WebFullUrl, targetUrl)}/${filename}`;
-
-    const removeOptions: SpoFileRemoveOptions = {
-      webUrl: contextResponse.WebFullUrl,
-      url: targetFileServerRelativeUrl,
-      recycle: true,
-      confirm: true,
-      debug: this.debug,
-      verbose: this.verbose
-    };
-
-    try {
-      await Cli.executeCommand(removeCommand as Command, { options: { ...removeOptions, _: [] } });
-    }
-    catch (err: any) {
-      if (err.error !== undefined && err.error.message !== undefined && err.error.message.includes('does not exist')) {
-
-      }
-      else {
-        throw err;
-      }
-    }
+  /** Ensure the URL is an absolute URL. */
+  private getAbsoluteUrl(options: Options, url: string): string {
+    return url.startsWith('https://') ? url : urlUtil.getAbsoluteUrl(options.webUrl, url);
   }
 }
 


### PR DESCRIPTION
Reworked 'spo file copy' with new options. Closes #3911


### Remarks

Noticed a missing stub for `getProcessName` in command `spo eventreceiver remove` tests. Fixed it right away.