### PR TITLE
Enhances command `teams app list`, Closes #4130

### DIFF
--- a/docs/docs/cmd/teams/app/app-list.md
+++ b/docs/docs/cmd/teams/app/app-list.md
@@ -10,8 +10,8 @@ m365 teams app list [options]
 
 ## Options
 
-: `--distributionMethod`
-: The distribution method for which apps must be listed. Allowed values `store, organization, sideloaded`.
+`--distributionMethod [distributionMethod]`
+: The distribution method. Allowed values `store`, `organization`, `sideloaded`.
 
 --8<-- "docs/cmd/_global.md"
 

--- a/docs/docs/cmd/teams/app/app-list.md
+++ b/docs/docs/cmd/teams/app/app-list.md
@@ -1,6 +1,6 @@
 # teams app list
 
-Lists apps from the Microsoft Teams app catalog or apps installed in the specified team
+Lists apps from the Microsoft Teams app catalog
 
 ## Usage
 
@@ -10,45 +10,23 @@ m365 teams app list [options]
 
 ## Options
 
-`-a, --all`
-: Specify, to get apps from your organization only
-
-`-i, --teamId [teamId]`
-: The ID of the team for which to list installed apps. Specify either `teamId` or `teamName` but not both
-
-`-t, --teamName [teamName]`
-: The display name of the team for which to list installed apps. Specify either `teamId` or `teamName` but not both
+: `--distributionMethod`
+: The distribution method for which apps must be listed. Allowed values `store, organization, sideloaded`.
 
 --8<-- "docs/cmd/_global.md"
 
-## Remarks
-
-To list apps installed in the specified Microsoft Teams team, specify that team's ID using the `teamId` option. If the `teamId` option is not specified, the command will list apps available in the Teams app catalog.
-
 ## Examples
 
-List all Microsoft Teams apps from your organization's app catalog only
+List all apps from the Microsoft Teams app catalog
 
 ```sh
 m365 teams app list
 ```
 
-List all apps from the Microsoft Teams app catalog and the Microsoft Teams store
+List all apps from the Microsoft Teams app catalog according to a given distribution method
 
 ```sh
-m365 teams app list --all
-```
-
-List your organization's apps installed in the specified Microsoft Teams team with id _6f6fd3f7-9ba5-4488-bbe6-a789004d0d55_
-
-```sh
-m365 teams app list --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
-```
-
-List your organization's apps installed in the specified Microsoft Teams team with name _Team Name_
-
-```sh
-m365 teams app list --teamName "Team Name"
+m365 teams app list --distributionMethod 'store'
 ```
 
 ## Response

--- a/docs/docs/v6-upgrade-guidance.md
+++ b/docs/docs/v6-upgrade-guidance.md
@@ -168,6 +168,17 @@ As a side issue, we've also updated the response output of the `spo group member
 
 Update your scripts to use the new `member` noun instead of `user`. If you are using the output of `spo group member list` in JSON output mode, update your scripts and remove the `value` object. 
 
+## Logic to retrieve installed team apps with `teams app list` has changed
+The logic to list the installed apps in a specified team is moved to a new command `teams team app list`. As a result, the command `teams app list` only displays the installed apps from the Microsoft Teams app catalog. The command `teams app list` does no longer contains the options `all`, `teamId` and `teamName`. In addition, there is a new option for this command that allows you to indicate which installed apps from the Microsoft Teams app catalog you want to list according to the distribution method.
+
+The updated documentation of these commands
+- [teams app list](./cmd/teams/app/app-list.md)
+- [teams team app list](./cmd/teams/team/app-list.md)
+
+### What action do I need to take?
+
+Update your scripts to use the `teams app list` command if you want to list the installed apps in the Microsoft Teams app catalog. If you want to list the installed apps in a specified team, use the `teams team app list` command.
+
 ## Aligned options with naming convention
 
 As we've been adding more commands to the CLI, we noticed that several commands were using inconsistent options names. Our naming convention states that options that refer to the last noun in the command, don't need that noun as a prefix. for example: the option `--webUrl` for `m365 spo web list` has been renamed to `--url` as the last noun is `web`. In version 6 of the CLI for Microsoft 365, we updated all these options to be consistent and make it easier for you to use the CLI.

--- a/docs/docs/v6-upgrade-guidance.md
+++ b/docs/docs/v6-upgrade-guidance.md
@@ -172,6 +172,7 @@ Update your scripts to use the new `member` noun instead of `user`. If you are u
 The logic to list the installed apps in a specified team is moved to a new command `teams team app list`. As a result, the command `teams app list` only displays the installed apps from the Microsoft Teams app catalog. The command `teams app list` does no longer contains the options `all`, `teamId` and `teamName`. In addition, there is a new option for this command that allows you to indicate which installed apps from the Microsoft Teams app catalog you want to list according to the distribution method.
 
 The updated documentation of these commands
+
 - [teams app list](./cmd/teams/app/app-list.md)
 `- [teams team app list](./cmd/teams/team/app-list.md)`
 

--- a/docs/docs/v6-upgrade-guidance.md
+++ b/docs/docs/v6-upgrade-guidance.md
@@ -169,16 +169,11 @@ As a side issue, we've also updated the response output of the `spo group member
 Update your scripts to use the new `member` noun instead of `user`. If you are using the output of `spo group member list` in JSON output mode, update your scripts and remove the `value` object. 
 
 ## Logic to retrieve installed team apps with `teams app list` has changed
-The logic to list the installed apps in a specified team is moved to a new command `teams team app list`. As a result, the command `teams app list` only displays the installed apps from the Microsoft Teams app catalog. The command `teams app list` does no longer contains the options `all`, `teamId` and `teamName`. In addition, there is a new option for this command that allows you to indicate which installed apps from the Microsoft Teams app catalog you want to list according to the distribution method.
-
-The updated documentation of these commands
-
-- [teams app list](./cmd/teams/app/app-list.md)
-`- [teams team app list](./cmd/teams/team/app-list.md)`
+The logic to list the installed apps in a specified team is moved to a new command `[teams team app list](./cmd/teams/team/app-list.md)`. As a result, the command [teams app list](./cmd/teams/app/app-list.md) only displays the installed apps from the Microsoft Teams app catalog. The command [teams app list](./cmd/teams/app/app-list.md) does no longer contains the options `all`, `teamId` and `teamName`. In addition, there is a new option for this command that allows you to indicate which installed apps from the Microsoft Teams app catalog you want to list according to the distribution method.
 
 ### What action do I need to take?
 
-Update your scripts to use the `teams app list` command if you want to list the installed apps in the Microsoft Teams app catalog. If you want to list the installed apps in a specified team, use the `teams team app list` command.
+Update your scripts to use the [teams app list](./cmd/teams/app/app-list.md) command if you want to list the installed apps in the Microsoft Teams app catalog. If you want to list the installed apps in a specified team, use the `[teams team app list](./cmd/teams/team/app-list.md)` command.
 
 ## Aligned options with naming convention
 

--- a/docs/docs/v6-upgrade-guidance.md
+++ b/docs/docs/v6-upgrade-guidance.md
@@ -173,7 +173,7 @@ The logic to list the installed apps in a specified team is moved to a new comma
 
 The updated documentation of these commands
 - [teams app list](./cmd/teams/app/app-list.md)
-- [teams team app list](./cmd/teams/team/app-list.md)
+`- [teams team app list](./cmd/teams/team/app-list.md)`
 
 ### What action do I need to take?
 

--- a/src/m365/teams/commands/app/app-list.spec.ts
+++ b/src/m365/teams/commands/app/app-list.spec.ts
@@ -70,14 +70,14 @@ describe(commands.APP_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'displayName', 'distributionMethod']);
   });
 
-  it('fails validation if both teamId and teamName options are passed', async () => {
-    const actual = await command.validate({
-      options: {
-        teamId: '00000000-0000-0000-0000-000000000000',
-        teamName: 'Team Name'
-      }
-    }, commandInfo);
+  it('fails validation if invalid distribution method specified', async () => {
+    const actual = await command.validate({ options: { distributionMethod: 'invalid distribution method' } }, commandInfo);
     assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if valid distribution method specified', async () => {
+    const actual = await command.validate({ options: { distributionMethod: 'store' } }, commandInfo);
+    assert.strictEqual(actual, true);
   });
 
   it('lists Microsoft Teams apps in the organization app catalog', async () => {
@@ -98,7 +98,7 @@ describe(commands.APP_LIST, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { debug: false } });
+    await command.action(logger, { options: { debug: false, distributionMethod: 'organization' } });
     assert(loggerLogSpy.calledWith([
       {
         "id": "7131a36d-bb5f-46b8-bb40-0b199a3fad74",
@@ -107,44 +107,6 @@ describe(commands.APP_LIST, () => {
         "distributionMethod": "organization"
       }
     ]));
-  });
-
-  it('fails when team name does not exist', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
-        return Promise.resolve({
-          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "createdDateTime": null,
-              "displayName": "Team Name",
-              "description": "Team Description",
-              "internalId": null,
-              "classification": null,
-              "specialization": null,
-              "visibility": null,
-              "webUrl": null,
-              "isArchived": false,
-              "isMembershipLimitedToOwners": null,
-              "memberSettings": null,
-              "guestSettings": null,
-              "messagingSettings": null,
-              "funSettings": null,
-              "discoverySettings": null,
-              "resourceProvisioningOptions": []
-            }
-          ]
-        }
-        );
-      }
-      return Promise.reject('Invalid request');
-    });
-
-    await assert.rejects(command.action(logger, { options: { 
-      debug: true,
-      teamName: 'Team Name' } } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
   });
 
   it('lists Microsoft Teams apps in the organization app catalog and Microsoft Teams store', async () => {
@@ -200,204 +162,12 @@ describe(commands.APP_LIST, () => {
     ]));
   });
 
-  it('lists organization\'s apps installed in a team by team id', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/teams/6f6fd3f7-9ba5-4488-bbe6-a789004d0d55/installedApps?$expand=teamsApp&$filter=teamsApp/distributionMethod eq 'organization'`) {
-        return Promise.resolve({
-          "value": [{
-            "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyNiOGNjZjNmNC04NGVlLTRlNjItODJkMC1iZjZiZjk1YmRiODM=", "teamsApp": { "id": "b8ccf3f4-84ee-4e62-82d0-bf6bf95bdb83", "externalId": "912e9d76-1794-414f-82fd-e5b60fab731b", "displayName": "HelloWorld", "distributionMethod": "organization" }
-          }]
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    await command.action(logger, { options: { debug: false, teamId: '6f6fd3f7-9ba5-4488-bbe6-a789004d0d55' } });
-    assert(loggerLogSpy.calledWith([{
-      "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyNiOGNjZjNmNC04NGVlLTRlNjItODJkMC1iZjZiZjk1YmRiODM=",
-      "teamsApp": {
-        "id": "b8ccf3f4-84ee-4e62-82d0-bf6bf95bdb83",
-        "externalId": "912e9d76-1794-414f-82fd-e5b60fab731b",
-        "displayName": "HelloWorld",
-        "distributionMethod": "organization"
-      },
-      "displayName": "HelloWorld",
-      "distributionMethod": "organization"
-    }]));
-  });
-
-  it('lists organization\'s apps installed in a team by team name', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
-        return Promise.resolve({
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "createdDateTime": null,
-              "displayName": "Team Name",
-              "description": "Team Description",
-              "internalId": null,
-              "classification": null,
-              "specialization": null,
-              "visibility": null,
-              "webUrl": null,
-              "isArchived": false,
-              "isMembershipLimitedToOwners": null,
-              "memberSettings": null,
-              "guestSettings": null,
-              "messagingSettings": null,
-              "funSettings": null,
-              "discoverySettings": null,
-              "resourceProvisioningOptions": ["Team"]
-            }
-          ]
-        });
-      }
-
-      if ((opts.url as string).indexOf(`/installedApps?$expand=teamsApp&$filter=teamsApp/distributionMethod eq 'organization'`) > -1) {
-        return Promise.resolve({
-          "value": [{
-            "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyNiOGNjZjNmNC04NGVlLTRlNjItODJkMC1iZjZiZjk1YmRiODM=", "teamsApp": { "id": "b8ccf3f4-84ee-4e62-82d0-bf6bf95bdb83", "externalId": "912e9d76-1794-414f-82fd-e5b60fab731b", "displayName": "HelloWorld", "distributionMethod": "organization" }
-          }]
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    await command.action(logger, { options: { debug: false, teamName: 'Team Name' } });
-    assert(loggerLogSpy.calledWith([{
-      "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyNiOGNjZjNmNC04NGVlLTRlNjItODJkMC1iZjZiZjk1YmRiODM=",
-      "teamsApp": {
-        "id": "b8ccf3f4-84ee-4e62-82d0-bf6bf95bdb83",
-        "externalId": "912e9d76-1794-414f-82fd-e5b60fab731b",
-        "displayName": "HelloWorld",
-        "distributionMethod": "organization"
-      },
-      "displayName": "HelloWorld",
-      "distributionMethod": "organization"
-    }]));
-  });
-
-  it('lists all apps installed in a team', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/teams/6f6fd3f7-9ba5-4488-bbe6-a789004d0d55/installedApps?$expand=teamsApp`) {
-        return Promise.resolve({
-          "value": [
-            {
-              "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyNiOGNjZjNmNC04NGVlLTRlNjItODJkMC1iZjZiZjk1YmRiODM=", "teamsApp": { "id": "b8ccf3f4-84ee-4e62-82d0-bf6bf95bdb83", "externalId": "912e9d76-1794-414f-82fd-e5b60fab731b", "displayName": "HelloWorld", "distributionMethod": "organization" }
-            },
-            {
-              "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyMwZDgyMGVjZC1kZWYyLTQyOTctYWRhZC03ODA1NmNkZTdjNzg=", "teamsApp": { "id": "0d820ecd-def2-4297-adad-78056cde7c78", "externalId": null, "displayName": "OneNote", "distributionMethod": "store" }
-            },
-            {
-              "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyMxNGQ2OTYyZC02ZWViLTRmNDgtODg5MC1kZTU1NDU0YmIxMzY=", "teamsApp": { "id": "14d6962d-6eeb-4f48-8890-de55454bb136", "externalId": null, "displayName": "Activity", "distributionMethod": "store" }
-            }
-          ]
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    await command.action(logger, { options: { debug: false, teamId: '6f6fd3f7-9ba5-4488-bbe6-a789004d0d55', all: true } });
-    assert(loggerLogSpy.calledWith([{
-      "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyNiOGNjZjNmNC04NGVlLTRlNjItODJkMC1iZjZiZjk1YmRiODM=",
-      "teamsApp": {
-        "id": "b8ccf3f4-84ee-4e62-82d0-bf6bf95bdb83",
-        "externalId": "912e9d76-1794-414f-82fd-e5b60fab731b",
-        "displayName": "HelloWorld",
-        "distributionMethod": "organization"
-      },
-      "displayName": "HelloWorld",
-      "distributionMethod": "organization"
-    },
-    {
-      "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyMwZDgyMGVjZC1kZWYyLTQyOTctYWRhZC03ODA1NmNkZTdjNzg=",
-      "teamsApp": {
-        "id": "0d820ecd-def2-4297-adad-78056cde7c78",
-        "externalId": null,
-        "displayName": "OneNote",
-        "distributionMethod": "store"
-      },
-      "displayName": "OneNote",
-      "distributionMethod": "store"
-    },
-    {
-      "id": "NmY2ZmQzZjctOWJhNS00NDg4LWJiZTYtYTc4OTAwNGQwZDU1IyMxNGQ2OTYyZC02ZWViLTRmNDgtODg5MC1kZTU1NDU0YmIxMzY=",
-      "teamsApp": {
-        "id": "14d6962d-6eeb-4f48-8890-de55454bb136",
-        "externalId": null,
-        "displayName": "Activity",
-        "distributionMethod": "store"
-      },
-      "displayName": "Activity",
-      "distributionMethod": "store"
-    }]));
-  });
-
-  it('lists all properties for output json', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?$filter=distributionMethod eq 'organization'`) {
-        return Promise.resolve({
-          "value": [
-            {
-              "id": "7131a36d-bb5f-46b8-bb40-0b199a3fad74",
-              "externalId": "4f0cd7c8-995e-4868-812d-d1d402a81eca",
-              "displayName": "WsInfo",
-              "distributionMethod": "organization"
-            }
-          ]
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    await command.action(logger, { options: { output: 'json', debug: false } });
-    assert(loggerLogSpy.calledWith([
-      {
-        "id": "7131a36d-bb5f-46b8-bb40-0b199a3fad74",
-        "externalId": "4f0cd7c8-995e-4868-812d-d1d402a81eca",
-        "displayName": "WsInfo",
-        "distributionMethod": "organization"
-      }
-    ]));
-  });
-
   it('correctly handles error when retrieving apps', async () => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject('An error has occurred');
     });
 
     await assert.rejects(command.action(logger, { options: { output: 'json', debug: false } } as any), new CommandError('An error has occurred'));
-  });
-
-  it('fails validation if the teamId is not a valid GUID', async () => {
-    const actual = await command.validate({
-      options: {
-        teamId: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('passes validation if the teamId is not specified', async () => {
-    const actual = await command.validate({
-      options: {
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
-  });
-
-  it('passes validation when the teamId is a valid GUID', async () => {
-    const actual = await command.validate({
-      options: {
-        teamId: '6f6fd3f7-9ba5-4488-bbe6-a789004d0d55'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/m365/teams/commands/app/app-list.ts
+++ b/src/m365/teams/commands/app/app-list.ts
@@ -1,35 +1,30 @@
-import { Group } from '@microsoft/microsoft-graph-types';
+// import { Group } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import { odata } from '../../../../utils/odata';
-import { validation } from '../../../../utils/validation';
-import { aadGroup } from '../../../../utils/aadGroup';
+// import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 import { TeamsApp } from '../../TeamsApp';
-import { formatting } from '../../../../utils/formatting';
+// import { formatting } from '../../../../utils/formatting';
 
 interface CommandArgs {
   options: Options;
 }
 
 interface Options extends GlobalOptions {
-  all?: boolean;
-  teamId?: string;
-  teamName?: string;
-}
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
+  distributionMethod?: string;
 }
 
 class TeamsAppListCommand extends GraphCommand {
+  private static allowedDistributionMethods: string[] = ['store', 'organization', 'sideloaded'];
+
   public get name(): string {
     return commands.APP_LIST;
   }
 
   public get description(): string {
-    return 'Lists apps from the Microsoft Teams app catalog or apps installed in the specified team';
+    return 'Lists apps from the Microsoft Teams app catalog';
   }
 
   public defaultProperties(): string[] | undefined {
@@ -47,9 +42,7 @@ class TeamsAppListCommand extends GraphCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        all: args.options.all || false,
-        teamId: typeof args.options.teamId !== 'undefined',
-        teamName: typeof args.options.teamName !== 'undefined'
+        distributionMethod: typeof args.options.distributionMethod !== 'undefined'
       });
     });
   }
@@ -57,13 +50,8 @@ class TeamsAppListCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-a, --all'
-      },
-      {
-        option: '-i, --teamId [teamId]'
-      },
-      {
-        option: '-t --teamName [teamName]'
+        option: '--distributionMethod',
+        autocomplete: TeamsAppListCommand.allowedDistributionMethods
       }
     );
   }
@@ -71,12 +59,9 @@ class TeamsAppListCommand extends GraphCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (args.options.teamId && args.options.teamName) {
-          return 'Specify either teamId or teamName, but not both.';
-        }
-
-        if (args.options.teamId && !validation.isValidGuid(args.options.teamId)) {
-          return `${args.options.teamId} is not a valid GUID`;
+        if (args.options.distributionMethod &&
+          TeamsAppListCommand.allowedDistributionMethods.indexOf(args.options.distributionMethod) < 0) {
+          return `'${args.options.distributionMethod}' is not a valid distribution method. Allowed distribution methods are ${TeamsAppListCommand.allowedDistributionMethods.join(', ')}`;
         }
 
         return true;
@@ -84,63 +69,11 @@ class TeamsAppListCommand extends GraphCommand {
     );
   }
 
-  private getTeamId(args: CommandArgs): Promise<string> {
-    if (args.options.teamId) {
-      return Promise.resolve(args.options.teamId);
-    }
-
-    return aadGroup
-      .getGroupByDisplayName(args.options.teamName!)
-      .then(group => {
-        if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-          return Promise.reject(`The specified team does not exist in the Microsoft Teams`);
-        }
-
-        return group.id!;
-      });
-  }
-
-  private getEndpointUrl(args: CommandArgs): Promise<string> {
-    return new Promise<string>((resolve: (endpoint: string) => void, reject: (error: string) => void): void => {
-      if (args.options.teamId || args.options.teamName) {
-        this
-          .getTeamId(args)
-          .then((teamId: string): void => {
-            let endpoint: string = `${this.resource}/v1.0/teams/${formatting.encodeQueryParameter(teamId)}/installedApps?$expand=teamsApp`;
-
-            if (!args.options.all) {
-              endpoint += `&$filter=teamsApp/distributionMethod eq 'organization'`;
-            }
-
-            return resolve(endpoint);
-          })
-          .catch((err: any) => {
-            reject(err);
-          });
-      }
-      else {
-        let endpoint: string = `${this.resource}/v1.0/appCatalogs/teamsApps`;
-
-        if (!args.options.all) {
-          endpoint += `?$filter=distributionMethod eq 'organization'`;
-        }
-
-        return resolve(endpoint);
-      }
-    });
-  }
-
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const endpoint = await this.getEndpointUrl(args);
-      const items = await odata.getAllItems<TeamsApp>(endpoint);
+      const requestUrl: string = `${this.resource}/v1.0/appCatalogs/teamsApps${args.options.distributionMethod ? `?$filter=distributionMethod eq '${args.options.distributionMethod}'` : ''}`;
 
-      if (args.options.teamId || args.options.teamName) {
-        items.forEach(t => {
-          t.displayName = (t as any).teamsApp.displayName;
-          t.distributionMethod = (t as any).teamsApp.distributionMethod;
-        });
-      }
+      const items = await odata.getAllItems<TeamsApp>(requestUrl);
 
       logger.log(items);
     }

--- a/src/m365/teams/commands/app/app-list.ts
+++ b/src/m365/teams/commands/app/app-list.ts
@@ -1,12 +1,9 @@
-// import { Group } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import { odata } from '../../../../utils/odata';
-// import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
 import { TeamsApp } from '../../TeamsApp';
-// import { formatting } from '../../../../utils/formatting';
 
 interface CommandArgs {
   options: Options;
@@ -42,7 +39,7 @@ class TeamsAppListCommand extends GraphCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        distributionMethod: typeof args.options.distributionMethod !== 'undefined'
+        distributionMethod: args.options.distributionMethod || false
       });
     });
   }
@@ -50,7 +47,7 @@ class TeamsAppListCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '--distributionMethod',
+        option: '--distributionMethod [distributionMethod]',
         autocomplete: TeamsAppListCommand.allowedDistributionMethods
       }
     );
@@ -61,7 +58,7 @@ class TeamsAppListCommand extends GraphCommand {
       async (args: CommandArgs) => {
         if (args.options.distributionMethod &&
           TeamsAppListCommand.allowedDistributionMethods.indexOf(args.options.distributionMethod) < 0) {
-          return `'${args.options.distributionMethod}' is not a valid distribution method. Allowed distribution methods are ${TeamsAppListCommand.allowedDistributionMethods.join(', ')}`;
+          return `'${args.options.distributionMethod}' is not a valid distributionMethod. Allowed distribution methods are: ${TeamsAppListCommand.allowedDistributionMethods.join(', ')}`;
         }
 
         return true;
@@ -71,7 +68,11 @@ class TeamsAppListCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const requestUrl: string = `${this.resource}/v1.0/appCatalogs/teamsApps${args.options.distributionMethod ? `?$filter=distributionMethod eq '${args.options.distributionMethod}'` : ''}`;
+      let requestUrl: string = `${this.resource}/v1.0/appCatalogs/teamsApps`;
+
+      if (args.options.distributionMethod) {
+        requestUrl += `?$filter=distributionMethod eq '${args.options.distributionMethod}'`;
+      }
 
       const items = await odata.getAllItems<TeamsApp>(requestUrl);
 


### PR DESCRIPTION
This pr enhances command `teams app list`.

I've also put a piece of text about this breaking change in the v6 upgrade guidance. Please note that i've put the link to the command `teams team app list` in comment since it is not yet available and thus breaking this pr otherwise.

It's best to uncomment this link when merging with the new command `teams team app list`

Closes #4130