### PR TITLE
Fixes 'spo navigation node add' command. Closes #4093

### DIFF
--- a/docs/docs/cmd/spo/navigation/navigation-node-add.md
+++ b/docs/docs/cmd/spo/navigation/navigation-node-add.md
@@ -11,22 +11,22 @@ m365 spo navigation node add [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: Absolute URL of the site to which navigation should be modified
+: Absolute URL of the site to which navigation should be modified.
 
 `-l, --location [location]`
-: Navigation type where the node should be added. Available options: `QuickLaunch`, `TopNavigationBar`
+: Navigation type where the node should be added. Available options: `QuickLaunch`, `TopNavigationBar`. Specify either `location` or `parentNodeId` but not both.
 
 `-t, --title <title>`
-: Navigation node title
+: Navigation node title.
 
 `--url <url>`
-: Navigation node URL
+: Navigation node URL.
 
 `--parentNodeId [parentNodeId]`
-: ID of the node below which the node should be added
+: ID of the node below which the node should be added. Specify either `location` or `parentNodeId` but not both.
 
 `--isExternal`
-: Set, if the navigation node points to an external URL
+: Set, if the navigation node points to an external URL.
 
 --8<-- "docs/cmd/_global.md"
 

--- a/src/m365/spo/commands/navigation/navigation-node-add.spec.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-add.spec.ts
@@ -20,7 +20,7 @@ describe(commands.NAVIGATION_NODE_ADD, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -62,6 +62,30 @@ describe(commands.NAVIGATION_NODE_ADD, () => {
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if both location and parentNodeId options are not passed', async () => {
+    const actual = await command.validate({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+        title: 'About',
+        url: '/sites/team-a/sitepages/about.aspx'
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both location and parentNodeId options are passed', async () => {
+    const actual = await command.validate({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+        title: 'About',
+        url: '/sites/team-a/sitepages/about.aspx',
+        location: 'TopNavigationBar',
+        parentNodeId: 1000
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
   });
 
   it('excludes options from URL processing', () => {

--- a/src/m365/spo/commands/navigation/navigation-node-add.spec.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-add.spec.ts
@@ -64,28 +64,9 @@ describe(commands.NAVIGATION_NODE_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if both location and parentNodeId options are not passed', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: 'https://contoso.sharepoint.com/sites/team-a',
-        title: 'About',
-        url: '/sites/team-a/sitepages/about.aspx'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if both location and parentNodeId options are passed', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: 'https://contoso.sharepoint.com/sites/team-a',
-        title: 'About',
-        url: '/sites/team-a/sitepages/about.aspx',
-        location: 'TopNavigationBar',
-        parentNodeId: 1000
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('defines correct option sets', () => {
+    const optionSets = command.optionSets;
+    assert.deepStrictEqual(optionSets, [{ options: ['location', 'parentNodeId'] }]);
   });
 
   it('excludes options from URL processing', () => {

--- a/src/m365/spo/commands/navigation/navigation-node-add.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-add.ts
@@ -33,12 +33,14 @@ class SpoNavigationNodeAddCommand extends SpoCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         isExternal: args.options.isExternal,
+        location: typeof args.options.location !== 'undefined',
         parentNodeId: typeof args.options.parentNodeId !== 'undefined'
       });
     });
@@ -90,6 +92,12 @@ class SpoNavigationNodeAddCommand extends SpoCommand {
 
         return true;
       }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push(
+      ['location', 'parentNodeId']
     );
   }
 

--- a/src/m365/spo/commands/navigation/navigation-node-add.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-add.ts
@@ -97,7 +97,7 @@ class SpoNavigationNodeAddCommand extends SpoCommand {
 
   #initOptionSets(): void {
     this.optionSets.push(
-      ['location', 'parentNodeId']
+      { options: ['location', 'parentNodeId'] }
     );
   }
 


### PR DESCRIPTION
Fixes 'spo navigation node add' command. Closes #4093
Added OptionSets for `location` and `parentNodeId` options.