### PR TITLE
Adds deprecation label to some options of 'spo list retentionlabel set'. Closes #4221

### DIFF
--- a/docs/docs/cmd/spo/list/list-retentionlabel-set.md
+++ b/docs/docs/cmd/spo/list/list-retentionlabel-set.md
@@ -17,28 +17,28 @@ m365 spo list label set [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: The URL of the site where the list is located
+: The URL of the site where the list is located.
 
 `--label <label>`
-: The label to set on the list
+: The label to set on the list.
 
 `-t, --listTitle [listTitle]`
-: The title of the list on which to set the label. Specify only one of `listTitle`, `listId` or `listUrl`
+: The title of the list on which to set the label. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
 
 `-l, --listId [listId]`
-: The ID of the list on which to set the label. Specify only one of `listTitle`, `listId` or `listUrl`
+: The ID of the list on which to set the label. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
 
 `--listUrl [listUrl]`
-: Server- or web-relative URL of the list on which to set the label. Specify only one of `listTitle`, `listId` or `listUrl`
+: Server- or web-relative URL of the list on which to set the label. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
 
 `--syncToItems`
-: Specify, to set the label on all existing items in the list
+: Specify, to set the label on all existing items in the list.
 
 `--blockDelete`
-: Specify, to disallow deleting items in the list
+: (deprecated) Specify, to disallow deleting items in the list.
 
 `--blockEdit`
-: Specify, to disallow editing items in the list
+: (deprecated) Specify, to disallow editing items in the list.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -48,13 +48,13 @@ A list retention label is a default label that will be applied to all new items 
 
 ## Examples
 
-Sets retention label "Some label" on the list _Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Sets retention label on the list with specified site-relative URL located in the specified site.
 
 ```sh
 m365 spo list retentionlabel set --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents' --label 'Some label'
 ```
 
-Sets retention label "Some label" and disables editing and deleting items on the list and all existing items for list for list _Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Sets retention label and disables editing and deleting items on the list and all existing items for the list with specified title located in the specified site.
 
 ```sh
 m365 spo list retentionlabel set --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'Documents' --label 'Some label' --blockEdit --blockDelete --syncToItems

--- a/src/m365/spo/commands/list/list-retentionlabel-set.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-set.ts
@@ -106,6 +106,14 @@ class SpoListRetentionLabelSetCommand extends SpoCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     this.showDeprecationWarning(logger, commands.LIST_LABEL_SET, commands.LIST_RETENTIONLABEL_SET);
 
+    if (args.options.blockDelete) {
+      this.warn(logger, `Option 'blockDelete' is deprecated.`);
+    }
+
+    if (args.options.blockEdit) {
+      this.warn(logger, `Option 'blockEdit' is deprecated.`);
+    }
+
     try {
       let listRestUrl: string = '';
       let listServerRelativeUrl: string = '';


### PR DESCRIPTION
Fixes 'spo list retentionlabel set' command. Closes #4221
Added a deprecation notice to the `--blockEdit` and `--blockDelete` options.