### PR TITLE
Adds documentation about arguments starting with a dash. Closes #4257

### DIFF
--- a/docs/docs/user-guide/using-cli.md
+++ b/docs/docs/user-guide/using-cli.md
@@ -49,6 +49,15 @@ When the value, that you want to provide contains quotes, it needs to be wrapped
 m365 spo sitescript add --title "Contoso" --description "Contoso theme script" --content '{"abc": "def"}'
 ```
 
+## Values starting with a dash (-)
+
+In cases, when the option's value starts with a dash (-), use an embedded option value with an `=` operator. For example, to get a planner task with ID _-9rMKQooUjZdxgv1qQVZYABEuw_, you would execute in the shell:
+
+```sh
+m365 planner task get --id=-9rMKQooUjZdxgv1qQVZYABEuw
+```
+
+
 ## Working with SharePoint URLs in `spo` commands
 
 CLI for Microsoft 365 contains a number of commands for managing SharePoint Online. Each of these commands requires you to specify the site or web on which you want to execute the command. For example, to get information about a site collection located at `https://contoso.sharepoint.com/sites/contoso`, you'd execute:


### PR DESCRIPTION
Adds documentation about arguments starting with a dash. Closes #4257

Added `Values starting with a dash (-)` section to the [Use the CLI](https://pnp.github.io/cli-microsoft365/user-guide/using-cli/)  page.