### PR TITLE
Adds the ClientTag request header

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -76,7 +76,8 @@ class Request {
     this.req = Axios.create({
       headers: {
         'user-agent': `NONISV|SharePointPnP|CLIMicrosoft365/${packageJSON.version}`,
-        'accept-encoding': 'gzip, deflate'
+        'accept-encoding': 'gzip, deflate',
+        'X-ClientService-ClientTag': `M365CLI:${packageJSON.version}`
       },
       decompress: true,
       responseType: 'text',


### PR DESCRIPTION
Adds the ClientTag request header. With this header, requests issued from CLI will show up in MS engineering's dashboard along with other requests from PnP-made tooling.