### PR TITLE
Adds command `spo folder retentionlabel remove`, Closes #4164 

### DIFF
--- a/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.md
+++ b/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.md
@@ -1,0 +1,43 @@
+# spo folder retentionlabel remove
+
+Clears the retention label from a folder
+
+## Usage
+
+```sh
+m365 spo folder retentionlabel remove [options]
+```
+
+## Options
+
+`-u, --webUrl <webUrl>`
+: The url of the web.
+
+`--folderUrl [folderUrl]`
+: The server-relative URL of the folder of which the label should be removed. Specify either `folderUrl` or `folderId` but not both.
+
+`-i, --folderId [folderId]`
+: The UniqueId (GUID) of the folder of which the label should be removed. Specify either `folderUrl` or `folderId` but not both.
+
+`--confirm`
+: Don't prompt for confirming to remove the label.
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Removes the retention label from a folder in a given site based on the folder id
+
+```sh
+m365 spo folder retentionlabel remove --webUrl https://contoso.sharepoint.com/sites/project-x --folderId 0cd891ef-afce-4e55-b836-fce03286cccf
+```
+
+Removes the retention label from a folder in a given site based on the folder url
+
+```sh
+m365 spo folder retentionlabel remove --webUrl https://contoso.sharepoint.com/sites/project-x --folderUrl /sites/project-x/Shared Documents/Folder --id 1
+```
+
+## Response
+
+The command won't return a response on success.

--- a/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.md
+++ b/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.md
@@ -24,6 +24,10 @@ m365 spo folder retentionlabel remove [options]
 
 --8<-- "docs/cmd/_global.md"
 
+## Remarks
+
+Removing a retentionlabel is only supported on subfolders. Removing a retentionlabel from a rootfolder is currently not supported by by this command:
+
 ## Examples
 
 Removes the retention label from a folder in a given site based on the folder id

--- a/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.md
+++ b/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.md
@@ -26,7 +26,7 @@ m365 spo folder retentionlabel remove [options]
 
 ## Remarks
 
-Removing a retentionlabel is only supported on subfolders. Removing a retentionlabel from a rootfolder is currently not supported by by this command:
+Removing a retentionlabel is only supported on subfolders. Removing a retentionlabel from a rootfolder is currently not supported by by this command.
 
 ## Examples
 

--- a/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.md
+++ b/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.md
@@ -14,7 +14,7 @@ m365 spo folder retentionlabel remove [options]
 : The url of the web.
 
 `--folderUrl [folderUrl]`
-: The server-relative URL of the folder of which the label should be removed. Specify either `folderUrl` or `folderId` but not both.
+: The site- or server relative URL of the folder of which the label should be removed. Specify either `folderUrl` or `folderId` but not both.
 
 `-i, --folderId [folderId]`
 : The UniqueId (GUID) of the folder of which the label should be removed. Specify either `folderUrl` or `folderId` but not both.
@@ -26,7 +26,7 @@ m365 spo folder retentionlabel remove [options]
 
 ## Remarks
 
-Removing a retentionlabel is only supported on subfolders. Removing a retentionlabel from a rootfolder is currently not supported by by this command.
+Removing a retentionlabel with this command is only supported on the folders inside a document library. Removing a retentionlabel on the document library itself is currently not supported by by this command.
 
 ## Examples
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -426,6 +426,7 @@ nav:
         - folder remove: cmd/spo/folder/folder-remove.md
         - folder rename: cmd/spo/folder/folder-rename.md
         - folder retentionlabel ensure: cmd/spo/folder/folder-retentionlabel-ensure.md
+        - folder retentionlabel remove: cmd/spo/folder/folder-retentionlabel-remove.md
         - folder roleassignment add: cmd/spo/folder/folder-roleassignment-add.md
         - folder roleassignment remove: cmd/spo/folder/folder-roleassignment-remove.md
         - folder roleinheritance break: cmd/spo/folder/folder-roleinheritance-break.md

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -79,6 +79,7 @@ export default {
   FOLDER_REMOVE: `${prefix} folder remove`,
   FOLDER_RENAME: `${prefix} folder rename`,
   FOLDER_RETENTIONLABEL_ENSURE: `${prefix} folder retentionlabel ensure`,
+  FOLDER_RETENTIONLABEL_REMOVE: `${prefix} folder retentionlabel remove`,
   FOLDER_ROLEASSIGNMENT_REMOVE: `${prefix} folder roleassignment remove`,
   FOLDER_ROLEASSIGNMENT_ADD: `${prefix} folder roleassignment add`,
   FOLDER_ROLEINHERITANCE_BREAK: `${prefix} folder roleinheritance break`,

--- a/src/m365/spo/commands/folder/FolderProperties.ts
+++ b/src/m365/spo/commands/folder/FolderProperties.ts
@@ -13,6 +13,7 @@ export interface FolderProperties {
   WelcomePage: string;
   ListItemAllFields: ListItemAllFields;
 }
+
 export interface ListItemAllFields {
   RoleAssignments: RoleAssignment[];
   ParentList: ParentListFields;

--- a/src/m365/spo/commands/folder/folder-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-remove.spec.ts
@@ -20,6 +20,14 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
   const folderId = 'b2307a39-e878-458b-bc90-03bc578531d6';
   const listId = 1;
   const SpoListItemRetentionLabelRemoveCommandOutput = `{ "stdout": "", "stderr": "" }`;
+  const folderResponse = {
+    ListItemAllFields: {
+      Id: listId,
+      ParentList: {
+        Id: '75c4d697-bbff-40b8-a740-bf9b9294e5aa'
+      }
+    }
+  };
 
   let log: any[];
   let logger: Logger;
@@ -79,7 +87,7 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
   });
 
   it('prompts before removing retentionlabel from a folder when confirmation argument not passed', async () => {
-    await command.action(logger, { options: { debug: false, webUrl: webUrl, folderUrl: folderUrl } });
+    await command.action(logger, { options: { webUrl: webUrl, folderUrl: folderUrl } });
     let promptIssued = false;
 
     if (promptOptions && promptOptions.type === 'confirm') {
@@ -97,7 +105,6 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
     ));
     await command.action(logger, {
       options: {
-        debug: false,
         folderUrl: folderUrl,
         webUrl: webUrl
       }
@@ -107,8 +114,8 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
 
   it('removes the retentionlabel from a folder based on folderUrl when prompt confirmed', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields`) {
-        return { ListItemAllFields: { Id: listId }, ServerRelativeUrl: folderUrl };
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+        return folderResponse;
       }
 
       throw 'Invalid request';
@@ -119,7 +126,7 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
       { continue: true }
     ));
 
-    const postSpy = sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === SpoListItemRetentionLabelRemoveCommand) {
         return ({
           stdout: SpoListItemRetentionLabelRemoveCommandOutput
@@ -129,20 +136,18 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
       throw new CommandError('Unknown case');
     });
 
-    await command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
-        debug: false,
         folderUrl: folderUrl,
         webUrl: webUrl
       }
-    });
-    assert(postSpy.called);
+    }));
   });
 
   it('removes the retentionlabel from a folder based on folderId when prompt confirmed', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields`) {
-        return { ListItemAllFields: { Id: listId }, ServerRelativeUrl: folderUrl };
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+        return folderResponse;
       }
 
       throw 'Invalid request';
@@ -153,7 +158,7 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
       { continue: true }
     ));
 
-    const postSpy = sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === SpoListItemRetentionLabelRemoveCommand) {
         return ({
           stdout: SpoListItemRetentionLabelRemoveCommandOutput
@@ -163,27 +168,25 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
       throw new CommandError('Unknown case');
     });
 
-    await command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
-        debug: false,
         folderId: folderId,
         webUrl: webUrl,
         listItemId: 1
       }
-    });
-    assert(postSpy.called);
+    }));
   });
 
   it('removes the retentionlabel from a folder based on folderId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields`) {
-        return { ListItemAllFields: { Id: listId }, ServerRelativeUrl: folderUrl };
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+        return folderResponse;
       }
 
       throw 'Invalid request';
     });
 
-    const postSpy = sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === SpoListItemRetentionLabelRemoveCommand) {
         return ({
           stdout: SpoListItemRetentionLabelRemoveCommandOutput
@@ -193,16 +196,15 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
       throw new CommandError('Unknown case');
     });
 
-    await command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
-        debug: false,
+        debug: true,
         folderId: folderId,
         webUrl: webUrl,
         listItemId: 1,
         confirm: true
       }
-    });
-    assert(postSpy.called);
+    }));
   });
 
   it('correctly handles API OData error', async () => {

--- a/src/m365/spo/commands/folder/folder-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-remove.spec.ts
@@ -1,0 +1,263 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { telemetry } from '../../../../telemetry';
+import auth from '../../../../Auth';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { formatting } from '../../../../utils/formatting';
+import { pid } from '../../../../utils/pid';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+import * as SpoListItemRetentionLabelRemoveCommand from '../listitem/listitem-retentionlabel-remove';
+const command: Command = require('./folder-retentionlabel-remove');
+
+describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
+  const webUrl = 'https://contoso.sharepoint.com';
+  const folderUrl = `/Shared Documents/Fo'lde'r`;
+  const folderId = 'b2307a39-e878-458b-bc90-03bc578531d6';
+  const listId = 1;
+  const SpoListItemRetentionLabelRemoveCommandOutput = `{ "stdout": "", "stderr": "" }`;
+
+  let log: any[];
+  let logger: Logger;
+  let commandInfo: CommandInfo;
+  let promptOptions: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
+      promptOptions = options;
+      return { continue: false };
+    });
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      Cli.prompt,
+      Cli.executeCommandWithOutput
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      telemetry.trackEvent,
+      pid.getProcessName
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.FOLDER_RETENTIONLABEL_REMOVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('prompts before removing retentionlabel from a folder when confirmation argument not passed', async () => {
+    await command.action(logger, { options: { debug: false, webUrl: webUrl, folderUrl: folderUrl } });
+    let promptIssued = false;
+
+    if (promptOptions && promptOptions.type === 'confirm') {
+      promptIssued = true;
+    }
+
+    assert(promptIssued);
+  });
+
+  it('aborts removing folder retention label when prompt not confirmed', async () => {
+    const postSpy = sinon.spy(request, 'delete');
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: false }
+    ));
+    await command.action(logger, {
+      options: {
+        debug: false,
+        folderUrl: folderUrl,
+        webUrl: webUrl
+      }
+    });
+    assert(postSpy.notCalled);
+  });
+
+  it('removes the retentionlabel from a folder based on folderUrl when prompt confirmed', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields`) {
+        return { ListItemAllFields: { Id: listId }, ServerRelativeUrl: folderUrl };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
+
+    const postSpy = sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === SpoListItemRetentionLabelRemoveCommand) {
+        return ({
+          stdout: SpoListItemRetentionLabelRemoveCommandOutput
+        });
+      }
+
+      throw new CommandError('Unknown case');
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: false,
+        folderUrl: folderUrl,
+        webUrl: webUrl
+      }
+    });
+    assert(postSpy.called);
+  });
+
+  it('removes the retentionlabel from a folder based on folderId when prompt confirmed', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields`) {
+        return { ListItemAllFields: { Id: listId }, ServerRelativeUrl: folderUrl };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
+
+    const postSpy = sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === SpoListItemRetentionLabelRemoveCommand) {
+        return ({
+          stdout: SpoListItemRetentionLabelRemoveCommandOutput
+        });
+      }
+
+      throw new CommandError('Unknown case');
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: false,
+        folderId: folderId,
+        webUrl: webUrl,
+        listItemId: 1
+      }
+    });
+    assert(postSpy.called);
+  });
+
+  it('removes the retentionlabel from a folder based on folderId', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields`) {
+        return { ListItemAllFields: { Id: listId }, ServerRelativeUrl: folderUrl };
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postSpy = sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === SpoListItemRetentionLabelRemoveCommand) {
+        return ({
+          stdout: SpoListItemRetentionLabelRemoveCommandOutput
+        });
+      }
+
+      throw new CommandError('Unknown case');
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: false,
+        folderId: folderId,
+        webUrl: webUrl,
+        listItemId: 1,
+        confirm: true
+      }
+    });
+    assert(postSpy.called);
+  });
+
+  it('correctly handles API OData error', async () => {
+    const errorMessage = 'Something went wrong';
+
+    sinon.stub(request, 'get').callsFake(async () => { throw { error: { error: { message: errorMessage } } }; });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: true,
+        confirm: true,
+        folderUrl: folderUrl,
+        webUrl: webUrl
+      }
+    }), new CommandError(errorMessage));
+  });
+
+  it('supports specifying URL', () => {
+    const options = command.options;
+    let containsTypeOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('<webUrl>') > -1) {
+        containsTypeOption = true;
+      }
+    });
+    assert(containsTypeOption);
+  });
+
+  it('fails validation if both folderUrl or folderId options are not passed', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the url option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'foo', folderUrl: folderUrl } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the url option is a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, folderUrl: folderUrl } }, commandInfo);
+    assert(actual);
+  });
+
+  it('fails validation if the folderId option is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, folderId: '12345' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the folderId option is a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, folderId: folderId } }, commandInfo);
+    assert(actual);
+  });
+
+  it('fails validation if both folderId and folderUrl options are passed', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, folderId: folderId, folderUrl: folderUrl } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+});

--- a/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
@@ -1,0 +1,158 @@
+import { AxiosRequestConfig } from 'axios';
+import { Cli } from '../../../../cli/Cli';
+import { Logger } from '../../../../cli/Logger';
+import Command from '../../../../Command';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import { validation } from '../../../../utils/validation';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+import { FolderProperties } from './FolderProperties';
+import { Options as SpoListItemRetentionLabelRemoveCommandOptions } from '../listitem/listitem-retentionlabel-remove';
+import * as SpoListItemRetentionLabelRemoveCommand from '../listitem/listitem-retentionlabel-remove';
+import { formatting } from '../../../../utils/formatting';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  folderUrl?: string;
+  folderId?: string;
+  confirm?: boolean;
+}
+
+class SpoFolderRetentionLabelRemoveCommand extends SpoCommand {
+  public get name(): string {
+    return commands.FOLDER_RETENTIONLABEL_REMOVE;
+  }
+
+  public get description(): string {
+    return 'Clear the retention label from a folder';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initOptionSets();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        folderUrl: typeof args.options.folderUrl !== 'undefined',
+        folderId: typeof args.options.folderId !== 'undefined',
+        confirm: !!args.options.confirm
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '--folderUrl [folderUrl]'
+      },
+      {
+        option: '-i, --folderId [folderId]'
+      },
+      {
+        option: '--confirm'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+        if (isValidSharePointUrl !== true) {
+          return isValidSharePointUrl;
+        }
+
+        if (args.options.folderId &&
+          !validation.isValidGuid(args.options.folderId as string)) {
+          return `${args.options.folderId} is not a valid GUID`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['folderUrl', 'folderId'] });
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (args.options.confirm) {
+      await this.removeFolderRetentionLabel(logger, args);
+    }
+    else {
+      const result = await Cli.prompt<{ continue: boolean }>({
+        type: 'confirm',
+        name: 'continue',
+        default: false,
+        message: `Are you sure you want to remove the retentionlabel from folder ${args.options.folderId || args.options.folderUrl} located in site ${args.options.webUrl}?`
+      });
+
+      if (result.continue) {
+        await this.removeFolderRetentionLabel(logger, args);
+      }
+    }
+  }
+
+  private async removeFolderRetentionLabel(logger: Logger, args: CommandArgs): Promise<void> {
+    if (this.verbose) {
+      logger.logToStderr(`Removing retention label from folder ${args.options.folderId || args.options.folderUrl} in site at ${args.options.webUrl}...`);
+    }
+    try {
+      const folderProperties = await this.getFolderProperties(args);
+      const options: SpoListItemRetentionLabelRemoveCommandOptions = {
+        webUrl: args.options.webUrl,
+        listUrl: folderProperties.listServerRelativeUrl,
+        listItemId: folderProperties.id,
+        confirm: true,
+        output: 'json',
+        debug: this.debug,
+        verbose: this.verbose
+      };
+
+      await Cli.executeCommandWithOutput(SpoListItemRetentionLabelRemoveCommand as Command, { options: { ...options, _: [] } });
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+
+  private async getFolderProperties(args: CommandArgs): Promise<{ id: string, listServerRelativeUrl: string }> {
+    const requestOptions: AxiosRequestConfig = {
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    if (args.options.folderId) {
+      requestOptions.url = `${args.options.webUrl}/_api/web/GetFolderById('${args.options.folderId}')?$expand=ListItemAllFields`;
+    }
+    else {
+      requestOptions.url = `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(args.options.folderUrl!)}')?$expand=ListItemAllFields`;
+    }
+
+    const response = await request.get<FolderProperties>(requestOptions);
+    return { id: response.ListItemAllFields.Id, listServerRelativeUrl: this.getListServerRelativeUrl(response.ServerRelativeUrl) };
+  }
+
+  private getListServerRelativeUrl(folderUrl: string): string {
+    return folderUrl.replace(/\/[^\/]+$/, '');
+  }
+}
+
+module.exports = new SpoFolderRetentionLabelRemoveCommand();

--- a/src/m365/spo/commands/list/list-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-remove.ts
@@ -13,7 +13,7 @@ interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
+export interface Options extends GlobalOptions {
   webUrl: string;
   listId?: string;
   listTitle?: string;


### PR DESCRIPTION
This PR adds the command `spo folder retentionlabel remove`, which clears a retentionlabel from a folder.

Closes #4164 