### PR TITLE
Deletes 'defines correct option sets', Closes #4068

### DIFF
--- a/docs/docs/about/release-notes.md
+++ b/docs/docs/about/release-notes.md
@@ -83,6 +83,7 @@
 - adds userId option to 'spo group member add' [#4097](https://github.com/pnp/cli-microsoft365/issues/4097)
 - fixed page promotion for 'spo page add' and 'spo page set' commands [#4055](https://github.com/pnp/cli-microsoft365/issues/4055)
 - extended 'pp environment get' to retrieve the default environment [#4228](https://github.com/pnp/cli-microsoft365/issues/4228)
+- fixed retrieving process name on Azure Functions [#4229](https://github.com/pnp/cli-microsoft365/issues/4229)
 
 ## [v6.0.0](https://github.com/pnp/cli-microsoft365/releases/tag/v6.0.0)
 

--- a/src/m365/aad/commands/app/app-add.spec.ts
+++ b/src/m365/aad/commands/app/app-add.spec.ts
@@ -6503,13 +6503,6 @@ describe(commands.APP_ADD, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['name', 'manifest'] }
-    ]);
-  });
-
   it('creates AAD app reg for a web app from a manifest with redirectUris and options overriding them', async () => {
     sinon.stub(request, 'get').callsFake(opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/servicePrincipals?$select=appId,appRoles,id,oauth2PermissionScopes,servicePrincipalNames') {

--- a/src/m365/aad/commands/o365group/o365group-recyclebinitem-remove.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-recyclebinitem-remove.spec.ts
@@ -112,11 +112,6 @@ describe(commands.O365GROUP_RECYCLEBINITEM_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'displayName', 'mailNickname'] }]);
-  });
-
   it('fails validation when id is not a valid GUID', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/aad/commands/o365group/o365group-recyclebinitem-restore.spec.ts
+++ b/src/m365/aad/commands/o365group/o365group-recyclebinitem-restore.spec.ts
@@ -106,11 +106,6 @@ describe(commands.O365GROUP_RECYCLEBINITEM_RESTORE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'displayName', 'mailNickname'] }]);
-  });
-
   it('fails validation if the id is not a valid GUID', async () => {
     const actual = await command.validate({ options: { id: 'abc' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/adaptivecard/commands/adaptivecard-send.spec.ts
+++ b/src/m365/adaptivecard/commands/adaptivecard-send.spec.ts
@@ -820,11 +820,6 @@ describe(commands.SEND, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['title', 'card'] }]);
-  });
-
   it('supports specifying unknown options', () => {
     assert.strictEqual(command.allowUnknownOptions(), true);
   });

--- a/src/m365/booking/commands/business/business-get.spec.ts
+++ b/src/m365/booking/commands/business/business-get.spec.ts
@@ -78,11 +78,6 @@ describe(commands.BUSINESS_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('defines correct properties for the text output', () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'displayName', 'businessType', 'phone', 'email', 'defaultCurrencyIso']);
   });

--- a/src/m365/planner/commands/bucket/bucket-get.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.spec.ts
@@ -257,11 +257,6 @@ describe(commands.BUCKET_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('fails validation when no groups found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(validOwnerGroupName)}'`) {

--- a/src/m365/planner/commands/bucket/bucket-remove.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.spec.ts
@@ -150,11 +150,6 @@ describe(commands.BUCKET_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('fails validation id when id and plan details are specified', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/planner/commands/bucket/bucket-set.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.spec.ts
@@ -145,11 +145,6 @@ describe(commands.BUCKET_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('fails validation id when id and plan details are specified', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/planner/commands/plan/plan-get.spec.ts
+++ b/src/m365/planner/commands/plan/plan-get.spec.ts
@@ -116,11 +116,6 @@ describe(commands.PLAN_GET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title'] }]);
-  });
-
   it('fails validation when both ownerGroupId and ownerGroupName are specified when using title', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/planner/commands/plan/plan-remove.spec.ts
+++ b/src/m365/planner/commands/plan/plan-remove.spec.ts
@@ -112,11 +112,6 @@ describe(commands.PLAN_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title'] }]);
-  });
-
   it('fails validation when id and ownerGroupId is specified', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/planner/commands/plan/plan-set.spec.ts
+++ b/src/m365/planner/commands/plan/plan-set.spec.ts
@@ -177,11 +177,6 @@ describe(commands.PLAN_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title'] }]);
-  });
-
   it('defines correct properties for the default output', () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'title', 'createdDateTime', 'owner']);
   });

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -179,11 +179,6 @@ describe(commands.TASK_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title'] }]);
-  });
-
   it('fails validation when bucket name is used without id', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/planner/commands/task/task-reference-remove.spec.ts
+++ b/src/m365/planner/commands/task/task-reference-remove.spec.ts
@@ -141,11 +141,6 @@ describe(commands.TASK_REFERENCE_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['url', 'alias'] }]);
-  });
-
   it('prompts before removal when confirm option not passed', async () => {
     sinonUtil.restore(Cli.prompt);
     sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {

--- a/src/m365/planner/commands/task/task-remove.spec.ts
+++ b/src/m365/planner/commands/task/task-remove.spec.ts
@@ -171,11 +171,6 @@ describe(commands.TASK_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title'] }]);
-  });
-
   it('fails validation when title and id is used', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/pp/commands/solution/solution-remove.spec.ts
+++ b/src/m365/pp/commands/solution/solution-remove.spec.ts
@@ -83,11 +83,6 @@ describe(commands.SOLUTION_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('fails validation if id is not a valid guid.', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
@@ -78,11 +78,6 @@ describe(commands.EXTERNALCONNECTION_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('correctly handles error', async () => {
     sinon.stub(request, 'get').callsFake(() => {
       return Promise.reject('An error has occurred');

--- a/src/m365/search/commands/externalconnection/externalconnection-remove.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-remove.spec.ts
@@ -69,11 +69,6 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('prompts before removing the specified external connection by id when confirm option not passed', async () => {
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/contenttype/contenttype-set.spec.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-set.spec.ts
@@ -90,11 +90,6 @@ describe(commands.CONTENTTYPE_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('fails validation if webUrl is not a valid SharePoint URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'invalid', id: id } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/customaction/customaction-get.spec.ts
+++ b/src/m365/spo/commands/customaction/customaction-get.spec.ts
@@ -67,12 +67,6 @@ describe(commands.CUSTOMACTION_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    assert.deepStrictEqual(command.optionSets, [
-      { options: ['id', 'title'] }
-    ]);
-  });
-
   it('handles error when multiple user custom actions with the specified title found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/UserCustomActions?$filter=Title eq ') > -1) {

--- a/src/m365/spo/commands/customaction/customaction-remove.spec.ts
+++ b/src/m365/spo/commands/customaction/customaction-remove.spec.ts
@@ -94,12 +94,6 @@ describe(commands.CUSTOMACTION_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    assert.deepStrictEqual(command.optionSets, [
-      { options: ['id', 'title'] }
-    ]);
-  });
-
   it('handles error when multiple user custom actions with the specified title found', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/UserCustomActions?$filter=Title eq ') > -1) {

--- a/src/m365/spo/commands/eventreceiver/eventreceiver-get.spec.ts
+++ b/src/m365/spo/commands/eventreceiver/eventreceiver-get.spec.ts
@@ -81,11 +81,6 @@ describe(commands.EVENTRECEIVER_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['name', 'id'] }]);
-  });
-
   it('fails validation if the specified site URL is not a valid SharePoint URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'site.com', name: 'Event receiver' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/field/field-get.spec.ts
+++ b/src/m365/spo/commands/field/field-get.spec.ts
@@ -66,11 +66,6 @@ describe(commands.FIELD_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title'] }]);
-  });
-
   it('fails validation if the specified site URL is not a valid SharePoint URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'site.com', id: '03e45e84-1992-4d42-9116-26f756012634' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/field/field-remove.spec.ts
+++ b/src/m365/spo/commands/field/field-remove.spec.ts
@@ -529,11 +529,6 @@ describe(commands.FIELD_REMOVE, () => {
     assert(containsTypeOption);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title', 'group'] }]);
-  });
-
   it('fails validation if both id and title options are not passed', async () => {
     const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', confirm: true, listTitle: 'Documents' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/field/field-set.spec.ts
+++ b/src/m365/spo/commands/field/field-set.spec.ts
@@ -76,11 +76,6 @@ describe(commands.FIELD_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title'] }]);
-  });
-
   it('updates site column specified by title', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`/_vti_bin/client.svc/ProcessQuery`) > -1) {

--- a/src/m365/spo/commands/file/file-roleassignment-add.spec.ts
+++ b/src/m365/spo/commands/file/file-roleassignment-add.spec.ts
@@ -73,15 +73,6 @@ describe(commands.FILE_ROLEASSIGNMENT_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['fileId', 'fileUrl'] },
-      { options: ['principalId', 'upn', 'groupName'] },
-      { options: ['roleDefinitionId', 'roleDefinitionName'] }
-    ]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', fileId: fileId, groupName: 'Group name A', roleDefinitionName: 'Read' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/file/file-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-roleassignment-remove.spec.ts
@@ -83,14 +83,6 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['fileUrl', 'fileId'] },
-      { options: ['upn', 'groupName', 'principalId'] }
-    ]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', fileId: fileId, principalId: principalId, confirm: true } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/file/file-roleinheritance-break.spec.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-break.spec.ts
@@ -77,11 +77,6 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['fileId', 'fileUrl'] }]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', fileId: fileId, confirm: true } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/file/file-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-reset.spec.ts
@@ -73,11 +73,6 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['fileId', 'fileUrl'] }]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', fileId: fileId, confirm: true } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/file/file-version-list.spec.ts
+++ b/src/m365/spo/commands/file/file-version-list.spec.ts
@@ -97,11 +97,6 @@ describe(commands.FILE_VERSION_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['Created', 'ID', 'IsCurrentVersion', 'VersionLabel']);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['fileUrl', 'fileId'] }]);
-  });
-
   it('fails validation if fileId is not a valid guid', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/spo/commands/folder/folder-get.spec.ts
+++ b/src/m365/spo/commands/folder/folder-get.spec.ts
@@ -418,11 +418,6 @@ describe(commands.FOLDER_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['url', 'id'] }]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', url: '/Shared Documents' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/group/group-get.spec.ts
+++ b/src/m365/spo/commands/group/group-get.spec.ts
@@ -65,11 +65,6 @@ describe(commands.GROUP_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name', 'associatedGroup'] }]);
-  });
-
   it('retrieves group by id with output option json', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/_api/web/sitegroups/GetById') > -1) {

--- a/src/m365/spo/commands/group/group-set.spec.ts
+++ b/src/m365/spo/commands/group/group-set.spec.ts
@@ -80,11 +80,6 @@ describe(commands.GROUP_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('fails validation when group id is not a number', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/spo/commands/hubsite/hubsite-disconnect.spec.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-disconnect.spec.ts
@@ -134,11 +134,6 @@ describe(commands.HUBSITE_DISCONNECT, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title', 'url'] }]);
-  });
-
   it('prompts before disconnecting the hub site when confirmation argument not passed', async () => {
     await command.action(logger, { options: { id: id } });
     let promptIssued = false;

--- a/src/m365/spo/commands/hubsite/hubsite-get.spec.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-get.spec.ts
@@ -80,11 +80,6 @@ describe(commands.HUBSITE_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title', 'url'] }]);
-  });
-
   it('gets information about the specified hub site', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf(`/_api/hubsites/getbyid('${validId}')`) > -1) {

--- a/src/m365/spo/commands/list/list-get.spec.ts
+++ b/src/m365/spo/commands/list/list-get.spec.ts
@@ -1309,9 +1309,4 @@ describe(commands.LIST_GET, () => {
     const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF' } }, commandInfo);
     assert(actual);
   });
-
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'title', 'url'] }]);
-  });
 });

--- a/src/m365/spo/commands/list/list-retentionlabel-get.spec.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-get.spec.ts
@@ -528,9 +528,4 @@ describe(commands.LIST_RETENTIONLABEL_GET, () => {
     const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: 'cc27a922-8224-4296-90a5-ebbc54da2e85' } }, commandInfo);
     assert(actual);
   });
-
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['listId', 'listTitle', 'listUrl'] }]);
-  });
 });

--- a/src/m365/spo/commands/list/list-roleassignment-add.spec.ts
+++ b/src/m365/spo/commands/list/list-roleassignment-add.spec.ts
@@ -107,15 +107,6 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle', 'listUrl'] },
-      { options: ['principalId', 'upn', 'groupName'] },
-      { options: ['roleDefinitionId', 'roleDefinitionName'] }
-    ]);
-  });
-
   it('add role assignment on list by title and role definition id', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf('_api/web/lists/getByTitle(\'test\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {

--- a/src/m365/spo/commands/list/list-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-roleassignment-remove.spec.ts
@@ -104,14 +104,6 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle', 'listUrl'] },
-      { options: ['principalId', 'upn', 'groupName'] }
-    ]);
-  });
-
   it('remove role assignment from list by title', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf('_api/web/lists/getByTitle(\'test\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {

--- a/src/m365/spo/commands/list/list-sitescript-get.spec.ts
+++ b/src/m365/spo/commands/list/list-sitescript-get.spec.ts
@@ -1030,9 +1030,4 @@ describe(commands.LIST_SITESCRIPT_GET, () => {
     const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: 'cc27a922-8224-4296-90a5-ebbc54da2e85' } }, commandInfo);
     assert(actual);
   });
-
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['listId', 'listTitle', 'listUrl'] }]);
-  });
 });

--- a/src/m365/spo/commands/list/list-view-add.spec.ts
+++ b/src/m365/spo/commands/list/list-view-add.spec.ts
@@ -94,10 +94,6 @@ describe(commands.LIST_VIEW_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('has correct option sets', () => {
-    assert.deepStrictEqual(command.optionSets, [{ options: ['listId', 'listTitle', 'listUrl'] }]);
-  });
-
   it('fails validation if webUrl is not a valid SharePoint URL', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/spo/commands/list/list-view-field-add.spec.ts
+++ b/src/m365/spo/commands/list/list-view-field-add.spec.ts
@@ -155,15 +155,6 @@ describe(commands.LIST_VIEW_FIELD_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle', 'listUrl'] },
-      { options: ['viewId', 'viewTitle'] },
-      { options: ['id', 'title'] }
-    ]);
-  });
-
   it('supports specifying URL', () => {
     const options = command.options;
     let containsTypeOption = false;

--- a/src/m365/spo/commands/list/list-view-field-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-view-field-remove.spec.ts
@@ -168,15 +168,6 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle', 'listUrl'] },
-      { options: ['viewId', 'viewTitle'] },
-      { options: ['id', 'title'] }
-    ]);
-  });
-
   it('prompts before removing field from list view when confirmation argument not passed (list title, view id, field title)', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', viewId: 'cc27a922-8224-4296-90a5-ebbc54da2e81', title: 'Created By' } });
     let promptIssued = false;

--- a/src/m365/spo/commands/list/list-view-field-set.spec.ts
+++ b/src/m365/spo/commands/list/list-view-field-set.spec.ts
@@ -168,15 +168,6 @@ describe(commands.LIST_VIEW_FIELD_SET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle', 'listUrl'] },
-      { options: ['viewId', 'viewTitle'] },
-      { options: ['id', 'title'] }
-    ]);
-  });
-
   it('moves the field by title to the position index to viewTitle of listId', async () => {
     stubAllGetRequests();
 

--- a/src/m365/spo/commands/list/list-view-list.spec.ts
+++ b/src/m365/spo/commands/list/list-view-list.spec.ts
@@ -79,11 +79,6 @@ describe(commands.LIST_VIEW_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['Id', 'Title', 'DefaultView', 'Hidden', 'BaseViewId']);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['listId', 'listTitle', 'listUrl'] }]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', listId: listId } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/list/list-view-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-view-remove.spec.ts
@@ -78,14 +78,6 @@ describe(commands.LIST_VIEW_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle', 'listUrl'] },
-      { options: ['id', 'title'] }
-    ]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', id: viewId, listId: listId } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/list/list-view-set.spec.ts
+++ b/src/m365/spo/commands/list/list-view-set.spec.ts
@@ -102,14 +102,6 @@ describe(commands.LIST_VIEW_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle', 'listUrl'] },
-      { options: ['id', 'title'] }
-    ]);
-  });
-
   it('passes validation when id and listId specified as valid GUIDs', async () => {
     const actual = await command.validate({ options: { webUrl: webUrl, listId: listId, id: viewId } }, commandInfo);
     assert.strictEqual(actual, true);

--- a/src/m365/spo/commands/listitem/listitem-list.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-list.spec.ts
@@ -152,13 +152,6 @@ describe(commands.LISTITEM_LIST, () => {
     assert.notStrictEqual(command.types.string, 'undefined', 'command string types undefined');
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle'] }
-    ]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', listTitle: 'Demo List' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/listitem/listitem-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleassignment-remove.spec.ts
@@ -114,14 +114,6 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['listId', 'listTitle', 'listUrl'] },
-      { options: ['principalId', 'upn', 'groupName'] }
-    ]);
-  });
-
   it('remove role assignment from list item get list by title', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf('_api/web/lists/getByTitle(\'test\')/items(1)/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {

--- a/src/m365/spo/commands/listitem/listitem-roleinheritance-break.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleinheritance-break.spec.ts
@@ -82,11 +82,6 @@ describe(commands.LISTITEM_ROLEINHERITANCE_BREAK, () => {
     assert(containsTypeOption);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['listId', 'listTitle', 'listUrl'] }]);
-  });
-
   it('fails validation if the url option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', listItemId: '4', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/listitem/listitem-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleinheritance-reset.spec.ts
@@ -82,11 +82,6 @@ describe(commands.LISTITEM_ROLEINHERITANCE_RESET, () => {
     assert(containsTypeOption);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['listId', 'listTitle', 'listUrl'] }]);
-  });
-
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
     const actual = await command.validate({ options: { webUrl: 'foo', listItemId: 8, listTitle: 'Demo List' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/navigation/navigation-node-add.spec.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-add.spec.ts
@@ -64,11 +64,6 @@ describe(commands.NAVIGATION_NODE_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['location', 'parentNodeId'] }]);
-  });
-
   it('excludes options from URL processing', () => {
     assert.deepStrictEqual((command as any).getExcludedOptionsWithUrls(), ['url']);
   });

--- a/src/m365/spo/commands/page/page-clientsidewebpart-add.spec.ts
+++ b/src/m365/spo/commands/page/page-clientsidewebpart-add.spec.ts
@@ -2830,13 +2830,6 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['standardWebPart', 'webPartId'] }
-    ]);
-  });
-
   it('fails validation if webPartId value is not valid GUID', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/spo/commands/sitedesign/sitedesign-get.spec.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-get.spec.ts
@@ -75,13 +75,6 @@ describe(commands.SITEDESIGN_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['id', 'title'] }
-    ]);
-  });
-
   it('fails to get site design when it does not exists', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesigns`) > -1) {

--- a/src/m365/spo/commands/web/web-roleassignment-add.spec.ts
+++ b/src/m365/spo/commands/web/web-roleassignment-add.spec.ts
@@ -97,14 +97,6 @@ describe(commands.WEB_ROLEASSIGNMENT_ADD, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['principalId', 'upn', 'groupName'] },
-      { options: ['roleDefinitionId', 'roleDefinitionName'] }
-    ]);
-  });
-
   it('add role assignment on web by role definition id', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf('_api/web/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {

--- a/src/m365/spo/commands/web/web-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/web/web-roleassignment-remove.spec.ts
@@ -94,13 +94,6 @@ describe(commands.WEB_ROLEASSIGNMENT_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['principalId', 'upn', 'groupName'] }
-    ]);
-  });
-
   it('remove role assignment from web', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf('_api/web/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {

--- a/src/m365/teams/commands/channel/channel-member-add.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.spec.ts
@@ -257,15 +257,6 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['teamId', 'teamName'] },
-      { options: ['channelId', 'channelName'] },
-      { options: ['userId', 'userDisplayName'] }
-    ]);
-  });
-
   it('fails validation if the teamId is not a valid guid', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/teams/commands/channel/channel-member-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.spec.ts
@@ -85,14 +85,6 @@ describe(commands.CHANNEL_MEMBER_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    assert.deepStrictEqual(command.optionSets, [
-      { options: ['teamId', 'teamName'] },
-      { options: ['channelId', 'channelName'] },
-      { options: ['userId', 'userName', 'id'] }
-    ]);
-  });
-
   it('fails validation if the teamId is not a valid guid', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/teams/commands/channel/channel-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-remove.spec.ts
@@ -97,14 +97,6 @@ describe(commands.CHANNEL_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['id', 'name'] },
-      { options: ['teamId', 'teamName'] }
-    ]);
-  });
-
   it('fails validation if the id is not valid', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/teams/commands/channel/channel-set.spec.ts
+++ b/src/m365/teams/commands/channel/channel-set.spec.ts
@@ -120,14 +120,6 @@ describe(commands.CHANNEL_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['id', 'name'] },
-      { options: ['teamId', 'teamName'] }
-    ]);
-  });
-
   it('fails to patch channel when channel does not exists', async () => {
     const errorMessage = 'The specified channel does not exist in this Microsoft Teams team';
     sinon.stub(request, 'get').callsFake(async (opts) => {

--- a/src/m365/teams/commands/team/team-archive.spec.ts
+++ b/src/m365/teams/commands/team/team-archive.spec.ts
@@ -91,13 +91,6 @@ describe(commands.TEAM_ARCHIVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [
-      { options: ['id', 'name'] }
-    ]);
-  });
-
   it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {

--- a/src/m365/teams/commands/team/team-clone.spec.ts
+++ b/src/m365/teams/commands/team/team-clone.spec.ts
@@ -163,11 +163,6 @@ describe(commands.TEAM_CLONE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('creates a clone of a Microsoft Teams team with mandatory parameters', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/teams/15d7a78e-fd77-4599-97a5-dbb6372846c5/clone`) {

--- a/src/m365/teams/commands/team/team-remove.spec.ts
+++ b/src/m365/teams/commands/team/team-remove.spec.ts
@@ -72,11 +72,6 @@ describe(commands.TEAM_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('fails validation if the id is not a valid guid.', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/teams/commands/team/team-unarchive.spec.ts
+++ b/src/m365/teams/commands/team/team-unarchive.spec.ts
@@ -66,11 +66,6 @@ describe(commands.TEAM_UNARCHIVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct option sets', () => {
-    const optionSets = command.optionSets;
-    assert.deepStrictEqual(optionSets, [{ options: ['id', 'name'] }]);
-  });
-
   it('fails validation if the id is not a valid guid.', async () => {
     const actual = await command.validate({
       options: {


### PR DESCRIPTION
This pr deleted the 'defines correct option sets', it seemed that the option sets were already covered making the  'defines correct option sets' unnecessary!

Closes #4068