### PR TITLE
Fixes 'spo sharinglink list' response

### DIFF
--- a/docs/docs/cmd/spo/file/file-sharinglink-list.md
+++ b/docs/docs/cmd/spo/file/file-sharinglink-list.md
@@ -72,9 +72,9 @@ m365 spo file sharinglink list --webUrl https://contoso.sharepoint.com/sites/dem
           }
         ],
         "link": {
-          "scope": "anonymous",
+          "scope": "organization",
           "type": "view",
-          "webUrl": "https://contoso.sharepoint.com/:b:/s/demo/EY50lub3559MtRKfj2hrZqoBWnHOpGIcgi4gzw9XiWYJ-A",
+          "webUrl": "https://contoso.sharepoint.com/:w:/s/demo/EY50lub3559MtRKfj2hrZqoBWnHOpGIcgi4gzw9XiWYJ-A",
           "preventsDownload": false
         }
       }


### PR DESCRIPTION
Noticed an error in the response of `spo file sharinglink list` command.
The output shows that the link is assigned to a specific user, however the link type says it's an anonymous link.