### PR TITLE
Add command `onenote page list`

### DIFF
--- a/docs/docs/cmd/onenote/page/page-list.md
+++ b/docs/docs/cmd/onenote/page/page-list.md
@@ -1,0 +1,136 @@
+# onenote page list
+
+Retrieve a list of OneNote pages.
+
+## Usage
+
+```sh
+m365 onenote page list [options]
+```
+
+## Options
+
+`--userId [userId]`
+: Id of the user. Use either `userId`, `userName`, `groupId`, `groupName` or `webUrl` but not multiple.
+
+`--userName [userName]`
+: Name of the user. Use either `userId`, `userName`, `groupId`, `groupName` or `webUrl` but not multiple.
+
+`--groupId [groupId]`
+: Id of the SharePoint group. Use either `userId`, `userName`, `groupId`, `groupName` or `webUrl` but not multiple.
+
+`--groupName [groupName]`
+: Name of the SharePoint group. Use either `userId`, `userName`, `groupId`, `groupName` or `webUrl` but not multiple.
+
+`-u, --webUrl [webUrl]`
+: URL of the SharePoint site. Use either `userId`, `userName`, `groupId`, `groupName` or `webUrl` but not multiple.
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+List Microsoft OneNote pages for the currently logged in user
+
+```sh
+m365 onenote page list
+```
+
+List Microsoft OneNote pages in a specific group specified by id
+
+```sh
+m365 onenote page list --groupId 233e43d0-dc6a-482e-9b4e-0de7a7bce9b4
+```
+
+List Microsoft OneNote pages in a specific group specified by name
+
+```sh
+m365 onenote page list --groupName "MyGroup"
+```
+
+List Microsoft OneNote pages for a specific user specified by name
+
+```sh
+m365 onenote page list --userName user1@contoso.onmicrosoft.com
+```
+
+List Microsoft OneNote pages for a specific user specified by id
+
+```sh
+m365 onenote page list --userId 2609af39-7775-4f94-a3dc-0dd67657e900
+```
+
+List Microsoft OneNote pages for a specific site
+
+```sh
+m365 onenote page list --webUrl https://contoso.sharepoint.com/sites/testsite
+```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    [
+      {
+        "id": "1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678",
+        "self": "https://graph.microsoft.com/v1.0/users/john@contoso.com/onenote/pages/1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678",
+        "createdDateTime": "2023-01-07T10:57:15Z",
+        "title": "Page B",
+        "createdByAppId": "",
+        "contentUrl": "https://graph.microsoft.com/v1.0/users/john@contoso.com/onenote/pages/1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678/content",
+        "lastModifiedDateTime": "2023-01-07T10:57:17Z",
+        "links": {
+          "oneNoteClientUrl": {
+            "href": "onenote:https://contoso-my.sharepoint.com/personal/john_contoso_com/Documents/Notitieblokken/My%20OneNote/Test.one#Page%20B&section-id=94cacaca-d6b5-428d-b967-d3cf01b95c28&page-id=46a1b220-7ffd-4512-a571-55322097c08d&end"
+          },
+          "oneNoteWebUrl": {
+            "href": "https://contoso-my.sharepoint.com/personal/john_contoso_com/Documents/Notitieblokken/My%20OneNote?wd=target%28Test.one%7C94cacaca-d6b5-428d-b967-d3cf01b95c28%2FPage%20B%7C46a1b220-7ffd-4512-a571-55322097c08d%2F%29"
+          }
+        },
+        "parentSection": {
+          "id": "1-3eb21088-b613-4698-98df-92a7d34e0678",
+          "displayName": "Test",
+          "self": "https://graph.microsoft.com/v1.0/users/john@contoso.com/onenote/sections/1-3eb21088-b613-4698-98df-92a7d34e0678"
+        }
+      }
+    ]
+    ```
+
+=== "Text"
+
+    ```text
+    createdDateTime       title   id
+    --------------------  ------  --------------------------------------------------------------------------
+    2023-01-07T10:57:15Z  Page B  1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678
+    ```
+
+=== "CSV"
+
+    ```csv
+    createdDateTime,title,id
+    2023-01-07T10:57:15Z,Page B,1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678
+    ```
+
+=== "Markdown"
+
+    ```md
+    # onenote page list --userName "mathijs@mathijsdev2.onmicrosoft.com"
+
+    Date: 07/01/2023
+
+    ## Page A (1-a26aaec43ed348bd82edf4eb44e73d6c!14-3eb21088-b613-4698-98df-92a7d34e0678)
+
+    ## Page B (1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678)
+
+    Property | Value
+    ---------|-------
+    id | 1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678
+    self | https://graph.microsoft.com/v1.0/users/john@contoso.com/onenote/pages/1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678
+    createdDateTime | 2023-01-07T10:57:15Z
+    title | Page B
+    createdByAppId |
+    contentUrl | https://graph.microsoft.com/v1.0/users/john@contoso.com/onenote/pages/1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678/content
+    lastModifiedDateTime | 2023-01-07T10:57:17Z
+    links | { "oneNoteClientUrl": { "href": "onenote:https://contoso-my.sharepoint.com/personal/john_contoso_com/Documents/Notitieblokken/My%20OneNote/Test.one#Page%20B& -id=94cacaca-d6b5-428d-b967-d3cf01b95c28&page-id=46a1b220-7ffd-4512-a571-55322097c08d&end" }, "oneNoteWebUrl": { "href": "https://contoso-my.sharepoint.com/personal/john_contoso_com/Documents/Notitieblokken/My%20OneNote?wd=target%28Test.one%7C94cacaca-d6b5-428d-b967-d3cf01b95c28%2FPage%20B%7C46a1b220-7ffd-4512-a571-55322097c08d%2F%29"}}
+    parentSection | {"id":"1-3eb21088-b613-4698-98df-92a7d34e0678","displayName":"Test","self":"https://graph.microsoft.com/v1.0/users/john@contoso.com/onenote/sections/1-3eb21088-b613-4698-98df-92a7d34e0678"}
+    ```

--- a/docs/docs/cmd/onenote/page/page-list.md
+++ b/docs/docs/cmd/onenote/page/page-list.md
@@ -27,6 +27,10 @@ m365 onenote page list [options]
 
 --8<-- "docs/cmd/_global.md"
 
+## Remarks
+
+When we don't specify either `userId`, `userName`, `groupId`, `groupName` or `webUrl`, the OneNote pages will be retrieved of the currently logged in user.
+
 ## Examples
 
 List Microsoft OneNote pages for the currently logged in user

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -177,6 +177,8 @@ nav:
     - OneNote (onenote):
       - notebook:
         - notebook list: cmd/onenote/notebook/notebook-list.md
+      - page:
+        - page list: cmd/onenote/page/page-list.md
     - Outlook (outlook):
       - mail:
         - mail send: cmd/outlook/mail/mail-send.md

--- a/src/m365/onenote/commands.ts
+++ b/src/m365/onenote/commands.ts
@@ -1,5 +1,6 @@
 const prefix: string = 'onenote';
 
 export default {
-  NOTEBOOK_LIST: `${prefix} notebook list`
+  NOTEBOOK_LIST: `${prefix} notebook list`,
+  PAGE_LIST: `${prefix} page list`
 };

--- a/src/m365/onenote/commands/page/page-list.spec.ts
+++ b/src/m365/onenote/commands/page/page-list.spec.ts
@@ -1,0 +1,308 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { telemetry } from '../../../../telemetry';
+import auth from '../../../../Auth';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+//, { CommandError } 
+import request from '../../../../request';
+import { pid } from '../../../../utils/pid';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+import { odata } from '../../../../utils/odata';
+import { formatting } from '../../../../utils/formatting';
+const command: Command = require('./page-list');
+
+describe(commands.PAGE_LIST, () => {
+  const userId = '0e38b3b3-d9ac-42fa-81db-437ac8caec2f';
+  const userName = 'john@contoso.com';
+  const groupId = 'bba4c915-0ac8-47a1-bd05-087a44c92d3b';
+  const groupName = 'Dummy Group A';
+  const webUrl = 'https://contoso.sharepoint.com/sites/HR';
+  const siteId = 'contoso.sharepoint.com,c2ceff0c-063b-45b3-a9ec-3a7f8e67547f,4aef2b1f-7a54-4f54-be16-167abba63cf2';
+  const pageResponse = {
+    value: [
+      {
+        "id": "1-a26aaec43ed348bd82edf4eb44e73d6c!14-3eb21088-b613-4698-98df-92a7d34e0678",
+        "self": "https://graph.microsoft.com/v1.0/users/mathijs@mathijsdev2.onmicrosoft.com/onenote/pages/1-a26aaec43ed348bd82edf4eb44e73d6c!14-3eb21088-b613-4698-98df-92a7d34e0678",
+        "createdDateTime": "2023-01-07T10:56:45Z",
+        "title": "Page A",
+        "createdByAppId": "",
+        "contentUrl": "https://graph.microsoft.com/v1.0/users/mathijs@mathijsdev2.onmicrosoft.com/onenote/pages/1-a26aaec43ed348bd82edf4eb44e73d6c!14-3eb21088-b613-4698-98df-92a7d34e0678/content",
+        "lastModifiedDateTime": "2023-01-07T10:57:24Z",
+        "links": {
+          "oneNoteClientUrl": {
+            "href": "onenote:https://mathijsdev2-my.sharepoint.com/personal/mathijs_mathijsdev2_onmicrosoft_com/Documents/Notitieblokken/My%20OneNote/Test.one#Page%20A&section-id=94cacaca-d6b5-428d-b967-d3cf01b95c28&page-id=8ca085ba-cad9-4cf4-824e-07e66520ac3f&end"
+          },
+          "oneNoteWebUrl": {
+            "href": "https://mathijsdev2-my.sharepoint.com/personal/mathijs_mathijsdev2_onmicrosoft_com/Documents/Notitieblokken/My%20OneNote?wd=target%28Test.one%7C94cacaca-d6b5-428d-b967-d3cf01b95c28%2FPage%20A%7C8ca085ba-cad9-4cf4-824e-07e66520ac3f%2F%29"
+          }
+        },
+        "parentSection": {
+          "id": "1-3eb21088-b613-4698-98df-92a7d34e0678",
+          "displayName": "Test",
+          "self": "https://graph.microsoft.com/v1.0/users/mathijs@mathijsdev2.onmicrosoft.com/onenote/sections/1-3eb21088-b613-4698-98df-92a7d34e0678"
+        }
+      },
+      {
+        "id": "1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678",
+        "self": "https://graph.microsoft.com/v1.0/users/mathijs@mathijsdev2.onmicrosoft.com/onenote/pages/1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678",
+        "createdDateTime": "2023-01-07T10:57:15Z",
+        "title": "Page B",
+        "createdByAppId": "",
+        "contentUrl": "https://graph.microsoft.com/v1.0/users/mathijs@mathijsdev2.onmicrosoft.com/onenote/pages/1-a26aaec43ed348bd82edf4eb44e73d6c!68-3eb21088-b613-4698-98df-92a7d34e0678/content",
+        "lastModifiedDateTime": "2023-01-07T10:57:17Z",
+        "links": {
+          "oneNoteClientUrl": {
+            "href": "onenote:https://mathijsdev2-my.sharepoint.com/personal/mathijs_mathijsdev2_onmicrosoft_com/Documents/Notitieblokken/My%20OneNote/Test.one#Page%20B&section-id=94cacaca-d6b5-428d-b967-d3cf01b95c28&page-id=46a1b220-7ffd-4512-a571-55322097c08d&end"
+          },
+          "oneNoteWebUrl": {
+            "href": "https://mathijsdev2-my.sharepoint.com/personal/mathijs_mathijsdev2_onmicrosoft_com/Documents/Notitieblokken/My%20OneNote?wd=target%28Test.one%7C94cacaca-d6b5-428d-b967-d3cf01b95c28%2FPage%20B%7C46a1b220-7ffd-4512-a571-55322097c08d%2F%29"
+          }
+        },
+        "parentSection": {
+          "id": "1-3eb21088-b613-4698-98df-92a7d34e0678",
+          "displayName": "Test",
+          "self": "https://graph.microsoft.com/v1.0/users/mathijs@mathijsdev2.onmicrosoft.com/onenote/sections/1-3eb21088-b613-4698-98df-92a7d34e0678"
+        }
+      }
+    ]
+  };
+
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      odata.getAllItems
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      telemetry.trackEvent,
+      pid.getProcessName
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.PAGE_LIST), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('defines correct properties for the default output', () => {
+    assert.deepStrictEqual(command.defaultProperties(), ['createdDateTime', 'title', 'id']);
+  });
+
+  it('fails validation if multiple options are specified', async () => {
+    const actual = await command.validate({ options: { userId: userId, userName: userName, groupId: groupId, groupName: groupName, webUrl: webUrl } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the userId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { userId: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the groupId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { groupId: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if webUrl is not a valid SharePoint URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the groupId is a valid GUID', async () => {
+    const actual = await command.validate({ options: { groupId: groupId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if the userId is a valid GUID', async () => {
+    const actual = await command.validate({ options: { userId: userId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if no option specified', async () => {
+    const actual = await command.validate({ options: {} }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('lists Microsoft OneNote pages for the currently logged in user', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url: string) => {
+      if (url === `https://graph.microsoft.com/v1.0/me/onenote/pages`) {
+        return pageResponse.value;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { debug: true } });
+    assert(loggerLogSpy.calledWith(pageResponse.value));
+  });
+
+  it('lists Microsoft OneNote pages for user by id', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url: string) => {
+      if (url === `https://graph.microsoft.com/v1.0/users/${userId}/onenote/pages`) {
+        return pageResponse.value;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { userId: userId } });
+    assert(loggerLogSpy.calledWith(pageResponse.value));
+  });
+
+  it('lists Microsoft OneNote pages for user by name', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url: string) => {
+      if (url === `https://graph.microsoft.com/v1.0/users/${userName}/onenote/pages`) {
+        return pageResponse.value;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { userName: userName } });
+    assert(loggerLogSpy.calledWith(pageResponse.value));
+  });
+
+  it('lists Microsoft OneNote pages in group by id', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url: string) => {
+      if (url === `https://graph.microsoft.com/v1.0/groups/${groupId}/onenote/pages`) {
+        return pageResponse.value;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { groupId: groupId } });
+    assert(loggerLogSpy.calledWith(pageResponse.value));
+  });
+
+  it('lists Microsoft OneNote pages in group by name', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url: string) => {
+      if (url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(groupName)}'`) {
+        return [{
+          "id": groupId,
+          "description": groupName,
+          "displayName": groupName
+        }];
+      }
+      if (url === `https://graph.microsoft.com/v1.0/groups/${groupId}/onenote/pages`) {
+        return pageResponse.value;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { groupName: groupName } });
+    assert(loggerLogSpy.calledWith(pageResponse.value));
+  });
+
+  it('lists Microsoft OneNote pages for site', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url: string) => {
+      if (url === `https://graph.microsoft.com/v1.0/sites/${siteId}/onenote/pages`) {
+        return pageResponse.value;
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts: any) => {
+      const url = new URL(webUrl);
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/${url.hostname}:${url.pathname}`) {
+        return { id: siteId };
+      }
+      throw 'Invalid request';
+    });
+
+
+    await command.action(logger, { options: { webUrl: webUrl } });
+    assert(loggerLogSpy.calledWith(pageResponse.value));
+  });
+
+  it('throws error when retrieving Microsoft OneNote notebooks for site and no site with specified url is found', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      const url = new URL(webUrl);
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/${url.hostname}:${url.pathname}`) {
+        throw {
+          "error": {
+            "code": "itemNotFound",
+            "message": "Requested site could not be found",
+            "innerError": {
+              "date": "2023-01-07T11:55:48",
+              "request-id": "18925839-f7e6-4827-bcb2-935a7836e734",
+              "client-request-id": "18925839-f7e6-4827-bcb2-935a7836e734"
+            }
+          }
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl } } as any), new CommandError('Requested site could not be found'));
+  });
+
+  it('throws error if group by displayName returns no results', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url: string) => {
+      if (url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(groupName)}'`) {
+        return [];
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { groupName: groupName } } as any), new CommandError(`The specified group '${groupName}' does not exist.`));
+  });
+
+  it('throws an error if group by displayName returns multiple results', async () => {
+    const duplicateGroupId = '9f3c2c36-1682-4922-9ae1-f57d2caf0de1';
+    sinon.stub(odata, 'getAllItems').callsFake(async (url: string) => {
+      if (url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(groupName)}'`) {
+        return [{
+          "id": groupId,
+          "description": groupName,
+          "displayName": groupName
+        }, {
+          "id": duplicateGroupId,
+          "description": groupName,
+          "displayName": groupName
+        }];
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { groupName: groupName } } as any), new CommandError(`Multiple groups with name '${groupName}' found: ${groupId},${duplicateGroupId}.`));
+  });
+});

--- a/src/m365/onenote/commands/page/page-list.spec.ts
+++ b/src/m365/onenote/commands/page/page-list.spec.ts
@@ -6,7 +6,6 @@ import { Cli } from '../../../../cli/Cli';
 import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
-//, { CommandError } 
 import request from '../../../../request';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -241,7 +240,6 @@ describe(commands.PAGE_LIST, () => {
       }
       throw 'Invalid request';
     });
-
 
     await command.action(logger, { options: { webUrl: webUrl } });
     assert(loggerLogSpy.calledWith(pageResponse.value));

--- a/src/m365/onenote/commands/page/page-list.spec.ts
+++ b/src/m365/onenote/commands/page/page-list.spec.ts
@@ -129,11 +129,6 @@ describe(commands.PAGE_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['createdDateTime', 'title', 'id']);
   });
 
-  it('fails validation if multiple options are specified', async () => {
-    const actual = await command.validate({ options: { userId: userId, userName: userName, groupId: groupId, groupName: groupName, webUrl: webUrl } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('fails validation if the userId is not a valid GUID', async () => {
     const actual = await command.validate({ options: { userId: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/onenote/commands/page/page-list.ts
+++ b/src/m365/onenote/commands/page/page-list.ts
@@ -98,7 +98,7 @@ class OneNotePageListCommand extends GraphCommand {
       endpoint += `users/${args.options.userName}`;
     }
     else if (args.options.groupId) {
-      endpoint = `${this.resource}/v1.0/groups/${args.options.groupId}`;
+      endpoint += `groups/${args.options.groupId}`;
     }
     else if (args.options.groupName) {
       const groupId = await this.getGroupId(args.options.groupName);

--- a/src/m365/onenote/commands/page/page-list.ts
+++ b/src/m365/onenote/commands/page/page-list.ts
@@ -39,6 +39,7 @@ class OneNotePageListCommand extends GraphCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initTelemetry(): void {
@@ -66,11 +67,6 @@ class OneNotePageListCommand extends GraphCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        const options = [args.options.userId, args.options.userName, args.options.groupId, args.options.groupName, args.options.webUrl];
-        if (options.filter(item => item !== undefined).length > 1) {
-          return `Specify either userId, userName, groupId, groupName or webUrl, but not multiple`;
-        }
-
         if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
           return `${args.options.userId} is not a valid GUID`;
         }
@@ -86,6 +82,16 @@ class OneNotePageListCommand extends GraphCommand {
         return true;
       }
     );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push({
+      options: ['userId', 'userName', 'groupId', 'groupName', 'webUrl'],
+      runsWhen: (args) => {
+        const options = [args.options.userId, args.options.userName, args.options.groupId, args.options.groupName, args.options.webUrl];
+        return options.some(item => item !== undefined);
+      }
+    });
   }
 
   private async getEndpointUrl(args: CommandArgs): Promise<string> {

--- a/src/m365/onenote/commands/page/page-list.ts
+++ b/src/m365/onenote/commands/page/page-list.ts
@@ -1,0 +1,149 @@
+import { OnenotePage } from '@microsoft/microsoft-graph-types';
+import { Logger } from '../../../../cli/Logger';
+import GlobalOptions from '../../../../GlobalOptions';
+import request, { CliRequestOptions } from '../../../../request';
+import { odata } from '../../../../utils/odata';
+import { validation } from '../../../../utils/validation';
+import { aadGroup } from '../../../../utils/aadGroup';
+import GraphCommand from '../../../base/GraphCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  userId?: string;
+  userName?: string;
+  groupId?: string;
+  groupName?: string;
+  webUrl?: string;
+}
+
+class OneNotePageListCommand extends GraphCommand {
+  public get name(): string {
+    return commands.PAGE_LIST;
+  }
+
+  public get description(): string {
+    return 'Retrieve a list of OneNote pages.';
+  }
+
+  public defaultProperties(): string[] | undefined {
+    return ['createdDateTime', 'title', 'id'];
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        userId: typeof args.options.userId !== 'undefined',
+        userName: typeof args.options.userName !== 'undefined',
+        groupId: typeof args.options.groupId !== 'undefined',
+        groupName: typeof args.options.groupName !== 'undefined',
+        webUrl: typeof args.options.webUrl !== 'undefined'
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      { option: '--userId [userId]' },
+      { option: '--userName [userName]' },
+      { option: '--groupId [groupId]' },
+      { option: '--groupName [groupName]' },
+      { option: '-u, --webUrl [webUrl]' }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        const options = [args.options.userId, args.options.userName, args.options.groupId, args.options.groupName, args.options.webUrl];
+        if (options.filter(item => item !== undefined).length > 1) {
+          return `Specify either userId, userName, groupId, groupName or webUrl, but not multiple`;
+        }
+
+        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
+          return `${args.options.userId} is not a valid GUID`;
+        }
+
+        if (args.options.groupId && !validation.isValidGuid(args.options.groupId)) {
+          return `${args.options.groupId} is not a valid GUID`;
+        }
+
+        if (args.options.webUrl) {
+          return validation.isValidSharePointUrl(args.options.webUrl);
+        }
+
+        return true;
+      }
+    );
+  }
+
+  private async getEndpointUrl(args: CommandArgs): Promise<string> {
+    let endpoint: string = `${this.resource}/v1.0/`;
+
+    if (args.options.userId) {
+      endpoint += `users/${args.options.userId}`;
+    }
+    else if (args.options.userName) {
+      endpoint += `users/${args.options.userName}`;
+    }
+    else if (args.options.groupId) {
+      endpoint = `${this.resource}/v1.0/groups/${args.options.groupId}`;
+    }
+    else if (args.options.groupName) {
+      const groupId = await this.getGroupId(args.options.groupName);
+      endpoint += `groups/${groupId}`;
+    }
+    else if (args.options.webUrl) {
+      const siteId = await this.getSpoSiteId(args.options.webUrl);
+      endpoint += `sites/${siteId}`;
+    }
+    else {
+      endpoint += 'me';
+    }
+    endpoint += '/onenote/pages';
+    return endpoint;
+  }
+
+  private async getGroupId(groupName: string): Promise<string> {
+    const group = await aadGroup.getGroupByDisplayName(groupName);
+    return group.id!;
+  }
+
+  private async getSpoSiteId(webUrl: string): Promise<string> {
+    const url = new URL(webUrl);
+    const requestOptions: CliRequestOptions = {
+      url: `${this.resource}/v1.0/sites/${url.hostname}:${url.pathname}`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    const site = await request.get<{ id: string }>(requestOptions);
+    return site.id;
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      const endpoint = await this.getEndpointUrl(args);
+      const items = await odata.getAllItems<OnenotePage>(endpoint);
+      logger.log(items);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+}
+
+module.exports = new OneNotePageListCommand();


### PR DESCRIPTION
Closes #4001 

Also noticed that the telemtry in `onenote notebook list` was wrong, so I've resolved this.

I believe that currently, in this command, it is also possible to add both `groupId` and `userId`, and only the `userId` will be used, which shouldn't be allowed if I'm correct. Should I log an issue for this?