### PR TITLE
Add missing sample script to mkdocs.yml file

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -845,6 +845,7 @@ nav:
       - sample-scripts/spo/list-tenant-wide-extensions/index.md
       - sample-scripts/spo/list-all-list-folders-itemcount/index.md
       - sample-scripts/spo/list-site-collection-owners/index.md
+      - sample-scripts/spo/list-all-files-with-missing-required-metadata/index.md
       - sample-scripts/spo/monitor-site-collection-storage-usage/index.md
       - sample-scripts/spo/perform-operations-not-covered-by-cli-for-microsoft-365/index.md
       - sample-scripts/spo/planner-migrate-sharepoint-list/index.md


### PR DESCRIPTION
Noticed missing link in mkdocs.yml file, which I've added. Little overkill to create an issue I believe.