### PR TITLE
Adds command `spo file sharinglink set`, Closes #4026

### DIFF
--- a/docs/docs/cmd/spo/file/file-sharinglink-set.md
+++ b/docs/docs/cmd/spo/file/file-sharinglink-set.md
@@ -1,6 +1,6 @@
 # spo file sharinglink set
 
-Updates a sharing link from a file
+Updates a sharing link of a file
 
 ## Usage
 
@@ -10,42 +10,29 @@ m365 spo file sharinglink set [options]
 
 ## Options
 
-`-w, --webUrl <webUrl>`
+`-u, --webUrl <webUrl>`
 :	The URL of the site where the file is located.
 
-`-u, --fileUrl [fileUrl]`
-:	The server-relative URL of the file. Specify either `fileUrl` or `fileId` but not both.
+`--fileUrl [fileUrl]`
+:	The server-relative (decoded) URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
-`-i, --fileId [fileId]`
+`--fileId [fileId]`
 :	The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `--id <id>`
 : The ID of the sharing link.
 
-`--role [role]`
-: The role to set. Possible options are: `read` or `write`. Specify either `role` or `expirationDateTime` but not both.
-
-`--expirationDateTime [expirationDateTime]`
-:	The date and time to set the expiration. This should be defined as a valid ISO 8601 string. Specify either `role` or `expirationDateTime` but not both.
+`--expirationDateTime <expirationDateTime>`
+:	The date and time to set the expiration. This should be defined as a valid ISO 8601 string. This options only works for anonymous links.
 
 --8<-- "docs/cmd/_global.md"
 
-## Remarks
-- you can only set the expiration date for anonymous sharing links
-- you can only set the role for user sharing
-
 ## Examples
-
-Updates a user sharing link from a file with the role parameter
-
-```sh
-m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com/sites/demo --fileId daebb04b-a773-4baa-b1d1-3625418e3234 --role read
-```
 
 Updates an anonymous sharing link from a file with the expirationDateTime parameter
 
 ```sh
-m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com/sites/demo --fileUrl "/Shared Documents/Document.docx" --expirationDateTime "2023-01-09"
+m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com --fileUrl "/Shared Documents/Document.docx" --expirationDateTime "2023-01-09T16:57:00.000Z"
 ```
 
 ## Response
@@ -54,147 +41,38 @@ m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com/sites/demo
 
     ```json
     {
-      "__metadata": {
-        "type": "SP.SharingLinkInfo"
-      },
-      "AllowsAnonymousAccess": true,
-      "ApplicationId": null,
-      "BlocksDownload": false,
-      "Created": "2023-01-09T20:20:22.999Z",
-      "CreatedBy": {
-        "__metadata": {
-          "type": "SP.Sharing.Principal"
-        },
-        "directoryObjectId": null,
-        "email": "john@contoso.onmicrosoft.com",
-        "expiration": null,
-        "id": 10,
-        "isActive": true,
-        "isExternal": false,
-        "jobTitle": null,
-        "loginName": "i:0#.f|membership|john@contoso.onmicrosoft.com",
-        "name": "John Doe",
-        "principalType": 1,
-        "userId": null,
-        "userPrincipalName": "john@contoso.onmicrosoft.com"
-      },
-      "Description": null,
-      "Embeddable": false,
-      "Expiration": "2023-10-31T23:00:00.000Z",
-      "HasExternalGuestInvitees": false,
-      "Invitations": {
-        "__metadata": {
-          "type": "Collection(SP.Sharing.LinkInvitation)"
-        },
-        "results": []
-      },
-      "IsActive": true,
-      "IsAddressBarLink": false,
-      "IsCreateOnlyLink": false,
-      "IsDefault": true,
-      "IsEditLink": false,
-      "IsFormsLink": false,
-      "IsManageListLink": false,
-      "IsReviewLink": false,
-      "IsUnhealthy": false,
-      "LastModified": "2023-01-09T21:14:53.181Z",
-      "LastModifiedBy": {
-        "__metadata": {
-          "type": "SP.Sharing.Principal"
-        },
-        "directoryObjectId": null,
-        "email": "john@contoso.onmicrosoft.com",
-        "expiration": null,
-        "id": 10,
-        "isActive": true,
-        "isExternal": false,
-        "jobTitle": null,
-        "loginName": "i:0#.f|membership|john@contoso.onmicrosoft.com",
-        "name": "John Doe",
-        "principalType": 1,
-        "userId": null,
-        "userPrincipalName": "john@contoso.onmicrosoft.com"
-      },
-      "LimitUseToApplication": false,
-      "LinkKind": 4,
-      "PasswordLastModified": "",
-      "PasswordLastModifiedBy": null,
-      "RedeemedUsers": {
-        "__metadata": {
-          "type": "Collection(SP.Sharing.LinkInvitation)"
-        },
-        "results": []
-      },
-      "RequiresPassword": false,
-      "RestrictedShareMembership": false,
-      "Scope": 0,
-      "ShareId": "7c9f97c9-1bda-433c-9364-bb83e81771ee",
-      "ShareTokenString": "share=EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g",
-      "SharingLinkStatus": 2,
-      "TrackLinkUsers": false,
-      "Url": "https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g"
+      "id": "7c9f97c9-1bda-433c-9364-bb83e81771ee",
+      "roles": [
+        "read"
+      ],
+      "expirationDateTime": "2023-02-09T16:57:00Z",
+      "hasPassword": false,
+      "grantedToIdentitiesV2": [],
+      "grantedToIdentities": [],
+      "link": {
+        "scope": "anonymous",
+        "type": "view",
+        "webUrl": "https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g",
+        "preventsDownload": false
+      }
     }
     ```
 
 === "Text"
 
     ```text
-    id   : 7c9f97c9-1bda-433c-9364-bb83e81771ee
-    link : https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g
-    scope: 0
+    expirationDateTime   : 2023-02-09T16:57:00Z
+    grantedToIdentities  : []
+    grantedToIdentitiesV2: []
+    hasPassword          : false
+    id                   : 7c9f97c9-1bda-433c-9364-bb83e81771ee
+    link                 : {"scope":"anonymous","type":"view","webUrl":"https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g","preventsDownload":false}
+    roles                : ["read"]
     ```
 
 === "CSV"
 
     ```csv
-    id,link,scope
-    7c9f97c9-1bda-433c-9364-bb83e81771ee,https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g,0
-    ```
-
-=== "Markdown"
-
-    ```md
-    # spo file sharinglink set --webUrl "https://contoso.sharepoint.com" --fileUrl "/Shared Documents/Document.docx" --id "7c9f97c9-1bda-433c-9364-bb83e81771ee" --expirationDateTime "2023-11-01"
-
-    Date: 9/1/2023
-
-    ## undefined (https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g)
-
-    Property | Value
-    ---------|-------
-    \_\_metadata | {"type":"SP.SharingLinkInfo"}
-    AllowsAnonymousAccess | true
-    ApplicationId | null
-    BlocksDownload | false
-    Created | 2023-01-09T20:20:22.999Z
-    CreatedBy | {"\_\_metadata":{"type":"SP.Sharing.Principal"},"directoryObjectId":null,"email":"john@contoso.onmicrosoft.com","expiration":null,"id":10,"isActive":true,"isExternal":false,"jobTitle":null,"loginName":"i:0#.f\|membership\|john@contoso.onmicrosoft.com","name":"John Doe","principalType":1,"userId":null,"userPrincipalName":"john@contoso.onmicrosoft.com"}
-    Description | null
-    Embeddable | false
-    Expiration | 2023-10-31T23:00:00.000Z
-    HasExternalGuestInvitees | false
-    Invitations | {"\_\_metadata":{"type":"Collection(SP.Sharing.LinkInvitation)"},"results":[]}
-    IsActive | true
-    IsAddressBarLink | false
-    IsCreateOnlyLink | false
-    IsDefault | true
-    IsEditLink | false
-    IsFormsLink | false
-    IsManageListLink | false
-    IsReviewLink | false
-    IsUnhealthy | false
-    LastModified | 2023-01-09T21:14:53.181Z
-    LastModifiedBy | {"\_\_metadata":{"type":"SP.Sharing.Principal"},"directoryObjectId":null,"email":"john@contoso.onmicrosoft.com","expiration":null,"id":10,"isActive":true,"isExternal":false,"jobTitle":null,"loginName":"i:0#.f\|membership\|john@contoso.onmicrosoft.com","name":"John Doe","principalType":1,"userId":null,"userPrincipalName":"john@contoso.onmicrosoft.com"}
-    LimitUseToApplication | false
-    LinkKind | 4
-    PasswordLastModified |
-    PasswordLastModifiedBy | null
-    RedeemedUsers | {"\_\_metadata":{"type":"Collection(SP.Sharing.LinkInvitation)"},"results":[]}
-    RequiresPassword | false
-    RestrictedShareMembership | false
-    Scope | 0
-    ShareId | 7c9f97c9-1bda-433c-9364-bb83e81771ee
-    ShareTokenString | share=EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-\_527\_fI9g
-    SharingLinkStatus | 2
-    TrackLinkUsers | false
-    Url | https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-\_527\_fI9g
+    id,roles,expirationDateTime,hasPassword,grantedToIdentitiesV2,grantedToIdentities,link
+    7c9f97c9-1bda-433c-9364-bb83e81771ee,"[""read""]",2023-02-09T16:57:00Z,,[],[],"{""scope"":""anonymous"",""type"":""view"",""webUrl"":""https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g"",""preventsDownload"":false}"
     ```

--- a/docs/docs/cmd/spo/file/file-sharinglink-set.md
+++ b/docs/docs/cmd/spo/file/file-sharinglink-set.md
@@ -29,10 +29,16 @@ m365 spo file sharinglink set [options]
 
 ## Examples
 
-Updates an anonymous sharing link from a file with the expirationDateTime parameter
+Updates an anonymous sharing link from a file by a specified site-relative URL with the expirationDateTime parameter
 
 ```sh
-m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com --fileUrl "/Shared Documents/Document.docx" --expirationDateTime "2023-01-09T16:57:00.000Z"
+m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com --fileUrl "/sites/demo/Shared Documents/Document.docx" --id "7c9f97c9-1bda-433c-9364-bb83e81771ee" --expirationDateTime "2023-01-09T16:57:00.000Z"
+```
+
+Updates an anonymous sharing link from a file by id with the expirationDateTime parameter
+
+```sh
+m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com --fileId daebb04b-a773-4baa-b1d1-3625418e3234 --id "7c9f97c9-1bda-433c-9364-bb83e81771ee" --expirationDateTime "2023-01-09T16:57:00.000Z"
 ```
 
 ## Response
@@ -52,7 +58,7 @@ m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com --fileUrl 
       "link": {
         "scope": "anonymous",
         "type": "view",
-        "webUrl": "https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g",
+        "webUrl": "https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g",
         "preventsDownload": false
       }
     }
@@ -66,7 +72,7 @@ m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com --fileUrl 
     grantedToIdentitiesV2: []
     hasPassword          : false
     id                   : 7c9f97c9-1bda-433c-9364-bb83e81771ee
-    link                 : {"scope":"anonymous","type":"view","webUrl":"https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g","preventsDownload":false}
+    link                 : {"scope":"anonymous","type":"view","webUrl":"https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g","preventsDownload":false}
     roles                : ["read"]
     ```
 
@@ -74,5 +80,25 @@ m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com --fileUrl 
 
     ```csv
     id,roles,expirationDateTime,hasPassword,grantedToIdentitiesV2,grantedToIdentities,link
-    7c9f97c9-1bda-433c-9364-bb83e81771ee,"[""read""]",2023-02-09T16:57:00Z,,[],[],"{""scope"":""anonymous"",""type"":""view"",""webUrl"":""https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g"",""preventsDownload"":false}"
+    7c9f97c9-1bda-433c-9364-bb83e81771ee,"[""read""]",2023-02-09T16:57:00Z,,[],[],"{""scope"":""anonymous"",""type"":""view"",""webUrl"":""https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g"",""preventsDownload"":false}"
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo file sharinglink set --webUrl "https://contoso.sharepoint.com" --fileUrl "/sites/demo/Shared Documents/Document.docx" --expirationDateTime "2023-02-09T16:57:00.000Z" --id "7c9f97c9-1bda-433c-9364-bb83e81771ee"
+
+    Date: 5/2/2023
+
+    ## 7c9f97c9-1bda-433c-9364-bb83e81771ee
+
+    Property | Value
+    ---------|-------
+    id | 7c9f97c9-1bda-433c-9364-bb83e81771ee
+    roles | ["read"]
+    expirationDateTime | 2023-02-09T16:57:00Z
+    hasPassword | false
+    grantedToIdentitiesV2 | []
+    grantedToIdentities | []
+    link | {"scope":"anonymous","type":"view","webUrl":"https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-\_527\_fI9g","preventsDownload":false}
     ```

--- a/docs/docs/cmd/spo/file/file-sharinglink-set.md
+++ b/docs/docs/cmd/spo/file/file-sharinglink-set.md
@@ -1,0 +1,200 @@
+# spo file sharinglink set
+
+Updates a sharing link from a file
+
+## Usage
+
+```sh
+m365 spo file sharinglink set [options]
+```
+
+## Options
+
+`-w, --webUrl <webUrl>`
+:	The URL of the site where the file is located.
+
+`-u, --fileUrl [fileUrl]`
+:	The server-relative URL of the file. Specify either `fileUrl` or `fileId` but not both.
+
+`-i, --fileId [fileId]`
+:	The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.
+
+`--id <id>`
+: The ID of the sharing link.
+
+`--role [role]`
+: The role to set. Possible options are: `read` or `write`. Specify either `role` or `expirationDateTime` but not both.
+
+`--expirationDateTime [expirationDateTime]`
+:	The date and time to set the expiration. This should be defined as a valid ISO 8601 string. Specify either `role` or `expirationDateTime` but not both.
+
+--8<-- "docs/cmd/_global.md"
+
+## Remarks
+- you can only set the expiration date for anonymous sharing links
+- you can only set the role for user sharing
+
+## Examples
+
+Updates a user sharing link from a file with the role parameter
+
+```sh
+m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com/sites/demo --fileId daebb04b-a773-4baa-b1d1-3625418e3234 --role read
+```
+
+Updates an anonymous sharing link from a file with the expirationDateTime parameter
+
+```sh
+m365 spo file sharinglink set --webUrl https://contoso.sharepoint.com/sites/demo --fileUrl "/Shared Documents/Document.docx" --expirationDateTime "2023-01-09"
+```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    {
+      "__metadata": {
+        "type": "SP.SharingLinkInfo"
+      },
+      "AllowsAnonymousAccess": true,
+      "ApplicationId": null,
+      "BlocksDownload": false,
+      "Created": "2023-01-09T20:20:22.999Z",
+      "CreatedBy": {
+        "__metadata": {
+          "type": "SP.Sharing.Principal"
+        },
+        "directoryObjectId": null,
+        "email": "john@contoso.onmicrosoft.com",
+        "expiration": null,
+        "id": 10,
+        "isActive": true,
+        "isExternal": false,
+        "jobTitle": null,
+        "loginName": "i:0#.f|membership|john@contoso.onmicrosoft.com",
+        "name": "John Doe",
+        "principalType": 1,
+        "userId": null,
+        "userPrincipalName": "john@contoso.onmicrosoft.com"
+      },
+      "Description": null,
+      "Embeddable": false,
+      "Expiration": "2023-10-31T23:00:00.000Z",
+      "HasExternalGuestInvitees": false,
+      "Invitations": {
+        "__metadata": {
+          "type": "Collection(SP.Sharing.LinkInvitation)"
+        },
+        "results": []
+      },
+      "IsActive": true,
+      "IsAddressBarLink": false,
+      "IsCreateOnlyLink": false,
+      "IsDefault": true,
+      "IsEditLink": false,
+      "IsFormsLink": false,
+      "IsManageListLink": false,
+      "IsReviewLink": false,
+      "IsUnhealthy": false,
+      "LastModified": "2023-01-09T21:14:53.181Z",
+      "LastModifiedBy": {
+        "__metadata": {
+          "type": "SP.Sharing.Principal"
+        },
+        "directoryObjectId": null,
+        "email": "john@contoso.onmicrosoft.com",
+        "expiration": null,
+        "id": 10,
+        "isActive": true,
+        "isExternal": false,
+        "jobTitle": null,
+        "loginName": "i:0#.f|membership|john@contoso.onmicrosoft.com",
+        "name": "John Doe",
+        "principalType": 1,
+        "userId": null,
+        "userPrincipalName": "john@contoso.onmicrosoft.com"
+      },
+      "LimitUseToApplication": false,
+      "LinkKind": 4,
+      "PasswordLastModified": "",
+      "PasswordLastModifiedBy": null,
+      "RedeemedUsers": {
+        "__metadata": {
+          "type": "Collection(SP.Sharing.LinkInvitation)"
+        },
+        "results": []
+      },
+      "RequiresPassword": false,
+      "RestrictedShareMembership": false,
+      "Scope": 0,
+      "ShareId": "7c9f97c9-1bda-433c-9364-bb83e81771ee",
+      "ShareTokenString": "share=EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g",
+      "SharingLinkStatus": 2,
+      "TrackLinkUsers": false,
+      "Url": "https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g"
+    }
+    ```
+
+=== "Text"
+
+    ```text
+    id   : 7c9f97c9-1bda-433c-9364-bb83e81771ee
+    link : https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g
+    scope: 0
+    ```
+
+=== "CSV"
+
+    ```csv
+    id,link,scope
+    7c9f97c9-1bda-433c-9364-bb83e81771ee,https://ordidev.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g,0
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo file sharinglink set --webUrl "https://contoso.sharepoint.com" --fileUrl "/Shared Documents/Document.docx" --id "7c9f97c9-1bda-433c-9364-bb83e81771ee" --expirationDateTime "2023-11-01"
+
+    Date: 9/1/2023
+
+    ## undefined (https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g)
+
+    Property | Value
+    ---------|-------
+    \_\_metadata | {"type":"SP.SharingLinkInfo"}
+    AllowsAnonymousAccess | true
+    ApplicationId | null
+    BlocksDownload | false
+    Created | 2023-01-09T20:20:22.999Z
+    CreatedBy | {"\_\_metadata":{"type":"SP.Sharing.Principal"},"directoryObjectId":null,"email":"john@contoso.onmicrosoft.com","expiration":null,"id":10,"isActive":true,"isExternal":false,"jobTitle":null,"loginName":"i:0#.f\|membership\|john@contoso.onmicrosoft.com","name":"John Doe","principalType":1,"userId":null,"userPrincipalName":"john@contoso.onmicrosoft.com"}
+    Description | null
+    Embeddable | false
+    Expiration | 2023-10-31T23:00:00.000Z
+    HasExternalGuestInvitees | false
+    Invitations | {"\_\_metadata":{"type":"Collection(SP.Sharing.LinkInvitation)"},"results":[]}
+    IsActive | true
+    IsAddressBarLink | false
+    IsCreateOnlyLink | false
+    IsDefault | true
+    IsEditLink | false
+    IsFormsLink | false
+    IsManageListLink | false
+    IsReviewLink | false
+    IsUnhealthy | false
+    LastModified | 2023-01-09T21:14:53.181Z
+    LastModifiedBy | {"\_\_metadata":{"type":"SP.Sharing.Principal"},"directoryObjectId":null,"email":"john@contoso.onmicrosoft.com","expiration":null,"id":10,"isActive":true,"isExternal":false,"jobTitle":null,"loginName":"i:0#.f\|membership\|john@contoso.onmicrosoft.com","name":"John Doe","principalType":1,"userId":null,"userPrincipalName":"john@contoso.onmicrosoft.com"}
+    LimitUseToApplication | false
+    LinkKind | 4
+    PasswordLastModified |
+    PasswordLastModifiedBy | null
+    RedeemedUsers | {"\_\_metadata":{"type":"Collection(SP.Sharing.LinkInvitation)"},"results":[]}
+    RequiresPassword | false
+    RestrictedShareMembership | false
+    Scope | 0
+    ShareId | 7c9f97c9-1bda-433c-9364-bb83e81771ee
+    ShareTokenString | share=EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-\_527\_fI9g
+    SharingLinkStatus | 2
+    TrackLinkUsers | false
+    Url | https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-\_527\_fI9g
+    ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -404,6 +404,7 @@ nav:
         - file sharinglink get: cmd/spo/file/file-sharinglink-get.md
         - file sharinglink list: cmd/spo/file/file-sharinglink-list.md
         - file sharinglink remove: cmd/spo/file/file-sharinglink-remove.md
+        - file sharinglink set: cmd/spo/file/file-sharinglink-set.md
         - file version clear: cmd/spo/file/file-version-clear.md
         - file version get: cmd/spo/file/file-version-get.md
         - file version list: cmd/spo/file/file-version-list.md

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -64,6 +64,7 @@ export default {
   FILE_SHARINGLINK_GET: `${prefix} file sharinglink get`,
   FILE_SHARINGLINK_LIST: `${prefix} file sharinglink list`,
   FILE_SHARINGLINK_REMOVE: `${prefix} file sharinglink remove`,
+  FILE_SHARINGLINK_SET: `${prefix} file sharinglink set`,
   FILE_VERSION_CLEAR: `${prefix} file version clear`,
   FILE_VERSION_GET: `${prefix} file version get`,
   FILE_VERSION_LIST: `${prefix} file version list`,

--- a/src/m365/spo/commands/file/file-sharinglink-set.spec.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-set.spec.ts
@@ -1,0 +1,435 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { telemetry } from '../../../../telemetry';
+import auth from '../../../../Auth';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { pid } from '../../../../utils/pid';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+import { formatting } from '../../../../utils/formatting';
+const command: Command = require('./file-sharinglink-set');
+
+describe(commands.FILE_SHARINGLINK_SET, () => {
+  let log: any[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+
+  const webUrl = 'https://contoso.sharepoint.com';
+  const listId = 'eb15c4c1-6820-4462-aff9-87e1fb98590b';
+  const fileId = 'f09c4efe-b8c0-4e89-a166-03418661b89b';
+  const sharingLinkId = '7c9f97c9-1bda-433c-9364-bb83e81771ee';
+  const fileUrl = '/sites/project-x/documents/SharedFile.docx';
+  const fileDetailsResponse = {
+    ListId: listId,
+    UniqueId: fileId
+  };
+
+  const shareLinkResponseText = {
+    id: '7c9f97c9-1bda-433c-9364-bb83e81771ee',
+    link: 'https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g',
+    scope: 0
+  };
+
+  const sharingInformationResponse = {
+    d: {
+      __metadata: {
+        id: 'https://contoso.sharepoint.com/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation',
+        uri: 'https://contoso.sharepoint.com/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation',
+        type: 'SP.Sharing.SharingInformation'
+      },
+      pickerSettings: { __deferred: [Object] },
+      anonymousLinkExpirationRestrictionDays: -1,
+      anyoneLinkTrackUsers: false,
+      blockPeoplePickerAndSharing: false,
+      canAddExternalPrincipal: true,
+      canAddInternalPrincipal: true,
+      canRequestAccessForGrantAccess: true,
+      canSendEmail: true,
+      canUseSimplifiedRoles: true,
+      currentRole: 3,
+      customizedExternalSharingServiceUrl: '',
+      defaultLinkKind: 5,
+      defaultShareLinkPermission: 2,
+      defaultShareLinkScope: 0,
+      defaultShareLinkToExistingAccess: false,
+      directUrl: 'https://contoso.sharepoint.com/:b:/r/Shared%20Documents/Document.docx?csf=1&web=1',
+      displayName: 'Document.docx',
+      enforceIBSegmentFiltering: false,
+      enforceSPOSearch: false,
+      fileExtension: 'docx',
+      hasUniquePermissions: true,
+      isStubFile: false,
+      itemUniqueId: 'f09c4efe-b8c0-4e89-a166-03418661b89b',
+      itemUrl: 'https://contoso.sharepoint.com/_api/v2.0/drives/b!cLoLZkprP0qqo4PG4KBxvLNbttihbPJNpL4O_givJYCARvYucPShT4HI2ULs_paW/items/017S3RUYVWOHQQH4U53FDKPIOV7IF5EPSL',
+      microserviceShareUiUrl: 'https://www.odwebp.svc.ms/share',
+      outlookEndpointHostUrl: 'outlook.office.com',
+      sensitivityLabelInformation: null,
+      sharedObjectType: 1,
+      shareUiUrl: 'https://conoso.sharepoint.com/Shared%20Documents/Forms/AllItems.aspx?p=12&id=%2FShared%20Documents%2FDocument%2Edocx&clientId=clientId',
+      sharingAbilities: {
+        __metadata: [Object],
+        anonymousLinkAbilities: [Object],
+        anyoneLinkAbilities: [Object],
+        directSharingAbilities: [Object],
+        organizationLinkAbilities: [Object],
+        peopleSharingLinkAbilities: [Object]
+      },
+      sharingLinkTemplates: {
+        __metadata: [Object], templates: {
+          __metadata: { type: 'Collection(SP.Sharing.SharingLinkDefaultTemplate)' },
+          results: [
+            {
+              linkDetails: {
+                __metadata: { type: 'SP.SharingLinkInfo' },
+                AllowsAnonymousAccess: true,
+                ApplicationId: null,
+                BlocksDownload: false,
+                Created: '2023-01-09T20:19:55.215Z',
+                CreatedBy: {
+                  __metadata: [Object],
+                  directoryObjectId: null,
+                  email: 'john@contoso.onmicrosoft.com',
+                  expiration: null,
+                  id: 10,
+                  isActive: true,
+                  isExternal: false,
+                  jobTitle: null,
+                  loginName: 'i:0#.f|membership|john@contoso.onmicrosoft.com',
+                  name: 'John Doe',
+                  principalType: 1,
+                  userId: null,
+                  userPrincipalName: 'john@contoso.onmicrosoft.com'
+                },
+                Description: null,
+                Embeddable: false,
+                Expiration: '',
+                HasExternalGuestInvitees: false,
+                Invitations: { __metadata: [Object], results: [] },
+                IsActive: true,
+                IsAddressBarLink: false,
+                IsCreateOnlyLink: false,
+                IsDefault: true,
+                IsEditLink: true,
+                IsFormsLink: false,
+                IsManageListLink: false,
+                IsReviewLink: false,
+                IsUnhealthy: false,
+                LastModified: '2023-01-09T20:19:55.215Z',
+                LastModifiedBy: {
+                  __metadata: [Object],
+                  directoryObjectId: null,
+                  email: 'john@contoso.onmicrosoft.com',
+                  expiration: null,
+                  id: 10,
+                  isActive: true,
+                  isExternal: false,
+                  jobTitle: null,
+                  loginName: 'i:0#.f|membership|john@contoso.onmicrosoft.com',
+                  name: 'John Doe',
+                  principalType: 1,
+                  userId: null,
+                  userPrincipalName: 'john@contoso.onmicrosoft.com'
+                },
+                LimitUseToApplication: false,
+                LinkKind: 5,
+                PasswordLastModified: '',
+                PasswordLastModifiedBy: null,
+                RedeemedUsers: { __metadata: [Object], results: [] },
+                RequiresPassword: false,
+                RestrictedShareMembership: false,
+                Scope: 0,
+                ShareId: '7c9f97c9-1bda-433c-9364-bb83e81771ee',
+                ShareTokenString: 'share=EbZx4QPyndlGp6HV-gvSPksBLEqz3k4gJxPFPm4f4tZtVA',
+                SharingLinkStatus: 0,
+                TrackLinkUsers: false,
+                Url: 'https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBLEqz3k4gJxPFPm4f4tZtVA'
+              },
+              passwordProtected: false,
+              role: 2,
+              scope: 0,
+              shareKind: 5,
+              trackLinkUsers: false
+            },
+            {}],
+          linkDetails: [Object],
+          passwordProtected: false,
+          role: 2,
+          scope: 0,
+          shareKind: 5,
+          trackLinkUsers: false
+        }
+      },
+      sharingStatus: 2,
+      showExternalSharingWarning: false,
+      siteIBMode: 'Open',
+      siteIBSegmentIDs: { __metadata: [Object], results: [] },
+      standardRolesModified: true,
+      userIsSharingViaMCS: null,
+      userPhotoCdnBaseUrl: 'https://contoso.sharepoint.com/_vti_bin/afdcache.ashx/_userprofile/userphoto.jpg?_oat_=1673331428_28ca8e187ff361085b115bc79aa0ad8cb06fe6f6d81cf4ed5e6622ec67707075&P1=1673303395&P2=864232212&P3=1&P4=ln0ppMcWTpAaN6GRFeFG4zIfkAYGDEP%2b%2fndebReEd5LPqTjr62Hgubd0Q7W%2fUudwaqWIhiWjdAO5dNl8jLgvPROXRk4yZAaneMd0%2ffRubh5CLc6jVD7gEozoxslVD0xQnYN1Ol4P1eUjnO1TjoZEN5MV%2b8dBPlCGYWmn8YWNGPpfWal9rWzfzSNRhPhM6ndgxPIzY2DVfSU%2bfMqPfEEKjqewPul8RgAbHh9T%2f7HrZDoNuA53CPD3oujItPYsQ%2fHoNjM5IUpBFWrkt6amBtXmwUZKuJQ97kQgN1GJ0V3ysTJzwaSLG7T2kTnkiRRkWXyOhp%2fh1e6clXJl2M87Gzrmeg%3d%3d',
+      webTemplateId: 68,
+      webUrl: 'https://contoso.sharepoint.com'
+    }
+  };
+
+  const shareLinkResponse = {
+    d: {
+      ShareLink: {
+        __metadata: {
+          type: "SP.Sharing.ShareLinkResponse"
+        },
+        sharingLinkInfo: {
+          __metadata: {
+            type: "SP.SharingLinkInfo"
+          },
+          AllowsAnonymousAccess: true,
+          ApplicationId: null,
+          BlocksDownload: false,
+          Created: "2023-01-09T20:20:22.999Z",
+          CreatedBy: {
+            __metadata: {
+              type: "SP.Sharing.Principal"
+            },
+            directoryObjectId: null,
+            email: "john@contoso.onmicrosoft.com",
+            expiration: null,
+            id: 10,
+            isActive: true,
+            isExternal: false,
+            jobTitle: null,
+            loginName: "i:0#.f|membership|john@contoso.onmicrosoft.com",
+            name: "John Doe",
+            principalType: 1,
+            userId: null,
+            userPrincipalName: "john@contoso.onmicrosoft.com"
+          },
+          Description: null,
+          Embeddable: false,
+          Expiration: "2023-10-31T23:00:00.000Z",
+          HasExternalGuestInvitees: false,
+          Invitations: {
+            __metadata: {
+              type: "Collection(SP.Sharing.LinkInvitation)"
+            },
+            results: []
+          },
+          IsActive: true,
+          IsAddressBarLink: false,
+          IsCreateOnlyLink: false,
+          IsDefault: true,
+          IsEditLink: false,
+          IsFormsLink: false,
+          IsManageListLink: false,
+          IsReviewLink: false,
+          IsUnhealthy: false,
+          LastModified: "2023-01-09T21:14:53.181Z",
+          LastModifiedBy: {
+            __metadata: {
+              type: "SP.Sharing.Principal"
+            },
+            directoryObjectId: null,
+            email: "john@contoso.onmicrosoft.com",
+            expiration: null,
+            id: 10,
+            isActive: true,
+            isExternal: false,
+            jobTitle: null,
+            loginName: "i:0#.f|membership|john@contoso.onmicrosoft.com",
+            name: "John Doe",
+            principalType: 1,
+            userId: null,
+            userPrincipalName: "john@contoso.onmicrosoft.com"
+          },
+          LimitUseToApplication: false,
+          LinkKind: 4,
+          PasswordLastModified: "",
+          PasswordLastModifiedBy: null,
+          RedeemedUsers: {
+            __metadata: {
+              type: "Collection(SP.Sharing.LinkInvitation)"
+            },
+            results: []
+          },
+          RequiresPassword: false,
+          RestrictedShareMembership: false,
+          Scope: 0,
+          ShareId: "7c9f97c9-1bda-433c-9364-bb83e81771ee",
+          ShareTokenString: "share=EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g",
+          SharingLinkStatus: 2,
+          TrackLinkUsers: false,
+          Url: "https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g"
+        }
+      }
+    }
+  };
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      request.post
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      telemetry.trackEvent,
+      pid.getProcessName
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.FILE_SHARINGLINK_SET);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('updates a sharing link from a file specified by the id', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetFileById('${fileId}')?$select=ListId,UniqueId`) {
+        return fileDetailsResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'&$Expand=sharingLinkTemplates`) {
+        return sharingInformationResponse;
+      }
+
+      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/ShareLink?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'`) {
+        return shareLinkResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, fileId: fileId, output: 'json', id: sharingLinkId, role: 'read', verbose: true } } as any);
+    assert(loggerLogSpy.calledWith(shareLinkResponse.d.ShareLink.sharingLinkInfo));
+  });
+
+  it('updates a sharing link from a file specified by the url', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(decodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$select=ListId,UniqueId`) {
+        return fileDetailsResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'&$Expand=sharingLinkTemplates`) {
+        return sharingInformationResponse;
+      }
+
+      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/ShareLink?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'`) {
+        return shareLinkResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, fileUrl: fileUrl, output: 'json', id: sharingLinkId, expirationDateTime: '2023-01-09', verbose: true } } as any);
+    assert(loggerLogSpy.calledWith(shareLinkResponse.d.ShareLink.sharingLinkInfo));
+  });
+
+  it('updates a sharing link from a file specified by the id with text output', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetFileById('${fileId}')?$select=ListId,UniqueId`) {
+        return fileDetailsResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'&$Expand=sharingLinkTemplates`) {
+        return sharingInformationResponse;
+      }
+
+      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/ShareLink?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'`) {
+        return shareLinkResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, fileId: fileId, output: 'text', id: sharingLinkId, role: 'write', verbose: true } } as any);
+    assert(loggerLogSpy.calledWith(shareLinkResponseText));
+  });
+
+  it('throws error when file not found by id', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetFileById('${fileId}')?$select=ListId,UniqueId`) {
+        throw { error: { 'odata.error': { message: { value: 'File Not Found.' } } } };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, fileId: fileId, id: sharingLinkId, role: 'read', verbose: true } } as any),
+      new CommandError(`File Not Found.`));
+  });
+
+  it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'foo', fileId: fileId, id: sharingLinkId, role: 'read' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the fileId option is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: 'invalid', id: sharingLinkId, role: 'read' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the id option is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: 'invalid', role: 'read' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the expirationDateTime option is not a valid date', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: sharingLinkId, expirationDateTime: 'invalid date' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if invalid role specified', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: sharingLinkId, role: 'invalid role' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if options are valid', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: sharingLinkId, role: 'read' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+});

--- a/src/m365/spo/commands/file/file-sharinglink-set.spec.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-set.spec.ts
@@ -11,6 +11,7 @@ import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
 import { formatting } from '../../../../utils/formatting';
+import { GraphFileDetails } from './GraphFileDetails';
 const command: Command = require('./file-sharinglink-set');
 
 describe(commands.FILE_SHARINGLINK_SET, () => {
@@ -20,250 +21,28 @@ describe(commands.FILE_SHARINGLINK_SET, () => {
   let commandInfo: CommandInfo;
 
   const webUrl = 'https://contoso.sharepoint.com';
-  const listId = 'eb15c4c1-6820-4462-aff9-87e1fb98590b';
   const fileId = 'f09c4efe-b8c0-4e89-a166-03418661b89b';
-  const sharingLinkId = '7c9f97c9-1bda-433c-9364-bb83e81771ee';
   const fileUrl = '/sites/project-x/documents/SharedFile.docx';
-  const fileDetailsResponse = {
-    ListId: listId,
-    UniqueId: fileId
+  const fileDetailsResponse: GraphFileDetails = {
+    SiteId: "0f9b8f4f-0e8e-4630-bb0a-501442db9b64",
+    VroomItemID: "013TMHP6UOOSLON57HT5GLKEU7R5UGWZVK",
+    VroomDriveID: "b!T4-bD44OMEa7ClAUQtubZID9tc40pGJKpguycvELod_Gx-lo4ZQiRJ7vylonTufG"
   };
-
-  const shareLinkResponseText = {
-    id: '7c9f97c9-1bda-433c-9364-bb83e81771ee',
-    link: 'https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g',
-    scope: 0
-  };
-
-  const sharingInformationResponse = {
-    d: {
-      __metadata: {
-        id: 'https://contoso.sharepoint.com/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation',
-        uri: 'https://contoso.sharepoint.com/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation',
-        type: 'SP.Sharing.SharingInformation'
-      },
-      pickerSettings: { __deferred: [Object] },
-      anonymousLinkExpirationRestrictionDays: -1,
-      anyoneLinkTrackUsers: false,
-      blockPeoplePickerAndSharing: false,
-      canAddExternalPrincipal: true,
-      canAddInternalPrincipal: true,
-      canRequestAccessForGrantAccess: true,
-      canSendEmail: true,
-      canUseSimplifiedRoles: true,
-      currentRole: 3,
-      customizedExternalSharingServiceUrl: '',
-      defaultLinkKind: 5,
-      defaultShareLinkPermission: 2,
-      defaultShareLinkScope: 0,
-      defaultShareLinkToExistingAccess: false,
-      directUrl: 'https://contoso.sharepoint.com/:b:/r/Shared%20Documents/Document.docx?csf=1&web=1',
-      displayName: 'Document.docx',
-      enforceIBSegmentFiltering: false,
-      enforceSPOSearch: false,
-      fileExtension: 'docx',
-      hasUniquePermissions: true,
-      isStubFile: false,
-      itemUniqueId: 'f09c4efe-b8c0-4e89-a166-03418661b89b',
-      itemUrl: 'https://contoso.sharepoint.com/_api/v2.0/drives/b!cLoLZkprP0qqo4PG4KBxvLNbttihbPJNpL4O_givJYCARvYucPShT4HI2ULs_paW/items/017S3RUYVWOHQQH4U53FDKPIOV7IF5EPSL',
-      microserviceShareUiUrl: 'https://www.odwebp.svc.ms/share',
-      outlookEndpointHostUrl: 'outlook.office.com',
-      sensitivityLabelInformation: null,
-      sharedObjectType: 1,
-      shareUiUrl: 'https://conoso.sharepoint.com/Shared%20Documents/Forms/AllItems.aspx?p=12&id=%2FShared%20Documents%2FDocument%2Edocx&clientId=clientId',
-      sharingAbilities: {
-        __metadata: [Object],
-        anonymousLinkAbilities: [Object],
-        anyoneLinkAbilities: [Object],
-        directSharingAbilities: [Object],
-        organizationLinkAbilities: [Object],
-        peopleSharingLinkAbilities: [Object]
-      },
-      sharingLinkTemplates: {
-        __metadata: [Object], templates: {
-          __metadata: { type: 'Collection(SP.Sharing.SharingLinkDefaultTemplate)' },
-          results: [
-            {
-              linkDetails: {
-                __metadata: { type: 'SP.SharingLinkInfo' },
-                AllowsAnonymousAccess: true,
-                ApplicationId: null,
-                BlocksDownload: false,
-                Created: '2023-01-09T20:19:55.215Z',
-                CreatedBy: {
-                  __metadata: [Object],
-                  directoryObjectId: null,
-                  email: 'john@contoso.onmicrosoft.com',
-                  expiration: null,
-                  id: 10,
-                  isActive: true,
-                  isExternal: false,
-                  jobTitle: null,
-                  loginName: 'i:0#.f|membership|john@contoso.onmicrosoft.com',
-                  name: 'John Doe',
-                  principalType: 1,
-                  userId: null,
-                  userPrincipalName: 'john@contoso.onmicrosoft.com'
-                },
-                Description: null,
-                Embeddable: false,
-                Expiration: '',
-                HasExternalGuestInvitees: false,
-                Invitations: { __metadata: [Object], results: [] },
-                IsActive: true,
-                IsAddressBarLink: false,
-                IsCreateOnlyLink: false,
-                IsDefault: true,
-                IsEditLink: true,
-                IsFormsLink: false,
-                IsManageListLink: false,
-                IsReviewLink: false,
-                IsUnhealthy: false,
-                LastModified: '2023-01-09T20:19:55.215Z',
-                LastModifiedBy: {
-                  __metadata: [Object],
-                  directoryObjectId: null,
-                  email: 'john@contoso.onmicrosoft.com',
-                  expiration: null,
-                  id: 10,
-                  isActive: true,
-                  isExternal: false,
-                  jobTitle: null,
-                  loginName: 'i:0#.f|membership|john@contoso.onmicrosoft.com',
-                  name: 'John Doe',
-                  principalType: 1,
-                  userId: null,
-                  userPrincipalName: 'john@contoso.onmicrosoft.com'
-                },
-                LimitUseToApplication: false,
-                LinkKind: 5,
-                PasswordLastModified: '',
-                PasswordLastModifiedBy: null,
-                RedeemedUsers: { __metadata: [Object], results: [] },
-                RequiresPassword: false,
-                RestrictedShareMembership: false,
-                Scope: 0,
-                ShareId: '7c9f97c9-1bda-433c-9364-bb83e81771ee',
-                ShareTokenString: 'share=EbZx4QPyndlGp6HV-gvSPksBLEqz3k4gJxPFPm4f4tZtVA',
-                SharingLinkStatus: 0,
-                TrackLinkUsers: false,
-                Url: 'https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBLEqz3k4gJxPFPm4f4tZtVA'
-              },
-              passwordProtected: false,
-              role: 2,
-              scope: 0,
-              shareKind: 5,
-              trackLinkUsers: false
-            },
-            {}],
-          linkDetails: [Object],
-          passwordProtected: false,
-          role: 2,
-          scope: 0,
-          shareKind: 5,
-          trackLinkUsers: false
-        }
-      },
-      sharingStatus: 2,
-      showExternalSharingWarning: false,
-      siteIBMode: 'Open',
-      siteIBSegmentIDs: { __metadata: [Object], results: [] },
-      standardRolesModified: true,
-      userIsSharingViaMCS: null,
-      userPhotoCdnBaseUrl: 'https://contoso.sharepoint.com/_vti_bin/afdcache.ashx/_userprofile/userphoto.jpg?_oat_=1673331428_28ca8e187ff361085b115bc79aa0ad8cb06fe6f6d81cf4ed5e6622ec67707075&P1=1673303395&P2=864232212&P3=1&P4=ln0ppMcWTpAaN6GRFeFG4zIfkAYGDEP%2b%2fndebReEd5LPqTjr62Hgubd0Q7W%2fUudwaqWIhiWjdAO5dNl8jLgvPROXRk4yZAaneMd0%2ffRubh5CLc6jVD7gEozoxslVD0xQnYN1Ol4P1eUjnO1TjoZEN5MV%2b8dBPlCGYWmn8YWNGPpfWal9rWzfzSNRhPhM6ndgxPIzY2DVfSU%2bfMqPfEEKjqewPul8RgAbHh9T%2f7HrZDoNuA53CPD3oujItPYsQ%2fHoNjM5IUpBFWrkt6amBtXmwUZKuJQ97kQgN1GJ0V3ysTJzwaSLG7T2kTnkiRRkWXyOhp%2fh1e6clXJl2M87Gzrmeg%3d%3d',
-      webTemplateId: 68,
-      webUrl: 'https://contoso.sharepoint.com'
-    }
-  };
-
-  const shareLinkResponse = {
-    d: {
-      ShareLink: {
-        __metadata: {
-          type: "SP.Sharing.ShareLinkResponse"
-        },
-        sharingLinkInfo: {
-          __metadata: {
-            type: "SP.SharingLinkInfo"
-          },
-          AllowsAnonymousAccess: true,
-          ApplicationId: null,
-          BlocksDownload: false,
-          Created: "2023-01-09T20:20:22.999Z",
-          CreatedBy: {
-            __metadata: {
-              type: "SP.Sharing.Principal"
-            },
-            directoryObjectId: null,
-            email: "john@contoso.onmicrosoft.com",
-            expiration: null,
-            id: 10,
-            isActive: true,
-            isExternal: false,
-            jobTitle: null,
-            loginName: "i:0#.f|membership|john@contoso.onmicrosoft.com",
-            name: "John Doe",
-            principalType: 1,
-            userId: null,
-            userPrincipalName: "john@contoso.onmicrosoft.com"
-          },
-          Description: null,
-          Embeddable: false,
-          Expiration: "2023-10-31T23:00:00.000Z",
-          HasExternalGuestInvitees: false,
-          Invitations: {
-            __metadata: {
-              type: "Collection(SP.Sharing.LinkInvitation)"
-            },
-            results: []
-          },
-          IsActive: true,
-          IsAddressBarLink: false,
-          IsCreateOnlyLink: false,
-          IsDefault: true,
-          IsEditLink: false,
-          IsFormsLink: false,
-          IsManageListLink: false,
-          IsReviewLink: false,
-          IsUnhealthy: false,
-          LastModified: "2023-01-09T21:14:53.181Z",
-          LastModifiedBy: {
-            __metadata: {
-              type: "SP.Sharing.Principal"
-            },
-            directoryObjectId: null,
-            email: "john@contoso.onmicrosoft.com",
-            expiration: null,
-            id: 10,
-            isActive: true,
-            isExternal: false,
-            jobTitle: null,
-            loginName: "i:0#.f|membership|john@contoso.onmicrosoft.com",
-            name: "John Doe",
-            principalType: 1,
-            userId: null,
-            userPrincipalName: "john@contoso.onmicrosoft.com"
-          },
-          LimitUseToApplication: false,
-          LinkKind: 4,
-          PasswordLastModified: "",
-          PasswordLastModifiedBy: null,
-          RedeemedUsers: {
-            __metadata: {
-              type: "Collection(SP.Sharing.LinkInvitation)"
-            },
-            results: []
-          },
-          RequiresPassword: false,
-          RestrictedShareMembership: false,
-          Scope: 0,
-          ShareId: "7c9f97c9-1bda-433c-9364-bb83e81771ee",
-          ShareTokenString: "share=EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g",
-          SharingLinkStatus: 2,
-          TrackLinkUsers: false,
-          Url: "https://contoso.sharepoint.com/:b:/g/EbZx4QPyndlGp6HV-gvSPksBftmUNAiXjm0y-_527_fI9g"
-        }
-      }
+  const validId = "5a872cfa-d5f6-496f-b434-3188fcdbee76";
+  const graphResponse = {
+    "id": "2a021f54-90a2-4016-b3b3-5f34d2e7d932",
+    "roles": [
+      "read"
+    ],
+    "expirationDateTime": "2023-02-09T16:57:00Z",
+    "hasPassword": false,
+    "grantedToIdentitiesV2": [],
+    "grantedToIdentities": [],
+    "link": {
+      "scope": "anonymous",
+      "type": "view",
+      "webUrl": "https://contoso.sharepoint.com/:b:/s/pnpcoresdktestgroup/EY50lub3559MtRKfj2hrZqoBWnHOpGIcgi4gzw9XiWYJ-A",
+      "preventsDownload": false
     }
   };
 
@@ -294,7 +73,7 @@ describe(commands.FILE_SHARINGLINK_SET, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.post
+      request.patch
     ]);
   });
 
@@ -317,119 +96,82 @@ describe(commands.FILE_SHARINGLINK_SET, () => {
 
   it('updates a sharing link from a file specified by the id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileById('${fileId}')?$select=ListId,UniqueId`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileById('${fileId}')?$select=SiteId,VroomItemId,VroomDriveId`) {
         return fileDetailsResponse;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'&$Expand=sharingLinkTemplates`) {
-        return sharingInformationResponse;
-      }
-
-      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/ShareLink?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'`) {
-        return shareLinkResponse;
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/${fileDetailsResponse.SiteId}/drives/${fileDetailsResponse.VroomDriveID}/items/${fileDetailsResponse.VroomItemID}/permissions/${validId}`) {
+        return graphResponse;
       }
 
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, fileId: fileId, output: 'json', id: sharingLinkId, role: 'read', verbose: true } } as any);
-    assert(loggerLogSpy.calledWith(shareLinkResponse.d.ShareLink.sharingLinkInfo));
+    await command.action(logger, { options: { webUrl: webUrl, fileId: fileId, id: validId, expirationDateTime: '2023-02-09T16:57:00Z', verbose: true } } as any);
+    assert(loggerLogSpy.calledWith(graphResponse));
   });
 
   it('updates a sharing link from a file specified by the url', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(decodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$select=ListId,UniqueId`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(decodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$select=SiteId,VroomItemId,VroomDriveId`) {
         return fileDetailsResponse;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'&$Expand=sharingLinkTemplates`) {
-        return sharingInformationResponse;
-      }
-
-      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/ShareLink?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'`) {
-        return shareLinkResponse;
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/${fileDetailsResponse.SiteId}/drives/${fileDetailsResponse.VroomDriveID}/items/${fileDetailsResponse.VroomItemID}/permissions/${validId}`) {
+        return graphResponse;
       }
 
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, fileUrl: fileUrl, output: 'json', id: sharingLinkId, expirationDateTime: '2023-01-09', verbose: true } } as any);
-    assert(loggerLogSpy.calledWith(shareLinkResponse.d.ShareLink.sharingLinkInfo));
-  });
-
-  it('updates a sharing link from a file specified by the id with text output', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileById('${fileId}')?$select=ListId,UniqueId`) {
-        return fileDetailsResponse;
-      }
-
-      throw 'Invalid request';
-    });
-
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'&$Expand=sharingLinkTemplates`) {
-        return sharingInformationResponse;
-      }
-
-      if (opts.url === `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/ShareLink?@a1='${fileDetailsResponse.ListId}'&@a2='${fileDetailsResponse.UniqueId}'`) {
-        return shareLinkResponse;
-      }
-
-      throw 'Invalid request';
-    });
-
-    await command.action(logger, { options: { webUrl: webUrl, fileId: fileId, output: 'text', id: sharingLinkId, role: 'write', verbose: true } } as any);
-    assert(loggerLogSpy.calledWith(shareLinkResponseText));
+    await command.action(logger, { options: { webUrl: webUrl, fileUrl: fileUrl, expirationDateTime: '2023-02-09T16:57:00Z', id: validId, verbose: true } } as any);
+    assert(loggerLogSpy.calledWith(graphResponse));
   });
 
   it('throws error when file not found by id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileById('${fileId}')?$select=ListId,UniqueId`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileById('${fileId}')?$select=SiteId,VroomItemId,VroomDriveId`) {
         throw { error: { 'odata.error': { message: { value: 'File Not Found.' } } } };
       }
 
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, fileId: fileId, id: sharingLinkId, role: 'read', verbose: true } } as any),
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, fileId: fileId, expirationDateTime: '2023-02-09T16:57:00Z', id: validId, verbose: true } } as any),
       new CommandError(`File Not Found.`));
   });
 
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
-    const actual = await command.validate({ options: { webUrl: 'foo', fileId: fileId, id: sharingLinkId, role: 'read' } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'foo', fileId: fileId, expirationDateTime: '2023-02-09T16:57:00Z', id: validId } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if the fileId option is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: 'invalid', id: sharingLinkId, role: 'read' } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: 'invalid', expirationDateTime: '2023-02-09T16:57:00Z', id: validId } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if the id option is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: 'invalid', role: 'read' } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: 'invalid', expirationDateTime: '2023-02-09T16:57:00Z' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
+
 
   it('fails validation if the expirationDateTime option is not a valid date', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: sharingLinkId, expirationDateTime: 'invalid date' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if invalid role specified', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: sharingLinkId, role: 'invalid role' } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, expirationDateTime: 'invalid date', id: validId } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('passes validation if options are valid', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, id: sharingLinkId, role: 'read' } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', fileId: fileId, expirationDateTime: '2023-02-09T16:57:00Z', id: validId } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 });

--- a/src/m365/spo/commands/file/file-sharinglink-set.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-set.ts
@@ -1,0 +1,221 @@
+import chalk = require('chalk');
+import { Logger } from '../../../../cli/Logger';
+import GlobalOptions from '../../../../GlobalOptions';
+import request, { CliRequestOptions } from '../../../../request';
+import { formatting } from '../../../../utils/formatting';
+import { validation } from '../../../../utils/validation';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  id: string;
+  fileId?: string;
+  fileUrl?: string;
+  role?: string;
+  expirationDateTime: string;
+}
+
+class SpoFileSharingLinkSetCommand extends SpoCommand {
+  private static role: string[] = ['read', 'write'];
+
+  public get name(): string {
+    return commands.FILE_SHARINGLINK_SET;
+  }
+
+  public get description(): string {
+    return 'Updates a sharing link to a file';
+  }
+
+  public defaultProperties(): string[] | undefined {
+    return ['id', 'link', 'scope'];
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initOptionSets();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        fileId: typeof args.options.fileId !== 'undefined',
+        fileUrl: typeof args.options.fileUrl !== 'undefined',
+        expirationDateTime: typeof args.options.expirationDateTime !== 'undefined',
+        role: typeof args.options.role !== 'undefined'
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-i, --fileId [fileId]'
+      },
+      {
+        option: '-f, --fileUrl [fileUrl]'
+      },
+      {
+        option: '--id <id>'
+      },
+      {
+        option: '--role [role]',
+        autocomplete: SpoFileSharingLinkSetCommand.role
+      },
+      {
+        option: '--expirationDateTime [expirationDateTime]'
+      },
+
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+        if (isValidSharePointUrl !== true) {
+          return isValidSharePointUrl;
+        }
+
+        if (args.options.fileId && !validation.isValidGuid(args.options.fileId)) {
+          return `${args.options.fileId} is not a valid GUID`;
+        }
+
+        if (args.options.id && !validation.isValidGuid(args.options.id)) {
+          return `${args.options.id} is not a valid GUID`;
+        }
+
+        if (args.options.role &&
+          SpoFileSharingLinkSetCommand.role.indexOf(args.options.role) < 0) {
+          return `'${args.options.role}' is not a valid scope type. Allowed scope types are ${SpoFileSharingLinkSetCommand.role.join(', ')}`;
+        }
+
+        const parsedDateTime = Date.parse(args.options.expirationDateTime as string);
+        if (args.options.expirationDateTime && !(!parsedDateTime) !== true) {
+          return `${args.options.expirationDateTime} is not a valid date format. Provide the date in one of the following formats:
+      ${chalk.grey('YYYY-MM-DD')}
+      ${chalk.grey('YYYY-MM-DDThh:mm')}
+      ${chalk.grey('YYYY-MM-DDThh:mmZ')}
+      ${chalk.grey('YYYY-MM-DDThh:mm±hh:mm')}`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['fileId', 'fileUrl'] });
+    this.optionSets.push({ options: ['role', 'expirationDateTime'] });
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (this.verbose) {
+      logger.logToStderr(`Updates a sharing link for file ${args.options.fileId || args.options.fileUrl}...`);
+    }
+
+    try {
+      const fileDetails = await this.getFileDetails(args.options.webUrl, args.options.fileId, args.options.fileUrl);
+      const sharingInformation = await this.getSharingInformation(args.options.webUrl, fileDetails, args.options.id);
+      if (args.options.role) {
+        sharingInformation.role = args.options.role === "read" ? 1 : 2;
+      }
+      else {
+        sharingInformation.expiration = this.parseDateExact(args.options.expirationDateTime);
+      }
+
+      const requestOptions: CliRequestOptions = {
+        url: `${args.options.webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/ShareLink?@a1='${fileDetails.ListId}'&@a2='${fileDetails.UniqueId}'`,
+        headers: {
+          accept: 'application/json;odata=verbose'
+        },
+        responseType: 'json',
+        data: {
+          "request": {
+            "createLink": true,
+            "settings": sharingInformation,
+            "emailData": {
+              "body": ""
+            }
+          }
+        }
+      };
+
+      const sharingLink: any = await request.post(requestOptions);
+
+      if (!args.options.output || args.options.output === 'json' || args.options.output === 'md') {
+        logger.log(sharingLink.d.ShareLink.sharingLinkInfo);
+      }
+      else {
+        logger.log({
+          id: sharingLink.d.ShareLink.sharingLinkInfo.ShareId,
+          link: sharingLink.d.ShareLink.sharingLinkInfo.Url,
+          scope: sharingLink.d.ShareLink.sharingLinkInfo.Scope
+        });
+      }
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+  private async getSharingInformation(webUrl: string, fileDetails: any, id: string): Promise<any> {
+    const requestOptions: CliRequestOptions = {
+      url: `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation?@a1='${fileDetails.ListId}'&@a2='${fileDetails.UniqueId}'&$Expand=sharingLinkTemplates`,
+      headers: {
+        accept: 'application/json;odata=verbose'
+      },
+      responseType: 'json'
+    };
+
+    const sharingInformation: any = await request.post(requestOptions);
+    const sharingInformationOfId: any = sharingInformation.d.sharingLinkTemplates.templates.results.filter((x: any) => x.linkDetails ? x.linkDetails.ShareId === id : false)[0];
+
+    return ({
+      expiration: sharingInformationOfId.linkDetails.Expiration,
+      linkKind: sharingInformationOfId.linkDetails.LinkKind,
+      restrictShareMembership: sharingInformationOfId.linkDetails.RestrictedShareMembership,
+      role: sharingInformationOfId.role,
+      scope: sharingInformationOfId.scope,
+      shareId: id
+    });
+  }
+
+  private async getFileDetails(webUrl: string, fileId?: string, fileUrl?: string): Promise<any> {
+    let requestUrl: string = `${webUrl}/_api/web/`;
+
+    if (fileId) {
+      requestUrl += `GetFileById('${fileId}')`;
+    }
+    else if (fileUrl) {
+      requestUrl += `GetFileByServerRelativePath(decodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`;
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: requestUrl += '?$select=ListId,UniqueId',
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+    const res = await request.get<any>(requestOptions);
+    return res;
+  }
+
+  private parseDateExact(date: string): string {
+    const d: Date = new Date(Date.parse(date));
+    return d.toISOString().split('.')[0].replaceAll('-', '').replaceAll(':', '') + d.toString().split('GMT')[1].split(' ')[0];
+  }
+}
+
+module.exports = new SpoFileSharingLinkSetCommand();

--- a/src/m365/spo/commands/file/file-sharinglink-set.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-set.ts
@@ -214,7 +214,7 @@ class SpoFileSharingLinkSetCommand extends SpoCommand {
 
   private parseDateExact(date: string): string {
     const d: Date = new Date(Date.parse(date));
-    return d.toISOString().split('.')[0].replaceAll('-', '').replaceAll(':', '') + d.toString().split('GMT')[1].split(' ')[0];
+    return d.toISOString().split('.')[0].replace(/-/g, '').replace(/:/g, '') + d.toString().split('GMT')[1].split(' ')[0];
   }
 }
 

--- a/src/m365/spo/commands/file/file-sharinglink-set.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-set.ts
@@ -1,4 +1,3 @@
-import chalk = require('chalk');
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
@@ -6,6 +5,7 @@ import { formatting } from '../../../../utils/formatting';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
+import { GraphFileDetails } from './GraphFileDetails';
 
 interface CommandArgs {
   options: Options;
@@ -16,23 +16,16 @@ interface Options extends GlobalOptions {
   id: string;
   fileId?: string;
   fileUrl?: string;
-  role?: string;
   expirationDateTime: string;
 }
 
 class SpoFileSharingLinkSetCommand extends SpoCommand {
-  private static role: string[] = ['read', 'write'];
-
   public get name(): string {
     return commands.FILE_SHARINGLINK_SET;
   }
 
   public get description(): string {
-    return 'Updates a sharing link to a file';
-  }
-
-  public defaultProperties(): string[] | undefined {
-    return ['id', 'link', 'scope'];
+    return 'Updates a sharing link of a file';
   }
 
   constructor() {
@@ -48,9 +41,7 @@ class SpoFileSharingLinkSetCommand extends SpoCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         fileId: typeof args.options.fileId !== 'undefined',
-        fileUrl: typeof args.options.fileUrl !== 'undefined',
-        expirationDateTime: typeof args.options.expirationDateTime !== 'undefined',
-        role: typeof args.options.role !== 'undefined'
+        fileUrl: typeof args.options.fileUrl !== 'undefined'
       });
     });
   }
@@ -61,20 +52,16 @@ class SpoFileSharingLinkSetCommand extends SpoCommand {
         option: '-u, --webUrl <webUrl>'
       },
       {
-        option: '-i, --fileId [fileId]'
+        option: '--fileId [fileId]'
       },
       {
-        option: '-f, --fileUrl [fileUrl]'
+        option: '--fileUrl [fileUrl]'
       },
       {
         option: '--id <id>'
       },
       {
-        option: '--role [role]',
-        autocomplete: SpoFileSharingLinkSetCommand.role
-      },
-      {
-        option: '--expirationDateTime [expirationDateTime]'
+        option: '--expirationDateTime <expirationDateTime>'
       },
 
     );
@@ -92,22 +79,12 @@ class SpoFileSharingLinkSetCommand extends SpoCommand {
           return `${args.options.fileId} is not a valid GUID`;
         }
 
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
+        if (!validation.isValidGuid(args.options.id)) {
           return `${args.options.id} is not a valid GUID`;
         }
 
-        if (args.options.role &&
-          SpoFileSharingLinkSetCommand.role.indexOf(args.options.role) < 0) {
-          return `'${args.options.role}' is not a valid scope type. Allowed scope types are ${SpoFileSharingLinkSetCommand.role.join(', ')}`;
-        }
-
-        const parsedDateTime = Date.parse(args.options.expirationDateTime as string);
-        if (args.options.expirationDateTime && !(!parsedDateTime) !== true) {
-          return `${args.options.expirationDateTime} is not a valid date format. Provide the date in one of the following formats:
-      ${chalk.grey('YYYY-MM-DD')}
-      ${chalk.grey('YYYY-MM-DDThh:mm')}
-      ${chalk.grey('YYYY-MM-DDThh:mmZ')}
-      ${chalk.grey('YYYY-MM-DDThh:mm±hh:mm')}`;
+        if (!validation.isValidISODateTime(args.options.expirationDateTime)) {
+          return `'${args.options.expirationDateTime}' is not a valid ISO date string`;
         }
 
         return true;
@@ -117,81 +94,37 @@ class SpoFileSharingLinkSetCommand extends SpoCommand {
 
   #initOptionSets(): void {
     this.optionSets.push({ options: ['fileId', 'fileUrl'] });
-    this.optionSets.push({ options: ['role', 'expirationDateTime'] });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (this.verbose) {
-      logger.logToStderr(`Updates a sharing link for file ${args.options.fileId || args.options.fileUrl}...`);
+      logger.logToStderr(`Updating sharing link of file ${args.options.fileId || args.options.fileUrl}...`);
     }
 
     try {
       const fileDetails = await this.getFileDetails(args.options.webUrl, args.options.fileId, args.options.fileUrl);
-      const sharingInformation = await this.getSharingInformation(args.options.webUrl, fileDetails, args.options.id);
-      if (args.options.role) {
-        sharingInformation.role = args.options.role === "read" ? 1 : 2;
-      }
-      else {
-        sharingInformation.expiration = this.parseDateExact(args.options.expirationDateTime);
-      }
 
       const requestOptions: CliRequestOptions = {
-        url: `${args.options.webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/ShareLink?@a1='${fileDetails.ListId}'&@a2='${fileDetails.UniqueId}'`,
+        url: `https://graph.microsoft.com/v1.0/sites/${fileDetails.SiteId}/drives/${fileDetails.VroomDriveID}/items/${fileDetails.VroomItemID}/permissions/${args.options.id}`,
         headers: {
-          accept: 'application/json;odata=verbose'
+          accept: 'application/json;odata.metadata=none'
         },
         responseType: 'json',
         data: {
-          "request": {
-            "createLink": true,
-            "settings": sharingInformation,
-            "emailData": {
-              "body": ""
-            }
-          }
+          expirationDateTime: args.options.expirationDateTime
         }
       };
 
-      const sharingLink: any = await request.post(requestOptions);
+      const sharingLink = await request.patch<any>(requestOptions);
 
-      if (!args.options.output || args.options.output === 'json' || args.options.output === 'md') {
-        logger.log(sharingLink.d.ShareLink.sharingLinkInfo);
-      }
-      else {
-        logger.log({
-          id: sharingLink.d.ShareLink.sharingLinkInfo.ShareId,
-          link: sharingLink.d.ShareLink.sharingLinkInfo.Url,
-          scope: sharingLink.d.ShareLink.sharingLinkInfo.Scope
-        });
-      }
+      logger.log(sharingLink);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
   }
-  private async getSharingInformation(webUrl: string, fileDetails: any, id: string): Promise<any> {
-    const requestOptions: CliRequestOptions = {
-      url: `${webUrl}/_api/web/Lists(@a1)/GetItemByUniqueId(@a2)/GetSharingInformation?@a1='${fileDetails.ListId}'&@a2='${fileDetails.UniqueId}'&$Expand=sharingLinkTemplates`,
-      headers: {
-        accept: 'application/json;odata=verbose'
-      },
-      responseType: 'json'
-    };
 
-    const sharingInformation: any = await request.post(requestOptions);
-    const sharingInformationOfId: any = sharingInformation.d.sharingLinkTemplates.templates.results.filter((x: any) => x.linkDetails ? x.linkDetails.ShareId === id : false)[0];
-
-    return ({
-      expiration: sharingInformationOfId.linkDetails.Expiration,
-      linkKind: sharingInformationOfId.linkDetails.LinkKind,
-      restrictShareMembership: sharingInformationOfId.linkDetails.RestrictedShareMembership,
-      role: sharingInformationOfId.role,
-      scope: sharingInformationOfId.scope,
-      shareId: id
-    });
-  }
-
-  private async getFileDetails(webUrl: string, fileId?: string, fileUrl?: string): Promise<any> {
+  private async getFileDetails(webUrl: string, fileId?: string, fileUrl?: string): Promise<GraphFileDetails> {
     let requestUrl: string = `${webUrl}/_api/web/`;
 
     if (fileId) {
@@ -202,19 +135,14 @@ class SpoFileSharingLinkSetCommand extends SpoCommand {
     }
 
     const requestOptions: CliRequestOptions = {
-      url: requestUrl += '?$select=ListId,UniqueId',
+      url: requestUrl += '?$select=SiteId,VroomItemId,VroomDriveId',
       headers: {
         accept: 'application/json;odata=nometadata'
       },
       responseType: 'json'
     };
-    const res = await request.get<any>(requestOptions);
+    const res = await request.get<GraphFileDetails>(requestOptions);
     return res;
-  }
-
-  private parseDateExact(date: string): string {
-    const d: Date = new Date(Date.parse(date));
-    return d.toISOString().split('.')[0].replace(/-/g, '').replace(/:/g, '') + d.toString().split('GMT')[1].split(' ')[0];
   }
 }
 


### PR DESCRIPTION
This PR adds the command `spo file sharinglink set`.

Had to use a very different approach than the one in the issue since the graph endpoint doesn't modify the `role` parameter when it contains a webUrl (see this [article](https://learn.microsoft.com/en-us/answers/questions/986279/why-is-update-permission-graph-api-for-files-not-w.html)).

Also please note, I have added 2 remarks:
- you can only set the expiration date for anonymous sharing links
- you can only set the role for user sharing

Closes #4026