### PR TITLE
Adds command `spo list retentionlabel remove`, Closes #4290

### DIFF
--- a/docs/docs/cmd/spo/list/list-retentionlabel-remove.md
+++ b/docs/docs/cmd/spo/list/list-retentionlabel-remove.md
@@ -1,0 +1,49 @@
+# spo list retentionlabel remove
+
+Clears the retention label on the specified list or library.
+
+## Usage
+
+```sh
+m365 spo list retentionlabel remove [options]
+```
+
+## Options
+
+`-u, --webUrl <webUrl>`
+: The URL of the site where the list is located.
+
+`-t, --listTitle [listTitle]`
+: The title of the list on which to remove the label. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
+
+`-l, --listId [listId]`
+: The ID of the list on which to remove the label. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
+
+`--listUrl [listUrl]`
+: Server- or web-relative URL of the list on which to remove the label. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Clears the retention label on a given list by URL
+
+```sh
+m365 spo list retentionlabel remove --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents'
+```
+
+Clears the retention label on a given list by title
+
+```sh
+m365 spo list retentionlabel remove --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'Documents'
+```
+
+Clears the retention label on a given list by ID without confirmation
+
+```sh
+m365 spo list retentionlabel remove --webUrl https://contoso.sharepoint.com/sites/project-x --listId 'Documents' --confirm
+```
+
+## Response
+
+The command won't return a response on success.

--- a/docs/docs/cmd/spo/list/list-retentionlabel-remove.md
+++ b/docs/docs/cmd/spo/list/list-retentionlabel-remove.md
@@ -22,6 +22,9 @@ m365 spo list retentionlabel remove [options]
 `--listUrl [listUrl]`
 : Server- or web-relative URL of the list on which to remove the label. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
 
+`--confirm`
+: Don't prompt for confirmation.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -464,6 +464,7 @@ nav:
         - list contenttype default set: cmd/spo/list/list-contenttype-default-set.md        
         - list retentionlabel ensure: cmd/spo/list/list-retentionlabel-ensure.md
         - list retentionlabel get: cmd/spo/list/list-retentionlabel-get.md
+        - list retentionlabel remove: cmd/spo/list/list-retentionlabel-remove.md
         - list roleassignment add: cmd/spo/list/list-roleassignment-add.md
         - list roleassignment remove: cmd/spo/list/list-roleassignment-remove.md
         - list roleinheritance break: cmd/spo/list/list-roleinheritance-break.md

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -119,6 +119,7 @@ export default {
   LIST_REMOVE: `${prefix} list remove`,
   LIST_RETENTIONLABEL_ENSURE: `${prefix} list retentionlabel ensure`,
   LIST_RETENTIONLABEL_GET: `${prefix} list retentionlabel get`,
+  LIST_RETENTIONLABEL_REMOVE: `${prefix} list retentionlabel remove`,
   LIST_ROLEASSIGNMENT_REMOVE: `${prefix} list roleassignment remove`,
   LIST_ROLEASSIGNMENT_ADD: `${prefix} list roleassignment add`,
   LIST_ROLEINHERITANCE_BREAK: `${prefix} list roleinheritance break`,

--- a/src/m365/spo/commands/list/list-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-remove.spec.ts
@@ -117,7 +117,7 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
     assert(promptIssued);
   });
 
-  it('aborts removing role assignment when prompt not confirmed', async () => {
+  it('aborts removing list retentionlabel when prompt not confirmed', async () => {
     const getSpy = sinon.spy(request, 'get');
     await command.action(logger, {
       options: {
@@ -184,7 +184,7 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
   });
 
   it('should remove label for list with listTitle (debug)', async () => {
-    const postStub = sinon.stub(request, 'post').callsFake((opts) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) > -1) {
         return Promise.resolve();
       }
@@ -201,24 +201,18 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com/sites/team1',
         listTitle: 'MyLibrary',
         confirm: true
       }
-    });
-    const lastCall = postStub.lastCall.args[0];
-    assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
-    assert.strictEqual(lastCall.data.complianceTagValue, '');
-    assert.strictEqual(lastCall.data.blockDelete, false);
-    assert.strictEqual(lastCall.data.blockEdit, false);
-    assert.strictEqual(lastCall.data.syncToItems, false);
+    }));
   });
 
   it('should remove label for list with listId (debug)', async () => {
-    const postStub = sinon.stub(request, 'post').callsFake((opts) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) > -1) {
         return Promise.resolve();
       }
@@ -235,24 +229,18 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com/sites/team1',
         listId: 'faaa6af2-0157-4e9a-a352-6165195923c8',
         confirm: true
       }
-    });
-    const lastCall = postStub.lastCall.args[0];
-    assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
-    assert.strictEqual(lastCall.data.complianceTagValue, '');
-    assert.strictEqual(lastCall.data.blockDelete, false);
-    assert.strictEqual(lastCall.data.blockEdit, false);
-    assert.strictEqual(lastCall.data.syncToItems, false);
+    }));
   });
 
   it('should remove label for list with listUrl (debug)', async () => {
-    const postStub = sinon.stub(request, 'post').callsFake((opts) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) > -1) {
         return Promise.resolve();
       }
@@ -260,24 +248,18 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com/sites/team1',
         listUrl: '/sites/team1/MyLibrary',
         confirm: true
       }
-    });
-    const lastCall = postStub.lastCall.args[0];
-    assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
-    assert.strictEqual(lastCall.data.complianceTagValue, '');
-    assert.strictEqual(lastCall.data.blockDelete, false);
-    assert.strictEqual(lastCall.data.blockEdit, false);
-    assert.strictEqual(lastCall.data.syncToItems, false);
+    }));
   });
 
   it('should remove label for list with listUrl when prompt confirmed', async () => {
-    const postStub = sinon.stub(request, 'post').callsFake((opts) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) > -1) {
         return Promise.resolve();
       }
@@ -290,19 +272,13 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
       { continue: true }
     ));
 
-    await command.action(logger, {
+    await assert.doesNotReject(command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com/sites/team1',
         listUrl: '/sites/team1/MyLibrary'
       }
-    });
-    const lastCall = postStub.lastCall.args[0];
-    assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
-    assert.strictEqual(lastCall.data.complianceTagValue, '');
-    assert.strictEqual(lastCall.data.blockDelete, false);
-    assert.strictEqual(lastCall.data.blockEdit, false);
-    assert.strictEqual(lastCall.data.syncToItems, false);
+    }));
   });
 
   it('fails validation if the url option is not a valid SharePoint site URL', async () => {

--- a/src/m365/spo/commands/list/list-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-remove.spec.ts
@@ -1,0 +1,332 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { pid } from '../../../../utils/pid';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+const command: Command = require('./list-retentionlabel-remove');
+
+describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
+  let log: any[];
+  let logger: Logger;
+  let commandInfo: CommandInfo;
+  let promptOptions: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
+      promptOptions = options;
+      return { continue: false };
+    });
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      request.post,
+      Cli.prompt
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent,
+      pid.getProcessName
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.LIST_RETENTIONLABEL_REMOVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('prompts before removing the retentionlabel on the specified list when confirm option not passed (listTitle)', async () => {
+    await command.action(logger, {
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listTitle: 'MyLibrary'
+      }
+    });
+    let promptIssued = false;
+
+    if (promptOptions && promptOptions.type === 'confirm') {
+      promptIssued = true;
+    }
+
+    assert(promptIssued);
+  });
+
+  it('prompts before removing the retentionlabel on the specified list when confirm option not passed (listId)', async () => {
+    await command.action(logger, {
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF'
+      }
+    });
+    let promptIssued = false;
+
+    if (promptOptions && promptOptions.type === 'confirm') {
+      promptIssued = true;
+    }
+
+    assert(promptIssued);
+  });
+
+  it('prompts before removing the retentionlabel on the specified list when confirm option not passed (listUrl)', async () => {
+    await command.action(logger, {
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listUrl: '/sites/team1/MyLibrary'
+      }
+    });
+    let promptIssued = false;
+
+    if (promptOptions && promptOptions.type === 'confirm') {
+      promptIssued = true;
+    }
+
+    assert(promptIssued);
+  });
+
+  it('aborts removing role assignment when prompt not confirmed', async () => {
+    const getSpy = sinon.spy(request, 'get');
+    await command.action(logger, {
+      options: {
+        webUrl: 'https://contoso.sharepoint.com',
+        listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF'
+      }
+    });
+    assert(getSpy.notCalled);
+  });
+
+  it('should handle error when trying to remove label', async () => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) {
+        return Promise.reject({
+          error: {
+            'odata.error': {
+              code: '-1, Microsoft.SharePoint.Client.InvalidOperationException',
+              message: {
+                value: 'Can not find compliance tag with value: abc. SiteSubscriptionId: ea1787c6-7ce2-4e71-be47-5e0deb30f9e4'
+              }
+            }
+          }
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
+        return Promise.resolve({ "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listTitle: 'MyLibrary',
+        confirm: true
+      }
+    } as any), new CommandError("Can not find compliance tag with value: abc. SiteSubscriptionId: ea1787c6-7ce2-4e71-be47-5e0deb30f9e4"));
+  });
+
+  it('should handle error if list does not exist', async () => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
+        return Promise.reject(new Error("404 - \"404 FILE NOT FOUND\""));
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listTitle: 'MyLibrary',
+        confirm: true
+      }
+    } as any), new CommandError('404 - "404 FILE NOT FOUND"'));
+  });
+
+  it('should remove label for list with listTitle (debug)', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
+        return Promise.resolve({ "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listTitle: 'MyLibrary',
+        confirm: true
+      }
+    });
+    const lastCall = postStub.lastCall.args[0];
+    assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
+    assert.strictEqual(lastCall.data.complianceTagValue, '');
+    assert.strictEqual(lastCall.data.blockDelete, false);
+    assert.strictEqual(lastCall.data.blockEdit, false);
+    assert.strictEqual(lastCall.data.syncToItems, false);
+  });
+
+  it('should remove label for list with listId (debug)', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists(guid'faaa6af2-0157-4e9a-a352-6165195923c8')/?$expand=RootFolder&$select=RootFolder`) {
+        return Promise.resolve({ "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } }
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listId: 'faaa6af2-0157-4e9a-a352-6165195923c8',
+        confirm: true
+      }
+    });
+    const lastCall = postStub.lastCall.args[0];
+    assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
+    assert.strictEqual(lastCall.data.complianceTagValue, '');
+    assert.strictEqual(lastCall.data.blockDelete, false);
+    assert.strictEqual(lastCall.data.blockEdit, false);
+    assert.strictEqual(lastCall.data.syncToItems, false);
+  });
+
+  it('should remove label for list with listUrl (debug)', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listUrl: '/sites/team1/MyLibrary',
+        confirm: true
+      }
+    });
+    const lastCall = postStub.lastCall.args[0];
+    assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
+    assert.strictEqual(lastCall.data.complianceTagValue, '');
+    assert.strictEqual(lastCall.data.blockDelete, false);
+    assert.strictEqual(lastCall.data.blockEdit, false);
+    assert.strictEqual(lastCall.data.syncToItems, false);
+  });
+
+  it('should remove label for list with listUrl when prompt confirmed', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team1/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`) > -1) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
+
+    await command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        listUrl: '/sites/team1/MyLibrary'
+      }
+    });
+    const lastCall = postStub.lastCall.args[0];
+    assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
+    assert.strictEqual(lastCall.data.complianceTagValue, '');
+    assert.strictEqual(lastCall.data.blockDelete, false);
+    assert.strictEqual(lastCall.data.blockEdit, false);
+    assert.strictEqual(lastCall.data.syncToItems, false);
+  });
+
+  it('fails validation if the url option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'foo', listId: 'cc27a922-8224-4296-90a5-ebbc54da2e85' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the url option is a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF' } }, commandInfo);
+    assert(actual);
+  });
+
+  it('fails validation if the listid option is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: 'XXXXX' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the listid option is a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: 'cc27a922-8224-4296-90a5-ebbc54da2e85' } }, commandInfo);
+    assert(actual);
+  });
+
+  it('fails validation if listId, listUrl and listTitle options are not passed', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+});

--- a/src/m365/spo/commands/list/list-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-remove.spec.ts
@@ -17,6 +17,11 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let promptOptions: any;
+  const listResponse = {
+    "RootFolder": {
+      "ServerRelativeUrl": "/sites/team1/Shared Documents"
+    }
+  };
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
@@ -147,9 +152,8 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
     });
 
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
-        return Promise.resolve({ "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } }
-        );
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
+        return Promise.resolve(listResponse);
       }
 
       return Promise.reject('Invalid request');
@@ -166,7 +170,7 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
 
   it('should handle error if list does not exist', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
         return Promise.reject(new Error("404 - \"404 FILE NOT FOUND\""));
       }
 
@@ -193,9 +197,8 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
     });
 
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
-        return Promise.resolve({ "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } }
-        );
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
+        return Promise.resolve(listResponse);
       }
 
       return Promise.reject('Invalid request');
@@ -221,9 +224,8 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
     });
 
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists(guid'faaa6af2-0157-4e9a-a352-6165195923c8')/?$expand=RootFolder&$select=RootFolder`) {
-        return Promise.resolve({ "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } }
-        );
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists(guid'faaa6af2-0157-4e9a-a352-6165195923c8')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
+        return Promise.resolve(listResponse);
       }
 
       return Promise.reject('Invalid request');

--- a/src/m365/spo/commands/list/list-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-remove.ts
@@ -1,0 +1,170 @@
+import { Cli } from '../../../../cli/Cli';
+import { Logger } from '../../../../cli/Logger';
+import GlobalOptions from '../../../../GlobalOptions';
+import request from '../../../../request';
+import { formatting } from '../../../../utils/formatting';
+import { urlUtil } from '../../../../utils/urlUtil';
+import { validation } from '../../../../utils/validation';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+import { ListInstance } from './ListInstance';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  listId?: string;
+  listTitle?: string;
+  listUrl?: string;
+  confirm: boolean;
+}
+
+class SpoListRetentionLabelRemoveCommand extends SpoCommand {
+  public get name(): string {
+    return commands.LIST_RETENTIONLABEL_REMOVE;
+  }
+
+  public alias(): string[] | undefined {
+    return [commands.LIST_LABEL_SET];
+  }
+
+  public get description(): string {
+    return 'Clears the retention label on the specified list or library.';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initOptionSets();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        listId: typeof args.options.listId !== 'undefined',
+        listTitle: typeof args.options.listTitle !== 'undefined',
+        listUrl: typeof args.options.listUrl !== 'undefined',
+        confirm: !!args.options.confirm
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-t, --listTitle [listTitle]'
+      },
+      {
+        option: '-l, --listId [listId]'
+      },
+      {
+        option: '--listUrl [listUrl]'
+      },
+      {
+        option: '--confirm'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        if (args.options.listId && !validation.isValidGuid(args.options.listId)) {
+          return `${args.options.listId} is not a valid GUID`;
+        }
+
+        return validation.isValidSharePointUrl(args.options.webUrl);
+      }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['listId', 'listTitle', 'listUrl'] });
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (this.verbose) {
+      logger.logToStderr(`Clears the retention label from list ${args.options.listId || args.options.listTitle || args.options.listUrl} in site at ${args.options.webUrl}...`);
+    }
+
+    if (args.options.confirm) {
+      await this.removeListRetentionLabel(args);
+    }
+    else {
+      const result = await Cli.prompt<{ continue: boolean }>({
+        type: 'confirm',
+        name: 'continue',
+        default: false,
+        message: `Are you sure you want to remove the retention label from list '${args.options.listId || args.options.listTitle || args.options.listUrl}'?`
+      });
+
+      if (result.continue) {
+        await this.removeListRetentionLabel(args);
+      }
+    }
+  }
+
+  private async removeListRetentionLabel(args: CommandArgs): Promise<void> {
+    try {
+      let listRestUrl: string = '';
+      let listServerRelativeUrl: string = '';
+
+      if (args.options.listUrl) {
+        const listServerRelativeUrlFromPath: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
+
+        listServerRelativeUrl = listServerRelativeUrlFromPath;
+      }
+      else {
+        if (args.options.listId) {
+          listRestUrl = `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/`;
+        }
+        else {
+          listRestUrl = `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/`;
+        }
+
+        const requestOptions: any = {
+          url: `${args.options.webUrl}/_api/web/${listRestUrl}?$expand=RootFolder&$select=RootFolder`,
+          headers: {
+            'accept': 'application/json;odata=nometadata'
+          },
+          responseType: 'json'
+        };
+
+        const listInstance: ListInstance = await request.get<ListInstance>(requestOptions);
+        listServerRelativeUrl = listInstance.RootFolder.ServerRelativeUrl;
+      }
+
+      const listAbsoluteUrl: string = urlUtil.getAbsoluteUrl(args.options.webUrl, listServerRelativeUrl);
+      const requestUrl: string = `${args.options.webUrl}/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`;
+      const requestOptions: any = {
+        url: requestUrl,
+        headers: {
+          'accept': 'application/json;odata=nometadata'
+        },
+        data: {
+          listUrl: listAbsoluteUrl,
+          complianceTagValue: '',
+          blockDelete: args.options.blockDelete || false,
+          blockEdit: args.options.blockEdit || false,
+          syncToItems: args.options.syncToItems || false
+        },
+        responseType: 'json'
+      };
+
+      await request.post(requestOptions);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+}
+
+module.exports = new SpoListRetentionLabelRemoveCommand();


### PR DESCRIPTION
This PR adds the command `spo list retentionlabel remove`, which clears the retentionlabel from a list or library.

Closes #4290