### PR TITLE
Adds command `pp ai builder model get`, Closes #4325

### DIFF
--- a/docs/docs/cmd/pp/aibuildermodel/aibuildermodel-get.md
+++ b/docs/docs/cmd/pp/aibuildermodel/aibuildermodel-get.md
@@ -1,0 +1,99 @@
+# pp aibuildermodel get
+
+Gets a specific AI builder models in the specified Power Platform environment
+
+## Usage
+
+```sh
+pp aibuildermodel get [options]
+```
+
+## Options
+
+`-e, --environment <environment>`
+: The name of the environment
+
+`-i, --id [id]`
+: The id of the AI Builder model. Specify either `id` or `name` but not both
+
+`-n, --name [name]`
+: The name of the AI Builder model. Specify either `id` or `name` but not both
+
+`--asAdmin`
+: Run the command as admin for environments you do not have explicitly assigned permissions to
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Get an AI Builder model in a specific environment
+
+```sh
+m365 pp aibuildermodel get --environment "Default-d87a7535-dd31-4437-bfe1-95340acd55c5" --name "Document Processing 11/29/2022, 12:58:43 PM"
+```
+
+Get an AI Builder models in a specific environment by id as admin
+
+```sh
+m365 pp aibuildermodel get --environment "Default-d87a7535-dd31-4437-bfe1-95340acd55c5" --id "08ffffbe-ec1c-4e64-b64b-dd1db926c613" --asAdmin
+```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    {
+      "statecode": 0,
+      "_msdyn_templateid_value": "10707e4e-1d56-e911-8194-000d3a6cd5a5",
+      "msdyn_modelcreationcontext": "{}",
+      "createdon": "2022-11-29T11:58:45Z",
+      "_ownerid_value": "5fa787c1-1c4d-ed11-bba1-000d3a2caf7f",
+      "modifiedon": "2022-11-29T11:58:45Z",
+      "msdyn_sharewithorganizationoncreate": false,
+      "msdyn_aimodelidunique": "b0328b67-47e2-4202-8189-e617ec9a88bd",
+      "solutionid": "fd140aae-4df4-11dd-bd17-0019b9312238",
+      "ismanaged": false,
+      "versionnumber": 1458121,
+      "msdyn_name": "Document Processing 11/29/2022, 12:58:43 PM",
+      "introducedversion": "1.0",
+      "statuscode": 0,
+      "_modifiedby_value": "5fa787c1-1c4d-ed11-bba1-000d3a2caf7f",
+      "overwritetime": "1900-01-01T00:00:00Z",
+      "componentstate": 0,
+      "_createdby_value": "5fa787c1-1c4d-ed11-bba1-000d3a2caf7f",
+      "_owningbusinessunit_value": "6da087c1-1c4d-ed11-bba1-000d3a2caf7f",
+      "_owninguser_value": "5fa787c1-1c4d-ed11-bba1-000d3a2caf7f",
+      "msdyn_aimodelid": "08ffffbe-ec1c-4e64-b64b-dd1db926c613",
+      "_msdyn_activerunconfigurationid_value": null,
+      "overriddencreatedon": null,
+      "_msdyn_retrainworkflowid_value": null,
+      "importsequencenumber": null,
+      "_msdyn_scheduleinferenceworkflowid_value": null,
+      "_modifiedonbehalfby_value": null,
+      "utcconversiontimezonecode": null,
+      "_createdonbehalfby_value": null,
+      "_owningteam_value": null,
+      "timezoneruleversionnumber": null,
+      "iscustomizable": {
+        "Value": true,
+        "CanBeChanged": true,
+        "ManagedPropertyLogicalName": "iscustomizableanddeletable"
+      }
+    }
+    ```
+
+=== "Text"
+
+    ```text
+    createdon             modifiedon            msdyn_aimodelid                       msdyn_name
+    --------------------  --------------------  ------------------------------------  -------------------------------------------
+    2022-10-25T14:44:48Z  2022-10-25T14:44:48Z  08ffffbe-ec1c-4e64-b64b-dd1db926c613  Document Processing 11/29/2022, 12:58:43 PM
+    ```
+
+=== "CSV"
+
+    ```csv
+    msdyn_name,msdyn_aimodelid,createdon,modifiedon
+    "Document Processing 11/29/2022, 12:58:43 PM",08ffffbe-ec1c-4e64-b64b-dd1db926c613,2022-11-29T11:58:45Z,2022-11-29T11:58:45Z
+    ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -264,6 +264,7 @@ nav:
         - run resubmit: cmd/flow/run/run-resubmit.md
     - Power Platform (pp):
       - aibuildermodel:
+        - aibuildermodel get: cmd/pp/aibuildermodel/aibuildermodel-get.md
         - aibuildermodel list: cmd/pp/aibuildermodel/aibuildermodel-list.md
       - card:
         - card clone: cmd/pp/card/card-clone.md

--- a/src/m365/pp/commands.ts
+++ b/src/m365/pp/commands.ts
@@ -1,6 +1,7 @@
 const prefix: string = 'pp';
 
 export default {
+  AIBUILDERMODEL_GET: `${prefix} aibuildermodel get`,
   AIBUILDERMODEL_LIST: `${prefix} aibuildermodel list`,
   CARD_CLONE: `${prefix} card clone`,
   CARD_GET: `${prefix} card get`,

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.spec.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.spec.ts
@@ -11,62 +11,53 @@ import { pid } from '../../../../utils/pid';
 import { powerPlatform } from '../../../../utils/powerPlatform';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
-const command: Command = require('./card-get');
+const command: Command = require('./aibuildermodel-get');
 
-describe(commands.CARD_GET, () => {
+describe(commands.AIBUILDERMODEL_GET, () => {
   let commandInfo: CommandInfo;
   //#region Mocked Responses
   const validEnvironment = '4be50206-9576-4237-8b17-38d8aadfaa36';
   const validId = '3a081d91-5ea8-40a7-8ac9-abbaa3fcb893';
-  const validName = 'CLI 365 Card';
+  const validName = 'CLI 365 AI Builder Model';
   const envUrl = "https://contoso-dev.api.crm4.dynamics.com";
-  const cardResponse = {
+  const aiBuilderModelResponse = {
     "value": [
       {
-        "solutionid": "fd140aae-4df4-11dd-bd17-0019b9312238",
-        "modifiedon": "2022-10-11T08:52:12Z",
-        "_owninguser_value": "7d48edd3-69fd-ec11-82e5-000d3ab87733",
-        "overriddencreatedon": null,
-        "ismanaged": false,
-        "schemaversion": null,
-        "tags": null,
-        "importsequencenumber": null,
-        "componentidunique": "d7c1acb5-37a4-4873-b24e-34b18c15c6a5",
-        "_modifiedonbehalfby_value": null,
-        "componentstate": 0,
         "statecode": 0,
-        "name": "DummyCard",
-        "versionnumber": 3044006,
-        "utcconversiontimezonecode": null,
-        "cardid": "69703efe-4149-ed11-bba2-000d3adf7537",
-        "publishdate": null,
-        "_createdonbehalfby_value": null,
-        "_modifiedby_value": "7d48edd3-69fd-ec11-82e5-000d3ab87733",
-        "createdon": "2022-10-11T08:52:12Z",
+        "_msdyn_templateid_value": "10707e4e-1d56-e911-8194-000d3a6cd5a5",
+        "msdyn_modelcreationcontext": "{}",
+        "createdon": "2022-11-29T11:58:45Z",
+        "_ownerid_value": "5fa787c1-1c4d-ed11-bba1-000d3a2caf7f",
+        "modifiedon": "2022-11-29T11:58:45Z",
+        "msdyn_sharewithorganizationoncreate": false,
+        "msdyn_aimodelidunique": "b0328b67-47e2-4202-8189-e617ec9a88bd",
+        "solutionid": "fd140aae-4df4-11dd-bd17-0019b9312238",
+        "ismanaged": false,
+        "versionnumber": 1458121,
+        "msdyn_name": "Document Processing 11/29/2022, 12:58:43 PM",
+        "introducedversion": "1.0",
+        "statuscode": 0,
+        "_modifiedby_value": "5fa787c1-1c4d-ed11-bba1-000d3a2caf7f",
         "overwritetime": "1900-01-01T00:00:00Z",
-        "_owningbusinessunit_value": "2199f44c-195b-ec11-8f8f-000d3adca49c",
-        "hiddentags": null,
-        "description": " ",
-        "appdefinition": "{\"screens\":{\"main\":{\"template\":{\"type\":\"AdaptiveCard\",\"body\":[{\"type\":\"TextBlock\",\"size\":\"Medium\",\"weight\":\"bolder\",\"text\":\"Your card title goes here\"},{\"type\":\"TextBlock\",\"text\":\"Add and remove element to customize your new card.\",\"wrap\":true}],\"actions\":[],\"$schema\":\"http://adaptivecards.io/schemas/1.4.0/adaptive-card.json\",\"version\":\"1.4\"},\"verbs\":{\"submit\":\"echo\"}}},\"sampleData\":{\"main\":{}},\"connections\":{},\"variables\":{},\"flows\":{}}",
-        "statuscode": 1,
-        "remixsourceid": null,
-        "sizes": null,
+        "componentstate": 0,
+        "_createdby_value": "5fa787c1-1c4d-ed11-bba1-000d3a2caf7f",
+        "_owningbusinessunit_value": "6da087c1-1c4d-ed11-bba1-000d3a2caf7f",
+        "_owninguser_value": "5fa787c1-1c4d-ed11-bba1-000d3a2caf7f",
+        "msdyn_aimodelid": "08ffffbe-ec1c-4e64-b64b-dd1db926c613",
+        "_msdyn_activerunconfigurationid_value": null,
+        "overriddencreatedon": null,
+        "_msdyn_retrainworkflowid_value": null,
+        "importsequencenumber": null,
+        "_msdyn_scheduleinferenceworkflowid_value": null,
+        "_modifiedonbehalfby_value": null,
+        "utcconversiontimezonecode": null,
+        "_createdonbehalfby_value": null,
         "_owningteam_value": null,
-        "coowners": null,
-        "_createdby_value": "7d48edd3-69fd-ec11-82e5-000d3ab87733",
-        "_ownerid_value": "7d48edd3-69fd-ec11-82e5-000d3ab87733",
-        "publishsourceid": null,
         "timezoneruleversionnumber": null,
         "iscustomizable": {
           "Value": true,
           "CanBeChanged": true,
           "ManagedPropertyLogicalName": "iscustomizableanddeletable"
-        },
-        "owninguser": {
-          "azureactivedirectoryobjectid": "88e85b64-e687-4e0b-bbf4-f42f5f8e574c",
-          "fullname": "Contoso Admin",
-          "systemuserid": "7d48edd3-69fd-ec11-82e5-000d3ab87733",
-          "ownerid": "7d48edd3-69fd-ec11-82e5-000d3ab87733"
         }
       }
     ]
@@ -118,15 +109,11 @@ describe(commands.CARD_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.CARD_GET), true);
+    assert.strictEqual(command.name.startsWith(commands.AIBUILDERMODEL_GET), true);
   });
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
-  });
-
-  it('defines correct properties for the default output', () => {
-    assert.deepStrictEqual(command.defaultProperties(), ['name', 'cardid', 'publishdate', 'createdon', 'modifiedon']);
   });
 
   it('fails validation if id is not a valid guid.', async () => {
@@ -149,11 +136,38 @@ describe(commands.CARD_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('throws error when no card found', async () => {
+  it('throws error when multiple AI builder models with same name were found', async () => {
+    sinon.stub(powerPlatform, 'getDynamicsInstanceApiUrl').callsFake(async () => envUrl);
+
+    const multipleAiBuilderModelsResponse = {
+      value: [
+        { ["msdyn_aimodelid"]: '69703efe-4149-ed11-bba2-000d3adf7537' },
+        { ["msdyn_aimodelid"]: '3a081d91-5ea8-40a7-8ac9-abbaa3fcb893' }
+      ]
+    };
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/msdyn_aimodels?$filter=msdyn_name eq '${validName}' and iscustomizable/Value eq true`)) {
+        if ((opts.headers?.accept as string)?.indexOf('application/json') === 0) {
+          return multipleAiBuilderModelsResponse;
+        }
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        environment: validEnvironment,
+        name: validName
+      }
+    }), new CommandError(`Multiple AI builder models with name '${validName}' found: ${multipleAiBuilderModelsResponse.value.map(x => x.msdyn_aimodelid).join(',')}`));
+  });
+
+  it('throws error when no AI builder model found', async () => {
     sinon.stub(powerPlatform, 'getDynamicsInstanceApiUrl').callsFake(async () => envUrl);
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/cards?$filter=name eq '${validName}'`)) {
+      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/msdyn_aimodels?$filter=msdyn_name eq '${validName}' and iscustomizable/Value eq true`)) {
         if ((opts.headers?.accept as string)?.indexOf('application/json') === 0) {
           return ({ "value": [] });
         }
@@ -167,43 +181,16 @@ describe(commands.CARD_GET, () => {
         environment: validEnvironment,
         name: validName
       }
-    }), new CommandError(`The specified card '${validName}' does not exist.`));
+    }), new CommandError(`The specified AI builder model '${validName}' does not exist.`));
   });
 
-  it('throws error when multiple cards with same name were found', async () => {
-    sinon.stub(powerPlatform, 'getDynamicsInstanceApiUrl').callsFake(async () => envUrl);
-
-    const multipleCardsResponse = {
-      value: [
-        { cardid: '69703efe-4149-ed11-bba2-000d3adf7537' },
-        { cardid: '3a081d91-5ea8-40a7-8ac9-abbaa3fcb893' }
-      ]
-    };
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/cards?$filter=name eq '${validName}'`)) {
-        if ((opts.headers?.accept as string)?.indexOf('application/json') === 0) {
-          return multipleCardsResponse;
-        }
-      }
-
-      throw 'Invalid request';
-    });
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        environment: validEnvironment,
-        name: validName
-      }
-    }), new CommandError(`Multiple cards with name '${validName}' found: ${multipleCardsResponse.value.map(x => x.cardid).join(',')}`));
-  });
-
-  it('retrieves a specific card with the name parameter', async () => {
+  it('retrieves a specific AI builder model with the name parameter', async () => {
     sinon.stub(powerPlatform, 'getDynamicsInstanceApiUrl').callsFake(async () => envUrl);
 
     sinon.stub(request, 'get').callsFake(async opts => {
-      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/cards?$filter=name eq '${validName}'`)) {
+      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/msdyn_aimodels?$filter=msdyn_name eq '${validName}' and iscustomizable/Value eq true`)) {
         if ((opts.headers?.accept as string)?.indexOf('application/json') === 0) {
-          return cardResponse;
+          return aiBuilderModelResponse;
         }
       }
 
@@ -211,16 +198,16 @@ describe(commands.CARD_GET, () => {
     });
 
     await command.action(logger, { options: { verbose: true, environment: validEnvironment, name: validName } });
-    assert(loggerLogSpy.calledWith(cardResponse.value[0]));
+    assert(loggerLogSpy.calledWith(aiBuilderModelResponse.value[0]));
   });
 
-  it('retrieves a specific card with the id parameter', async () => {
+  it('retrieves a specific AI builder model with the id parameter', async () => {
     sinon.stub(powerPlatform, 'getDynamicsInstanceApiUrl').callsFake(async () => envUrl);
 
     sinon.stub(request, 'get').callsFake(async opts => {
-      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/cards(${validId})`)) {
+      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/msdyn_aimodels(${validId})?$filter=iscustomizable/Value eq true`)) {
         if ((opts.headers?.accept as string)?.indexOf('application/json') === 0) {
-          return cardResponse.value[0];
+          return aiBuilderModelResponse.value[0];
         }
       }
 
@@ -228,14 +215,14 @@ describe(commands.CARD_GET, () => {
     });
 
     await command.action(logger, { options: { verbose: true, environment: validEnvironment, id: validId } });
-    assert(loggerLogSpy.calledWith(cardResponse.value[0]));
+    assert(loggerLogSpy.calledWith(aiBuilderModelResponse.value[0]));
   });
 
   it('correctly handles API OData error', async () => {
     sinon.stub(powerPlatform, 'getDynamicsInstanceApiUrl').callsFake(async () => envUrl);
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/cards?$filter=name eq '${validName}'`)) {
+      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.1/msdyn_aimodels?$filter=msdyn_name eq '${validName}' and iscustomizable/Value eq true`)) {
         if ((opts.headers?.accept as string)?.indexOf('application/json') === 0) {
           throw {
             error: {

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.ts
@@ -1,0 +1,132 @@
+import { Logger } from '../../../../cli/Logger';
+import GlobalOptions from '../../../../GlobalOptions';
+import request, { CliRequestOptions } from '../../../../request';
+import { powerPlatform } from '../../../../utils/powerPlatform';
+import { validation } from '../../../../utils/validation';
+import PowerPlatformCommand from '../../../base/PowerPlatformCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  environment: string;
+  id?: string;
+  name?: string;
+  asAdmin?: boolean;
+}
+
+class PpAiBuilderModelGetCommand extends PowerPlatformCommand {
+  public get name(): string {
+    return commands.AIBUILDERMODEL_GET;
+  }
+
+  public get description(): string {
+    return 'Get an AI builder model in the specified Power Platform environment.';
+  }
+
+  public defaultProperties(): string[] | undefined {
+    return ['msdyn_name', 'msdyn_aimodelid', 'createdon', 'modifiedon'];
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initOptionSets();
+    this.#initValidators();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        id: typeof args.options.id !== 'undefined',
+        name: typeof args.options.name !== 'undefined',
+        asAdmin: !!args.options.asAdmin
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-e, --environment <environment>'
+      },
+      {
+        option: '-i, --id [id]'
+      },
+      {
+        option: '-n, --name [name]'
+      },
+      {
+        option: '--asAdmin'
+      }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push(
+      { options: ['id', 'name'] }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        if (args.options.id && !validation.isValidGuid(args.options.id as string)) {
+          return `${args.options.id} is not a valid GUID`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (this.verbose) {
+      logger.logToStderr(`Retrieving an AI builder model '${args.options.id || args.options.name}'...`);
+    }
+
+    try {
+      const dynamicsApiUrl = await powerPlatform.getDynamicsInstanceApiUrl(args.options.environment, args.options.asAdmin);
+
+      const res = await this.getAiBuilderModel(dynamicsApiUrl, args.options);
+      logger.log(res);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+
+  private async getAiBuilderModel(dynamicsApiUrl: string, options: Options): Promise<any> {
+    const requestOptions: CliRequestOptions = {
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    if (options.id) {
+      requestOptions.url = `${dynamicsApiUrl}/api/data/v9.1/msdyn_aimodels(${options.id})?$filter=iscustomizable/Value eq true`;
+      const result = await request.get<any>(requestOptions);
+      return result;
+    }
+
+    requestOptions.url = `${dynamicsApiUrl}/api/data/v9.1/msdyn_aimodels?$filter=msdyn_name eq '${options.name}' and iscustomizable/Value eq true`;
+    const result = await request.get<{ value: any[] }>(requestOptions);
+
+    if (result.value.length === 0) {
+      throw `The specified AI builder model '${options.name}' does not exist.`;
+    }
+
+    if (result.value.length > 1) {
+      throw `Multiple AI builder models with name '${options.name}' found: ${result.value.map(x => x.msdyn_aimodelid).join(',')}`;
+    }
+
+    return result.value[0];
+  }
+}
+
+module.exports = new PpAiBuilderModelGetCommand();


### PR DESCRIPTION
This PR adds the command `pp ai builder model get`, which retrieve a specific AI builder model.

Also improved 2 tests from `pp card get` that worked but didn't do what was in the title of the test

Closes #4325