### PR TITLE
Fixing Microsoft Learn link in CDN related commands documentation

### DIFF
--- a/docs/docs/cmd/spo/cdn/cdn-get.md
+++ b/docs/docs/cmd/spo/cdn/cdn-get.md
@@ -38,4 +38,4 @@ m365 spo cdn get --type Private
 
 ## More information
 
-- General availability of Microsoft 365 CDN: [https://dev.office.com/blogs/general-availability-of-office-365-cdn](https://dev.office.com/blogs/general-availability-of-office-365-cdn)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-get.md
+++ b/docs/docs/cmd/spo/cdn/cdn-get.md
@@ -38,4 +38,4 @@ m365 spo cdn get --type Private
 
 ## More information
 
-- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-origin-add.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-add.md
@@ -35,4 +35,4 @@ m365 spo cdn origin add --type Public --origin */CDN
 
 ## More information
 
-- General availability of Microsoft 365 CDN: [https://dev.office.com/blogs/general-availability-of-office-365-cdn](https://dev.office.com/blogs/general-availability-of-office-365-cdn)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-origin-add.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-add.md
@@ -35,4 +35,4 @@ m365 spo cdn origin add --type Public --origin */CDN
 
 ## More information
 
-- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-origin-list.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-list.md
@@ -38,4 +38,4 @@ m365 spo cdn origin list --type Private
 
 ## More information
 
-- General availability of Microsoft 365 CDN: [https://dev.office.com/blogs/general-availability-of-office-365-cdn](https://dev.office.com/blogs/general-availability-of-office-365-cdn)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-origin-list.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-list.md
@@ -38,4 +38,4 @@ m365 spo cdn origin list --type Private
 
 ## More information
 
-- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-origin-remove.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-remove.md
@@ -38,4 +38,4 @@ m365 spo cdn origin remove --type Public --origin */CDN
 
 ## More information
 
-- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-origin-remove.md
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-remove.md
@@ -38,4 +38,4 @@ m365 spo cdn origin remove --type Public --origin */CDN
 
 ## More information
 
-- General availability of Microsoft 365 CDN: [https://dev.office.com/blogs/general-availability-of-office-365-cdn](https://dev.office.com/blogs/general-availability-of-office-365-cdn)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-policy-list.md
+++ b/docs/docs/cmd/spo/cdn/cdn-policy-list.md
@@ -38,4 +38,4 @@ m365 spo cdn policy list --cdnType Private
 
 ## More information
 
-- General availability of Microsoft 365 CDN: [https://dev.office.com/blogs/general-availability-of-office-365-cdn](https://dev.office.com/blogs/general-availability-of-office-365-cdn)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-policy-list.md
+++ b/docs/docs/cmd/spo/cdn/cdn-policy-list.md
@@ -38,4 +38,4 @@ m365 spo cdn policy list --cdnType Private
 
 ## More information
 
-- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-policy-set.md
+++ b/docs/docs/cmd/spo/cdn/cdn-policy-set.md
@@ -38,4 +38,4 @@ m365 spo cdn policy set --cdnType Public --policy IncludeFileExtensions --value 
 
 ## More information
 
-- General availability of Microsoft 365 CDN: [https://dev.office.com/blogs/general-availability-of-office-365-cdn](https://dev.office.com/blogs/general-availability-of-office-365-cdn)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-policy-set.md
+++ b/docs/docs/cmd/spo/cdn/cdn-policy-set.md
@@ -38,4 +38,4 @@ m365 spo cdn policy set --cdnType Public --policy IncludeFileExtensions --value 
 
 ## More information
 
-- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-set.md
+++ b/docs/docs/cmd/spo/cdn/cdn-set.md
@@ -66,4 +66,4 @@ m365 spo cdn set --type Both --enabled true --noDefaultOrigins
 
 ## More information
 
-- General availability of Microsoft 365 CDN: [https://dev.office.com/blogs/general-availability-of-office-365-cdn](https://dev.office.com/blogs/general-availability-of-office-365-cdn)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)

--- a/docs/docs/cmd/spo/cdn/cdn-set.md
+++ b/docs/docs/cmd/spo/cdn/cdn-set.md
@@ -66,4 +66,4 @@ m365 spo cdn set --type Both --enabled true --noDefaultOrigins
 
 ## More information
 
-- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/en-us/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)
+- Use Microsoft 365 CDN with SharePoint Online: [https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide](https://learn.microsoft.com/microsoft-365/enterprise/use-microsoft-365-cdn-with-spo?view=o365-worldwide)


### PR DESCRIPTION
- update `spo cdn` commands documentation pages to fix link mentioned in _More information_ section

Closes #4352