### PR TITLE
Fixes planner commands to support application permissions. Closes #4330

### DIFF
--- a/src/m365/planner/commands/bucket/bucket-add.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -128,7 +127,6 @@ describe(commands.BUCKET_ADD, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     sinon.stub(request, 'post').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets` &&
         JSON.stringify(opts.data) === JSON.stringify({
@@ -167,8 +165,7 @@ describe(commands.BUCKET_ADD, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.post,
-      accessToken.isAppOnlyAccessToken
+      request.post
     ]);
   });
 
@@ -332,18 +329,6 @@ describe(commands.BUCKET_ADD, () => {
         ownerGroupName: 'foo'
       }
     }), new CommandError(`The specified group 'foo' does not exist.`));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        name: 'My Planner Bucket',
-        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('correctly handles API OData error', async () => {

--- a/src/m365/planner/commands/bucket/bucket-add.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.ts
@@ -1,8 +1,6 @@
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -104,11 +102,6 @@ class PlannerBucketAddCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const planId = await this.getPlanId(args);
 

--- a/src/m365/planner/commands/bucket/bucket-get.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -102,7 +101,6 @@ describe(commands.BUCKET_GET, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     log = [];
     logger = {
       log: (msg: string) => {
@@ -121,8 +119,7 @@ describe(commands.BUCKET_GET, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.patch,
-      accessToken.isAppOnlyAccessToken
+      request.patch
     ]);
   });
 
@@ -325,17 +322,6 @@ describe(commands.BUCKET_GET, () => {
         planId: validPlanId
       }
     }), new CommandError(`Multiple buckets with name ${validBucketName} found: ${multipleBucketByNameResponse.value.map(x => x.id)}`));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        id: validBucketId
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('Correctly gets bucket by id', async () => {

--- a/src/m365/planner/commands/bucket/bucket-get.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.ts
@@ -1,9 +1,7 @@
 import { PlannerBucket } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -128,11 +126,6 @@ class PlannerBucketGetCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const bucketId = await this.getBucketId(args);
       const bucket = await this.getBucketById(bucketId);

--- a/src/m365/planner/commands/bucket/bucket-list.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -130,7 +129,6 @@ describe(commands.BUCKET_LIST, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
     sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
@@ -173,8 +171,7 @@ describe(commands.BUCKET_LIST, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      accessToken.isAppOnlyAccessToken
+      request.get
     ]);
   });
 
@@ -322,17 +319,6 @@ describe(commands.BUCKET_LIST, () => {
         ownerGroupName: 'foo'
       }
     }), new CommandError(`The specified group 'foo' does not exist.`));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('correctly handles API OData error', async () => {

--- a/src/m365/planner/commands/bucket/bucket-list.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.ts
@@ -1,8 +1,6 @@
 import { PlannerBucket } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
-import { accessToken } from '../../../../utils/accessToken';
 import { odata } from '../../../../utils/odata';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
@@ -96,11 +94,6 @@ class PlannerBucketListCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const planId = await this.getPlanId(args);
       const buckets = await odata.getAllItems<PlannerBucket>(`${this.resource}/v1.0/planner/plans/${planId}/buckets`);

--- a/src/m365/planner/commands/bucket/bucket-remove.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -91,7 +90,6 @@ describe(commands.BUCKET_REMOVE, () => {
   let promptOptions: any;
 
   before(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
     sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
@@ -127,7 +125,6 @@ describe(commands.BUCKET_REMOVE, () => {
     sinonUtil.restore([
       request.get,
       request.delete,
-      accessToken.isAppOnlyAccessToken,
       Cli.prompt
     ]);
   });
@@ -279,18 +276,6 @@ describe(commands.BUCKET_REMOVE, () => {
       }
     });
     assert(postSpy.notCalled);
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        name: 'My Planner Bucket',
-        planId: validPlanId
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('fails validation when no groups found', async () => {

--- a/src/m365/planner/commands/bucket/bucket-remove.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.ts
@@ -1,10 +1,8 @@
 import { PlannerBucket } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Cli } from '../../../../cli/Cli';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -132,11 +130,6 @@ class PlannerBucketRemoveCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     const removeBucket: () => Promise<void> = async (): Promise<void> => {
       try {
         const bucket = await this.getBucket(args);

--- a/src/m365/planner/commands/bucket/bucket-set.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -103,7 +102,6 @@ describe(commands.BUCKET_SET, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     log = [];
     logger = {
       log: (msg: string) => {
@@ -122,8 +120,7 @@ describe(commands.BUCKET_SET, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.patch,
-      accessToken.isAppOnlyAccessToken
+      request.patch
     ]);
   });
 
@@ -259,19 +256,6 @@ describe(commands.BUCKET_SET, () => {
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        id: validBucketId,
-        planId: validPlanId,
-        newName: validBucketName
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('fails validation when no groups found', async () => {

--- a/src/m365/planner/commands/bucket/bucket-set.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.ts
@@ -1,9 +1,7 @@
 import { PlannerBucket } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -142,11 +140,6 @@ class PlannerBucketSetCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const bucket = await this.getBucket(args);
 

--- a/src/m365/planner/commands/plan/plan-add.spec.ts
+++ b/src/m365/planner/commands/plan/plan-add.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -106,7 +105,6 @@ describe(commands.PLAN_ADD, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     (command as any).items = [];
   });
 
@@ -114,8 +112,7 @@ describe(commands.PLAN_ADD, () => {
     sinonUtil.restore([
       request.get,
       request.post,
-      request.patch,
-      accessToken.isAppOnlyAccessToken
+      request.patch
     ]);
   });
 
@@ -224,18 +221,6 @@ describe(commands.PLAN_ADD, () => {
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        title: validTitle,
-        ownerGroupId: validOwnerGroupId
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('correctly adds planner plan with given title with available ownerGroupId', async () => {

--- a/src/m365/planner/commands/plan/plan-add.ts
+++ b/src/m365/planner/commands/plan/plan-add.ts
@@ -1,10 +1,8 @@
 import { PlannerPlan, PlannerPlanDetails, User } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { aadGroup } from '../../../../utils/aadGroup';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { validation } from '../../../../utils/validation';
 import GraphCommand from '../../../base/GraphCommand';
@@ -100,11 +98,6 @@ class PlannerPlanAddCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const groupId = await this.getGroupId(args);
       const requestOptions: any = {

--- a/src/m365/planner/commands/plan/plan-get.spec.ts
+++ b/src/m365/planner/commands/plan/plan-get.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
@@ -61,7 +60,6 @@ describe(commands.PLAN_GET, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     log = [];
     logger = {
       log: (msg: string) => {
@@ -80,8 +78,7 @@ describe(commands.PLAN_GET, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      accessToken.isAppOnlyAccessToken
+      request.get
     ]);
   });
 
@@ -212,17 +209,6 @@ describe(commands.PLAN_GET, () => {
 
     await command.action(logger, { options: options });
     assert(loggerLogSpy.calledWith(outputResponse));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        id: validId
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('correctly get planner plan with given title and ownerGroupName', async () => {

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -1,9 +1,7 @@
 import { PlannerPlan, PlannerPlanDetails } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -98,11 +96,6 @@ class PlannerPlanGetCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       if (args.options.id) {
         const plan = await planner.getPlanById(args.options.id);

--- a/src/m365/planner/commands/plan/plan-list.spec.ts
+++ b/src/m365/planner/commands/plan/plan-list.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
@@ -32,7 +31,6 @@ describe(commands.PLAN_LIST, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     log = [];
     logger = {
       log: (msg: string) => {
@@ -51,8 +49,7 @@ describe(commands.PLAN_LIST, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      accessToken.isAppOnlyAccessToken
+      request.get
     ]);
   });
 
@@ -336,17 +333,6 @@ describe(commands.PLAN_LIST, () => {
         }
       }
     }]));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        ownerGroupId: '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4'
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('correctly handles no plan found with given ownerGroupId', async () => {

--- a/src/m365/planner/commands/plan/plan-list.ts
+++ b/src/m365/planner/commands/plan/plan-list.ts
@@ -1,7 +1,5 @@
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
-import { accessToken } from '../../../../utils/accessToken';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -76,11 +74,6 @@ class PlannerPlanListCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const groupId = await this.getGroupId(args);
       const result = await planner.getPlansByGroupId(groupId);

--- a/src/m365/planner/commands/plan/plan-remove.spec.ts
+++ b/src/m365/planner/commands/plan/plan-remove.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -78,7 +77,6 @@ describe(commands.PLAN_REMOVE, () => {
       }
     };
     promptOptions = undefined;
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
       promptOptions = options;
       return { continue: false };
@@ -89,7 +87,6 @@ describe(commands.PLAN_REMOVE, () => {
     sinonUtil.restore([
       request.get,
       request.delete,
-      accessToken.isAppOnlyAccessToken,
       Cli.prompt
     ]);
   });
@@ -195,17 +192,6 @@ describe(commands.PLAN_REMOVE, () => {
       }
     });
     assert(deleteSpy.notCalled);
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        id: validPlanId
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('Correctly deletes plan by id', async () => {

--- a/src/m365/planner/commands/plan/plan-remove.ts
+++ b/src/m365/planner/commands/plan/plan-remove.ts
@@ -1,10 +1,8 @@
 import { PlannerPlan } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Cli } from '../../../../cli/Cli';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -103,11 +101,6 @@ class PlannerPlanRemoveCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     const removePlan: () => Promise<void> = async (): Promise<void> => {
       try {
         const plan = await this.getPlan(args);

--- a/src/m365/planner/commands/plan/plan-set.spec.ts
+++ b/src/m365/planner/commands/plan/plan-set.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -147,15 +146,13 @@ describe(commands.PLAN_SET, () => {
     };
 
     loggerLogSpy = sinon.spy(logger, 'log');
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     (command as any).items = [];
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.patch,
-      accessToken.isAppOnlyAccessToken
+      request.patch
     ]);
   });
 
@@ -275,18 +272,6 @@ describe(commands.PLAN_SET, () => {
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        title: title,
-        ownerGroupId: ownerGroupId
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('correctly updates planner plan title with given id (debug)', async () => {

--- a/src/m365/planner/commands/plan/plan-set.ts
+++ b/src/m365/planner/commands/plan/plan-set.ts
@@ -1,9 +1,7 @@
 import { PlannerPlan, PlannerPlanDetails, User } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
@@ -318,11 +316,6 @@ class PlannerPlanSetCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const planId: string = await this.getPlanId(args);
 

--- a/src/m365/planner/commands/task/task-add.spec.ts
+++ b/src/m365/planner/commands/task/task-add.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -180,7 +179,6 @@ describe(commands.TASK_ADD, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     sinon.stub(request, 'post').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/tasks`) {
         return Promise.resolve(taskAddResponse);
@@ -209,8 +207,7 @@ describe(commands.TASK_ADD, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.post,
-      accessToken.isAppOnlyAccessToken
+      request.post
     ]);
   });
 
@@ -501,19 +498,6 @@ describe(commands.TASK_ADD, () => {
 
     await command.action(logger, { options: options } as any);
     assert(loggerLogSpy.calledWith(taskAddResponse));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        title: 'My Planner Task',
-        planId: '8QZEH7b3wkS_bGQobscsM5gADCBb',
-        bucketId: 'IK8tuFTwQEa5vTonM7ZMRZgAKdno'
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('correctly adds planner bucket with title, bucketId, planTitle, and ownerGroupName', async () => {

--- a/src/m365/planner/commands/task/task-add.ts
+++ b/src/m365/planner/commands/task/task-add.ts
@@ -1,9 +1,7 @@
 import { PlannerBucket, PlannerTask, PlannerTaskDetails, User } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
@@ -185,11 +183,6 @@ class PlannerTaskAddCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       this.planId = await this.getPlanId(args);
       this.bucketId = await this.getBucketId(args, this.planId);

--- a/src/m365/planner/commands/task/task-checklistitem-add.spec.ts
+++ b/src/m365/planner/commands/task/task-checklistitem-add.spec.ts
@@ -5,7 +5,6 @@ import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -47,7 +46,6 @@ describe(commands.TASK_CHECKLISTITEM_ADD, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     log = [];
     logger = {
       log: (msg: string) => {
@@ -67,8 +65,7 @@ describe(commands.TASK_CHECKLISTITEM_ADD, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.patch,
-      accessToken.isAppOnlyAccessToken
+      request.patch
     ]);
   });
 
@@ -185,17 +182,5 @@ describe(commands.TASK_CHECKLISTITEM_ADD, () => {
         title: validTitle
       }
     }), new CommandError('Planner task was not found.'));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        name: 'My Planner Bucket',
-        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 });

--- a/src/m365/planner/commands/task/task-checklistitem-add.ts
+++ b/src/m365/planner/commands/task/task-checklistitem-add.ts
@@ -1,10 +1,8 @@
 import { PlannerTaskDetails } from '@microsoft/microsoft-graph-types';
 import { v4 } from 'uuid';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
@@ -56,11 +54,6 @@ class PlannerTaskChecklistItemAddCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const etag = await this.getTaskDetailsEtag(args.options.taskId);
       const body: PlannerTaskDetails = {

--- a/src/m365/planner/commands/task/task-checklistitem-list.spec.ts
+++ b/src/m365/planner/commands/task/task-checklistitem-list.spec.ts
@@ -5,7 +5,6 @@ import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
@@ -86,7 +85,6 @@ describe(commands.TASK_CHECKLISTITEM_LIST, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     log = [];
     logger = {
       log: (msg: string) => {
@@ -105,8 +103,7 @@ describe(commands.TASK_CHECKLISTITEM_LIST, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      accessToken.isAppOnlyAccessToken
+      request.get
     ]);
   });
 
@@ -130,17 +127,6 @@ describe(commands.TASK_CHECKLISTITEM_LIST, () => {
 
   it('defines correct properties for the default output', () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'title', 'isChecked']);
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        taskId: 'vzCcZoOv-U27PwydxHB8opcADJo-'
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('successfully handles item found(JSON)', async () => {

--- a/src/m365/planner/commands/task/task-checklistitem-list.ts
+++ b/src/m365/planner/commands/task/task-checklistitem-list.ts
@@ -1,8 +1,6 @@
-import auth from "../../../../Auth";
 import { Logger } from "../../../../cli/Logger";
 import GlobalOptions from "../../../../GlobalOptions";
 import request from "../../../../request";
-import { accessToken } from "../../../../utils/accessToken";
 import { formatting } from "../../../../utils/formatting";
 import GraphCommand from "../../../base/GraphCommand";
 import commands from "../../commands";
@@ -43,11 +41,6 @@ class PlannerTaskChecklistItemListCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     const requestOptions: any = {
       url: `${this.resource}/v1.0/planner/tasks/${formatting.encodeQueryParameter(args.options.taskId)}/details?$select=checklist`,
       headers: {

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -137,7 +136,6 @@ describe(commands.TASK_GET, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     log = [];
     logger = {
       log: (msg: string) => {
@@ -156,8 +154,7 @@ describe(commands.TASK_GET, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      accessToken.isAppOnlyAccessToken
+      request.get
     ]);
   });
 
@@ -286,17 +283,6 @@ describe(commands.TASK_GET, () => {
       }
     }, commandInfo);
     assert.strictEqual(actual, true);
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        id: validTaskId
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('fails validation when no groups found', async () => {

--- a/src/m365/planner/commands/task/task-get.ts
+++ b/src/m365/planner/commands/task/task-get.ts
@@ -1,9 +1,7 @@
 import { PlannerBucket, PlannerTask, PlannerTaskDetails } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
 import { planner } from '../../../../utils/planner';
@@ -122,11 +120,6 @@ class PlannerTaskGetCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       const taskId = await this.getTaskId(args.options);
       const task = await this.getTask(taskId);

--- a/src/m365/planner/commands/task/task-list.spec.ts
+++ b/src/m365/planner/commands/task/task-list.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -278,7 +277,6 @@ describe(commands.TASK_LIST, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter('My Planner Group')}'`) {
         return Promise.resolve(groupByDisplayNameResponse);
@@ -327,8 +325,7 @@ describe(commands.TASK_LIST, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      accessToken.isAppOnlyAccessToken
+      request.get
     ]);
   });
 
@@ -523,18 +520,6 @@ describe(commands.TASK_LIST, () => {
         ownerGroupName: 'foo'
       }
     }), new CommandError(`The specified group 'foo' does not exist.`));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        bucketId: 'FtzysDykv0-9s9toWiZhdskAD67z',
-        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('fails validation when bucketName not found', async () => {

--- a/src/m365/planner/commands/task/task-list.ts
+++ b/src/m365/planner/commands/task/task-list.ts
@@ -1,9 +1,7 @@
 import { PlannerTask } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { odata } from '../../../../utils/odata';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
@@ -115,11 +113,6 @@ class PlannerTaskListCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     const bucketName: string | undefined = args.options.bucketName;
     let bucketId: string | undefined = args.options.bucketId;
     const planTitle: string | undefined = args.options.planTitle;

--- a/src/m365/planner/commands/task/task-reference-list.spec.ts
+++ b/src/m365/planner/commands/task/task-reference-list.spec.ts
@@ -5,7 +5,6 @@ import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -51,7 +50,6 @@ describe(commands.TASK_REFERENCE_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
     sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
@@ -81,8 +79,7 @@ describe(commands.TASK_REFERENCE_LIST, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      accessToken.isAppOnlyAccessToken
+      request.get
     ]);
   });
 
@@ -102,17 +99,6 @@ describe(commands.TASK_REFERENCE_LIST, () => {
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        taskId: "uBk5fK_MHkeyuPYlCo4OFpcAMowf"
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('successfully handles item found', async () => {

--- a/src/m365/planner/commands/task/task-reference-list.ts
+++ b/src/m365/planner/commands/task/task-reference-list.ts
@@ -1,8 +1,6 @@
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
@@ -39,11 +37,6 @@ class PlannerTaskReferenceListCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     const requestOptions: any = {
       url: `${this.resource}/v1.0/planner/tasks/${formatting.encodeQueryParameter(args.options.taskId)}/details?$select=references`,
       headers: {

--- a/src/m365/planner/commands/task/task-set.spec.ts
+++ b/src/m365/planner/commands/task/task-set.spec.ts
@@ -7,7 +7,6 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
@@ -152,7 +151,6 @@ describe(commands.TASK_SET, () => {
   });
 
   beforeEach(() => {
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
     log = [];
     logger = {
       log: (msg: string) => {
@@ -175,8 +173,7 @@ describe(commands.TASK_SET, () => {
     sinonUtil.restore([
       request.get,
       request.post,
-      request.patch,
-      accessToken.isAppOnlyAccessToken
+      request.patch
     ]);
   });
 
@@ -417,18 +414,6 @@ describe(commands.TASK_SET, () => {
 
     await command.action(logger, { options: options } as any);
     assert(loggerLogSpy.calledWith(taskResponse));
-  });
-
-  it('fails validation when using app only access token', async () => {
-    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
-    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        id: 'Z-RLQGfppU6H3663DBzfs5gAMD3o',
-        title: 'My Planner Task'
-      }
-    }), new CommandError('This command does not support application permissions.'));
   });
 
   it('uses correct value for urgent priority', async () => {

--- a/src/m365/planner/commands/task/task-set.ts
+++ b/src/m365/planner/commands/task/task-set.ts
@@ -1,9 +1,7 @@
 import { PlannerBucket, PlannerTask, PlannerTaskDetails, User } from '@microsoft/microsoft-graph-types';
-import auth from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
-import { accessToken } from '../../../../utils/accessToken';
 import { formatting } from '../../../../utils/formatting';
 import { validation } from '../../../../utils/validation';
 import { aadGroup } from '../../../../utils/aadGroup';
@@ -179,11 +177,6 @@ class PlannerTaskSetCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
-      this.handleError('This command does not support application permissions.');
-      return;
-    }
-
     try {
       this.bucketId = await this.getBucketId(args.options);
       this.assignments = await this.generateUserAssignments(args.options);


### PR DESCRIPTION
Fixes `planner` commands to support application permissions. Closes #4330