### PR TITLE
Mark option `schemaXml` as deprecated on `spo list add` and `spo list set`

### DIFF
--- a/docs/docs/cmd/spo/list/list-add.md
+++ b/docs/docs/cmd/spo/list/list-add.md
@@ -26,7 +26,7 @@ m365 spo list add [options]
 : The globally unique identifier (GUID) of a template feature that is associated with the list
 
 `--schemaXml [schemaXml]`
-: The schema in Collaborative Application Markup Language (CAML) schemas that defines the list
+: (deprecated) The schema in Collaborative Application Markup Language (CAML) schemas that defines the list
 
 `--allowDeletion [allowDeletion]`
 : Boolean value specifying whether the list can be deleted. Valid values are `true,false`

--- a/docs/docs/cmd/spo/list/list-set.md
+++ b/docs/docs/cmd/spo/list/list-set.md
@@ -179,7 +179,7 @@ m365 spo list set [options]
 : A boolean value that indicates whether the this list is a restricted one or not The value can't be changed if there are existing items in the list
 
 `--schemaXml [schemaXml]`
-: The schema in Collaborative Application Markup Language (CAML) schemas that defines the list
+: (deprecated) The schema in Collaborative Application Markup Language (CAML) schemas that defines the list
 
 `--sendToLocationName [sendToLocationName]`
 : Gets or sets a file name to use when copying an item in the list to another document library.

--- a/src/m365/spo/commands/list/list-add.ts
+++ b/src/m365/spo/commands/list/list-add.ts
@@ -575,6 +575,10 @@ class SpoListAddCommand extends SpoCommand {
       logger.logToStderr(`Creating list in site at ${args.options.webUrl}...`);
     }
 
+    if (args.options.schemaXml) {
+      this.warn(logger, `Option 'schemaXml' is deprecated.`);
+    }
+
     const requestBody: any = this.mapRequestBody(args.options);
 
     const requestOptions: any = {

--- a/src/m365/spo/commands/list/list-set.ts
+++ b/src/m365/spo/commands/list/list-set.ts
@@ -576,6 +576,10 @@ class SpoListSetCommand extends SpoCommand {
       logger.logToStderr(`Updating list in site at ${args.options.webUrl}...`);
     }
 
+    if (args.options.schemaXml) {
+      this.warn(logger, `Option 'schemaXml' is deprecated.`);
+    }
+
     const requestBody: any = this.mapRequestBody(args.options);
 
     let requestUrl = `${args.options.webUrl}/_api/web/`;


### PR DESCRIPTION
This PR will mark the option `schemaXml` deprecated on both the `spo list add` and `spo list set` command. 
Issue ref: #2906 

@waldekmastykarz Do you put the task to remove the option completely on the roadmap for the next major release?

Closes #2906