### PR TITLE
Remove short options for `spo file sharinglink list`, Closes #4386

### DIFF
--- a/docs/docs/cmd/spo/file/file-sharinglink-list.md
+++ b/docs/docs/cmd/spo/file/file-sharinglink-list.md
@@ -13,10 +13,10 @@ m365 spo file sharinglink list [options]
 `-u, --webUrl <webUrl>`
 : The URL of the site where the file is located.
 
-`-f, --fileUrl [fileUrl]`
+`--fileUrl [fileUrl]`
 : The server-relative (decoded) URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
-`-i, --fileId [fileId]`
+`--fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `--scope [scope]`

--- a/src/m365/spo/commands/file/file-sharinglink-list.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-list.ts
@@ -59,10 +59,10 @@ class SpoFileSharingLinkListCommand extends SpoCommand {
         option: '-u, --webUrl <webUrl>'
       },
       {
-        option: '-i, --fileId [fileId]'
+        option: '--fileId [fileId]'
       },
       {
-        option: '-f, --fileUrl [fileUrl]'
+        option: '--fileUrl [fileUrl]'
       },
       {
         option: '--scope [scope]',


### PR DESCRIPTION
This PR removes the short options for `spo file sharinglink list`.

Closes #4386