### PR TITLE
Bug-fix: Issue removing plan by `title`

### DIFF
--- a/src/m365/planner/commands/plan/plan-remove.ts
+++ b/src/m365/planner/commands/plan/plan-remove.ts
@@ -145,7 +145,7 @@ class PlannerPlanRemoveCommand extends GraphCommand {
     }
 
     const groupId = await this.getGroupId(args);
-    return await planner.getPlanByTitle(title!, groupId);
+    return await planner.getPlanByTitle(title!, groupId, 'minimal');
   }
 
   private async getGroupId(args: CommandArgs): Promise<string> {

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -33,8 +33,8 @@ export const planner = {
    * Get all Planner plans for a specific group.
    * @param groupId Group ID.
    */
-  getPlansByGroupId(groupId: string): Promise<PlannerPlan[]> {
-    return odata.getAllItems<PlannerPlan>(`${graphResource}/v1.0/groups/${groupId}/planner/plans`, 'none');
+  getPlansByGroupId(groupId: string, metadata: 'none' | 'minimal' | 'full' = 'none'): Promise<PlannerPlan[]> {
+    return odata.getAllItems<PlannerPlan>(`${graphResource}/v1.0/groups/${groupId}/planner/plans`, metadata);
   },
 
   /**
@@ -42,8 +42,8 @@ export const planner = {
    * @param title Title of the Planner plan. Case insensitive.
    * @param groupId Owner group ID .
    */
-  async getPlanByTitle(title: string, groupId: string): Promise<PlannerPlan> {
-    const plans = await this.getPlansByGroupId(groupId);
+  async getPlanByTitle(title: string, groupId: string, metadata: 'none' | 'minimal' | 'full' = 'none'): Promise<PlannerPlan> {
+    const plans = await this.getPlansByGroupId(groupId, metadata);
     const filteredPlans = plans.filter(p => p.title && p.title.toLowerCase() === title.toLowerCase());
 
     if (!filteredPlans.length) {


### PR DESCRIPTION
Closes #4446 

@milanholemans  I noticed that in `planner plan set`, we will only retrieve the `etag` for the plan when we are updating the title value. Implementing this there would make the request larger. Should I implement it anyways?