### PR TITLE
Enhances `flow environment get`, Closes #4445

### DIFF
--- a/docs/docs/cmd/flow/environment/environment-get.md
+++ b/docs/docs/cmd/flow/environment/environment-get.md
@@ -10,8 +10,8 @@ m365 flow environment get [options]
 
 ## Options
 
-`-n, --name <name>`
-: The name of the environment to get information about
+`-n, --name [name]`
+: The name of the environment to get information about. When not specified, the default environment is retrieved.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -24,10 +24,15 @@ If the environment with the name you specified doesn't exist, you will get the `
 
 ## Examples
 
-Get information about the Microsoft Flow environment named _Default-d87a7535-dd31-4437-bfe1-95340acd55c5_
+Get information about a Microsoft Flow environment specified by name
 
 ```sh
 m365 flow environment get --name Default-d87a7535-dd31-4437-bfe1-95340acd55c5
+```
+
+Get information about the default Microsoft Flow environment
+```sh
+m365 flow environment get
 ```
 
 ## Response

--- a/docs/docs/cmd/flow/environment/environment-get.md
+++ b/docs/docs/cmd/flow/environment/environment-get.md
@@ -134,3 +134,26 @@ m365 flow environment get
     name,id,location,displayName,provisioningState,environmentSku,azureRegionHint,isDefault
     Default-d87a7535-dd31-4437-bfe1-95340acd55c5,/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5,india,contoso (default),Succeeded,Default,centralindia,1  
     ```
+
+=== "Markdown"
+
+    ```md
+    # flow environment get
+
+    Date: 8/2/2023
+
+    ## contoso (default) (/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5)
+
+    Property | Value
+    ---------|-------
+    name | Default-d87a7535-dd31-4437-bfe1-95340acd55c5
+    location | india
+    type | Microsoft.ProcessSimple/environments
+    id | /providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5
+    properties | {"displayName":"contoso (default)","createdTime":"2019-12-21T18:32:11.8708704Z","createdBy":{"id":"SYSTEM","displayName": "SYSTEM","type": "NotSpecified"},"provisioningState":"Succeeded","creationType":"DefaultTenant","environmentSku":"Default","environmentType":"NotSpecified","states":{"management":{"id":"NotSpecified"},"runtime":{"runtimeReasonCode":"NotSpecified","requestedBy":{"displayName":"SYSTEM","type":"NotSpecified"},"id":"Enabled"}},"isDefault":true,"isPayAsYouGoEnabled":false,"azureRegionHint":"centralindia","runtimeEndpoints":{"microsoft.BusinessAppPlatform":"https://india.api.bap.microsoft.com","microsoft.CommonDataModel":"https://india.api.cds.microsoft.com","microsoft.PowerApps":"https://india.api.powerapps.com",microsoft.PowerAppsAdvisor":"https://india.api.advisor.powerapps.com","microsoft.PowerVirtualAgents":"https://powervamg.in-il101.gateway.prod.island.powerapps.com","microsoft.ApiManagement":"https://management.INDIA.azure-apihub.net","microsoft.Flow":"https://india.api.flow.microsoft.com"},"linkedEnvironmentMetadata":{"type":"NotSpecified","resourceId":"3aa550bf-52ac-42fc-98f7-5d1833c1501c","friendlyName":"contoso (default)","uniqueName":"orgfc80770f","domainName":"orgfc80770f","version":"9.2.22105.00154","instanceUrl":"https://orgfc80770f.crm8.dynamics.com/","instanceApiUrl":"https://orgfc80770f.api.crm8.dynamics.com","baseLanguage":1033,"instanceState":"Ready","createdTime":"2019-12-25T15:46:14.433Z"},"environmentFeatures":{"isOpenApiEnabled":false},"cluster":{"category":"Prod","number":"101","uriSuffix":"in-il101.gateway.prod.island","geoShortName":"IN","environment":"Prod"},"governanceConfiguration":{"protectionLevel":"Basic"}}
+    displayName | contoso (default)
+    provisioningState | Succeeded
+    environmentSku | Default
+    azureRegionHint | centralindia
+    isDefault | true
+    ```

--- a/src/m365/flow/commands/environment/FlowEnvironmentDetails.ts
+++ b/src/m365/flow/commands/environment/FlowEnvironmentDetails.ts
@@ -1,0 +1,33 @@
+export interface FlowEnvironmentDetails {
+  displayName?: string,
+  provisioningState?: string,
+  environmentSku?: string,
+  azureRegionHint?: string,
+  isDefault?: boolean,
+  name: string,
+  location: string,
+  type: string,
+  id: string,
+  properties: FlowEnvironmentProperties
+}
+
+interface FlowEnvironmentProperties {
+  displayName: string,
+  createdTime: string,
+  createdBy: {
+    id: string,
+    displayName: string,
+    type: string
+  },
+  provisioningState: string,
+  creationType: string,
+  environmentSku: string,
+  environmentType: string,
+  isDefault: boolean,
+  azureRegionHint: string,
+  runtimeEndpoints: RuntimeEndpoints
+}
+
+interface RuntimeEndpoints<T = string> {
+  [key: string]: T;
+}

--- a/src/m365/flow/commands/environment/environment-get.spec.ts
+++ b/src/m365/flow/commands/environment/environment-get.spec.ts
@@ -8,8 +8,6 @@ import request from '../../../../request';
 import { pid } from '../../../../utils/pid';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
-import { Cli } from '../../../../cli/Cli';
-import * as FlowEnvironmentListCommand from './environment-list';
 import { FlowEnvironmentDetails } from './FlowEnvironmentDetails';
 const command: Command = require('./environment-get');
 
@@ -17,38 +15,39 @@ describe(commands.ENVIRONMENT_GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
-  const flowStdout: string = `[{ "name": "Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "location": "europe", "type": "Microsoft.ProcessSimple/environments", "id": "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "properties": { "displayName": "Contoso (default)", "createdTime": "2018-03-22T20:20:46.08653Z", "createdBy": { "id": "SYSTEM", "displayName": "SYSTEM", "type": "NotSpecified" }, "provisioningState": "Succeeded", "creationType": "DefaultTenant", "environmentSku": "Default", "environmentType": "Production", "isDefault": true, "azureRegionHint": "westeurope", "runtimeEndpoints": { "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com", "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com", "microsoft.PowerApps": "https://europe.api.powerapps.com", "microsoft.Flow": "https://europe.api.flow.microsoft.com" } } }]`;
-  const flowResponse: FlowEnvironmentDetails = {
-    displayName: "Contoso (default)",
-    provisioningState: "Succeeded",
-    environmentSku: "Default",
-    azureRegionHint: "westeurope",
-    isDefault: true,
-    name: "Default-d87a7535-dd31-4437-bfe1-95340acd55c5",
-    location: "europe",
-    type: "Microsoft.ProcessSimple/environments",
-    id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5",
-    properties: {
+  const flowResponse: { value: Array<FlowEnvironmentDetails> } = {
+    value: [{
       displayName: "Contoso (default)",
-      createdTime: "2018-03-22T20:20:46.08653Z",
-      createdBy: {
-        id: "SYSTEM",
-        displayName: "SYSTEM",
-        type: "NotSpecified"
-      },
       provisioningState: "Succeeded",
-      creationType: "DefaultTenant",
       environmentSku: "Default",
-      environmentType: "Production",
-      isDefault: true,
       azureRegionHint: "westeurope",
-      runtimeEndpoints: {
-        "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
-        "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
-        "microsoft.PowerApps": "https://europe.api.powerapps.com",
-        "microsoft.Flow": "https://europe.api.flow.microsoft.com"
+      isDefault: true,
+      name: "Default-d87a7535-dd31-4437-bfe1-95340acd55c5",
+      location: "europe",
+      type: "Microsoft.ProcessSimple/environments",
+      id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5",
+      properties: {
+        displayName: "Contoso (default)",
+        createdTime: "2018-03-22T20:20:46.08653Z",
+        createdBy: {
+          id: "SYSTEM",
+          displayName: "SYSTEM",
+          type: "NotSpecified"
+        },
+        provisioningState: "Succeeded",
+        creationType: "DefaultTenant",
+        environmentSku: "Default",
+        environmentType: "Production",
+        isDefault: true,
+        azureRegionHint: "westeurope",
+        runtimeEndpoints: {
+          "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
+          "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
+          "microsoft.PowerApps": "https://europe.api.powerapps.com",
+          "microsoft.Flow": "https://europe.api.flow.microsoft.com"
+        }
       }
-    }
+    }]
   };
 
   before(() => {
@@ -76,8 +75,7 @@ describe(commands.ENVIRONMENT_GET, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      Cli.executeCommandWithOutput
+      request.get
     ]);
   });
 
@@ -103,48 +101,42 @@ describe(commands.ENVIRONMENT_GET, () => {
   });
 
   it('retrieves information about the specified environment (debug)', async () => {
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === FlowEnvironmentListCommand) {
-        return ({
-          stdout: flowStdout
-        });
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01`)) {
+        return flowResponse;
       }
 
-      throw 'Unknown case';
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { debug: true, name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
-    assert(loggerLogSpy.calledWith(flowResponse));
+    assert(loggerLogSpy.calledWith(flowResponse.value[0]));
   });
 
   it('retrieves information about the specified environment', async () => {
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === FlowEnvironmentListCommand) {
-        return ({
-          stdout: flowStdout
-        });
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01`)) {
+        return flowResponse;
       }
 
-      throw 'Unknown case';
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
-    assert(loggerLogSpy.calledWith(flowResponse));
+    assert(loggerLogSpy.calledWith(flowResponse.value[0]));
   });
 
   it('retrieves information about the default environment', async () => {
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === FlowEnvironmentListCommand) {
-        return ({
-          stdout: flowStdout
-        });
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01`)) {
+        return flowResponse;
       }
 
-      throw 'Unknown case';
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { verbose: true } });
-    assert(loggerLogSpy.calledWith(flowResponse));
+    assert(loggerLogSpy.calledWith(flowResponse.value[0]));
   });
 
   it('correctly handles no environment found', async () => {

--- a/src/m365/flow/commands/environment/environment-get.spec.ts
+++ b/src/m365/flow/commands/environment/environment-get.spec.ts
@@ -15,39 +15,37 @@ describe(commands.ENVIRONMENT_GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
-  const flowResponse: { value: Array<FlowEnvironmentDetails> } = {
-    value: [{
+  const flowResponse: FlowEnvironmentDetails = {
+    displayName: "Contoso (default)",
+    provisioningState: "Succeeded",
+    environmentSku: "Default",
+    azureRegionHint: "westeurope",
+    isDefault: true,
+    name: "Default-d87a7535-dd31-4437-bfe1-95340acd55c5",
+    location: "europe",
+    type: "Microsoft.ProcessSimple/environments",
+    id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5",
+    properties: {
       displayName: "Contoso (default)",
+      createdTime: "2018-03-22T20:20:46.08653Z",
+      createdBy: {
+        id: "SYSTEM",
+        displayName: "SYSTEM",
+        type: "NotSpecified"
+      },
       provisioningState: "Succeeded",
+      creationType: "DefaultTenant",
       environmentSku: "Default",
-      azureRegionHint: "westeurope",
+      environmentType: "Production",
       isDefault: true,
-      name: "Default-d87a7535-dd31-4437-bfe1-95340acd55c5",
-      location: "europe",
-      type: "Microsoft.ProcessSimple/environments",
-      id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5",
-      properties: {
-        displayName: "Contoso (default)",
-        createdTime: "2018-03-22T20:20:46.08653Z",
-        createdBy: {
-          id: "SYSTEM",
-          displayName: "SYSTEM",
-          type: "NotSpecified"
-        },
-        provisioningState: "Succeeded",
-        creationType: "DefaultTenant",
-        environmentSku: "Default",
-        environmentType: "Production",
-        isDefault: true,
-        azureRegionHint: "westeurope",
-        runtimeEndpoints: {
-          "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
-          "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
-          "microsoft.PowerApps": "https://europe.api.powerapps.com",
-          "microsoft.Flow": "https://europe.api.flow.microsoft.com"
-        }
+      azureRegionHint: "westeurope",
+      runtimeEndpoints: {
+        "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
+        "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
+        "microsoft.PowerApps": "https://europe.api.powerapps.com",
+        "microsoft.Flow": "https://europe.api.flow.microsoft.com"
       }
-    }]
+    }
   };
 
   before(() => {
@@ -89,7 +87,7 @@ describe(commands.ENVIRONMENT_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.ENVIRONMENT_GET), true);
+    assert.strictEqual(command.name, commands.ENVIRONMENT_GET);
   });
 
   it('has a description', () => {
@@ -102,7 +100,7 @@ describe(commands.ENVIRONMENT_GET, () => {
 
   it('retrieves information about the specified environment (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async opts => {
-      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01`)) {
+      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5?api-version=2016-11-01`)) {
         return flowResponse;
       }
 
@@ -110,12 +108,12 @@ describe(commands.ENVIRONMENT_GET, () => {
     });
 
     await command.action(logger, { options: { debug: true, name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
-    assert(loggerLogSpy.calledWith(flowResponse.value[0]));
+    assert(loggerLogSpy.calledWith(flowResponse));
   });
 
   it('retrieves information about the specified environment', async () => {
     sinon.stub(request, 'get').callsFake(async opts => {
-      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01`)) {
+      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5?api-version=2016-11-01`)) {
         return flowResponse;
       }
 
@@ -123,12 +121,12 @@ describe(commands.ENVIRONMENT_GET, () => {
     });
 
     await command.action(logger, { options: { name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
-    assert(loggerLogSpy.calledWith(flowResponse.value[0]));
+    assert(loggerLogSpy.calledWith(flowResponse));
   });
 
   it('retrieves information about the default environment', async () => {
     sinon.stub(request, 'get').callsFake(async opts => {
-      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01`)) {
+      if ((opts.url === `https://management.azure.com/providers/Microsoft.ProcessSimple/environments/~default?api-version=2016-11-01`)) {
         return flowResponse;
       }
 
@@ -136,7 +134,7 @@ describe(commands.ENVIRONMENT_GET, () => {
     });
 
     await command.action(logger, { options: { verbose: true } });
-    assert(loggerLogSpy.calledWith(flowResponse.value[0]));
+    assert(loggerLogSpy.calledWith(flowResponse));
   });
 
   it('correctly handles no environment found', async () => {

--- a/src/m365/flow/commands/environment/environment-get.spec.ts
+++ b/src/m365/flow/commands/environment/environment-get.spec.ts
@@ -10,14 +10,15 @@ import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
 import { Cli } from '../../../../cli/Cli';
 import * as FlowEnvironmentListCommand from './environment-list';
+import { FlowEnvironmentDetails } from './FlowEnvironmentDetails';
 const command: Command = require('./environment-get');
 
 describe(commands.ENVIRONMENT_GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
-  const flowStdout: any = `[{ "name": "Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "location": "europe", "type": "Microsoft.ProcessSimple/environments", "id": "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "properties": { "displayName": "Contoso (default)", "createdTime": "2018-03-22T20:20:46.08653Z", "createdBy": { "id": "SYSTEM", "displayName": "SYSTEM", "type": "NotSpecified" }, "provisioningState": "Succeeded", "creationType": "DefaultTenant", "environmentSku": "Default", "environmentType": "Production", "isDefault": true, "azureRegionHint": "westeurope", "runtimeEndpoints": { "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com", "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com", "microsoft.PowerApps": "https://europe.api.powerapps.com", "microsoft.Flow": "https://europe.api.flow.microsoft.com" } } }]`;
-  const flowResponse: any = {
+  const flowStdout: string = `[{ "name": "Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "location": "europe", "type": "Microsoft.ProcessSimple/environments", "id": "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "properties": { "displayName": "Contoso (default)", "createdTime": "2018-03-22T20:20:46.08653Z", "createdBy": { "id": "SYSTEM", "displayName": "SYSTEM", "type": "NotSpecified" }, "provisioningState": "Succeeded", "creationType": "DefaultTenant", "environmentSku": "Default", "environmentType": "Production", "isDefault": true, "azureRegionHint": "westeurope", "runtimeEndpoints": { "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com", "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com", "microsoft.PowerApps": "https://europe.api.powerapps.com", "microsoft.Flow": "https://europe.api.flow.microsoft.com" } } }]`;
+  const flowResponse: FlowEnvironmentDetails = {
     displayName: "Contoso (default)",
     provisioningState: "Succeeded",
     environmentSku: "Default",

--- a/src/m365/flow/commands/environment/environment-get.ts
+++ b/src/m365/flow/commands/environment/environment-get.ts
@@ -1,10 +1,8 @@
-import { Cli } from '../../../../cli/Cli';
 import { Logger } from '../../../../cli/Logger';
-import Command from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
+import { odata } from '../../../../utils/odata';
 import AzmgmtCommand from '../../../base/AzmgmtCommand';
 import commands from '../../commands';
-import * as FlowEnvironmentListCommand from './environment-list';
 import { FlowEnvironmentDetails } from './FlowEnvironmentDetails';
 
 interface CommandArgs {
@@ -48,16 +46,8 @@ class FlowEnvironmentGetCommand extends AzmgmtCommand {
     }
 
     try {
-      const options: GlobalOptions = {
-        output: 'json',
-        debug: this.debug,
-        verbose: this.verbose
-      };
-
-      const output = await Cli.executeCommandWithOutput(FlowEnvironmentListCommand as Command, { options: { ...options, _: [] } });
-      const flowEnvironmentListOutput = JSON.parse(output.stdout);
-
-      const flowItem: FlowEnvironmentDetails = flowEnvironmentListOutput.filter(((flow: any) => args.options.name ? flow.name === args.options.name : flow.properties.isDefault === true))[0];
+      const response = await odata.getAllItems<FlowEnvironmentDetails>(`${this.resource}providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01`);
+      const flowItem: FlowEnvironmentDetails = response.filter(((flow: any) => args.options.name ? flow.name === args.options.name : flow.properties.isDefault === true))[0];
 
       flowItem.displayName = flowItem.properties.displayName;
       flowItem.provisioningState = flowItem.properties.provisioningState;

--- a/src/m365/flow/commands/environment/environment-get.ts
+++ b/src/m365/flow/commands/environment/environment-get.ts
@@ -5,6 +5,7 @@ import GlobalOptions from '../../../../GlobalOptions';
 import AzmgmtCommand from '../../../base/AzmgmtCommand';
 import commands from '../../commands';
 import * as FlowEnvironmentListCommand from './environment-list';
+import { FlowEnvironmentDetails } from './FlowEnvironmentDetails';
 
 interface CommandArgs {
   options: Options;
@@ -47,7 +48,7 @@ class FlowEnvironmentGetCommand extends AzmgmtCommand {
     }
 
     try {
-      const options: any = {
+      const options: GlobalOptions = {
         output: 'json',
         debug: this.debug,
         verbose: this.verbose
@@ -56,7 +57,7 @@ class FlowEnvironmentGetCommand extends AzmgmtCommand {
       const output = await Cli.executeCommandWithOutput(FlowEnvironmentListCommand as Command, { options: { ...options, _: [] } });
       const flowEnvironmentListOutput = JSON.parse(output.stdout);
 
-      const flowItem: any = flowEnvironmentListOutput.filter(((flow: any) => args.options.name ? flow.name === args.options.name : flow.properties.isDefault === true))[0];
+      const flowItem: FlowEnvironmentDetails = flowEnvironmentListOutput.filter(((flow: any) => args.options.name ? flow.name === args.options.name : flow.properties.isDefault === true))[0];
 
       flowItem.displayName = flowItem.properties.displayName;
       flowItem.provisioningState = flowItem.properties.provisioningState;


### PR DESCRIPTION
This PR enhances `flow environment get`,  retrieving the default environemt when no `name` option is provided.

Closes #4445