### PR TITLE
Fixes typo in docs remark

### DIFF
--- a/docs/docs/cmd/spo/navigation/navigation-node-add.md
+++ b/docs/docs/cmd/spo/navigation/navigation-node-add.md
@@ -35,7 +35,7 @@ m365 spo navigation node add [options]
 
 ## Remarks
 
-In order to use option `audienceIds`, make sure that audience targeted navigation is enabled using command [spo web set](../web/web-set.md).
+To enable/disable audience targeting for the navigation bar, use the [`spo web set`](../web/web-set.md) command.
 
 ## Examples
 

--- a/docs/docs/cmd/spo/navigation/navigation-node-set.md
+++ b/docs/docs/cmd/spo/navigation/navigation-node-set.md
@@ -32,7 +32,7 @@ m365 spo navigation node set [options]
 
 ## Remarks
 
-To enable/disable audience targeting for the nsavigation bar, use command [`spo web set`](../web/web-set.md).
+To enable/disable audience targeting for the navigation bar, use the [`spo web set`](../web/web-set.md) command.
 
 ## Examples
 


### PR DESCRIPTION
Noticed a small typo in the docs remark. Updated both commands to use the same remark.