### PR TITLE
Extends 'spo sitedesign add' command with support for specifying 'thumbnailUrl' option. Closes #4453

### DIFF
--- a/docs/docs/cmd/spo/sitedesign/sitedesign-add.md
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-add.md
@@ -28,6 +28,9 @@ m365 spo sitedesign add [options]
 `-a, --previewImageAltText [previewImageAltText]`
 : The alt text description of the image for accessibility
 
+`--thumbnailUrl [thumbnailUrl]`
+: The new URL of a thumbnail image. If none is specified SharePoint will use a generic image
+
 `--isDefault`
 : Set if the site design is applied as the default site design
 

--- a/src/m365/spo/commands/sitedesign/sitedesign-add.spec.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-add.spec.ts
@@ -90,6 +90,7 @@ describe(commands.SITEDESIGN_ADD, () => {
           "IsDefault": false,
           "PreviewImageAltText": null,
           "PreviewImageUrl": null,
+          "ThumbnailUrl": null,
           "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
           "Title": "Contoso",
           "Version": 1,
@@ -107,6 +108,7 @@ describe(commands.SITEDESIGN_ADD, () => {
       "IsDefault": false,
       "PreviewImageAltText": null,
       "PreviewImageUrl": null,
+      "ThumbnailUrl": null,
       "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
       "Title": "Contoso",
       "Version": 1,
@@ -130,6 +132,7 @@ describe(commands.SITEDESIGN_ADD, () => {
           "IsDefault": false,
           "PreviewImageAltText": null,
           "PreviewImageUrl": null,
+          "ThumbnailUrl": null,
           "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
           "Title": "Contoso",
           "Version": 1,
@@ -147,6 +150,7 @@ describe(commands.SITEDESIGN_ADD, () => {
       "IsDefault": false,
       "PreviewImageAltText": null,
       "PreviewImageUrl": null,
+      "ThumbnailUrl": null,
       "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
       "Title": "Contoso",
       "Version": 1,
@@ -154,7 +158,7 @@ describe(commands.SITEDESIGN_ADD, () => {
     }));
   });
 
-  it('adds new team site site design wilt multiple site script IDs', async () => {
+  it('adds new team site site design with multiple site script IDs', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.CreateSiteDesign`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
@@ -170,6 +174,7 @@ describe(commands.SITEDESIGN_ADD, () => {
           "IsDefault": false,
           "PreviewImageAltText": null,
           "PreviewImageUrl": null,
+          "ThumbnailUrl": null,
           "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24", "449c0c6d-5380-4df2-b84b-622e0ac8ec25"],
           "Title": "Contoso",
           "Version": 1,
@@ -200,6 +205,7 @@ describe(commands.SITEDESIGN_ADD, () => {
           "IsDefault": false,
           "PreviewImageAltText": null,
           "PreviewImageUrl": null,
+          "ThumbnailUrl": null,
           "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
           "Title": "Contoso",
           "Version": 1,
@@ -217,6 +223,7 @@ describe(commands.SITEDESIGN_ADD, () => {
       "IsDefault": false,
       "PreviewImageAltText": null,
       "PreviewImageUrl": null,
+      "ThumbnailUrl": null,
       "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
       "Title": "Contoso",
       "Version": 1,
@@ -241,6 +248,7 @@ describe(commands.SITEDESIGN_ADD, () => {
           "IsDefault": false,
           "PreviewImageAltText": null,
           "PreviewImageUrl": null,
+          "ThumbnailUrl": null,
           "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
           "Title": "Contoso",
           "Version": 1,
@@ -258,6 +266,7 @@ describe(commands.SITEDESIGN_ADD, () => {
       "IsDefault": false,
       "PreviewImageAltText": null,
       "PreviewImageUrl": null,
+      "ThumbnailUrl": null,
       "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
       "Title": "Contoso",
       "Version": 1,
@@ -306,6 +315,49 @@ describe(commands.SITEDESIGN_ADD, () => {
     }));
   });
 
+  it('adds new team site site design with ThumbnailUrl', async () => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.CreateSiteDesign`) > -1 &&
+        JSON.stringify(opts.data) === JSON.stringify({
+          info: {
+            Title: 'Contoso',
+            WebTemplate: '64',
+            SiteScriptIds: ['449c0c6d-5380-4df2-b84b-622e0ac8ec24'],
+            ThumbnailUrl: 'https://contoso.com/assets/team-site-thumbnail.png'
+          }
+        })) {
+        return Promise.resolve({
+          "Description": null,
+          "Id": "2a9f178a-4d1d-449c-9296-df509ab4702c",
+          "IsDefault": false,
+          "PreviewImageAltText": null,
+          "PreviewImageUrl": null,
+          "ThumbnailUrl": "https://contoso.com/assets/team-site-thumbnail.png",
+          "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
+          "Title": "Contoso",
+          "Version": 1,
+          "WebTemplate": 64
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, { options: { title: 'Contoso', webTemplate: 'TeamSite', siteScripts: "449c0c6d-5380-4df2-b84b-622e0ac8ec24", thumbnailUrl: 'https://contoso.com/assets/team-site-thumbnail.png' } });
+    assert(loggerLogSpy.calledWith({
+      "Description": null,
+      "Id": "2a9f178a-4d1d-449c-9296-df509ab4702c",
+      "IsDefault": false,
+      "PreviewImageAltText": null,
+      "PreviewImageUrl": null,
+      "ThumbnailUrl": "https://contoso.com/assets/team-site-thumbnail.png",
+      "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
+      "Title": "Contoso",
+      "Version": 1,
+      "WebTemplate": 64
+    }));
+  });
+
   it('adds new team site site design with previewImageAltText', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.CreateSiteDesign`) > -1 &&
@@ -323,6 +375,7 @@ describe(commands.SITEDESIGN_ADD, () => {
           "IsDefault": false,
           "PreviewImageAltText": 'Contoso team site preview',
           "PreviewImageUrl": null,
+          "ThumbnailUrl": null,
           "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
           "Title": "Contoso",
           "Version": 1,
@@ -340,6 +393,7 @@ describe(commands.SITEDESIGN_ADD, () => {
       "IsDefault": false,
       "PreviewImageAltText": 'Contoso team site preview',
       "PreviewImageUrl": null,
+      "ThumbnailUrl": null,
       "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
       "Title": "Contoso",
       "Version": 1,
@@ -364,6 +418,7 @@ describe(commands.SITEDESIGN_ADD, () => {
           "IsDefault": true,
           "PreviewImageAltText": null,
           "PreviewImageUrl": null,
+          "ThumbnailUrl": null,
           "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
           "Title": "Contoso",
           "Version": 1,
@@ -381,6 +436,7 @@ describe(commands.SITEDESIGN_ADD, () => {
       "IsDefault": true,
       "PreviewImageAltText": null,
       "PreviewImageUrl": null,
+      "ThumbnailUrl": null,
       "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
       "Title": "Contoso",
       "Version": 1,
@@ -399,6 +455,7 @@ describe(commands.SITEDESIGN_ADD, () => {
             Description: 'Contoso team site',
             PreviewImageUrl: 'https://contoso.com/assets/team-site-preview.png',
             PreviewImageAltText: 'Contoso team site preview',
+            ThumbnailUrl: 'https://contoso.com/assets/team-site-thumbnail.png',
             IsDefault: true
           }
         })) {
@@ -409,6 +466,7 @@ describe(commands.SITEDESIGN_ADD, () => {
           "PreviewImageAltText": 'Contoso team site preview',
           "PreviewImageUrl": 'https://contoso.com/assets/team-site-preview.png',
           "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
+          "ThumbnailUrl": 'https://contoso.com/assets/team-site-thumbnail.png',
           "Title": "Contoso",
           "Version": 1,
           "WebTemplate": 64
@@ -418,13 +476,14 @@ describe(commands.SITEDESIGN_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { title: 'Contoso', webTemplate: 'TeamSite', siteScripts: "449c0c6d-5380-4df2-b84b-622e0ac8ec24", description: 'Contoso team site', previewImageUrl: 'https://contoso.com/assets/team-site-preview.png', previewImageAltText: 'Contoso team site preview', isDefault: true } });
+    await command.action(logger, { options: { title: 'Contoso', webTemplate: 'TeamSite', siteScripts: "449c0c6d-5380-4df2-b84b-622e0ac8ec24", description: 'Contoso team site', previewImageUrl: 'https://contoso.com/assets/team-site-preview.png', thumbnailUrl: 'https://contoso.com/assets/team-site-thumbnail.png', previewImageAltText: 'Contoso team site preview', isDefault: true } });
     assert(loggerLogSpy.calledWith({
       "Description": 'Contoso team site',
       "Id": "2a9f178a-4d1d-449c-9296-df509ab4702c",
       "IsDefault": true,
-      "PreviewImageAltText": 'Contoso team site preview',
-      "PreviewImageUrl": 'https://contoso.com/assets/team-site-preview.png',
+      "PreviewImageAltText": "Contoso team site preview",
+      "PreviewImageUrl": "https://contoso.com/assets/team-site-preview.png",
+      "ThumbnailUrl": "https://contoso.com/assets/team-site-thumbnail.png",
       "SiteScriptIds": ["449c0c6d-5380-4df2-b84b-622e0ac8ec24"],
       "Title": "Contoso",
       "Version": 1,
@@ -495,6 +554,17 @@ describe(commands.SITEDESIGN_ADD, () => {
     let containsOption = false;
     options.forEach(o => {
       if (o.option.indexOf('--previewImageUrl') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying thumbnailUrl', () => {
+    const options = command.options;
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--thumbnailUrl') > -1) {
         containsOption = true;
       }
     });

--- a/src/m365/spo/commands/sitedesign/sitedesign-add.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-add.ts
@@ -17,6 +17,7 @@ interface Options extends GlobalOptions {
   description?: string;
   previewImageUrl?: string;
   previewImageAltText?: string;
+  thumbnailUrl?: string;
   isDefault?: boolean;
 }
 
@@ -45,6 +46,7 @@ class SpoSiteDesignAddCommand extends SpoCommand {
         description: (!(!args.options.description)).toString(),
         previewImageUrl: (!(!args.options.previewImageUrl)).toString(),
         previewImageAltText: (!(!args.options.previewImageAltText)).toString(),
+        thumbnailUrl: (!(!args.options.thumbnailUrl)).toString(),
         isDefault: args.options.isDefault || false
       });
     });
@@ -70,6 +72,9 @@ class SpoSiteDesignAddCommand extends SpoCommand {
       },
       {
         option: '-a, --previewImageAltText [previewImageAltText]'
+      },
+      {
+        option: '--thumbnailUrl [thumbnailUrl]'
       },
       {
         option: '--isDefault'
@@ -117,6 +122,9 @@ class SpoSiteDesignAddCommand extends SpoCommand {
       if (args.options.previewImageAltText) {
         info.PreviewImageAltText = args.options.previewImageAltText;
       }
+      if (args.options.thumbnailUrl) {
+        info.ThumbnailUrl = args.options.thumbnailUrl;
+      }
       if (args.options.isDefault) {
         info.IsDefault = true;
       }
@@ -134,7 +142,8 @@ class SpoSiteDesignAddCommand extends SpoCommand {
 
       const res = await request.post(requestOptions);
       logger.log(res);
-    } 
+      console.log(res);
+    }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }


### PR DESCRIPTION
Extends `spo sitedesign add` command with support for specifying `thumbnailUrl` option. Closes #4453