### PR TITLE
Fixes md output new lines

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -606,17 +606,16 @@ export default abstract class Command {
         const id = this.getLogItemId(l);
 
         if (title && id) {
-          output.push(`## ${title} (${id})`);
+          output.push(`## ${title} (${id})`, os.EOL, os.EOL);
         }
         else if (title) {
-          output.push(`## ${title}`);
+          output.push(`## ${title}`, os.EOL, os.EOL);
         }
         else if (id) {
-          output.push(`## ${id}`);
+          output.push(`## ${id}`, os.EOL, os.EOL);
         }
 
         output.push(
-          os.EOL, os.EOL,
           `Property | Value`, os.EOL,
           `---------|-------`, os.EOL
         );


### PR DESCRIPTION
While using `md` output, we are getting excessive new lines when there is no title available.

Example:

```md
# planner task reference list --taskId "OopX1ANphEu7Lm4-0tVtl5cAFRGQ"

Date: 4/2/2023



Property | Value
---------|-------
https%3A//microsoft%2Ecom | {"alias":null,"type":null,"previewPriority":"8585260585929911173P;","lastModifiedDateTime":"2023-02-04T22:05:52.564603Z","lastModifiedBy":{"user":{"displayName":null,"id":"b2091e18-7882-4efe-b7d1-90703f5a5c65"}}}
```

As you can see we are having 3 new lines after the date.