### PR TITLE
Enhances `planner plan get`, Closes #4465 

### DIFF
--- a/docs/docs/cmd/planner/plan/plan-get.md
+++ b/docs/docs/cmd/planner/plan/plan-get.md
@@ -11,19 +11,19 @@ m365 planner plan get [options]
 ## Options
 
 `-i, --id [id]`
-: ID of the plan. Specify either `id` or `title` but not both.
+: ID of the plan. Specify either `id`, `title` or `rosterId` but not multiple.
 
 `-t, --title [title]`
-: Title of the plan. Specify either `id` or `title` but not both.
-
-`--ownerGroupId [ownerGroupId]`
-: ID of the Group that owns the plan. Specify either `ownerGroupId`, `ownerGroupName` or `rosterId` when using `title`.
-
-`--ownerGroupName [ownerGroupName]`
-: Name of the Group that owns the plan. Specify either `ownerGroupId`, `ownerGroupName` or `rosterId` when using `title`.
+: Title of the plan. Specify either `id`, `title` or `rosterId` but not multiple.
 
 `--rosterId [rosterId]`
-: ID of the Planner Roster. Specify either `ownerGroupId`, `ownerGroupName` or `rosterId` when using `title`.
+: ID of the Planner Roster. Specify either `id`, `title` or `rosterId` but not multiple.
+
+`--ownerGroupId [ownerGroupId]`
+: ID of the Group that owns the plan. Specify either `ownerGroupId` or `ownerGroupName` when using `title` but not both.
+
+`--ownerGroupName [ownerGroupName]`
+: Name of the Group that owns the plan. Specify either `ownerGroupId` or `ownerGroupName` when using `title` but not both.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -34,28 +34,28 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 ## Examples
 
-Returns the Microsoft Planner plan with id _gndWOTSK60GfPQfiDDj43JgACDCb_
+Returns the Microsoft Planner plan by id
 
 ```sh
 m365 planner plan get --id "gndWOTSK60GfPQfiDDj43JgACDCb"
 ```
 
-Returns the Microsoft Planner plan with title _MyPlan_ for Group _233e43d0-dc6a-482e-9b4e-0de7a7bce9b4_
+Returns the Microsoft Planner plan by title and owner group id 
 
 ```sh
 m365 planner plan get --title "MyPlan" --ownerGroupId "233e43d0-dc6a-482e-9b4e-0de7a7bce9b4"
 ```
 
-Returns the Microsoft Planner plan with title _MyPlan_ for Group _My Planner Group_
+Returns the Microsoft Planner plan by title and owner group name
 
 ```sh
 m365 planner plan get --title "MyPlan" --ownerGroupName "My Planner Group"
 ```
 
-Returns the Microsoft Planner plan with title _MyPlan_ for Roster _FeMZFDoK8k2oWmuGE-XFHZcAEwtn_
+Returns the Microsoft Planner plan by roster id
 
 ```sh
-m365 planner plan get --title "MyPlan" --rosterId "FeMZFDoK8k2oWmuGE-XFHZcAEwtn"
+m365 planner plan get --rosterId "FeMZFDoK8k2oWmuGE-XFHZcAEwtn"
 ```
 
 ## Response

--- a/src/m365/planner/commands/plan/plan-get.spec.ts
+++ b/src/m365/planner/commands/plan/plan-get.spec.ts
@@ -144,10 +144,9 @@ describe(commands.PLAN_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation when title and valid rosterId specified', async () => {
+  it('passes validation when rosterId specified', async () => {
     const actual = await command.validate({
       options: {
-        title: validTitle,
         rosterId: validRosterId
       }
     }, commandInfo);
@@ -224,7 +223,7 @@ describe(commands.PLAN_GET, () => {
     assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly get planner plan with given title and rosterId', async () => {
+  it('correctly get planner plan with given rosterId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/beta/planner/rosters/${validRosterId}/plans`) {
         return { "value": [planResponse] };
@@ -238,7 +237,6 @@ describe(commands.PLAN_GET, () => {
     });
 
     const options: any = {
-      title: validTitle,
       rosterId: validRosterId
     };
 

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -120,6 +120,7 @@ class PlannerPlanGetCommand extends GraphCommand {
           }
           plan = await planner.getPlanByTitle(args.options.title!, groupId);
         }
+
         const result = await this.getPlanDetails(plan);
 
         if (result) {

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -15,9 +15,9 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   id?: string;
   title?: string;
+  rosterId?: string;
   ownerGroupId?: string;
   ownerGroupName?: string;
-  rosterId?: string;
 }
 
 class PlannerPlanGetCommand extends GraphCommand {
@@ -47,9 +47,9 @@ class PlannerPlanGetCommand extends GraphCommand {
       Object.assign(this.telemetryProperties, {
         id: typeof args.options.id !== 'undefined',
         title: typeof args.options.title !== 'undefined',
+        rosterId: typeof args.options.rosterId !== 'undefined',
         ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined'
+        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined'
       });
     });
   }
@@ -63,13 +63,13 @@ class PlannerPlanGetCommand extends GraphCommand {
         option: '-t, --title [title]'
       },
       {
+        option: '--rosterId [rosterId]'
+      },
+      {
         option: '--ownerGroupId [ownerGroupId]'
       },
       {
         option: '--ownerGroupName [ownerGroupName]'
-      },
-      {
-        option: '--rosterId [rosterId]'
       }
     );
   }
@@ -89,10 +89,10 @@ class PlannerPlanGetCommand extends GraphCommand {
   #initOptionSets(): void {
     this.optionSets.push(
       {
-        options: ['id', 'title']
+        options: ['id', 'title', 'rosterId']
       },
       {
-        options: ['ownerGroupId', 'ownerGroupName', 'rosterId'],
+        options: ['ownerGroupId', 'ownerGroupName'],
         runsWhen: (args) => {
           return args.options.title !== undefined;
         }
@@ -108,11 +108,18 @@ class PlannerPlanGetCommand extends GraphCommand {
         logger.log(result);
       }
       else {
-        let groupId = undefined;
-        if (args.options.ownerGroupId || args.options.ownerGroupName) {
-          groupId = await this.getGroupId(args);
+        let plan: PlannerPlan = {};
+        if (args.options.rosterId) {
+          const plans: PlannerPlan[] = await planner.getPlansByRosterId(args.options.rosterId);
+          plan = plans[0];
         }
-        const plan = await planner.getPlanByTitle(args.options.title!, groupId, args.options.rosterId);
+        else {
+          let groupId = undefined;
+          if (args.options.ownerGroupId || args.options.ownerGroupName) {
+            groupId = await this.getGroupId(args);
+          }
+          plan = await planner.getPlanByTitle(args.options.title!, groupId);
+        }
         const result = await this.getPlanDetails(plan);
 
         if (result) {

--- a/src/m365/planner/commands/plan/plan-remove.ts
+++ b/src/m365/planner/commands/plan/plan-remove.ts
@@ -145,7 +145,7 @@ class PlannerPlanRemoveCommand extends GraphCommand {
     }
 
     const groupId = await this.getGroupId(args);
-    return await planner.getPlanByTitle(title!, groupId, undefined, 'minimal');
+    return await planner.getPlanByTitle(title!, groupId, 'minimal');
   }
 
   private async getGroupId(args: CommandArgs): Promise<string> {

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -51,13 +51,10 @@ export const planner = {
    * @param groupId Owner group ID.
    * @param rosterId Roster ID.
    */
-  async getPlanByTitle(title: string, groupId?: string, rosterId?: string, metadata: 'none' | 'minimal' | 'full' = 'none'): Promise<PlannerPlan> {
+  async getPlanByTitle(title: string, groupId?: string, metadata: 'none' | 'minimal' | 'full' = 'none'): Promise<PlannerPlan> {
     let plans: PlannerPlan[] = [];
     if (groupId) {
       plans = await this.getPlansByGroupId(groupId, metadata);
-    }
-    else if (rosterId) {
-      plans = await this.getPlansByRosterId(rosterId, metadata);
     }
     const filteredPlans = plans.filter(p => p.title && p.title.toLowerCase() === title.toLowerCase());
 


### PR DESCRIPTION
This pr enhances `planner plan get`, Closes #4465.

Disconnected `getPlansByRosterId` from `getPlanByTitle` due to no longer being relevant