### PR TITLE
Refactor customaction commands to query get/list through a util class. Closes #4327

### DIFF
--- a/src/m365/spo/commands/customaction/customaction-get.ts
+++ b/src/m365/spo/commands/customaction/customaction-get.ts
@@ -1,7 +1,7 @@
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
-import request from '../../../../request';
 import { formatting } from '../../../../utils/formatting';
+import { spo } from '../../../../utils/spo';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
@@ -93,21 +93,9 @@ class SpoCustomActionGetCommand extends SpoCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      let customAction: CustomAction;
-      if (args.options.scope && args.options.scope.toLowerCase() !== "all") {
-        customAction = await this.getCustomAction(args.options);
-      }
-      else {
-        customAction = await this.searchAllScopes(args.options);
-      }
+      const customAction = await this.getCustomAction(args.options);
 
-
-      if (customAction["odata.null"] === true) {
-        if (this.verbose) {
-          logger.logToStderr(`Custom action with id ${args.options.id} not found`);
-        }
-      }
-      else {
+      if (customAction) {
         logger.log({
           ClientSideComponentId: customAction.ClientSideComponentId,
           ClientSideComponentProperties: customAction.ClientSideComponentProperties,
@@ -136,70 +124,28 @@ class SpoCustomActionGetCommand extends SpoCommand {
     }
   }
 
-  private getCustomAction(options: Options): Promise<CustomAction> {
-    const filter: string = options.id ?
-      `('${formatting.encodeQueryParameter(options.id as string)}')` :
-      `?$filter=Title eq '${formatting.encodeQueryParameter(options.title as string)}'`;
-
-    const requestOptions: any = {
-      url: `${options.webUrl}/_api/${options.scope}/UserCustomActions${filter}`,
-      headers: {
-        accept: 'application/json;odata=nometadata'
-      },
-      responseType: 'json'
-    };
-
+  private async getCustomAction(options: Options): Promise<CustomAction | undefined> {
     if (options.id) {
-      return request
-        .get<CustomAction>(requestOptions)
-        .then((res: CustomAction): Promise<CustomAction> => {
-          return Promise.resolve(res);
-        });
+      const customAction = await spo.getCustomActionById(options.webUrl, options.id, options.scope);
+
+      if (!customAction) {
+        throw `No user custom action with id '${options.id}' found`;
+      }
+
+      return customAction;
     }
 
-    return request
-      .get<{ value: CustomAction[] }>(requestOptions)
-      .then((res: { value: CustomAction[] }): Promise<CustomAction> => {
-        if (res.value.length === 1) {
-          return Promise.resolve(res.value[0]);
-        }
+    const customActions = await spo.getCustomActions(options.webUrl, options.scope, `Title eq '${formatting.encodeQueryParameter(options.title as string)}'`);
 
-        if (res.value.length === 0) {
-          return Promise.reject(`No user custom action with title '${options.title}' found`);
-        }
+    if (customActions.length === 1) {
+      return customActions[0];
+    }
 
-        return Promise.reject(`Multiple user custom actions with title '${options.title}' found. Please disambiguate using IDs: ${res.value.map(a => a.Id).join(', ')}`);
-      });
-  }
+    if (customActions.length === 0) {
+      throw `No user custom action with title '${options.title}' found`;
+    }
 
-  /**
-   * Get request with `web` scope is send first. 
-   * If custom action not found then 
-   * another get request is send with `site` scope.
-   */
-  private searchAllScopes(options: Options): Promise<CustomAction> {
-    return new Promise<CustomAction>((resolve: (customAction: CustomAction) => void, reject: (error: any) => void): void => {
-      options.scope = "Web";
-
-      this
-        .getCustomAction(options)
-        .then((webResult: CustomAction): void => {
-          if (webResult["odata.null"] !== true) {
-            return resolve(webResult);
-          }
-
-          options.scope = "Site";
-          this
-            .getCustomAction(options)
-            .then((siteResult: CustomAction): void => {
-              return resolve(siteResult);
-            }, (err: any): void => {
-              reject(err);
-            });
-        }, (err: any): void => {
-          reject(err);
-        });
-    });
+    throw `Multiple user custom actions with title '${options.title}' found. Please disambiguate using IDs: ${customActions.map(a => a.Id).join(', ')}`;
   }
 
   private humanizeScope(scope: number): string {

--- a/src/m365/spo/commands/customaction/customaction-list.spec.ts
+++ b/src/m365/spo/commands/customaction/customaction-list.spec.ts
@@ -70,64 +70,6 @@ describe(commands.CUSTOMACTION_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['Name', 'Location', 'Scope', 'Id']);
   });
 
-  it('getCustomActions called once when scope is Web', async () => {
-    const getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/Web/UserCustomActions') > -1) {
-        return Promise.resolve({ value: [] });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    const getCustomActionsSpy = sinon.spy((command as any), 'getCustomActions');
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      scope: 'Web'
-    };
-
-    try {
-      await command.action(logger, { options: options } as any);
-      assert(getRequestSpy.calledOnce);
-      assert(getCustomActionsSpy.calledWith({
-        webUrl: 'https://contoso.sharepoint.com',
-        scope: 'Web'
-      }));
-      assert(getCustomActionsSpy.calledOnce);
-    }
-    finally {
-      sinonUtil.restore((command as any)['getCustomActions']);
-    }
-  });
-
-  it('getCustomActions called once when scope is Site', async () => {
-    const getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/Site/UserCustomActions') > -1) {
-        return Promise.resolve({ value: [] });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    const getCustomActionsSpy = sinon.spy((command as any), 'getCustomActions');
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      scope: 'Site'
-    };
-
-    try {
-      await command.action(logger, { options: options } as any);
-      assert(getRequestSpy.calledOnce);
-      assert(getCustomActionsSpy.calledWith({
-        webUrl: 'https://contoso.sharepoint.com',
-        scope: 'Site'
-      }));
-      assert(getCustomActionsSpy.calledOnce);
-    }
-    finally {
-      sinonUtil.restore((command as any)['getCustomActions']);
-    }
-  });
-
   it('returns all properties for output JSON', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/_api/Site/UserCustomActions') > -1) {
@@ -152,86 +94,6 @@ describe(commands.CUSTOMACTION_LIST, () => {
     }
   });
 
-  it('getCustomActions called twice when scope is All', async () => {
-    const getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/Web/UserCustomActions') > -1) {
-        return Promise.resolve({ value: [] });
-      }
-
-      if ((opts.url as string).indexOf('/_api/Site/UserCustomActions') > -1) {
-        return Promise.resolve({ value: [] });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    const getCustomActionsSpy = sinon.spy((command as any), 'getCustomActions');
-
-    try {
-      await command.action(logger, {
-        options: {
-          debug: true,
-          webUrl: 'https://contoso.sharepoint.com'
-        }
-      });
-      assert(getRequestSpy.calledTwice);
-      assert(getCustomActionsSpy.calledTwice);
-    }
-    finally {
-      sinonUtil.restore((command as any)['getCustomActions']);
-    }
-  });
-
-  it('searchAllScopes called when scope is All', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/Web/UserCustomActions') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    const searchAllScopesSpy = sinon.spy((command as any), 'searchAllScopes');
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      scope: "All"
-    };
-
-    try {
-      await assert.rejects(command.action(logger, { options: options } as any));
-      assert(searchAllScopesSpy.calledWith(sinon.match(
-        {
-          webUrl: 'https://contoso.sharepoint.com'
-        })));
-      assert(searchAllScopesSpy.calledOnce);
-    }
-    finally {
-      sinonUtil.restore((command as any)['searchAllScopes']);
-    }
-  });
-
-  it('searchAllScopes correctly handles no custom actions when All scope specified', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/Web/UserCustomActions') > -1) {
-        return Promise.resolve({ value: [] });
-      }
-
-      if ((opts.url as string).indexOf('/_api/Site/UserCustomActions') > -1) {
-        return Promise.resolve({ value: [] });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    await command.action(logger, {
-      options: {
-        verbose: false,
-        webUrl: 'https://contoso.sharepoint.com',
-        scope: 'All'
-      }
-    });
-    assert(loggerLogSpy.notCalled);
-  });
 
   it('correctly handles no custom actions when All scope specified (verbose)', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
@@ -261,6 +123,9 @@ describe(commands.CUSTOMACTION_LIST, () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if ((opts.url as string).indexOf('/_api/Web/UserCustomActions') > -1) {
         return Promise.reject(err);
+      }
+      else if ((opts.url as string).indexOf('/_api/Site/UserCustomActions') > -1) {
+        return Promise.resolve({ value: [] });
       }
 
       return Promise.reject('Invalid request');

--- a/src/m365/spo/commands/customaction/customaction-list.ts
+++ b/src/m365/spo/commands/customaction/customaction-list.ts
@@ -1,10 +1,9 @@
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
-import { odata } from '../../../../utils/odata';
+import { spo } from '../../../../utils/spo';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
-import { CustomAction } from './customaction';
 
 interface CommandArgs {
   options: Options;
@@ -86,13 +85,7 @@ class SpoCustomActionListCommand extends SpoCommand {
         logger.logToStderr('');
       }
 
-      let customActions: CustomAction[];
-      if (scope && scope.toLowerCase() !== "all") {
-        customActions = await this.getCustomActions(args.options);
-      }
-      else {
-        customActions = await this.searchAllScopes(args.options);
-      }
+      const customActions = await spo.getCustomActions(args.options.webUrl, args.options.scope);
 
       if (customActions.length === 0) {
         if (this.verbose) {
@@ -110,38 +103,6 @@ class SpoCustomActionListCommand extends SpoCommand {
     catch (err: any) {
       this.handleRejectedPromise(err);
     }
-  }
-
-  private async getCustomActions(options: Options): Promise<CustomAction[]> {
-    const response: CustomAction[] = await odata.getAllItems<CustomAction>(`${options.webUrl}/_api/${options.scope}/UserCustomActions`);
-
-    return response;
-  }
-
-  /**
-   * Two REST GET requests with `web` and `site` scope are sent.
-   * The results are combined in one array.
-   */
-  private searchAllScopes(options: Options): Promise<CustomAction[]> {
-    return new Promise<CustomAction[]>((resolve: (list: CustomAction[]) => void, reject: (error: any) => void): void => {
-      options.scope = "Web";
-      let webCustomActions: CustomAction[] = [];
-
-      this
-        .getCustomActions(options)
-        .then((customActions: CustomAction[]): Promise<CustomAction[]> => {
-          webCustomActions = customActions;
-
-          options.scope = "Site";
-
-          return this.getCustomActions(options);
-        })
-        .then((siteCustomActions: CustomAction[]): void => {
-          resolve(siteCustomActions.concat(webCustomActions));
-        }, (err: any): void => {
-          reject(err);
-        });
-    });
   }
 
   private humanizeScope(scope: number): string {

--- a/src/m365/spo/commands/customaction/customaction-remove.ts
+++ b/src/m365/spo/commands/customaction/customaction-remove.ts
@@ -3,6 +3,7 @@ import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request from '../../../../request';
 import { formatting } from '../../../../utils/formatting';
+import { spo } from '../../../../utils/spo';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
@@ -136,32 +137,22 @@ class SpoCustomActionRemoveCommand extends SpoCommand {
     }
   }
 
-  private getCustomActionId(options: Options): Promise<string> {
+  private async getCustomActionId(options: Options): Promise<string> {
     if (options.id) {
       return Promise.resolve(options.id);
     }
 
-    const customActionRequestOptions: any = {
-      url: `${options.webUrl}/_api/${options.scope}/UserCustomActions?$filter=Title eq '${formatting.encodeQueryParameter(options.title as string)}'`,
-      headers: {
-        accept: 'application/json;odata=nometadata'
-      },
-      responseType: 'json'
-    };
+    const customActions = await spo.getCustomActions(options.webUrl, options.scope, `Title eq '${formatting.encodeQueryParameter(options.title as string)}'`);
 
-    return request
-      .get<{ value: CustomAction[] }>(customActionRequestOptions)
-      .then((res: { value: CustomAction[] }): Promise<string> => {
-        if (res.value.length === 1) {
-          return Promise.resolve(res.value[0].Id);
-        }
+    if (customActions.length === 1) {
+      return customActions[0].Id;
+    }
 
-        if (res.value.length === 0) {
-          return Promise.reject(`No user custom action with title '${options.title}' found`);
-        }
+    if (customActions.length === 0) {
+      throw `No user custom action with title '${options.title}' found`;
+    }
 
-        return Promise.reject(`Multiple user custom actions with title '${options.title}' found. Please disambiguate using IDs: ${res.value.map(a => a.Id).join(', ')}`);
-      });
+    throw `Multiple user custom actions with title '${options.title}' found. Please disambiguate using IDs: ${customActions.map(a => a.Id).join(', ')}`;
   }
 
   private removeScopedCustomAction(options: Options): Promise<undefined> {


### PR DESCRIPTION
Closes #4327

Refactors customaction commands to query get/list functions through the `spo` util class.