### PR TITLE
Extends 'pa environment get' command with support to retrieve default environment. Closes #4491

### DIFF
--- a/docs/docs/cmd/pa/environment/environment-get.md
+++ b/docs/docs/cmd/pa/environment/environment-get.md
@@ -10,8 +10,8 @@ m365 pa environment get [options]
 
 ## Options
 
-`-n, --name <name>`
-: The name of the environment to get information about
+`-n, --name [name]`
+: The name of the environment. When not specified, the default environment is retrieved.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -23,6 +23,12 @@ m365 pa environment get [options]
 If the environment with the name you specified doesn't exist, you will get the `Access to the environment 'xyz' is denied.` error.
 
 ## Examples
+
+Get information about the default Power Apps environment
+
+```sh
+m365 pa environment get
+```
 
 Get information about the Power Apps environment named _Default-d87a7535-dd31-4437-bfe1-95340acd55c5_
 

--- a/src/m365/pa/commands/environment/environment-get.spec.ts
+++ b/src/m365/pa/commands/environment/environment-get.spec.ts
@@ -65,11 +65,11 @@ describe(commands.ENVIRONMENT_GET, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['name', 'id', 'location', 'displayName', 'provisioningState', 'environmentSku', 'azureRegionHint', 'isDefault']);
   });
 
-  it('retrieves information about the specified environment (debug)', async () => {
+  it('retrieves information about the default environment', async () => {
     const env: any = { "name": "Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "location": "europe", "type": "Microsoft.PowerApps/environments", "id": "/providers/Microsoft.PowerApps/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "properties": { "displayName": "Contoso (default)", "createdTime": "2018-03-22T20:20:46.08653Z", "createdBy": { "id": "SYSTEM", "displayName": "SYSTEM", "type": "NotSpecified" }, "provisioningState": "Succeeded", "creationType": "DefaultTenant", "environmentSku": "Default", "environmentType": "Production", "isDefault": true, "azureRegionHint": "westeurope", "runtimeEndpoints": { "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com", "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com", "microsoft.PowerApps": "https://europe.api.powerapps.com", "microsoft.Flow": "https://europe.api.flow.microsoft.com" } } };
 
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`providers/Microsoft.PowerApps/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5?api-version=2016-11-01`) > -1) {
+      if ((opts.url as string).indexOf(`providers/Microsoft.PowerApps/environments/~default?api-version=2016-11-01`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -80,7 +80,7 @@ describe(commands.ENVIRONMENT_GET, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { debug: true, name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith(env));
   });
 
@@ -99,7 +99,7 @@ describe(commands.ENVIRONMENT_GET, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: { debug: true, name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
     assert(loggerLogSpy.calledWith(env));
   });
 

--- a/src/m365/pa/commands/environment/environment-get.spec.ts
+++ b/src/m365/pa/commands/environment/environment-get.spec.ts
@@ -69,7 +69,7 @@ describe(commands.ENVIRONMENT_GET, () => {
     const env: any = { "name": "Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "location": "europe", "type": "Microsoft.PowerApps/environments", "id": "/providers/Microsoft.PowerApps/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "properties": { "displayName": "Contoso (default)", "createdTime": "2018-03-22T20:20:46.08653Z", "createdBy": { "id": "SYSTEM", "displayName": "SYSTEM", "type": "NotSpecified" }, "provisioningState": "Succeeded", "creationType": "DefaultTenant", "environmentSku": "Default", "environmentType": "Production", "isDefault": true, "azureRegionHint": "westeurope", "runtimeEndpoints": { "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com", "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com", "microsoft.PowerApps": "https://europe.api.powerapps.com", "microsoft.Flow": "https://europe.api.flow.microsoft.com" } } };
 
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`providers/Microsoft.PowerApps/environments/~default?api-version=2016-11-01`) > -1) {
+      if (opts.url === `https://api.powerapps.com/providers/Microsoft.PowerApps/environments/~default?api-version=2016-11-01`) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -80,7 +80,7 @@ describe(commands.ENVIRONMENT_GET, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: { debug: true, varbose: true } });
     assert(loggerLogSpy.calledWith(env));
   });
 
@@ -88,7 +88,7 @@ describe(commands.ENVIRONMENT_GET, () => {
     const env: any = { "name": "Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "location": "europe", "type": "Microsoft.PowerApps/environments", "id": "/providers/Microsoft.PowerApps/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5", "properties": { "displayName": "Contoso (default)", "createdTime": "2018-03-22T20:20:46.08653Z", "createdBy": { "id": "SYSTEM", "displayName": "SYSTEM", "type": "NotSpecified" }, "provisioningState": "Succeeded", "creationType": "DefaultTenant", "environmentSku": "Default", "environmentType": "Production", "isDefault": true, "azureRegionHint": "westeurope", "runtimeEndpoints": { "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com", "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com", "microsoft.PowerApps": "https://europe.api.powerapps.com", "microsoft.Flow": "https://europe.api.flow.microsoft.com" } } };
 
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf(`providers/Microsoft.PowerApps/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5?api-version=2016-11-01`) > -1) {
+      if (opts.url === `https://api.powerapps.com/providers/Microsoft.PowerApps/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5?api-version=2016-11-01`) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -99,7 +99,7 @@ describe(commands.ENVIRONMENT_GET, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { debug: true, name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: { debug: true, varbose: true, name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
     assert(loggerLogSpy.calledWith(env));
   });
 
@@ -133,16 +133,5 @@ describe(commands.ENVIRONMENT_GET, () => {
 
     await assert.rejects(command.action(logger, { options: { name: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } } as any),
       new CommandError('An error has occurred'));
-  });
-
-  it('supports specifying name', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--name') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
   });
 });

--- a/src/m365/pa/commands/environment/environment-get.ts
+++ b/src/m365/pa/commands/environment/environment-get.ts
@@ -50,12 +50,11 @@ class PaEnvironmentGetCommand extends PowerAppsCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    const environmentName = args.options.name ? formatting.encodeQueryParameter(args.options.name) : "~default";
-
     if (this.verbose) {
-      logger.logToStderr(`Retrieving information about Microsoft Power Apps environment ${environmentName}...`);
+      logger.logToStderr(`Retrieving information about Microsoft Power Apps environment ${args.options.name || 'default'}...`);
     }
 
+    const environmentName = args.options.name ? formatting.encodeQueryParameter(args.options.name) : '~default';
     const requestOptions: any = {
       url: `${this.resource}/providers/Microsoft.PowerApps/environments/${environmentName}?api-version=2016-11-01`,
       headers: {

--- a/src/m365/pa/commands/environment/environment-get.ts
+++ b/src/m365/pa/commands/environment/environment-get.ts
@@ -10,7 +10,7 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  name: string;
+  name?: string;
 }
 
 class PaEnvironmentGetCommand extends PowerAppsCommand {
@@ -29,24 +29,35 @@ class PaEnvironmentGetCommand extends PowerAppsCommand {
   constructor() {
     super();
 
+    this.#initTelemetry();
     this.#initOptions();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        name: typeof args.options.name !== 'undefined'
+      });
+    });
   }
 
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-n, --name <name>'
+        option: '-n, --name [name]'
       }
     );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    const environmentName = args.options.name ? formatting.encodeQueryParameter(args.options.name) : "~default";
+
     if (this.verbose) {
-      logger.logToStderr(`Retrieving information about Microsoft Power Apps environment ${args.options.name}...`);
+      logger.logToStderr(`Retrieving information about Microsoft Power Apps environment ${environmentName}...`);
     }
 
     const requestOptions: any = {
-      url: `${this.resource}/providers/Microsoft.PowerApps/environments/${formatting.encodeQueryParameter(args.options.name)}?api-version=2016-11-01`,
+      url: `${this.resource}/providers/Microsoft.PowerApps/environments/${environmentName}?api-version=2016-11-01`,
       headers: {
         accept: 'application/json'
       },


### PR DESCRIPTION
Extends `pa environment get` command with support to retrieve default environment. Closes #4491