### PR TITLE
Adds upn validation for some commands

### DIFF
--- a/src/m365/aad/commands/user/user-get.spec.ts
+++ b/src/m365/aad/commands/user/user-get.spec.ts
@@ -283,6 +283,11 @@ describe(commands.USER_GET, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation when userName has an invalid value', async () => {
+    const actual = await command.validate({ options: { userName: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('passes validation if the id is a valid GUID', async () => {
     const actual = await command.validate({ options: { id: '68be84bf-a585-4776-80b3-30aa5207aa22' } }, commandInfo);
     assert.strictEqual(actual, true);

--- a/src/m365/aad/commands/user/user-get.ts
+++ b/src/m365/aad/commands/user/user-get.ts
@@ -72,6 +72,10 @@ class AadUserGetCommand extends GraphCommand {
           return `${args.options.id} is not a valid GUID`;
         }
 
+        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
+          return `${args.options.userName} is not a valid userName`;
+        }
+
         return true;
       }
     );

--- a/src/m365/aad/commands/user/user-set.spec.ts
+++ b/src/m365/aad/commands/user/user-set.spec.ts
@@ -116,6 +116,11 @@ describe(commands.USER_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation when userPrincipalName has an invalid value', async () => {
+    const actual = await command.validate({ options: { userPrincipalName: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('passes validation if the objectId is a valid GUID', async () => {
     const actual = await command.validate({ options: { objectId: objectId } }, commandInfo);
     assert.strictEqual(actual, true);

--- a/src/m365/aad/commands/user/user-set.ts
+++ b/src/m365/aad/commands/user/user-set.ts
@@ -98,6 +98,10 @@ class AadUserSetCommand extends GraphCommand {
           return `${args.options.objectId} is not a valid GUID`;
         }
 
+        if (args.options.userPrincipalName && !validation.isValidUserPrincipalName(args.options.userPrincipalName)) {
+          return `${args.options.userPrincipalName} is not a valid userPrincipalName`;
+        }
+
         if (!args.options.resetPassword && ((args.options.currentPassword && !args.options.newPassword) || (args.options.newPassword && !args.options.currentPassword))) {
           return `Specify both currentPassword and newPassword when you want to change your password`;
         }

--- a/src/m365/aad/commands/user/user-signin-list.spec.ts
+++ b/src/m365/aad/commands/user/user-signin-list.spec.ts
@@ -330,6 +330,11 @@ describe(commands.USER_SIGNIN_LIST, () => {
     assert.strictEqual(actual, true);
   });
 
+  it('fails validation when userName has an invalid value', async () => {
+    const actual = await command.validate({ options: { userName: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('fails validation if appId and appDisplayName specified', async () => {
     const actual = await command.validate({ options: { appId: 'de8bc8b5-d9f9-48b1-a8ad-b748da725064', appDisplayName: 'Graph explorer' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/aad/commands/user/user-signin-list.ts
+++ b/src/m365/aad/commands/user/user-signin-list.ts
@@ -74,11 +74,15 @@ class AadUserSigninListCommand extends GraphCommand {
           return 'Specify either appId or appDisplayName, but not both';
         }
 
-        if (args.options.userId && !validation.isValidGuid(args.options.userId as string)) {
+        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
+          return `${args.options.userName} is not a valid userName`;
+        }
+
+        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
           return `${args.options.userId} is not a valid GUID`;
         }
 
-        if (args.options.appId && !validation.isValidGuid(args.options.appId as string)) {
+        if (args.options.appId && !validation.isValidGuid(args.options.appId)) {
           return `${args.options.appId} is not a valid GUID`;
         }
 

--- a/src/m365/planner/commands/roster/roster-member-add.spec.ts
+++ b/src/m365/planner/commands/roster/roster-member-add.spec.ts
@@ -87,6 +87,16 @@ describe(commands.ROSTER_MEMBER_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation when userName is not a valid upn', async () => {
+    const actual = await command.validate({
+      options: {
+        rosterId: validRosterId,
+        userName: 'Invalid upn'
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('passes validation if required options specified (id)', async () => {
     const actual = await command.validate({ options: { rosterId: validRosterId, userId: validUserId } }, commandInfo);
     assert.strictEqual(actual, true);

--- a/src/m365/planner/commands/roster/roster-member-add.ts
+++ b/src/m365/planner/commands/roster/roster-member-add.ts
@@ -74,6 +74,10 @@ class PlannerRosterMemberAddCommand extends GraphCommand {
           return `${args.options.userId} is not a valid GUID`;
         }
 
+        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
+          return `${args.options.userName} is not a valid user principal name (UPN)`;
+        }
+
         return true;
       }
     );


### PR DESCRIPTION
Noticed that `planner roster member add` has no UPN validation.

Didn't create an issue since it would be a bit overkill. Also not worth mentioning in the release notes since the command is still in beta.