### PR TITLE
Resolve typos in option descriptions

### DIFF
--- a/docs/docs/cmd/aad/approleassignment/approleassignment-add.md
+++ b/docs/docs/cmd/aad/approleassignment/approleassignment-add.md
@@ -20,10 +20,10 @@ m365 aad approleassignment add [options]
 : Application name of the App Registration to which the configured scopes (app roles) should be applied
 
 `-r, --resource <resource>`
-: Service principal name, appId or objectId that has the scopes (roles) ex. `SharePoint`.
+: Service principal name, appId or objectId that has the scopes (roles) e.g. `SharePoint`.
 
 `-s, --scope <scope>`
-: Permissions known also as scopes and roles to grant the application with. If multiple permissions have to be granted, they have to be comma separated ex. `Sites.Read.All,Sites.ReadWrite.all`
+: Permissions known also as scopes and roles to grant the application with. If multiple permissions have to be granted, they have to be comma-separated e.g. `Sites.Read.All,Sites.ReadWrite.all`
 
 --8<-- "docs/cmd/_global.md"
 
@@ -33,7 +33,7 @@ This command requires tenant administrator permissions.
 
 Specify either the `appId`, `appObjectId` or `appDisplayName` but not multiple. If you specify more than one option value, the command will fail with an error.
 
-Autocomplete values for the `resource` option do not mean allowed values. The autocomplete will just suggest some known names, but that doesn't restrict you to use name of your own custom application or other application within your tenant.
+Autocomplete values for the `resource` option do not mean allowed values. The autocomplete will just suggest some known names, but that doesn't restrict you to use the name of your own custom application or other application within your tenant.
 
 This command can also be used to assign permissions to system or user-assigned managed identity.
 
@@ -45,13 +45,13 @@ Adds SharePoint _Sites.Read.All_ application permissions to Azure AD application
 m365 aad approleassignment add --appId "57907bf8-73fa-43a6-89a5-1f603e29e451" --resource "SharePoint" --scope "Sites.Read.All"
 ```
 
-Adds multiple Microsoft Graph application permissions to an Azure AD application with name _MyAppName_
+Adds multiple Microsoft Graph application permissions to an Azure AD application with the name _MyAppName__
 
 ```sh
 m365 aad approleassignment add --appDisplayName "MyAppName" --resource "Microsoft Graph" --scope "Mail.Read,Mail.Send"
 ```
 
-Adds Microsoft Graph _Mail.Read_ application permissions to a system managed identity app with objectId _57907bf8-73fa-43a6-89a5-1f603e29e451_
+Adds Microsoft Graph _Mail.Read_ application permissions to a system-managed identity app with objectId _57907bf8-73fa-43a6-89a5-1f603e29e451_
 
 ```sh
 m365 aad approleassignment add --appObjectId "57907bf8-73fa-43a6-89a5-1f603e29e451" --resource "Microsoft Graph" --scope "Mail.Read"

--- a/docs/docs/cmd/aad/approleassignment/approleassignment-remove.md
+++ b/docs/docs/cmd/aad/approleassignment/approleassignment-remove.md
@@ -20,10 +20,10 @@ m365 aad approleassignment remove [options]
 : Application name of the App Registration for which the configured scopes (app roles) should be deleted
 
 `-r, --resource <resource>`
-: Service principal name, appId or objectId that has the scopes (roles) ex. `SharePoint`
+: Service principal name, appId or objectId that has the scopes (roles) e.g. `SharePoint`
 
 `-s, --scope <scope>`
-: Permissions known also as scopes and roles to be deleted from the application. If multiple permissions have to be deleted, they have to be comma separated ex. `Sites.Read.All`,`Sites.ReadWrite.All`
+: Permissions known also as scopes and roles to be deleted from the application. If multiple permissions have to be deleted, they have to be comma-separated e.g. `Sites.Read.All`,`Sites.ReadWrite.All`
 
 `--confirm`
 : Don't prompt for confirming removing the all role assignment
@@ -54,7 +54,7 @@ Deletes multiple Microsoft Graph application permissions from an Azure AD applic
 m365 aad approleassignment remove --appDisplayName "MyAppName" --resource "Microsoft Graph" --scope "Mail.Read,Mail.Send"
 ```
 
-Deletes Microsoft Graph _Mail.Read_ application permissions from a system managed identity app with objectId _57907bf8-73fa-43a6-89a5-1f603e29e451_
+Deletes Microsoft Graph _Mail.Read_ application permissions from a system-managed identity app with objectId _57907bf8-73fa-43a6-89a5-1f603e29e451_
 
 ```sh
 m365 aad approleassignment remove --appObjectId "57907bf8-73fa-43a6-89a5-1f603e29e451" --resource "Microsoft Graph" --scope "Mail.Read"

--- a/docs/docs/cmd/spo/group/group-member-add.md
+++ b/docs/docs/cmd/spo/group/group-member-add.md
@@ -20,16 +20,16 @@ m365 spo group member add [options]
 : Name of the SharePoint Group to which the user needs to be added, specify either `groupId` or `groupName`
 
 `--userName [userName]`
-: User's UPN (user principal name, eg. megan.bowen@contoso.com). If multiple users need to be added, they have to be comma separated (ex. megan.bowen@contoso.com,alex.wilber@contoso.com). Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`
+: User's UPN (user principal name, eg. megan.bowen@contoso.com). If multiple users need to be added, they have to be comma-separated (e.g. megan.bowen@contoso.com,alex.wilber@contoso.com). Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`
 
 `--email [email]`
-: User's email (eg. megan.bowen@contoso.com). If multiple users need to be added, they have to be comma separated (ex. megan.bowen@contoso.com,alex.wilber@contoso.com). Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`
+: User's email (eg. megan.bowen@contoso.com). If multiple users need to be added, they have to be comma-separated (e.g. megan.bowen@contoso.com,alex.wilber@contoso.com). Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`
 
 `--userId [userId]`
-: The user Id of the user to add as a member. (Id of the site user, for example: 14) If multiple users need to be added, the Ids have to be comma separated. Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`
+: The user Id of the user to add as a member. (Id of the site user, for example: 14) If multiple users need to be added, the Ids have to be comma-separated. Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`
 
 `--aadGroupId [aadGroupId]`
-: The object Id of the Azure AD group to add as a member. If multiple groups need to be added, the Ids have to be comma separated. Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`
+: The object Id of the Azure AD group to add as a member. If multiple groups need to be added, the Ids have to be comma-separated. Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`
 
 `--aadGroupName [aadGroupName]`
 : The name of the Azure AD group to add as a member. Specify either `userId`, `userName`, `email`, `aadGroupId` or `aadGroupName`

--- a/docs/docs/cmd/spo/navigation/navigation-node-add.md
+++ b/docs/docs/cmd/spo/navigation/navigation-node-add.md
@@ -29,7 +29,7 @@ m365 spo navigation node add [options]
 : Set, if the navigation node points to an external URL.
 
 `--audienceIds [audienceIds]`
-: Comma separated list of group IDs that will be used for audience targeting. The limit is 10 ids per navigation node.
+: Comma-separated list of group IDs that will be used for audience targeting. The limit is 10 ids per navigation node.
 
 --8<-- "docs/cmd/_global.md"
 

--- a/docs/docs/cmd/spo/navigation/navigation-node-set.md
+++ b/docs/docs/cmd/spo/navigation/navigation-node-set.md
@@ -23,7 +23,7 @@ m365 spo navigation node set [options]
 : New URL of the navigation node.
 
 `--audienceIds [audienceIds]`
-: Comma separated list of group IDs that will be used for audience targeting. Speficy an empty string `""` to clear this value. The limit is 10 ids per navigation node.
+: Comma-separated list of group IDs that will be used for audience targeting. Speficy an empty string `""` to clear this value. The limit is 10 ids per navigation node.
 
 `--isExternal [isExternal]`
 : Whether the navigation node points to an external URL. Valid values: `true` or `false`.

--- a/docs/docs/cmd/spo/tenant/tenant-settings-set.md
+++ b/docs/docs/cmd/spo/tenant/tenant-settings-set.md
@@ -10,8 +10,6 @@ m365 spo tenant settings set [options]
 
 ## Options
 
---8<-- "docs/cmd/_global.md"
-
 `--MinCompatibilityLevel [MinCompatibilityLevel]`
 : Specifies the lower bound on the compatibility level for new sites
 
@@ -263,6 +261,8 @@ m365 spo tenant settings set [options]
 
 `--SyncAadB2BManagementPolicy [SyncAadB2BManagementPolicy]`
 : Syncs Azure B2B Management Policies. Allowed values `true,false`. For more information, see [SharePoint and OneDrive integration with Azure AD B2B](https://aka.ms/spo-b2b-integration).
+
+--8<-- "docs/cmd/_global.md"
 
 !!! important
     To use this command you have to have permission to access the tenant admin site.

--- a/docs/docs/cmd/spo/tenant/tenant-settings-set.md
+++ b/docs/docs/cmd/spo/tenant/tenant-settings-set.md
@@ -19,7 +19,7 @@ m365 spo tenant settings set [options]
 : Specifies the upper bound on the compatibility level for new sites
 
 `--ExternalServicesEnabled [ExternalServicesEnabled]`
-: Enables external services for a tenant. External services are defined as services that are not in the Microsoft 365 datacenters. Allowed values `true,false`
+: Enables external services for a tenant. External services are defined as services that are not in the Microsoft 365 data centers. Allowed values `true,false`
 
 `--NoAccessRedirectUrl [NoAccessRedirectUrl]`
 : Specifies the URL of the redirected site for those site collections which have the locked state "NoAccess"
@@ -34,43 +34,43 @@ m365 spo tenant settings set [options]
 : Specifies URL of the form to load in the Start a Site dialog. The valid values are: "" (default) - Blank by default, this will also remove or clear any value that has been set. Full URL - Example:"https://contoso.sharepoint.com/path/to/form"
 
 `--ShowEveryoneClaim [ShowEveryoneClaim]`
-: Enables the administrator to hide the Everyone claim in the People Picker. When users share an item with Everyone, it is accessible to all authenticated users in the tenant\'s Azure Active Directory, including any active external users who have previously accepted invitations. Note, that some SharePoint system resources such as templates and pages are required to be shared to Everyone and this type of sharing does not expose any user data or metadata. Allowed values `true,false`
+: Enables the administrator to hide the Everyone claim in the People Picker. When users share an item with Everyone, it is accessible to all authenticated users in the tenant's Azure Active Directory, including any active external users who have previously accepted invitations. Note, that some SharePoint system resources such as templates and pages are required to be shared with Everyone and this type of sharing does not expose any user data or metadata. Allowed values `true,false`
 
 `--ShowAllUsersClaim [ShowAllUsersClaim]`
-: Enables the administrator to hide the All Users claim groups in People Picker. When users share an item with "All Users (x)", it is accessible to all organization members in the tenant\'s Azure Active Directory who have authenticated with via this method. When users share an item with "All Users (x)" it is accessible to all organization members in the tenant that used NTLM to authentication with SharePoint. Allowed values `true,false`
+: Enables the administrator to hide the All Users claim groups in People Picker. When users share an item with "All Users (x)", it is accessible to all organization members in the tenant's Azure Active Directory who have authenticated via this method. When users share an item with "All Users (x)" it is accessible to all organization members in the tenant that used NTLM to authenticate with SharePoint. Allowed values `true,false`
 
 `--ShowEveryoneExceptExternalUsersClaim [ShowEveryoneExceptExternalUsersClaim]`
 : Enables the administrator to hide the "Everyone except external users" claim in the People Picker. When users share an item with "Everyone except external users", it is accessible to all organization members in the tenant's Azure Active Directory, but not to any users who have previously accepted invitations. Allowed values `true,false`
 
 `--SearchResolveExactEmailOrUPN [SearchResolveExactEmailOrUPN]`
-: Removes the search capability from People Picker. Note, recently resolved names will still appear in the list until browser cache is cleared or expired. SharePoint Administrators will still be able to use starts with or partial name matching when enabled. Allowed values `true,false`
+: Removes the search capability from People Picker. Note, recently resolved names will still appear in the list until the browser cache is cleared or expired. SharePoint Administrators will still be able to use starts with or partial name matching when enabled. Allowed values `true,false`
 
 `--OfficeClientADALDisabled [OfficeClientADALDisabled]`
 : When set to true this will disable the ability to use Modern Authentication that leverages ADAL across the tenant. Allowed values `true,false`
 
 `--LegacyAuthProtocolsEnabled [LegacyAuthProtocolsEnabled]`
-: By default this value is set to true. Setting this parameter prevents Office clients using non-modern authentication protocols from accessing SharePoint Online resources. A value of true - Enables Office clients using non-modern authentication protocols (such as, Forms-Based Authentication (FBA) or Identity Client Runtime Library (IDCRL)) to access SharePoint resources. Allowed values `true,false`
+: By default, this value is set to true. Setting this parameter prevents Office clients using non-modern authentication protocols from accessing SharePoint Online resources. A value of true - Enables Office clients using non-modern authentication protocols (such as Forms-Based Authentication (FBA) or Identity Client Runtime Library (IDCRL)) to access SharePoint resources. Allowed values `true,false`
 
 `--RequireAcceptingAccountMatchInvitedAccount [RequireAcceptingAccountMatchInvitedAccount]`
 : Ensures that an external user can only accept an external sharing invitation with an account matching the invited email address. Administrators who desire increased control over external collaborators should consider enabling this feature. Allowed values `true,false`
 
 `--ProvisionSharedWithEveryoneFolder [ProvisionSharedWithEveryoneFolder]`
-: Creates a Shared with Everyone folder in every user\'s new OneDrive for Business document library. The valid values are: True (default) - The Shared with Everyone folder is created. False - No folder is created when the site and OneDrive for Business document library is created. Allowed values `true,false`
+: Creates a Shared with Everyone folder in every user's new OneDrive for Business document library. The valid values are: True (default) - The Shared with Everyone folder is created. False - No folder is created when the site and OneDrive for Business document library are created. Allowed values `true,false`
 
 `--SignInAccelerationDomain [SignInAccelerationDomain]`
-: Specifies the home realm discovery value to be sent to Azure Active Directory (AAD) during the user sign-in process. When the organization uses a third-party identity provider, this prevents the user from seeing the Azure Active Directory Home Realm Discovery web page and ensures the user only sees their company's Identity Provider's portal. This value can also be used with Azure Active Directory Premium to customize the Azure Active Directory login page. Acceleration will not occur on site collections that are shared externally. This value should be configured with the login domain that is used by your company (that is, example@contoso.com). If your company has multiple third-party identity providers, configuring the sign-in acceleration value will break sign-in for your organization. The valid values are: "" (default) - Blank by default, this will also remove or clear any value that has been set. Login Domain - For example: "contoso.com". No value assigned by default
+: Specifies the home realm discovery value to be sent to Azure Active Directory (AAD) during the user sign-in process. When the organization uses a third-party identity provider, this prevents the user from seeing the Azure Active Directory Home Realm Discovery web page and ensures the user only sees their company's Identity Provider's portal. This value can also be used with Azure Active Directory Premium to customize the Azure Active Directory login page. Acceleration will not occur on-site collections that are shared externally. This value should be configured with the login domain that is used by your company (that is, example@contoso.com). If your company has multiple third-party identity providers, configuring the sign-in acceleration value will break sign-in for your organization. The valid values are: "" (default) - Blank by default, this will also remove or clear any value that has been set. Login Domain - For example: "contoso.com". No value assigned by default
 
 `--EnableGuestSignInAcceleration [EnableGuestSignInAcceleration]`
 : Accelerates guest-enabled site collections as well as member-only site collections when the SignInAccelerationDomain parameter is set. Allowed values `true,false`
 
 `--UsePersistentCookiesForExplorerView [UsePersistentCookiesForExplorerView]`
-: Lets SharePoint issue a special cookie that will allow this feature to work even when "Keep Me Signed In" is not selected. "Open with Explorer" requires persisted cookies to operate correctly. When the user does not select "Keep Me Signed in" at the time of sign -in, "Open with Explorer" will fail. This special cookie expires after 30 minutes and cannot be cleared by closing the browser or signing out of SharePoint Online.To clear this cookie, the user must log out of their Windows session. The valid values are: False(default) - No special cookie is generated and the normal Microsoft 365 sign -in length / timing applies. True - Generates a special cookie that will allow "Open with Explorer" to function if the "Keep Me Signed In" box is not checked at sign -in. Allowed values `true,false`
+: Lets SharePoint issue a special cookie that will allow this feature to work even when "Keep Me Signed In" is not selected. "Open with Explorer" requires persisted cookies to operate correctly. When the user does not select "Keep Me Signed in" at the time of sign-in, "Open with Explorer" will fail. This special cookie expires after 30 minutes and cannot be cleared by closing the browser or signing out of SharePoint Online.To clear this cookie, the user must log out of their Windows session. The valid values are: False(default) - No special cookie is generated and the normal Microsoft 365 sign-in length/timing applies. True - Generates a special cookie that will allow "Open with Explorer" to function if the "Keep Me Signed In" box is not checked at sign-in. Allowed values `true,false`
 
 `--BccExternalSharingInvitations [BccExternalSharingInvitations]`
-: When the feature is enabled, all external sharing invitations that are sent will blind copy the e-mail messages listed in the BccExternalSharingsInvitationList. Allowed values `true,false`
+: When the feature is enabled, all external sharing invitations that are sent will blindly copy the e-mail messages listed in the BccExternalSharingsInvitationList. Allowed values `true,false`
 
 `--BccExternalSharingInvitationsList [BccExternalSharingInvitationsList]`
-: Specifies a list of e-mail addresses to be BCC'd when the BCC for External Sharing feature is enabled. Multiple addresses can be specified by creating a comma separated list with no spaces
+: Specifies a list of e-mail addresses to be BCC'd when the BCC for External Sharing feature is enabled. Multiple addresses can be specified by creating a comma-separated list with no spaces
 
 `--UserVoiceForFeedbackEnabled [UserVoiceForFeedbackEnabled]`
 : Enables or disables the User Voice Feedback button. Allowed values `true,false`
@@ -79,16 +79,16 @@ m365 spo tenant settings set [options]
 : Enables or disables the publish CDN. Allowed values `true,false`
 
 `--PublicCdnAllowedFileTypes [PublicCdnAllowedFileTypes]`
-: Sets public CDN allowed file types
+: Sets public CDN-allowed file types
 
 `--RequireAnonymousLinksExpireInDays [RequireAnonymousLinksExpireInDays]`
 : Specifies all anonymous links that have been created (or will be created) will expire after the set number of days. To remove the expiration requirement, set the value to zero (0)
 
 `--SharingAllowedDomainList [SharingAllowedDomainList]`
-: Specifies a list of email domains that is allowed for sharing with the external collaborators. Use the space character as the delimiter for entering multiple values. For example, "contoso.com fabrikam.com"
+: Specifies a list of email domains that are allowed for sharing with external collaborators. Use the space character as the delimiter for entering multiple values. For example, "contoso.com fabrikam.com"
 
 `--SharingBlockedDomainList [SharingBlockedDomainList]`
-: Specifies a list of email domains that is blocked or prohibited for sharing with the external collaborators. Use space character as the delimiter for entering multiple values. For example, "contoso.com fabrikam.com"
+: Specifies a list of email domains that are blocked or prohibited from sharing with external collaborators. Use space character as the delimiter for entering multiple values. For example, "contoso.com fabrikam.com"
 
 `--SharingDomainRestrictionMode [SharingDomainRestrictionMode]`
 : Specifies the external sharing mode for domains. Allowed values `None,AllowList,BlockList`
@@ -97,7 +97,7 @@ m365 spo tenant settings set [options]
 : Sets a default OneDrive for Business storage quota for the tenant. It will be used for new OneDrive for Business sites created. A typical use will be to reduce the amount of storage associated with OneDrive for Business to a level below what the License entitles the users. For example, it could be used to set the quota to 10 gigabytes (GB) by default
 
 `--OneDriveForGuestsEnabled [OneDriveForGuestsEnabled]`
-: Lets OneDrive for Business creation for administrator managed guest users. Administrator managed Guest users use credentials in the resource tenant to access the resources. Allowed values `true,false`
+: Lets OneDrive for Business creation for administrator-managed guest users. Administrator-managed Guest users use credentials in the resource tenant to access the resources. Allowed values `true,false`
 
 `--IPAddressEnforcement [IPAddressEnforcement]`
 : Allows access from network locations that are defined by an administrator. The values are true and false. The default value is false which means the setting is disabled. Before the iPAddressEnforcement parameter is set, make sure you add a valid IPv4 or IPv6 address to the iPAddressAllowList parameter. Allowed values `true,false`
@@ -109,10 +109,10 @@ m365 spo tenant settings set [options]
 : Sets IP Address WAC token lifetime'
 
 `--UseFindPeopleInPeoplePicker [UseFindPeopleInPeoplePicker]`
-: Sets use find people in PeoplePicker to true or false. Note: When set to true, users aren\'t able to share with security groups or SharePoint groups. Allowed values `true,false`
+: Sets use to find people in PeoplePicker to true or false. Note: When set to true, users aren't able to share with security groups or SharePoint groups. Allowed values `true,false`
 
 `--DefaultSharingLinkType [DefaultSharingLinkType]`
-: Lets administrators choose what type of link appears is selected in the “Get a link” sharing dialog box in OneDrive for Business and SharePoint Online. Allowed values `None,Direct,Internal,AnonymousAccess`
+: Let's administrators choose what type of link appears is selected in the “Get a link” sharing dialog box in OneDrive for Business and SharePoint Online. Allowed values `None,Direct,Internal,AnonymousAccess`
 
 `--ODBMembersCanShare [ODBMembersCanShare]`
 : Lets administrators set policy on re-sharing behavior in OneDrive for Business. Allowed values `Unspecified,On,Off`
@@ -145,7 +145,7 @@ m365 spo tenant settings set [options]
 : Enables or disables notifications in SharePoint. Allowed values `true,false`
 
 `--OwnerAnonymousNotification [OwnerAnonymousNotification]`
-: Enables or disables owner anonymous notification. Allowed values `true,false`
+: Enables or disables owner-anonymous notification. Allowed values `true,false`
 
 `--CommentsOnSitePagesDisabled [CommentsOnSitePagesDisabled]`
 : Enables or disables comments on site pages. Allowed values `true,false`
@@ -160,19 +160,19 @@ m365 spo tenant settings set [options]
 : Prevents the Download button from being displayed on the Virus Found warning page. Allowed values `true,false`
 
 `--DefaultLinkPermission [DefaultLinkPermission]`
-: Choose the dafault permission that is selected when users share. This applies to anonymous access, internal and direct links. Allowed values `None,View,Edit`
+: Choose the default permission that is selected when users share. This applies to anonymous access, internal and direct links. Allowed values `None,View,Edit`
 
 `--ConditionalAccessPolicy [ConditionalAccessPolicy]`
 : Configures conditional access policy. Allowed values `AllowFullAccess,AllowLimitedAccess,BlockAccess`
 
 `--AllowDownloadingNonWebViewableFiles [AllowDownloadingNonWebViewableFiles]`
-: Allows downloading non web viewable files. The Allowed values `true,false`
+: Allows downloading non-web viewable files. The Allowed values `true,false`
 
 `--AllowEditing [AllowEditing]`
 : Allows editing. Allowed values `true,false`
 
 `--ApplyAppEnforcedRestrictionsToAdHocRecipients [ApplyAppEnforcedRestrictionsToAdHocRecipients]`
-: Applies app enforced restrictions to AdHoc recipients. Allowed values `true,false`
+: Applies app-enforced restrictions to AdHoc recipients. Allowed values `true,false`
 
 `--FilePickerExternalImageSearchEnabled [FilePickerExternalImageSearchEnabled]`
 : Enables file picker external image search. Allowed values `true,false`
@@ -190,7 +190,7 @@ m365 spo tenant settings set [options]
 : Blocks access on unmanaged devices. Allowed values `true,false`
 
 `--AllowLimitedAccessOnUnmanagedDevices [AllowLimitedAccessOnUnmanagedDevices]`
-: Allows limited access on unmanaged devices blocks. Allowed values `true,false`
+: Allows limited access on unmanaged device blocks. Allowed values `true,false`
 
 `--BlockDownloadOfAllFilesForGuests [BlockDownloadOfAllFilesForGuests]`
 : Blocks download of all files for guests. Allowed values `true,false`
@@ -211,7 +211,7 @@ m365 spo tenant settings set [options]
 : Disables report problem dialog. Allowed values `true,false`
 
 `--DisplayNamesOfFileViewers [DisplayNamesOfFileViewers]`
-: Displayes names of file viewers. Allowed values `true,false`
+: Displays names of file viewers. Allowed values `true,false`
 
 `--EnableMinimumVersionRequirement [EnableMinimumVersionRequirement]`
 : Enables minimum version requirement. Allowed values `true,false`
@@ -235,7 +235,7 @@ m365 spo tenant settings set [options]
 : Organization news site url'
 
 `--PermissiveBrowserFileHandlingOverride [PermissiveBrowserFileHandlingOverride]`
-: Permissive browser fileHandling override. Allowed values `true,false`
+: Permissive browser file handling override. Allowed values `true,false`
 
 `--ShowNGSCDialogForSyncOnODB [ShowNGSCDialogForSyncOnODB]`
 : Show NGSC dialog for sync on OneDrive for Business. Allowed values `true,false`
@@ -265,7 +265,7 @@ m365 spo tenant settings set [options]
 : Syncs Azure B2B Management Policies. Allowed values `true,false`. For more information, see [SharePoint and OneDrive integration with Azure AD B2B](https://aka.ms/spo-b2b-integration).
 
 !!! important
-    To use this command you have to have permissions to access the tenant admin site.
+    To use this command you have to have permission to access the tenant admin site.
 
 ## Examples
 

--- a/docs/docs/cmd/teams/channel/channel-member-add.md
+++ b/docs/docs/cmd/teams/channel/channel-member-add.md
@@ -23,10 +23,10 @@ m365 teams channel member add [options]
 : The display name of the Microsoft Teams team channel. Specify either `channelId` or `channelName`, but not both.
 
 `--userId [userId]`
-: The user's ID or principal name. You can also pass a comma separated list of userIds.
+: The user's ID or principal name. You can also pass a comma-separated list of userIds.
 
 `--userDisplayName [userDisplayName]`
-: The display name of a user. You can also pass a comma separated list of display names.
+: The display name of a user. You can also pass a comma-separated list of display names.
 
 `--owner`
 : Assign the user the owner role. Defaults to member permissions.


### PR DESCRIPTION
No related issue. Found some typos in the docs for commands I was checking out. This PR resolves them.