### PR TITLE
Adds `assetId` option to `retentionlabel ensure` commands, Closes #4387

### DIFF
--- a/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
@@ -47,7 +47,7 @@ Applies a retention label to a file based on the label name and the fileId
 m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8' --name 'Some label'
 ```
 
-Applies a event-based retention label to a file based on the label name, the fileId and the asset id
+Applies a event-based retention label to a file and updates the Asset Id field
 
 ```sh
 m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8' --name 'Some label' --assetId 'XYZ'

--- a/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
@@ -44,13 +44,13 @@ m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/site
 Applies a retention label to a file based on the label name and the fileId
 
 ```sh
-m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8'  --name 'Some label'
+m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8' --name 'Some label'
 ```
 
 Applies a event-based retention label to a file based on the label name, the fileId and the asset id
 
 ```sh
-m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8'  --name 'Some label' --assetId 'XYZ'
+m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8' --name 'Some label' --assetId 'XYZ'
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
@@ -22,6 +22,9 @@ m365 spo file retentionlabel ensure [options]
 `--name <name>`
 : Name of the retention label to apply to the file.
 
+`-a, --assetId [assetId]`
+: A Compliance Asset Id to set on the item after it's labeled. See below for more information.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
@@ -40,6 +43,12 @@ Applies a retention label to a file based on the label name and the fileId
 
 ```sh
 m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8'  --name 'Some label'
+```
+
+Applies a event-based retention label to a file based on the label name, the fileId and the asset id
+
+```sh
+m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8'  --name 'Some label' --assetId 'XYZ'
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
@@ -31,6 +31,8 @@ m365 spo file retentionlabel ensure [options]
 
 You can also use [spo listitem retentionlabel remove](./../../../cmd/spo//listitem/listitem-retentionlabel-remove.md) for removing the retentionlabel from a listitem.
 
+The `--assetId` option has to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created.
+
 ## Examples
 
 Applies a retention label to a file based on the label name and the fileUrl

--- a/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.md
@@ -36,6 +36,10 @@ m365 spo listitem retentionlabel ensure [options]
 
 --8<-- "docs/cmd/_global.md"
 
+## Remarks
+
+The `--assetId` option has to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created.
+
 ## Examples
 
 Applies a retention label to a list item in a given site based on the list id and label name

--- a/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.md
@@ -60,7 +60,7 @@ Applies a retention label to a list item in a given site based on the server rel
 m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/lists/TestList --listItemId 1 --name 'Some label'
 ```
 
-Applies a retention label to a list item in a given site based on the server relative list url and with the asset id
+Applies a retention label to a list item in a given site based on the server relative list url and updates the Asset Id field
 
 ```sh
 m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/lists/TestList --listItemId 1 --name 'Some label' --assetId 'XYZ'

--- a/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.md
@@ -31,11 +31,14 @@ m365 spo listitem retentionlabel ensure [options]
 `-i, --id [id]`
 : The id of the retention label. Specify either `name` or `id`.
 
+`-a, --assetId [assetId]`
+: A Compliance Asset Id to set on the item after it's labeled. See below for more information.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Applies the retention label _Some label_ to a list item in a given site based on the list id and label name
+Applies a retention label to a list item in a given site based on the list id and label name
 
 ```sh
 m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf --listItemId 1 --name 'Some label'
@@ -47,10 +50,16 @@ Applies a retention label to a list item in a given site based on the list title
 m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'List 1' --listItemId 1 --id '7a621a91-063b-461b-aff6-d713d5fb23eb'
 ```
 
-Applies the retention label _Some label_ to a list item in a given site based on the server relative list url
+Applies a retention label to a list item in a given site based on the server relative list url
 
 ```sh
 m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/lists/TestList --listItemId 1 --name 'Some label'
+```
+
+Applies a retention label to a list item in a given site based on the server relative list url and with the asset id
+
+```sh
+m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/lists/TestList --listItemId 1 --name 'Some label' --assetId 'XYZ'
 ```
 
 ## Response

--- a/src/m365/spo/commands/file/file-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-ensure.spec.ts
@@ -12,6 +12,7 @@ import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
+import * as SpoListItemRetentionLabelEnsureCommand from '../listitem/listitem-retentionlabel-ensure';
 const command: Command = require('./file-retentionlabel-ensure');
 
 describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
@@ -20,6 +21,7 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
   const fileId = 'b2307a39-e878-458b-bc90-03bc578531d6';
   const listId = 1;
   const retentionlabelName = "retentionlabel";
+  const SpoListItemRetentionLabelEnsureCommandOutput = `{ "stdout": "", "stderr": "" }`;
   const fileResponse = {
     ListItemAllFields: {
       Id: listId,
@@ -27,10 +29,6 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
         Id: '75c4d697-bbff-40b8-a740-bf9b9294e5aa'
       }
     }
-  };
-
-  const retentionEnsureResponse = {
-    "odata.null": true
   };
 
   const retentionLabelResponse = {
@@ -122,7 +120,8 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.post
+      request.post,
+      Cli.executeCommandWithOutput
     ]);
   });
 
@@ -158,11 +157,14 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
     });
 
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${fileResponse.ListItemAllFields.ParentList.Id}')/items(${listId})/SetComplianceTag()`) {
-        return retentionEnsureResponse;
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === SpoListItemRetentionLabelEnsureCommand) {
+        return ({
+          stdout: SpoListItemRetentionLabelEnsureCommandOutput
+        });
       }
-      throw 'Invalid request';
+
+      throw new CommandError('Unknown case');
     });
 
     await assert.doesNotReject(command.action(logger, {
@@ -187,11 +189,14 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${fileResponse.ListItemAllFields.ParentList.Id}')/items(${listId})/SetComplianceTag()`) {
-        return retentionEnsureResponse;
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === SpoListItemRetentionLabelEnsureCommand) {
+        return ({
+          stdout: SpoListItemRetentionLabelEnsureCommandOutput
+        });
       }
-      throw 'Invalid request';
+
+      throw new CommandError('Unknown case');
     });
 
     await assert.doesNotReject(command.action(logger, {
@@ -217,12 +222,18 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
       throw 'Invalid request';
     });
 
-
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${fileResponse.ListItemAllFields.ParentList.Id}')/items(${listId})/SetComplianceTag()`) {
-        return retentionEnsureResponse;
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === SpoListItemRetentionLabelEnsureCommand) {
+        return ({
+          stdout: SpoListItemRetentionLabelEnsureCommandOutput
+        });
       }
 
+      throw new CommandError('Unknown case');
+    });
+
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${fileResponse.ListItemAllFields.ParentList.Id}')/items(${listId})/ValidateUpdateListItem()`) {
         return {
           "value": [
@@ -290,6 +301,16 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
       }
 
       throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === SpoListItemRetentionLabelEnsureCommand) {
+        return ({
+          stdout: SpoListItemRetentionLabelEnsureCommandOutput
+        });
+      }
+
+      throw new CommandError('Unknown case');
     });
 
 

--- a/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
@@ -8,7 +8,11 @@ import { FileProperties } from './FileProperties';
 import { formatting } from '../../../../utils/formatting';
 import { urlUtil } from '../../../../utils/urlUtil';
 import { spo } from '../../../../utils/spo';
+import { Options as SpoListItemRetentionLabelEnsureCommandOptions } from '../listitem/listitem-retentionlabel-ensure';
+import * as SpoListItemRetentionLabelEnsureCommand from '../listitem/listitem-retentionlabel-ensure';
 import { ListItemRetentionLabel } from '../listitem/ListItemRetentionLabel';
+import { Cli } from '../../../../cli/Cli';
+import Command from '../../../../Command';
 
 interface CommandArgs {
   options: Options;
@@ -105,21 +109,19 @@ class SpoFileRetentionLabelEnsureCommand extends SpoCommand {
         await this.applyAssetId(args.options.webUrl, fileProperties.ListItemAllFields.ParentList.Id, fileProperties.ListItemAllFields.Id, args.options.assetId);
       }
 
-      const requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(fileProperties.ListItemAllFields.ParentList.Id)}')/items(${fileProperties.ListItemAllFields.Id})/SetComplianceTag()`;
-
-      const requestOptions: CliRequestOptions = {
-        url: requestUrl,
-        headers: {
-          'accept': 'application/json;odata=nometadata'
-        },
-        data: labelInformation,
-        responseType: 'json'
+      const options: SpoListItemRetentionLabelEnsureCommandOptions = {
+        webUrl: args.options.webUrl,
+        listId: fileProperties.ListItemAllFields.ParentList.Id,
+        listItemId: fileProperties.ListItemAllFields.Id,
+        name: args.options.name,
+        output: 'json',
+        debug: this.debug,
+        verbose: this.verbose
       };
 
-      const response = await request.post(requestOptions);
-
+      const spoListItemRetentionLabelEnsureCommandOutput = await Cli.executeCommandWithOutput(SpoListItemRetentionLabelEnsureCommand as Command, { options: { ...options, _: [] } });
       if (this.verbose) {
-        logger.log(response);
+        logger.logToStderr(spoListItemRetentionLabelEnsureCommandOutput.stderr);
       }
     }
     catch (err: any) {

--- a/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
@@ -101,6 +101,9 @@ class SpoFileRetentionLabelEnsureCommand extends SpoCommand {
       if (args.options.assetId && !labelInformation.isEventBasedTag) {
         throw `The label that's being applied is not an event-based label`;
       }
+      if (args.options.assetId && labelInformation.isEventBasedTag) {
+        await this.applyAssetId(args.options.webUrl, fileProperties.ListItemAllFields.ParentList.Id, fileProperties.ListItemAllFields.Id, args.options.assetId);
+      }
 
       const requestUrl = `${args.options.webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(fileProperties.ListItemAllFields.ParentList.Id)}')/items(${fileProperties.ListItemAllFields.Id})/SetComplianceTag()`;
 
@@ -114,9 +117,7 @@ class SpoFileRetentionLabelEnsureCommand extends SpoCommand {
       };
 
       const response = await request.post(requestOptions);
-      if (args.options.assetId) {
-        await this.applyAssetId(args.options.webUrl, fileProperties.ListItemAllFields.ParentList.Id, fileProperties.ListItemAllFields.Id, args.options.assetId);
-      }
+
       if (this.verbose) {
         logger.log(response);
       }

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.spec.ts
@@ -87,7 +87,6 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let loggerLogStderrSpy: sinon.SinonSpy;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
@@ -111,7 +110,6 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
         log.push(msg);
       }
     };
-    loggerLogStderrSpy = sinon.spy(logger, 'logToStderr');
   });
 
   afterEach(() => {
@@ -193,36 +191,6 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
   it('passes validation if the listId option is a valid GUID', async () => {
     const actual = await command.validate({ options: { webUrl: webUrl, listId: listId, listItemId: 1, name: labelName } }, commandInfo);
     assert(actual);
-  });
-
-  it('applies a retentionlabel based on listId and name without assetId', async () => {
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/items(1)/SetComplianceTag()`
-        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":true,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
-        return;
-      }
-
-      throw 'Invalid request';
-    });
-
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === SpoWebRetentionLabelListCommand) {
-        return { stdout: JSON.stringify(mockSpoWebRetentionLabelListResponseArray) };
-      }
-
-      throw 'Unknown case';
-    });
-
-    await command.action(logger, {
-      options: {
-        debug: false,
-        listId: listId,
-        webUrl: webUrl,
-        listItemId: 1,
-        name: labelName
-      }
-    });
-    assert(loggerLogStderrSpy.notCalled);
   });
 
   it('applies a retentionlabel based on listId, id and with assetId (debug)', async () => {

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
@@ -129,9 +129,8 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
       if (args.options.assetId && !labelInformation.isEventBasedTag) {
         throw `The label that's being applied is not an event-based label`;
       }
-      if (args.options.assetId && labelInformation.isEventBasedTag) {
-        await this.applyAssetId(args.options, logger);
-      }
+
+      await this.applyAssetId(args.options, logger);
 
       await this.applyLabel(args.options, labelInformation, logger);
     }

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
@@ -132,11 +132,11 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
       if (args.options.assetId && !labelInformation.isEventBasedTag) {
         throw `The label that's being applied is not an event-based label`;
       }
-
-      await this.applyLabel(args.options, labelInformation, logger);
-      if (args.options.assetId) {
+      if (args.options.assetId && labelInformation.isEventBasedTag) {
         await this.applyAssetId(args.options, logger);
       }
+
+      await this.applyLabel(args.options, labelInformation, logger);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
@@ -1,18 +1,14 @@
 import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
-import request from '../../../../request';
+import request, { CliRequestOptions } from '../../../../request';
 import { formatting } from '../../../../utils/formatting';
 import { urlUtil } from '../../../../utils/urlUtil';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
-import { SiteRetentionLabel } from './SiteRetentionLabel';
-import * as SpoWebRetentionLabelListCommand from '../web/web-retentionlabel-list';
-import { Options as SpoWebRetentionLabelListCommandOptions } from '../web/web-retentionlabel-list';
-import Command from '../../../../Command';
-import { Cli } from '../../../../cli/Cli';
 import { ListItemRetentionLabel } from './ListItemRetentionLabel';
+import { spo } from '../../../../utils/spo';
 
 interface CommandArgs {
   options: Options;
@@ -26,6 +22,7 @@ export interface Options extends GlobalOptions {
   listItemId: string;
   name?: string;
   id?: string;
+  assetId?: string;
 }
 
 class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
@@ -53,7 +50,8 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
         listTitle: typeof args.options.listTitle !== 'undefined',
         listUrl: typeof args.options.listUrl !== 'undefined',
         name: typeof args.options.name !== 'undefined',
-        id: typeof args.options.id !== 'undefined'
+        id: typeof args.options.id !== 'undefined',
+        assetId: typeof args.options.assetId !== 'undefined'
       });
     });
   }
@@ -80,6 +78,9 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
       },
       {
         option: '-i, --id [id]'
+      },
+      {
+        option: '-a, --assetId [assetId]'
       }
     );
   }
@@ -119,47 +120,27 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const labelInformation = await this.getLabelInformation(args.options, logger);
+      let labelInformation: ListItemRetentionLabel;
+
+      if (args.options.name) {
+        labelInformation = await spo.getWebRetentionLabelInformationByName(args.options.webUrl, args.options.name);
+      }
+      else {
+        labelInformation = await spo.getWebRetentionLabelInformationById(args.options.webUrl, args.options.id!);
+      }
+
+      if (args.options.assetId && !labelInformation.isEventBasedTag) {
+        throw `The label that's being applied is not an event-based label`;
+      }
+
       await this.applyLabel(args.options, labelInformation, logger);
+      if (args.options.assetId) {
+        await this.applyAssetId(args.options, logger);
+      }
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
-  }
-
-  private async getLabelInformation(options: Options, logger: Logger): Promise<ListItemRetentionLabel> {
-    const cmdOptions: SpoWebRetentionLabelListCommandOptions = {
-      webUrl: options.webUrl,
-      output: 'json',
-      debug: options.debug,
-      verbose: options.verbose
-    };
-
-    const output = await Cli.executeCommandWithOutput(SpoWebRetentionLabelListCommand as Command, { options: { ...cmdOptions, _: [] } });
-
-    if (this.verbose) {
-      logger.logToStderr(output.stderr);
-    }
-
-    const labels = JSON.parse(output.stdout) as SiteRetentionLabel[];
-    const label = labels.find(l => l.TagName === options.name || l.TagId === options.id);
-
-    if (this.verbose && label !== undefined) {
-      logger.logToStderr(`Retention label found in the list of available labels: '${label.TagName}' / '${label.TagId}'...`);
-    }
-
-    if (label === undefined) {
-      throw new Error(`The specified retention label does not exist`);
-    }
-
-    return {
-      complianceTag: label.TagName,
-      isTagPolicyHold: label.BlockDelete,
-      isTagPolicyRecord: label.BlockEdit,
-      isEventBasedTag: label.IsEventTag,
-      isTagSuperLock: label.SuperLock,
-      isUnlockedAsDefault: label.UnlockedAsDefault
-    } as ListItemRetentionLabel;
   }
 
   private async applyLabel(options: Options, labelInformation: ListItemRetentionLabel, logger: Logger): Promise<void> {
@@ -186,6 +167,36 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
         'accept': 'application/json;odata=nometadata'
       },
       data: labelInformation,
+      responseType: 'json'
+    };
+
+    await request.post(requestOptions);
+  }
+
+  async applyAssetId(options: GlobalOptions, logger: Logger): Promise<void> {
+    if (this.verbose) {
+      logger.logToStderr(`Applying the asset Id ${options.assetId}...`);
+    }
+    let requestUrl = `${options.webUrl}/_api/web`;
+
+    if (options.listId) {
+      requestUrl += `/lists(guid'${formatting.encodeQueryParameter(options.listId)}')/items(${options.listItemId})/ValidateUpdateListItem()`;
+    }
+    else if (options.listTitle) {
+      requestUrl += `/lists/getByTitle('${formatting.encodeQueryParameter(options.listTitle)}')/items(${options.listItemId})/ValidateUpdateListItem()`;
+    }
+    else if (options.listUrl) {
+      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(options.webUrl, options.listUrl);
+      requestUrl += `/GetList(@listUrl)/items(${options.listItemId})/ValidateUpdateListItem()?@listUrl='${formatting.encodeQueryParameter(listServerRelativeUrl)}'`;
+    }
+    const requestBody = { "formValues": [{ "FieldName": "ComplianceAssetId", "FieldValue": options.assetId }] };
+
+    const requestOptions: CliRequestOptions = {
+      url: requestUrl,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      data: requestBody,
       responseType: 'json'
     };
 

--- a/src/utils/spo.spec.ts
+++ b/src/utils/spo.spec.ts
@@ -1012,29 +1012,4 @@ describe('utils/spo', () => {
 
     await assert.rejects(spo.getWebRetentionLabelInformationByName('https://contoso.sharepoint.com/sites/sales', 'Retention Label'), `Retention label not found`);
   });
-
-  it(`retrieves the web retention labels by name`, async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/SP.CompliancePolicy.SPPolicyStoreProxy.GetAvailableTagsForSite(siteUrl=@a1)?@a1='${formatting.encodeQueryParameter('https://contoso.sharepoint.com/sites/sales')}'`) {
-        return retentionLabelResponse;
-      }
-
-      throw 'invalid request';
-    });
-
-    const retentionLabel = await spo.getWebRetentionLabelInformationById('https://contoso.sharepoint.com/sites/sales', 'f6e20c71-7d56-414d-bb98-8ee927a308bd');
-    assert.deepEqual(retentionLabel, retentionLabelOutput);
-  });
-
-  it('throws error message when no retention label was found by id', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/SP.CompliancePolicy.SPPolicyStoreProxy.GetAvailableTagsForSite(siteUrl=@a1)?@a1='${formatting.encodeQueryParameter('https://contoso.sharepoint.com/sites/sales')}'`) {
-        return ({ value: [] });
-      }
-
-      throw `Invalid request`;
-    });
-
-    await assert.rejects(spo.getWebRetentionLabelInformationById('https://contoso.sharepoint.com/sites/sales', 'f6e20c71-7d56-414d-bb98-8ee927a308bd'), `Retention label not found`);
-  });
 });

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -9,8 +9,8 @@ import request, { CliRequestOptions } from "../request";
 import { formatting } from './formatting';
 import { CustomAction } from '../m365/spo/commands/customaction/customaction';
 import { odata } from './odata';
-import { ListItemRetentionLabel } from '../m365/spo/commands/listitem/ListItemRetentionLabel';
 import { SiteRetentionLabel } from '../m365/spo/commands/listitem/SiteRetentionLabel';
+import { ListItemRetentionLabel } from '../m365/spo/commands/listitem/ListItemRetentionLabel';
 
 export interface ContextInfo {
   FormDigestTimeoutSeconds: number;

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -9,6 +9,8 @@ import request, { CliRequestOptions } from "../request";
 import { formatting } from './formatting';
 import { CustomAction } from '../m365/spo/commands/customaction/customaction';
 import { odata } from './odata';
+import { ListItemRetentionLabel } from '../m365/spo/commands/listitem/ListItemRetentionLabel';
+import { SiteRetentionLabel } from '../m365/spo/commands/listitem/SiteRetentionLabel';
 
 export interface ContextInfo {
   FormDigestTimeoutSeconds: number;
@@ -694,5 +696,49 @@ export const spo = {
     const res = await request.get<{ AadObjectId: { NameId: string, NameIdIssuer: string } }>(requestOptions);
 
     return res.AadObjectId.NameId;
+  },
+
+  async getWebRetentionLabelInformationByName(webUrl: string, name: string): Promise<ListItemRetentionLabel> {
+
+    const requestUrl: string = `${webUrl}/_api/SP.CompliancePolicy.SPPolicyStoreProxy.GetAvailableTagsForSite(siteUrl=@a1)?@a1='${formatting.encodeQueryParameter(webUrl)}'`;
+
+    const labels: SiteRetentionLabel[] = await odata.getAllItems(requestUrl);
+
+    const label = labels.find(l => l.TagName === name);
+
+    if (label === undefined) {
+      throw new Error(`The specified retention label does not exist`);
+    }
+
+    return {
+      complianceTag: label.TagName,
+      isTagPolicyHold: label.BlockDelete,
+      isTagPolicyRecord: label.BlockEdit,
+      isEventBasedTag: label.IsEventTag,
+      isTagSuperLock: label.SuperLock,
+      isUnlockedAsDefault: label.UnlockedAsDefault
+    } as ListItemRetentionLabel;
+  },
+
+  async getWebRetentionLabelInformationById(webUrl: string, id: string): Promise<ListItemRetentionLabel> {
+
+    const requestUrl: string = `${webUrl}/_api/SP.CompliancePolicy.SPPolicyStoreProxy.GetAvailableTagsForSite(siteUrl=@a1)?@a1='${formatting.encodeQueryParameter(webUrl)}'`;
+
+    const labels: SiteRetentionLabel[] = await odata.getAllItems(requestUrl);
+
+    const label = labels.find(l => l.TagId === id);
+
+    if (label === undefined) {
+      throw new Error(`The specified retention label does not exist`);
+    }
+
+    return {
+      complianceTag: label.TagName,
+      isTagPolicyHold: label.BlockDelete,
+      isTagPolicyRecord: label.BlockEdit,
+      isEventBasedTag: label.IsEventTag,
+      isTagSuperLock: label.SuperLock,
+      isUnlockedAsDefault: label.UnlockedAsDefault
+    } as ListItemRetentionLabel;
   }
 };

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -720,25 +720,18 @@ export const spo = {
     } as ListItemRetentionLabel;
   },
 
-  async getWebRetentionLabelInformationById(webUrl: string, id: string): Promise<ListItemRetentionLabel> {
+  async getTenantAppCatalogUrl(logger: Logger, debug: boolean): Promise<string | null> {
+    const spoUrl = await spo.getSpoUrl(logger, debug);
 
-    const requestUrl: string = `${webUrl}/_api/SP.CompliancePolicy.SPPolicyStoreProxy.GetAvailableTagsForSite(siteUrl=@a1)?@a1='${formatting.encodeQueryParameter(webUrl)}'`;
+    const requestOptions: any = {
+      url: `${spoUrl}/_api/SP_TenantSettings_Current`,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
 
-    const labels: SiteRetentionLabel[] = await odata.getAllItems(requestUrl);
-
-    const label = labels.find(l => l.TagId === id);
-
-    if (label === undefined) {
-      throw new Error(`The specified retention label does not exist`);
-    }
-
-    return {
-      complianceTag: label.TagName,
-      isTagPolicyHold: label.BlockDelete,
-      isTagPolicyRecord: label.BlockEdit,
-      isEventBasedTag: label.IsEventTag,
-      isTagSuperLock: label.SuperLock,
-      isUnlockedAsDefault: label.UnlockedAsDefault
-    } as ListItemRetentionLabel;
+    const result = await request.get<{ CorporateCatalogUrl: string }>(requestOptions);
+    return result.CorporateCatalogUrl;
   }
 };

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -718,20 +718,5 @@ export const spo = {
       isTagSuperLock: label.SuperLock,
       isUnlockedAsDefault: label.UnlockedAsDefault
     } as ListItemRetentionLabel;
-  },
-
-  async getTenantAppCatalogUrl(logger: Logger, debug: boolean): Promise<string | null> {
-    const spoUrl = await spo.getSpoUrl(logger, debug);
-
-    const requestOptions: any = {
-      url: `${spoUrl}/_api/SP_TenantSettings_Current`,
-      headers: {
-        accept: 'application/json;odata=nometadata'
-      },
-      responseType: 'json'
-    };
-
-    const result = await request.get<{ CorporateCatalogUrl: string }>(requestOptions);
-    return result.CorporateCatalogUrl;
   }
 };


### PR DESCRIPTION
This PR adds the `assetId` option to `retentionlabel ensure` commands.

Also reworked the 2 commands so they don't use `executeCommandWithOutput` anymore

Closes #4387