### PR TITLE
/ is rejected as a URL when provided through a prompt, Closes #4530

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -186,6 +186,8 @@ export default abstract class Command {
       args.options[command.options[i].name] = missingRequireOptionValue;
     }
 
+    this.processOptions(args.options);
+
     return true;
   }
 

--- a/src/m365/spo/commands/hubsite/hubsite-get.spec.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-get.spec.ts
@@ -328,7 +328,7 @@ describe(commands.HUBSITE_GET, () => {
   it(`fails validation if the specified url is invalid`, async () => {
     const actual = await command.validate({
       options: {
-        url: '/'
+        url: 'invalid URL'
       }
     }, commandInfo);
     assert.notStrictEqual(actual, true);


### PR DESCRIPTION
The reason the bug occurred is because the options were processed before the validation and thus the prompt occurred in this case. Adding the "processOptions" function at the end of the validation solved the problem.

Closes #4530