### PR TITLE
`spo move`: unhandled exception when trying to move file from non-existent location, Closes #4537

### DIFF
--- a/src/m365/spo/commands/file/file-move.ts
+++ b/src/m365/spo/commands/file/file-move.ts
@@ -96,7 +96,7 @@ class SpoFileMoveCommand extends SpoCommand {
       // A user might enter folder instead of file as source url by mistake
       // then there are edge cases when deleteIfAlreadyExists flag is set
       // the user can receive misleading error message.
-      this.fileExists(tenantUrl, webUrl, args.options.sourceUrl);
+      await this.fileExists(tenantUrl, webUrl, args.options.sourceUrl);
 
       if (args.options.deleteIfAlreadyExists) {
         // try delete target file, if deleteIfAlreadyExists flag is set


### PR DESCRIPTION
the function `fileExists` was called without the await operator which resulted in the bug. With the await operator, the output results in `Error: The file /Shared Documents/non-existent-file.zip does not exist.`

Closes #4537