### PR TITLE
Includes md output for "spo homesite" until "spo navigation" commands. Closes #4301

### DIFF
--- a/docs/docs/cmd/spo/homesite/homesite-get.md
+++ b/docs/docs/cmd/spo/homesite/homesite-get.md
@@ -14,7 +14,7 @@ m365 spo homesite get [options]
 
 ## Examples
 
-Get information about the Home Site
+Get information about the Home Site.
 
 ```sh
 m365 spo homesite get
@@ -49,6 +49,25 @@ m365 spo homesite get
     ```csv
     SiteId,WebId,LogoUrl,Title,Url
     af80c11f-0138-4d72-bb37-514542c3aabb,6f90666d-b0e7-40c3-991f-4ab051d00a70,https://contoso.sharepoint.com/sites/intra/siteassets/work.png,Intranet,https://contoso.sharepoint.com/sites/intra
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo homesite get
+
+    Date: 2/20/2023
+
+    ## Intranet (https://contoso.sharepoint.com/sites/intra)
+
+    Property | Value
+    ---------|-------
+    IsInDraftMode | false
+    SiteId | af80c11f-0138-4d72-bb37-514542c3aabb
+    WebId |6f90666d-b0e7-40c3-991f-4ab051d00a70
+    LogoUrl | https://contoso.sharepoint.com/sites/intra/siteassets/work.png
+    Title | Intranet
+    Url | https://contoso.sharepoint.com/sites/intra
     ```
 
 ## More information

--- a/docs/docs/cmd/spo/homesite/homesite-remove.md
+++ b/docs/docs/cmd/spo/homesite/homesite-remove.md
@@ -11,7 +11,7 @@ m365 spo homesite remove [options]
 ## Options
 
 `--confirm`
-: Do not prompt for confirmation before removing the Home Site
+: Do not prompt for confirmation before removing the Home Site.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -20,7 +20,7 @@ m365 spo homesite remove [options]
 
 ## Examples
 
-Removes the current Home Site without confirmation
+Removes the current Home Site without confirmation.
 
 ```sh
 m365 spo homesite remove --confirm
@@ -43,6 +43,12 @@ m365 spo homesite remove --confirm
 === "CSV"
 
     ```csv
+    https://contoso.sharepoint.com has been removed as a Home site. It may take some time for the change to apply. Check aka.ms/homesites for details.
+    ```
+
+=== "Markdown"
+
+    ```md
     https://contoso.sharepoint.com has been removed as a Home site. It may take some time for the change to apply. Check aka.ms/homesites for details.
     ```
 

--- a/docs/docs/cmd/spo/homesite/homesite-set.md
+++ b/docs/docs/cmd/spo/homesite/homesite-set.md
@@ -11,7 +11,7 @@ m365 spo homesite set [options]
 ## Options
 
 `-u, --siteUrl <siteUrl>`
-: The URL of the site to set as Home Site
+: The URL of the site to set as Home Site.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -20,7 +20,7 @@ m365 spo homesite set [options]
 
 ## Examples
 
-Set the specified site as the Home Site
+Set the specified site as the Home Site.
 
 ```sh
 m365 spo homesite set --siteUrl https://contoso.sharepoint.com/sites/comms
@@ -43,6 +43,12 @@ m365 spo homesite set --siteUrl https://contoso.sharepoint.com/sites/comms
 === "CSV"
 
     ```csv
+    The Home site has been set to https://contoso.sharepoint.com. It may take some time for the change to apply. Check aka.ms/homesites for details.
+    ```
+
+=== "Markdown"
+
+    ```md
     The Home site has been set to https://contoso.sharepoint.com. It may take some time for the change to apply. Check aka.ms/homesites for details.
     ```
 

--- a/docs/docs/cmd/spo/hubsite/hubsite-connect.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-connect.md
@@ -11,22 +11,22 @@ m365 spo hubsite connect [options]
 ## Options
 
 `-i, --id [id]`
-: ID of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: ID of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `-t, --title [title]`
-: Title of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: Title of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `-u, --url [url]`
-: Absolute or server-relative URL of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: Absolute or server-relative URL of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `--parentId [parentId]`
-: ID of the parent hub site. Specify either `parentId`, `parentTitle` or `parentUrl` but not multiple.
+: ID of the parent hub site. Specify either `parentId`, `parentTitle`, or `parentUrl` but not multiple.
 
 `--parentTitle [parentTitle]`
-: Title of the parent hub site. Specify either `parentId`, `parentTitle` or `parentUrl` but not multiple.
+: Title of the parent hub site. Specify either `parentId`, `parentTitle`, or `parentUrl` but not multiple.
 
 `--parentUrl [parentUrl]`
-: Absolute or server-relative URL of the parent hub site. Specify either `parentId`, `parentTitle` or `parentUrl` but not multiple.
+: Absolute or server-relative URL of the parent hub site. Specify either `parentId`, `parentTitle`, or `parentUrl` but not multiple.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -39,19 +39,19 @@ To connect a regular site to a hub site, use command [spo site hubsite connect](
 
 ## Examples
 
-Connect a specific hub site to specific parent hub site by ID
+Connect a specific hub site to specific parent hub site by ID.
 
 ```sh
 m365 spo hubsite connect --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --parentId 637ed2ea-b65b-4a4b-a3d7-ad86953224a4
 ```
 
-Connect a specific hub site to specific parent hub site by URL
+Connect a specific hub site to specific parent hub site by URL.
 
 ```sh
 m365 spo hubsite connect --url https://contoso.sharepoint.com/sites/project-x --parentUrl https://contoso.sharepoint.com/sites/projects
 ```
 
-Connect a specific hub site with title to a parent hub site with ID
+Connect a specific hub site with title to a parent hub site with ID.
 
 ```sh
 m365 spo hubsite connect --title "My hub site" --parentId 637ed2ea-b65b-4a4b-a3d7-ad86953224a4

--- a/docs/docs/cmd/spo/hubsite/hubsite-data-get.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-data-get.md
@@ -11,23 +11,22 @@ m365 spo hubsite data get [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: URL of the site for which to retrieve hub site data
+: URL of the site for which to retrieve hub site data.
 
 `-f, --forceRefresh`
-: Set, to refresh the server cache with the latest updates
+: Set, to refresh the server cache with the latest updates.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
-By default, the hub site data is returned from the server's cache. To refresh the data with the latest updates, use the `-f, --forceRefresh` option. Use this option, if you just made changes and need to see them right
-away.
+By default, the hub site data is returned from the server's cache. To refresh the data with the latest updates, use the `-f, --forceRefresh` option. Use this option, if you just made changes and need to see them right away.
 
 If the specified site is not connected to a hub site site and is not a hub site itself, no data will be retrieved.
 
 ## Examples
 
-Get information about the hub site data for a site with URL https://contoso.sharepoint.com/sites/project-x
+Get information about the hub site data for a specific site with URL.
 
 ```sh
 m365 spo hubsite data get --webUrl https://contoso.sharepoint.com/sites/project-x
@@ -88,6 +87,36 @@ m365 spo hubsite data get --webUrl https://contoso.sharepoint.com/sites/project-
     ```csv
     headerEmphasis,themeKey,name,url,logoUrl,logoFileHash,usesMetadataNavigation,megaMenuEnabled,navigation,isNavAudienceTargeted,siteDesignId,requiresJoinApproval,hideNameInNavigation,parentHubSiteId,relatedHubSiteIds,tenantInstanceId,isSameTenantInstance
     None,7EDE94FF,Intranet,https://contoso.sharepoint.com/sites/intra,https://contoso.sharepoint.com/sites/intra/SiteAssets/work.png,637696294610000000,false,1,[],false,184644fb-90ed-4841-a7ad-6930cf819060,,,1e1232eb-1a78-4726-8bb9-56af3640228d,"[""af80c11f-0138-4d72-bb37-514542c3aabb""]",4d128b52-7228-46b5-8765-5b338476054d,1
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo hubsite data get --webUrl "https://contoso.sharepoint.com/sites/intra"
+
+    Date: 2/20/2023
+
+    ## Intranet (https://contoso.sharepoint.com/sites/intra)
+
+    Property | Value
+    ---------|-------
+    headerEmphasis | None
+    themeKey | 7EDE94FF
+    name | Intranet
+    url | https://contoso.sharepoint.com/sites/intra
+    logoUrl | https://contoso.sharepoint.com/sites/intra/SiteAssets/work.png
+    logoFileHash | 637696294610000000
+    usesMetadataNavigation | false
+    megaMenuEnabled | true
+    navigation | []
+    isNavAudienceTargeted | false
+    siteDesignId | 184644fb-90ed-4841-a7ad-6930cf819060
+    requiresJoinApproval | false
+    hideNameInNavigation | false
+    parentHubSiteId | 1e1232eb-1a78-4726-8bb9-56af3640228d
+    relatedHubSiteIds | ["af80c11f-0138-4d72-bb37-514542c3aabb"]
+    tenantInstanceId | 4d128b52-7228-46b5-8765-5b338476054d
+    isSameTenantInstance | true
     ```
 
 ## More information

--- a/docs/docs/cmd/spo/hubsite/hubsite-disconnect.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-disconnect.md
@@ -11,13 +11,13 @@ m365 spo hubsite disconnect [options]
 ## Options
 
 `-i, --id [id]`
-: ID of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: ID of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `-t, --title [title]`
-: Title of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: Title of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `-u, --url [url]`
-: Absolute or server-relative URL of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: Absolute or server-relative URL of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `--confirm`
 : Don't prompt for confirmation.
@@ -35,19 +35,19 @@ If the specified id doesn't point to a valid hub site, you will get a ResourceNo
 
 ## Examples
 
-Disconnect a specific hub site with id from its parent hub site
+Disconnect a specific hub site with id from its parent hub site.
 
 ```sh
 m365 spo hubsite disconnect --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a
 ```
 
-Disconnect a specific hub site with url from its parent hub site
+Disconnect a specific hub site with url from its parent hub site.
 
 ```sh
 m365 spo hubsite disconnect --url https://contoso.sharepoint.com/sites/project-x
 ```
 
-Disconnect a specific hub site with title from its parent hub site
+Disconnect a specific hub site with title from its parent hub site.
 
 ```sh
 m365 spo hubsite disconnect --title "My hub site"

--- a/docs/docs/cmd/spo/hubsite/hubsite-get.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-get.md
@@ -11,13 +11,13 @@ m365 spo hubsite get [options]
 ## Options
 
 `-i, --id [id]`
-: ID of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: ID of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `-t, --title [title]`
-: Title of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: Title of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `-u, --url [url]`
-: URL of the hub site. Specify either `id`, `title` or `url` but not multiple.
+: URL of the hub site. Specify either `id`, `title`, or `url` but not multiple.
 
 `--includeAssociatedSites`
 : Include the associated sites in the result (only in JSON output)
@@ -26,40 +26,28 @@ m365 spo hubsite get [options]
 
 ## Examples
 
-Get information about the hub site with ID _2c1ba4c4-cd9b-4417-832f-92a34bc34b2a_
+Get information about the hub site with specific ID.
 
 ```sh
 m365 spo hubsite get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a
 ```
 
-Get information about the hub site with Title _My Hub Site_
+Get information about the hub site with specific title.
 
 ```sh
 m365 spo hubsite get --title 'My Hub Site'
 ```
 
-Get information about the hub site with URL _https://contoso.sharepoint.com/sites/HubSite_
+Get information about the hub site with specific URL.
 
 ```sh
 m365 spo hubsite get --url 'https://contoso.sharepoint.com/sites/HubSite'
 ```
 
-Get information about the hub site with ID _2c1ba4c4-cd9b-4417-832f-92a34bc34b2a_, including its associated sites. Associated site info is only shown in JSON output.
+Get information about the hub site with specific ID, including its associated sites. Associated site info is only shown in JSON output.
 
 ```sh
 m365 spo hubsite get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --includeAssociatedSites --output json
-```
-
-Get information about the hub site with Title _My Hub Site_
-
-```sh
-m365 spo hubsite get --title "My Hub Site"
-```
-
-Get information about the hub site with URL _https://contoso.sharepoint.com/sites/HubSite_
-
-```sh
-m365 spo hubsite get --url "https://contoso.sharepoint.com/sites/HubSite"
 ```
 
 ## Response
@@ -115,6 +103,35 @@ m365 spo hubsite get --url "https://contoso.sharepoint.com/sites/HubSite"
     ```csv
     Description,EnablePermissionsSync,EnforcedECTs,EnforcedECTsVersion,HideNameInNavigation,ID,LogoUrl,ParentHubSiteId,PermissionsSyncTag,RequiresJoinApproval,SiteDesignId,SiteId,SiteUrl,Targets,TenantInstanceId,Title
     Intranet Hub Site,false,,0,false,af80c11f-0138-4d72-bb37-514542c3aabb,https://contoso.sharepoint.com/sites/intra/SiteAssets/work.png,ec78f3aa-5a74-4f16-be49-3396df045f34,0,false,184644fb-90ed-4841-a7ad-6930cf819060,af80c11f-0138-4d72-bb37-514542c3aabb,https://contoso.sharepoint.com/sites/intra,,5d128b52-7228-46b5-8765-5b338476054d,Intranet
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo hubsite get --url "https://contoso.sharepoint.com/sites/intra"
+
+    Date: 2/20/2023
+
+    ## Intranet (af80c11f-0138-4d72-bb37-514542c3aabb)
+
+    Property | Value
+    ---------|-------
+    Description | null
+    EnablePermissionsSync | false
+    EnforcedECTs | null
+    EnforcedECTsVersion | 0
+    HideNameInNavigation | false
+    ID | af80c11f-0138-4d72-bb37-514542c3aabb
+    LogoUrl | https://contoso.sharepoint.com/sites/intra/SiteAssets/work.png
+    ParentHubSiteId | ec78f3aa-5a74-4f16-be49-3396df045f34
+    PermissionsSyncTag | 0
+    RequiresJoinApproval | false
+    SiteDesignId | 184644fb-90ed-4841-a7ad-6930cf819060
+    SiteId | af80c11f-0138-4d72-bb37-514542c3aabb
+    SiteUrl | https://contoso.sharepoint.com/sites/intra
+    Targets | null
+    TenantInstanceId | 5d128b52-7228-46b5-8765-5b338476054d
+    Title | Intranet
     ```
 
 ### `includeAssociatedSites` response

--- a/docs/docs/cmd/spo/hubsite/hubsite-list.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-list.md
@@ -11,7 +11,7 @@ m365 spo hubsite list [options]
 ## Options
 
 `-i, --includeAssociatedSites`
-: Include the associated sites in the result (only in JSON output)
+: Include the associated sites in the result (only in JSON output).
 
 --8<-- "docs/cmd/_global.md"
 
@@ -77,6 +77,35 @@ m365 spo hubsite list --includeAssociatedSites --output json
     af80c11f-0138-4d72-bb37-514542c3aabb,https://contoso.sharepoint.com/sites/intra,Intranet
     ```
 
+=== "Markdown"
+
+    ```md
+    # spo hubsite list
+
+    Date: 2/20/2023
+
+    ## Intranet (af80c11f-0138-4d72-bb37-514542c3aabb)
+
+    Property | Value
+    ---------|-------
+    Description | Intranet Hub Site
+    EnablePermissionsSync | false
+    EnforcedECTs | null
+    EnforcedECTsVersion | 0
+    HideNameInNavigation | false
+    ID | af80c11f-0138-4d72-bb37-514542c3aabb
+    LogoUrl | https://contoso.sharepoint.com/sites/intra/SiteAssets/work.png
+    ParentHubSiteId | ec78f3aa-5a74-4f16-be49-3396df045f34
+    PermissionsSyncTag | 0
+    RequiresJoinApproval | false
+    SiteDesignId | 184644fb-90ed-4841-a7ad-6930cf819060
+    SiteId | af80c11f-0138-4d72-bb37-514542c3aabb
+    SiteUrl | https://contoso.sharepoint.com/sites/intra
+    Targets | null
+    TenantInstanceId | 5d128b52-7228-46b5-8765-5b338476054d
+    Title | Intranet
+    ```
+
 ### `includeAssociatedSites` response
 
 When we make use of the option `includeAssociatedSites` the response will differ. 
@@ -125,6 +154,35 @@ When we make use of the option `includeAssociatedSites` the response will differ
     ```csv
     ID,SiteUrl,Title
     af80c11f-0138-4d72-bb37-514542c3aabb,https://contoso.sharepoint.com/sites/intra,Intranet
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo hubsite list --includeAssociatedSites "true"
+
+    Date: 2/20/2023
+
+    ## Intranet (af80c11f-0138-4d72-bb37-514542c3aabb)
+
+    Property | Value
+    ---------|-------
+    Description | Intranet Hub Site
+    EnablePermissionsSync | false
+    EnforcedECTs | null
+    EnforcedECTsVersion | 0
+    HideNameInNavigation | false
+    ID | af80c11f-0138-4d72-bb37-514542c3aabb
+    LogoUrl | https://contoso.sharepoint.com/sites/intra/SiteAssets/work.png
+    ParentHubSiteId | ec78f3aa-5a74-4f16-be49-3396df045f34
+    PermissionsSyncTag | 0
+    RequiresJoinApproval | false
+    SiteDesignId | 184644fb-90ed-4841-a7ad-6930cf819060
+    SiteId | af80c11f-0138-4d72-bb37-514542c3aabb
+    SiteUrl | https://contoso.sharepoint.com/sites/intra
+    Targets | null
+    TenantInstanceId | 5d128b52-7228-46b5-8765-5b338476054d
+    Title | Intranet
     ```
 
 ## More information

--- a/docs/docs/cmd/spo/hubsite/hubsite-register.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-register.md
@@ -11,7 +11,7 @@ m365 spo hubsite register [options]
 ## Options
 
 `-u, --siteUrl <siteUrl>`
-: URL of the site collection to register as a hub site
+: URL of the site collection to register as a hub site.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -81,6 +81,35 @@ m365 spo hubsite register --siteUrl https://contoso.sharepoint.com/sites/sales
     ```csv
     Description,EnablePermissionsSync,EnforcedECTs,EnforcedECTsVersion,HideNameInNavigation,ID,LogoUrl,ParentHubSiteId,PermissionsSyncTag,RequiresJoinApproval,SiteDesignId,SiteId,SiteUrl,Targets,TenantInstanceId,Title
     ,,,0,,0f9b8f4f-0e8e-4630-bb0a-501442db9b64,,00000000-0000-0000-0000-000000000000,0,,00000000-0000-0000-0000-000000000000,0f9b8f4f-0e8e-4630-bb0a-501442db9b64,https://contoso.sharepoint.com/sites/newHubSite,,4d128b52-7228-46b5-8765-5b338476054d,New Hub Site
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo hubsite register --siteUrl "https://contoso.sharepoint.com/sites/newHubSite"
+
+    Date: 2/20/2023
+
+    ## New Hub Site (0f9b8f4f-0e8e-4630-bb0a-501442db9b64)
+
+    Property | Value
+    ---------|-------
+    Description | null
+    EnablePermissionsSync | false
+    EnforcedECTs | null
+    EnforcedECTsVersion | 0
+    HideNameInNavigation | false
+    ID | 0f9b8f4f-0e8e-4630-bb0a-501442db9b64
+    LogoUrl | null
+    ParentHubSiteId | 00000000-0000-0000-0000-000000000000
+    PermissionsSyncTag | 0
+    RequiresJoinApproval | false
+    SiteDesignId | 00000000-0000-0000-0000-000000000000
+    SiteId | 0f9b8f4f-0e8e-4630-bb0a-501442db9b64
+    SiteUrl | https://contoso.sharepoint.com/sites/newHubSite
+    Targets | null
+    TenantInstanceId | 4d128b52-7228-46b5-8765-5b338476054d
+    Title | New Hub Site
     ```
 
 ## More information

--- a/docs/docs/cmd/spo/hubsite/hubsite-rights-grant.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-rights-grant.md
@@ -11,13 +11,13 @@ m365 spo hubsite rights grant [options]
 ## Options
 
 `-u, --hubSiteUrl <hubSiteUrl>`
-: The URL of the hub site to grant rights on
+: The URL of the hub site to grant rights on.
 
 `-p, --principals <principals>`
-: Comma-separated list of principals to grant join rights. Principals can be users or mail-enabled security groups in the form of `alias` or `alias@<domain name>.com`
+: Comma-separated list of principals to grant join rights. Principals can be users or mail-enabled security groups in the form of `alias` or `alias@<domain name>.com`.
 
 `-r, --rights <rights>`
-: Rights to grant to principals. Available values `Join`
+: Rights to grant to principals. Available values `Join`.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -28,19 +28,19 @@ m365 spo hubsite rights grant [options]
 
 ## Examples
 
-Grant user with alias _PattiF_ permission to join sites to the hub site with URL _https://contoso.sharepoint.com/sites/sales_
+Grant user with specific alias, permission to join sites to the hub site with specific URL.
 
 ```sh
 m365 spo hubsite rights grant --hubSiteUrl https://contoso.sharepoint.com/sites/sales --principals PattiF --rights Join
 ```
 
-Grant users with aliases _PattiF_ and _AdeleV_ permission to join sites to the hub site with URL _https://contoso.sharepoint.com/sites/sales_
+Grant users with specific aliases, permission to join sites to the hub site with specific URL.
 
 ```sh
 m365 spo hubsite rights grant --hubSiteUrl https://contoso.sharepoint.com/sites/sales --principals "PattiF,AdeleV" --rights Join
 ```
 
-Grant user with email _PattiF@contoso.com_ permission to join sites to the hub site with URL _https://contoso.sharepoint.com/sites/sales_
+Grant user with specific email, permission to join sites to the hub site with specific URL.
 
 ```sh
 m365 spo hubsite rights grant --hubSiteUrl https://contoso.sharepoint.com/sites/sales --principals PattiF@contoso.com --rights Join

--- a/docs/docs/cmd/spo/hubsite/hubsite-rights-revoke.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-rights-revoke.md
@@ -11,10 +11,10 @@ m365 spo hubsite rights revoke [options]
 ## Options
 
 `-u, --hubSiteUrl <hubSiteUrl>`
-: The URL of the hub site to revoke rights on
+: The URL of the hub site to revoke rights on.
 
 `-p, --principals <principals>`
-: Comma-separated list of principals to revoke join rights. Principals can be users or mail-enabled security groups in the form of `alias` or `alias@<domain name>.com`
+: Comma-separated list of principals to revoke join rights. Principals can be users or mail-enabled security groups in the form of `alias` or `alias@<domain name>.com`.
 
 `--confirm`
 : Don't prompt for confirming revoking rights
@@ -28,13 +28,13 @@ m365 spo hubsite rights revoke [options]
 
 ## Examples
 
-Revoke rights to join sites to the hub site with URL _https://contoso.sharepoint.com/sites/sales_ from user with alias _PattiF_. Will prompt for confirmation before revoking the rights
+Revoke rights to join sites to the hub site with specific URL. from user with specific alias. Will prompt for confirmation before revoking the rights.
 
 ```sh
 m365 spo hubsite rights revoke --hubSiteUrl https://contoso.sharepoint.com/sites/sales --principals PattiF
 ```
 
-Revoke rights to join sites to the hub site with URL _https://contoso.sharepoint.com/sites/sales_ from user with aliases _PattiF_ and _AdeleV_ without prompting for confirmation
+Revoke rights to join sites to the hub site with specific URL. from user with specific aliases without prompting for confirmation.
 
 ```sh
 m365 spo hubsite rights revoke --hubSiteUrl https://contoso.sharepoint.com/sites/sales --principals "PattiF,AdeleV" --confirm

--- a/docs/docs/cmd/spo/hubsite/hubsite-set.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-set.md
@@ -11,16 +11,16 @@ m365 spo hubsite set [options]
 ## Options
 
 `-i, --id <id>`
-: ID of the hub site to update
+: ID of the hub site.
 
 `-t, --title [title]`
-: The new title for the hub site
+: The new title for the hub site.
 
 `-d, --description [description]`
-: The new description for the hub site
+: The new description for the hub site.
 
 `-l, --logoUrl [logoUrl]`
-: The URL of the new logo for the hub site
+: The URL of the new logo for the hub site.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -33,13 +33,13 @@ If the specified `id` doesn't refer to an existing hub site, you will get an `Un
 
 ## Examples
 
-Update hub site's title
+Update hub site's title.
 
 ```sh
 m365 spo hubsite set --id 255a50b2-527f-4413-8485-57f4c17a24d1 --title Sales
 ```
 
-Update hub site's title and description
+Update hub site's title and description.
 
 ```sh
 m365 spo hubsite set --id 255a50b2-527f-4413-8485-57f4c17a24d1 --title Sales --description "All things sales"
@@ -51,43 +51,68 @@ m365 spo hubsite set --id 255a50b2-527f-4413-8485-57f4c17a24d1 --title Sales --d
 
     ```json
     {
-      "Description": "Hello",
+      "Description": "All things sales",
       "EnablePermissionsSync": false,
       "HideNameInNavigation": false,
-      "ID": "af80c11f-0138-4d72-bb37-514542c3aabb",
+      "ID": "255a50b2-527f-4413-8485-57f4c17a24d1",
       "LogoUrl": "https://contoso.sharepoint.com/sites/intra/SiteAssets/teapoint.png",
       "ParentHubSiteId": "/Guid(00000000-0000-0000-0000-000000000000)/",
       "Permissions": null,
       "RequiresJoinApproval": false,
       "SiteDesignId": "/Guid(184644fb-90ed-4841-a7ad-6930cf819060)/",
-      "SiteId": "af80c11f-0138-4d72-bb37-514542c3aabb",
+      "SiteId": "255a50b2-527f-4413-8485-57f4c17a24d1",
       "SiteUrl": "https://contoso.sharepoint.com/sites/intra",
-      "Title": "Intranet"
+      "Title": "Sales"
     }
     ```
 
 === "Text"
 
     ```text
-    Description          : Hello
+    Description          : All things sales
     EnablePermissionsSync: false
     HideNameInNavigation : false
-    ID                   : af80c11f-0138-4d72-bb37-514542c3aabb
+    ID                   : 255a50b2-527f-4413-8485-57f4c17a24d1
     LogoUrl              : https://contoso.sharepoint.com/sites/intra/SiteAssets/teapoint.png
     ParentHubSiteId      : /Guid(00000000-0000-0000-0000-000000000000)/
     Permissions          : null
     RequiresJoinApproval : false
     SiteDesignId         : /Guid(184644fb-90ed-4841-a7ad-6930cf819060)/
-    SiteId               : af80c11f-0138-4d72-bb37-514542c3aabb
+    SiteId               : 255a50b2-527f-4413-8485-57f4c17a24d1
     SiteUrl              : https://contoso.sharepoint.com/sites/intra
-    Title                : Intranet
+    Title                : Sales
     ```
 
 === "CSV"
 
     ```csv
     Description,EnablePermissionsSync,HideNameInNavigation,ID,LogoUrl,ParentHubSiteId,Permissions,RequiresJoinApproval,SiteDesignId,SiteId,SiteUrl,Title
-    Hello,,,af80c11f-0138-4d72-bb37-514542c3aabb,https://contoso.sharepoint.com/sites/intra/SiteAssets/teapoint.png,/Guid(00000000-0000-0000-0000-000000000000)/,,,/Guid(184644fb-90ed-4841-a7ad-6930cf819060)/,af80c11f-0138-4d72-bb37-514542c3aabb,https://contoso.sharepoint.com/sites/intra,Intranet
+    All things sales,,,255a50b2-527f-4413-8485-57f4c17a24d1,https://contoso.sharepoint.com/sites/intra/SiteAssets/teapoint.png,/Guid(00000000-0000-0000-0000-000000000000)/,,,/Guid(184644fb-90ed-4841-a7ad-6930cf819060)/,255a50b2-527f-4413-8485-57f4c17a24d1,https://contoso.sharepoint.com/sites/intra,Sales
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo hubsite set --id "255a50b2-527f-4413-8485-57f4c17a24d1" --title "Sales" --description "All things sales"
+
+    Date: 2/20/2023
+
+    ## Sales (255a50b2-527f-4413-8485-57f4c17a24d1)
+
+    Property | Value
+    ---------|-------
+    Description | null
+    EnablePermissionsSync | false
+    HideNameInNavigation | false
+    ID | 255a50b2-527f-4413-8485-57f4c17a24d1
+    LogoUrl | https://contoso.sharepoint.com/sites/intra/SiteAssets/teapoint.png
+    ParentHubSiteId | /Guid(00000000-0000-0000-0000-000000000000)/
+    Permissions | null
+    RequiresJoinApproval | false
+    SiteDesignId | /Guid(00000000-0000-0000-0000-000000000000)/
+    SiteId | 255a50b2-527f-4413-8485-57f4c17a24d1
+    SiteUrl | https://contoso.sharepoint.com/sites/intra
+    Title | Sales
     ```
 
 ## More information

--- a/docs/docs/cmd/spo/hubsite/hubsite-unregister.md
+++ b/docs/docs/cmd/spo/hubsite/hubsite-unregister.md
@@ -11,10 +11,10 @@ m365 spo hubsite unregister [options]
 ## Options
 
 `-u, --url <url>`
-: URL of the site collection to unregister as a hub site
+: URL of the site collection.
 
 `--confirm`
-: Don't prompt for confirming unregistering the hub site
+: Don't prompt for confirmation.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -27,13 +27,13 @@ If the specified site collection is not registered as a hub site, you will get a
 
 ## Examples
 
-Unregister the site collection with URL _https://contoso.sharepoint.com/sites/sales_ as a hub site. Will prompt for confirmation before unregistering the hub site.
+Unregister the site collection with specific URL. as a hub site. Will prompt for confirmation before unregistering the hub site.
 
 ```sh
 m365 spo hubsite unregister --url https://contoso.sharepoint.com/sites/sales
 ```
 
-Unregister the site collection with URL _https://contoso.sharepoint.com/sites/sales_ as a hub site without prompting for confirmation.
+Unregister the site collection with specific URL. as a hub site without prompting for confirmation.
 
 ```sh
 m365 spo hubsite unregister --url https://contoso.sharepoint.com/sites/sales --confirm

--- a/docs/docs/cmd/spo/knowledgehub/knowledgehub-get.md
+++ b/docs/docs/cmd/spo/knowledgehub/knowledgehub-get.md
@@ -17,7 +17,7 @@ m365 spo knowledgehub get [options]
 
 ## Examples
 
-Gets the Knowledge Hub Site URL for your tenant
+Gets the Knowledge Hub Site URL for your tenant.
 
 ```sh
 m365 spo knowledgehub get
@@ -40,5 +40,11 @@ m365 spo knowledgehub get
 === "CSV"
 
     ```csv
+    https://contoso.sharepoint.com
+    ```
+
+=== "Markdown"
+
+    ```md
     https://contoso.sharepoint.com
     ```

--- a/docs/docs/cmd/spo/knowledgehub/knowledgehub-remove.md
+++ b/docs/docs/cmd/spo/knowledgehub/knowledgehub-remove.md
@@ -11,7 +11,7 @@ m365 spo knowledgehub remove [options]
 ## Options
 
 `--confirm`
-: Do not prompt for confirmation before removing the Knowledge Hub Site setting for your tenant
+: Do not prompt for confirmation before removing the Knowledge Hub Site setting for your tenant.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -20,13 +20,13 @@ m365 spo knowledgehub remove [options]
 
 ## Examples
 
-Removes the Knowledge Hub Site setting for your tenant
+Removes the Knowledge Hub Site setting for your tenant.
 
 ```sh
 m365 spo knowledgehub remove
 ```
 
-Removes the Knowledge Hub Site setting for your tenant without confirmation
+Removes the Knowledge Hub Site setting for your tenant without confirmation.
 
 ```sh
 m365 spo knowledgehub remove --confirm
@@ -49,5 +49,11 @@ m365 spo knowledgehub remove --confirm
 === "CSV"
 
     ```csv
+    The knowledge hub site setting was removed.
+    ```
+
+=== "Markdown"
+
+    ```md
     The knowledge hub site setting was removed.
     ```

--- a/docs/docs/cmd/spo/knowledgehub/knowledgehub-set.md
+++ b/docs/docs/cmd/spo/knowledgehub/knowledgehub-set.md
@@ -11,7 +11,7 @@ m365 spo knowledgehub set [options]
 ## Options
 
 `-u, --siteUrl <siteUrl>`
-: URL of the site to set as Knowledge Hub
+: URL of the site to set as Knowledge Hub.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -24,7 +24,7 @@ If the specified url doesn't refer to an existing site collection, you will get 
 
 ## Examples
 
-Sets the Knowledge Hub Site for your tenant
+Sets the Knowledge Hub Site for your tenant.
 
 ```sh
 m365 spo knowledgehub set --siteUrl https://contoso.sharepoint.com/sites/knowledgesite
@@ -47,5 +47,11 @@ m365 spo knowledgehub set --siteUrl https://contoso.sharepoint.com/sites/knowled
 === "CSV"
 
     ```csv
+    The knowledge hub site with url "https://contoso.sharepoint.com" is added to list.
+    ```
+
+=== "Markdown"
+
+    ```md
     The knowledge hub site with url "https://contoso.sharepoint.com" is added to list.
     ```

--- a/docs/docs/cmd/spo/list/list-add.md
+++ b/docs/docs/cmd/spo/list/list-add.md
@@ -11,130 +11,130 @@ m365 spo list add [options]
 ## Options
 
 `-t, --title <title>`
-: Title of the list to add
+: Title of the list to add.
 
 `--baseTemplate <baseTemplate>`
-: The list definition type on which the list is based. Allowed values `Announcements,Contacts,CustomGrid,DataSources,DiscussionBoard,DocumentLibrary,Events,GanttTasks,GenericList,IssuesTracking,Links,NoCodeWorkflows,PictureLibrary,Survey,Tasks,WebPageLibrary,WorkflowHistory,WorkflowProcess,XmlForm`. Default `GenericList`
+: The list definition type on which the list is based. Allowed values `Announcements`, `Contacts`, `CustomGrid`, `DataSources`,`DiscussionBoard`, `DocumentLibrary`, `Events`, `GanttTasks`, `GenericList`, `IssuesTracking`, `Links`, `NoCodeWorkflows`,`PictureLibrary`, `Survey`, `Tasks`, `WebPageLibrary`, `WorkflowHistory`, `WorkflowProcess`, `XmlForm`. Default `GenericList`.
 
 `-u, --webUrl <webUrl>`
-: URL of the site where the list should be added
+: URL of the site where the list should be added.
 
 `--description [description]`
-: The description for the list
+: The description for the list.
 
 `--templateFeatureId [templateFeatureId]`
-: The globally unique identifier (GUID) of a template feature that is associated with the list
+: The globally unique identifier (GUID) of a template feature that is associated with the list.
 
 `--allowDeletion [allowDeletion]`
-: Boolean value specifying whether the list can be deleted. Valid values are `true,false`
+: Boolean value specifying whether the list can be deleted. Valid values are `true`, `false`.
 
 `--allowEveryoneViewItems [allowEveryoneViewItems]`
-: Boolean value specifying whether everyone can view documents in the documentlibrary or attachments to items in the list. Valid values are `true,false`
+: Boolean value specifying whether everyone can view documents in the documentlibrary or attachments to items in the list. Valid values are `true`, `false`.
 
 `--allowMultiResponses [allowMultiResponses]`
-: Boolean value specifying whether users are allowed to give multiple responses to the survey. Valid values are `true,false`
+: Boolean value specifying whether users are allowed to give multiple responses to the survey. Valid values are `true`, `false`.
 
 `--contentTypesEnabled [contentTypesEnabled]`
-: Boolean value specifying whether content types are enabled for the list. Valid values are `true,false`
+: Boolean value specifying whether content types are enabled for the list. Valid values are `true`, `false`.
 
 `--crawlNonDefaultViews [crawlNonDefaultViews]`
-: Boolean value specifying whether to crawl non default views. Valid values are `true,false`
+: Boolean value specifying whether to crawl non default views. Valid values are `true`, `false`.
 
 `--defaultContentApprovalWorkflowId [defaultContentApprovalWorkflowId]`
-: Value that specifies the default workflow identifier for content approval onthe list (GUID)
+: Value that specifies the default workflow identifier for content approval onthe list (GUID).
 
 `--defaultDisplayFormUrl [defaultDisplayFormUrl]`
-: Value that specifies the location of the default display form for the list
+: Value that specifies the location of the default display form for the list.
 
 `--defaultEditFormUrl [defaultEditFormUrl]`
 : Value that specifies the URL of the edit form to use for list items in the list
-
+.
 `--direction [direction]`
-: Value that specifies the reading order of the list. Valid values are `NONE,LTR,RTL`
+: Value that specifies the reading order of the list. Valid values are `NONE`, `LTR`, `RTL`.
 
 `--disableGridEditing [disableGridEditing]`
-: Property for assigning or retrieving grid editing on the list. Valid values are `true,false`
+: Property for assigning or retrieving grid editing on the list. Valid values are `true`, `false`.
 
 `--draftVersionVisibility [draftVersionVisibility]`
-: Value that specifies the minimum permission required to view minor versions and drafts within the list. Allowed values `Reader,Author,Approver`. Default Reader
+: Value that specifies the minimum permission required to view minor versions and drafts within the list. Allowed values `Reader`, `Author`, `Approver`. Default `Reader`.
 
 `--emailAlias [emailAlias]`
 : If e-mail notification is enabled, gets or sets the e-mail address to use tonotify to the owner of an item when an assignment has changed or the item has been updated.
 
 `--enableAssignToEmail [enableAssignToEmail]`
-: Boolean value specifying whether e-mail notification is enabled for the list. Valid values are `true,false`
+: Boolean value specifying whether e-mail notification is enabled for the list. Valid values are `true`, `false`.
 
 `--enableAttachments [enableAttachments]`
-: Boolean value that specifies whether attachments can be added to items in the list. Valid values are `true,false`
+: Boolean value that specifies whether attachments can be added to items in the list. Valid values are `true`, `false`.
 
 `--enableDeployWithDependentList [enableDeployWithDependentList]`
-: Boolean value that specifies whether the list can be deployed with a dependent list. Valid values are `true,false`
+: Boolean value that specifies whether the list can be deployed with a dependent list. Valid values are `true`, `false`.
 
 `--enableFolderCreation [enableFolderCreation]`
-: Boolean value that specifies whether folders can be created for the list. Valid values are `true,false`
+: Boolean value that specifies whether folders can be created for the list. Valid values are `true`, `false`.
 
 `--enableMinorVersions [enableMinorVersions]`
-: Boolean value that specifies whether minor versions are enabled when versioning is enabled for the document library. Valid values are `true,false`
+: Boolean value that specifies whether minor versions are enabled when versioning is enabled for the document library. Valid values are `true`, `false`.
 
 `--enableModeration [enableModeration]`
-: Boolean value that specifies whether Content Approval is enabled for the list. Valid values are `true,false`
+: Boolean value that specifies whether Content Approval is enabled for the list. Valid values are `true`, `false`.
 
 `--enablePeopleSelector [enablePeopleSelector]`
-: Enable user selector on event list. Valid values are `true,false`
+: Enable user selector on event list. Valid values are `true`, `false`.
 
 `--enableResourceSelector [enableResourceSelector]`
-: Enables resource selector on an event list. Valid values are `true,false`
+: Enables resource selector on an event list. Valid values are `true`, `false`.
 
 `--enableSchemaCaching [enableSchemaCaching]`
-: Boolean value specifying whether schema caching is enabled for the list. Valid values are `true,false`
+: Boolean value specifying whether schema caching is enabled for the list. Valid values are `true`, `false`.
 
 `--enableSyndication [enableSyndication]`
-: Boolean value that specifies whether RSS syndication is enabled for the list. Valid values are `true,false`
+: Boolean value that specifies whether RSS syndication is enabled for the list. Valid values are `true`, `false`.
 
 `--enableThrottling [enableThrottling]`
-: Indicates whether throttling for this list is enabled or not. Valid values are `true,false`
+: Indicates whether throttling for this list is enabled or not. Valid values are `true`, `false`.
 
 `--enableVersioning [enableVersioning]`
-: Boolean value that specifies whether versioning is enabled for the document library. Valid values are `true,false`
+: Boolean value that specifies whether versioning is enabled for the document library. Valid values are `true`, `false`.
 
 `--enforceDataValidation [enforceDataValidation]`
-: Value that indicates whether certain field properties are enforced when an item is added or updated. Valid values are `true,false`
+: Value that indicates whether certain field properties are enforced when an item is added or updated. Valid values are `true`, `false`.
 
 `--excludeFromOfflineClient [excludeFromOfflineClient]`
-: Value that indicates whether the list should be downloaded to the client during offline synchronization. Valid values are `true,false`
+: Value that indicates whether the list should be downloaded to the client during offline synchronization. Valid values are `true`, `false`.
 
 `--fetchPropertyBagForListView [fetchPropertyBagForListView]`
-: Specifies whether property bag information, as part of the list schema JSON,is retrieved when the list is being rendered on the client. Valid values are `true,false`
+: Specifies whether property bag information, as part of the list schema JSON,is retrieved when the list is being rendered on the client. Valid values are `true`, `false`.
 
 `--followable [followable]`
-: Can a list be followed in an activity feed?. Valid values are `true,false`
+: Can a list be followed in an activity feed?. Valid values are `true`, `false`.
 
 `--forceCheckout [forceCheckout]`
-: Boolean value that specifies whether forced checkout is enabled for the document library. Valid values are `true,false`
+: Boolean value that specifies whether forced checkout is enabled for the document library. Valid values are `true`, `false`.
 
 `--forceDefaultContentType [forceDefaultContentType]`
-: Specifies whether we want to return the default Document root content type. Valid values are `true,false`
+: Specifies whether we want to return the default Document root content type. Valid values are `true`, `false`.
 
 `--hidden [hidden]`
-: Boolean value that specifies whether the list is hidden. Valid values are `true,false`
+: Boolean value that specifies whether the list is hidden. Valid values are `true`, `false`.
 
 `--includedInMyFilesScope [includedInMyFilesScope]`
-: Specifies whether this list is accessible to an app principal that has been granted an OAuth scope that contains the string “myfiles” by a case-insensitive comparison when the current user is a site collection administrator of the personal site that contains the list
+: Specifies whether this list is accessible to an app principal that has been granted an OAuth scope that contains the string “myfiles” by a case-insensitive comparison when the current user is a site collection administrator of the personal site that contains the list.
 
 `--irmEnabled [irmEnabled]`
-: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) is enabled for the list
+: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) is enabled for the list.
 
 `--irmExpire [irmExpire]`
-: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) expiration is enabled for the list
+: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) expiration is enabled for the list.
 
 `--irmReject [irmReject]`
-: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) rejection is enabled for the list
+: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) rejection is enabled for the list.
 
 `--isApplicationList [isApplicationList]`
-: Indicates whether this list should be treated as a top level navigation object or not
+: Indicates whether this list should be treated as a top level navigation object or not.
 
 `--listExperienceOptions [listExperienceOptions]`
-: Gets or sets the list experience for the list. Allowed values Auto,NewExperience,ClassicExperience. Default Auto
+: Gets or sets the list experience for the list. Allowed values `Auto`, `NewExperience`, `ClassicExperience`. Default `Auto`.
 
 `--majorVersionLimit [majorVersionLimit]`
 : Gets or sets the maximum number of major versions allowed for an item in a document library that uses version control with major versions only.
@@ -146,46 +146,46 @@ m365 spo list add [options]
 : Gets or sets a Boolean value that specifies whether the list in a Meeting Workspace sitecontains data for multiple meeting instances within the site
 
 `--navigateForFormsPages [navigateForFormsPages]`
-: Indicates whether to navigate for forms pages or use a modal dialog
+: Indicates whether to navigate for forms pages or use a modal dialog.
 
 `--needUpdateSiteClientTag [needUpdateSiteClientTag]`
 : A boolean value that determines whether to editing documents in this list should increment the ClientTag for the site. The tag is used to allow clients to cache JS/CSS/resources that are retrieved from the Content DB, including custom CSR templates.
 
 `--noCrawl [noCrawl]`
-: Gets or sets a Boolean value specifying whether crawling is enabled for the list
+: Gets or sets a Boolean value specifying whether crawling is enabled for the list.
 
 `--onQuickLaunch [onQuickLaunch]`
-: Gets or sets a Boolean value that specifies whether the list appears on the Quick Launcharea of the home page
+: Gets or sets a Boolean value that specifies whether the list appears on the Quick Launcharea of the home page.
 
 `--ordered [ordered]`
-: Gets or sets a Boolean value that specifies whether the option to allow users to reorderitems in the list is available on the Edit View page for the list
+: Gets or sets a Boolean value that specifies whether the option to allow users to reorderitems in the list is available on the Edit View page for the list.
 
 `--parserDisabled [parserDisabled]`
-: Gets or sets a Boolean value that specifies whether the parser should be disabled
+: Gets or sets a Boolean value that specifies whether the parser should be disabled.
 
 `--readOnlyUI [readOnlyUI]`
-: A boolean value that indicates whether the UI for this list should be presented in a read-only fashion. This will not affect security nor will it actually prevent changes to the list from occurring - it only affects the way the UI is displayed
+: A boolean value that indicates whether the UI for this list should be presented in a read-only fashion. This will not affect security nor will it actually prevent changes to the list from occurring - it only affects the way the UI is displayed.
 
 `--readSecurity [readSecurity]`
-: Gets or sets the Read security setting for the list. Valid values are 1 (All users have Read access to all items)|2 (Users have Read access only to items that they create)
+: Gets or sets the Read security setting for the list. Valid values are 1 (All users have Read access to all items)|2 (Users have Read access only to items that they create).
 
 `--requestAccessEnabled [requestAccessEnabled]`
-: Gets or sets a Boolean value that specifies whether the option to allow users to requestaccess to the list is available
+: Gets or sets a Boolean value that specifies whether the option to allow users to requestaccess to the list is available.
 
 `--restrictUserUpdates [restrictUserUpdates]`
-: A boolean value that indicates whether the this list is a restricted one or not The value can't be changed if there are existing items in the list
+: A boolean value that indicates whether the this list is a restricted one or not The value can't be changed if there are existing items in the list.
 
 `--sendToLocationName [sendToLocationName]`
 : Gets or sets a file name to use when copying an item in the list to another document library.
 
 `--sendToLocationUrl [sendToLocationUrl]`
-: Gets or sets a URL to use when copying an item in the list to another document library
+: Gets or sets a URL to use when copying an item in the list to another document library.
 
 `--showUser [showUser]`
-: Gets or sets a Boolean value that specifies whether names of users are shown in the results of the survey
+: Gets or sets a Boolean value that specifies whether names of users are shown in the results of the survey.
 
 `--useFormsForDisplay [useFormsForDisplay]`
-: Indicates whether forms should be considered for display context or not
+: Indicates whether forms should be considered for display context or not.
 
 `--validationFormula [validationFormula]`
 : Gets or sets a formula that is evaluated each time that a list item is added or updated.
@@ -194,22 +194,22 @@ m365 spo list add [options]
 : Gets or sets the message that is displayed when validation fails for a list item.
 
 `--writeSecurity [writeSecurity]`
-: Gets or sets the Write security setting for the list. Valid values are 1 (All users can modify all items)|2 (Users can modify only items that they create)|4 (Users cannot modify any list item)
+: Gets or sets the Write security setting for the list. Valid values are 1 (All users can modify all items)|2 (Users can modify only items that they create)|4 (Users cannot modify any list item).
 
 `--schemaXml [schemaXml]`
-: (deprecated) The schema in Collaborative Application Markup Language (CAML) schemas that defines the list
+: (deprecated) The schema in Collaborative Application Markup Language (CAML) schemas that defines the list.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Add a list with title _Announcements_ and baseTemplate _Announcements_ in site _https://contoso.sharepoint.com/sites/project-x_
+Add a list with specific title and baseTemplate in a specific site.
 
 ```sh
 m365 spo list add --title Announcements --baseTemplate Announcements --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
-Add a list with title _Announcements_, baseTemplate _Announcements_ in site _https://contoso.sharepoint.com/sites/project-x_ with content types and versioning enabled and major version limit set to _50_
+Add a list with specific title and baseTemplate in a specific site with content types and versioning enabled and major version limit set.
 
 ```sh
 m365 spo list add --webUrl https://contoso.sharepoint.com/sites/project-x --title Announcements --baseTemplate Announcements --contentTypesEnabled true --enableVersioning true --majorVersionLimit 50
@@ -346,6 +346,72 @@ m365 spo list add --webUrl https://contoso.sharepoint.com/sites/project-x --titl
     ```csv
     AllowContentTypes,BaseTemplate,BaseType,ContentTypesEnabled,CrawlNonDefaultViews,Created,CurrentChangeToken,DefaultContentApprovalWorkflowId,DefaultItemOpenUseListSetting,Description,Direction,DisableCommenting,DisableGridEditing,DocumentTemplateUrl,DraftVersionVisibility,EnableAttachments,EnableFolderCreation,EnableMinorVersions,EnableModeration,EnableRequestSignOff,EnableVersioning,EntityTypeName,ExemptFromBlockDownloadOfNonViewableFiles,FileSavePostProcessingEnabled,ForceCheckout,HasExternalDataSource,Hidden,Id,ImagePath,ImageUrl,DefaultSensitivityLabelForLibrary,IrmEnabled,IrmExpire,IrmReject,IsApplicationList,IsCatalog,IsPrivate,ItemCount,LastItemDeletedDate,LastItemModifiedDate,LastItemUserModifiedDate,ListExperienceOptions,ListItemEntityTypeFullName,MajorVersionLimit,MajorWithMinorVersionsLimit,MultipleDataList,NoCrawl,ParentWebPath,ParentWebUrl,ParserDisabled,ServerTemplateCanCreateFolders,TemplateFeatureId,Title
     1,100,0,,,2022-11-16T19:52:41Z,"{""StringValue"":""1;3;3b6bd39e-1e62-4ddf-ac8e-020bf5353891;638042251616230000;564166296""}",00000000-0000-0000-0000-000000000000,,,none,,,,0,1,,,,1,1,TestList,,,,,,3b6bd39e-1e62-4ddf-ac8e-020bf5353891,"{""DecodedUrl"":""/_layouts/15/images/itgen.png?rev=47""}",/_layouts/15/images/itgen.png?rev=47,,,,,,,,0,2022-11-16T19:52:41Z,2022-11-16T19:52:42Z,2022-11-16T19:52:41Z,0,SP.Data.TestListItem,50,0,,,"{""DecodedUrl"":""/""}",/,,1,00bfea71-de22-43b2-a848-c05709900100,Test
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo list add --contentTypesEnabled "true" --enableVersioning "true" --webUrl "https://contoso.sharepoint.com" --title "Test" --baseTemplate "GenericList" --majorVersionLimit "50"
+
+    Date: 2/20/2023
+
+    ## Test (ea3dc19f-bc1f-4b77-afb8-14e08f4c0f6d)
+
+    Property | Value
+    ---------|-------
+    AllowContentTypes | true
+    BaseTemplate | 100
+    BaseType | 0
+    ContentTypesEnabled | false
+    CrawlNonDefaultViews | false
+    Created | 2022-11-16T19:51:42Z
+    CurrentChangeToken | {"StringValue":"1;3;ea3dc19f-bc1f-4b77-afb8-14e08f4c0f6d;638042251016970000;564165920"}
+    DefaultContentApprovalWorkflowId | 00000000-0000-0000-0000-000000000000
+    DefaultItemOpenUseListSetting | false
+    Description | 
+    Direction | none
+    DisableCommenting | false
+    DisableGridEditing | false
+    DocumentTemplateUrl | null
+    DraftVersionVisibility | 0
+    EnableAttachments | true
+    EnableFolderCreation | false
+    EnableMinorVersions | false
+    EnableModeration | false
+    EnableRequestSignOff | true
+    EnableVersioning | true
+    EntityTypeName | AnnouncementsList
+    ExemptFromBlockDownloadOfNonViewableFiles | false
+    FileSavePostProcessingEnabled | false
+    ForceCheckout | false
+    HasExternalDataSource | false
+    Hidden | false
+    Id | ea3dc19f-bc1f-4b77-afb8-14e08f4c0f6d
+    ImagePath | {"DecodedUrl":"/\/_layouts/15/images/itgen.png?rev=47"}
+    ImageUrl | /\/_layouts/15/images/itgen.png?rev=47
+    DefaultSensitivityLabelForLibrary |
+    IrmEnabled | false
+    IrmExpire | false
+    IrmReject | false
+    IsApplicationList | false
+    IsCatalog | false
+    IsPrivate | false
+    ItemCount | 0
+    LastItemDeletedDate | 2022-11-16T19:51:42Z
+    LastItemModifiedDate | 2022-11-16T19:51:42Z
+    LastItemUserModifiedDate | 2022-11-16T19:51:42Z
+    ListExperienceOptions | 0
+    ListItemEntityTypeFullName | SP.Data.TestListItem
+    MajorVersionLimit | 50
+    MajorWithMinorVersionsLimit | 0
+    MultipleDataList | false
+    NoCrawl | false
+    ParentWebPath | {"DecodedUrl":"/"}
+    ParentWebUrl | /
+    ParserDisabled | false
+    ServerTemplateCanCreateFolders | true
+    TemplateFeatureId | 00bfea71-de22-43b2-a848-c05709900100
+    Title | Test
     ```
 
 ## More information

--- a/docs/docs/cmd/spo/list/list-contenttype-add.md
+++ b/docs/docs/cmd/spo/list/list-contenttype-add.md
@@ -14,16 +14,16 @@ m365 spo list contenttype add [options]
 : URL of the site where the list is located.
 
 `-l, --listId [listId]`
-: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: ID of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-t, --listTitle [listTitle]`
-: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Title of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-i, --id <id>`
-: ID of the content type to add to the list
+: ID of the content type to add to the list.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -132,4 +132,49 @@ m365 spo list contenttype add --webUrl https://contoso.sharepoint.com/sites/proj
     ```csv
     ClientFormCustomFormatter,Description,DisplayFormClientSideComponentId,DisplayFormClientSideComponentProperties,DisplayFormTarget,DisplayFormTemplateName,DisplayFormUrl,DocumentTemplate,DocumentTemplateUrl,EditFormClientSideComponentId,EditFormClientSideComponentProperties,EditFormTarget,EditFormTemplateName,EditFormUrl,Group,Hidden,Id,JSLink,MobileDisplayFormUrl,MobileEditFormUrl,MobileNewFormUrl,Name,NewFormClientSideComponentId,NewFormClientSideComponentProperties,NewFormTarget,NewFormTemplateName,NewFormUrl,ReadOnly,SchemaXml,Scope,Sealed,StringId
     ,Create a new list item.,,,0,ListForm,,,,,,0,ListForm,,List Content Types,,"{""StringValue"":""0x01006D9EF01B2D22B3428279F8CF918B5EE0""}",,,,,Item,,,0,ListForm,,,"<ContentType ID=""0x01006D9EF01B2D22B3428279F8CF918B5EE0"" Name=""Item"" Group=""List Content Types"" Description=""Create a new list item."" Version=""0"" FeatureId=""{695b6570-a48b-4a8e-8ea5-26ea7fc1d162}"" FeatureIds=""{695b6570-a48b-4a8e-8ea5-26ea7fc1d162};{c94c1702-30a7-454c-be15-5a895223428d}""><Folder TargetName=""Item""/><Fields><Field ID=""{c042a256-787d-4a6f-8a8a-cf6ab767f12d}"" Type=""Computed"" DisplayName=""Content Type"" Name=""ContentType"" DisplaceOnUpgrade=""TRUE"" RenderXMLUsingPattern=""TRUE"" Sortable=""FALSE"" SourceID=""http://schemas.microsoft.com/sharepoint/v3"" StaticName=""ContentType"" Group=""_Hidden"" PITarget=""MicrosoftWindowsSharePointServices"" PIAttribute=""ContentTypeID"" FromBaseType=""TRUE""><FieldRefs><FieldRef Name=""ContentTypeId""/></FieldRefs><DisplayPattern><MapToContentType><Column Name=""ContentTypeId""/></MapToContentType></DisplayPattern></Field><Field ID=""{fa564e0f-0c70-4ab9-b863-0177e6ddd247}"" Type=""Text"" Name=""Title"" DisplayName=""Title"" Required=""TRUE"" SourceID=""http://schemas.microsoft.com/sharepoint/v3"" StaticName=""Title"" FromBaseType=""TRUE"" ColName=""nvarchar1"" ShowInNewForm=""TRUE"" ShowInEditForm=""TRUE""/></Fields><XmlDocuments><XmlDocument NamespaceURI=""http://schemas.microsoft.com/sharepoint/v3/contenttype/forms""><FormTemplates xmlns=""http://schemas.microsoft.com/sharepoint/v3/contenttype/forms""><Display>ListForm</Display><Edit>ListForm</Edit><New>ListForm</New></FormTemplates></XmlDocument></XmlDocuments></ContentType>",/Lists/Test,,0x01006D9EF01B2D22B3428279F8CF918B5EE0
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo list contenttype add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "Documents" --id "0x0103"
+
+    Date: 2/20/2023
+
+    ## Item ([object Object])
+
+    Property | Value
+    ---------|-------
+    ClientFormCustomFormatter |
+    Description | Create a new list item.
+    DisplayFormClientSideComponentId |
+    DisplayFormClientSideComponentProperties |
+    DisplayFormTarget | 0
+    DisplayFormTemplateName | ListForm
+    DisplayFormUrl |
+    DocumentTemplate | 
+    DocumentTemplateUrl | 
+    EditFormClientSideComponentId |
+    EditFormClientSideComponentProperties |
+    EditFormTarget | 0
+    EditFormTemplateName | ListForm
+    EditFormUrl |
+    Group | List Content Types
+    Hidden | false
+    Id | {"StringValue":"0x01000B1208C5D23DF44B9F1AEE7373DE9D5E"}
+    JSLink |
+    MobileDisplayFormUrl |
+    MobileEditFormUrl |
+    MobileNewFormUrl |
+    Name | Issue
+    NewFormClientSideComponentId | null
+    NewFormClientSideComponentProperties |
+    NewFormTarget | 0
+    NewFormTemplateName | ListForm
+    NewFormUrl |
+    ReadOnly | false
+    SchemaXml | <ContentType ID="0x01000B1208C5D23DF44B9F1AEE7373DE9D5E" Name="Item" Group="List Content Types" Description="Create a new list item." Version="0" FeatureId="{695b6570-a48b-4a8e-8ea5-26ea7fc1d162}" FeatureIds="{695b6570-a48b-4a8e-8ea5-26ea7fc1d162};{c94c1702-30a7-454c-be15-5a895223428d}"><Folder TargetName="Item"/><Fields><Field ID="{c042a256-787d-4a6f-8a8a-cf6ab767f12d}" Type="Computed" DisplayName="Content Type" Name="ContentType" DisplaceOnUpgrade="TRUE" RenderXMLUsingPattern="TRUE" Sortable="FALSE" SourceID="http://schemas.microsoft.com/sharepoint/v3" StaticName="ContentType" Group="_Hidden" PITarget="MicrosoftWindowsSharePointServices" PIAttribute="ContentTypeID" FromBaseType="TRUE"><FieldRefs><FieldRef Name="ContentTypeId"/></FieldRefs><DisplayPattern><MapToContentType><Column Name="ContentTypeId"/></MapToContentType></DisplayPattern></Field><Field ID="{fa564e0f-0c70-4ab9-b863-0177e6ddd247}" Type="Text" Name="Title" DisplayName="Title" Required="TRUE" SourceID="http://schemas.microsoft.com/sharepoint/v3" StaticName="Title" FromBaseType="TRUE" ColName="nvarchar1" ShowInNewForm="TRUE" ShowInEditForm="TRUE"/></Fields><XmlDocuments><XmlDocument NamespaceURI="http://schemas.microsoft.com/sharepoint/v3/contenttype/forms"><FormTemplates xmlns="http://schemas.microsoft.com/sharepoint/v3/contenttype/forms"><Display>ListForm</Display><Edit>ListForm</Edit><New>ListForm</New></FormTemplates></XmlDocument></XmlDocuments></ContentType>
+    Scope | /Lists/Test
+    Sealed | false
+    StringId | 0x01000B1208C5D23DF44B9F1AEE7373DE9D5E
     ```

--- a/docs/docs/cmd/spo/list/list-contenttype-default-set.md
+++ b/docs/docs/cmd/spo/list/list-contenttype-default-set.md
@@ -14,13 +14,13 @@ m365 spo list contenttype default set [options]
 : URL of the site where the list is located.
 
 `-l, --listId [listId]`
-: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: ID of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-t, --listTitle [listTitle]`
-: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Title of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-c, --contentTypeId <contentTypeId>`
 : ID of the content type

--- a/docs/docs/cmd/spo/list/list-contenttype-list.md
+++ b/docs/docs/cmd/spo/list/list-contenttype-list.md
@@ -14,13 +14,13 @@ m365 spo list contenttype list [options]
 : URL of the site where the list is located.
 
 `-l, --listId [listId]`
-: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: ID of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-t, --listTitle [listTitle]`
-: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Title of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -102,4 +102,49 @@ m365 spo list contenttype list --webUrl https://contoso.sharepoint.com/sites/pro
     ```csv
     StringId,Name,Hidden,ReadOnly,Sealed
     0x01000B1208C5D23DF44B9F1AEE7373DE9D5E,Item,,,
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo list contenttype list --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "Documents"
+
+    Date: 2/20/2023
+
+    ## Document ([object Object])
+
+    Property | Value
+    ---------|-------
+    ClientFormCustomFormatter |
+    Description | Create a new list item.
+    DisplayFormClientSideComponentId |
+    DisplayFormClientSideComponentProperties |
+    DisplayFormTarget | 0
+    DisplayFormTemplateName | ListForm
+    DisplayFormUrl |
+    DocumentTemplate | 
+    DocumentTemplateUrl | 
+    EditFormClientSideComponentId |
+    EditFormClientSideComponentProperties |
+    EditFormTarget | 0
+    EditFormTemplateName | ListForm
+    EditFormUrl |
+    Group | List Content Types
+    Hidden | false
+    Id | {"StringValue":"0x01000B1208C5D23DF44B9F1AEE7373DE9D5E"}
+    JSLink |
+    MobileDisplayFormUrl |
+    MobileEditFormUrl |
+    MobileNewFormUrl |
+    Name | Item
+    NewFormClientSideComponentId | null
+    NewFormClientSideComponentProperties |
+    NewFormTarget | 0
+    NewFormTemplateName | ListForm
+    NewFormUrl |
+    ReadOnly | false
+    SchemaXml | <ContentType ID="0x01000B1208C5D23DF44B9F1AEE7373DE9D5E" Name="Item" Group="List Content Types" Description="Create a new list item." Version="0" FeatureId="{695b6570-a48b-4a8e-8ea5-26ea7fc1d162}" FeatureIds="{695b6570-a48b-4a8e-8ea5-26ea7fc1d162};{c94c1702-30a7-454c-be15-5a895223428d}"><Folder TargetName="Item"/><Fields><Field ID="{c042a256-787d-4a6f-8a8a-cf6ab767f12d}" Type="Computed" DisplayName="Content Type" Name="ContentType" DisplaceOnUpgrade="TRUE" RenderXMLUsingPattern="TRUE" Sortable="FALSE" SourceID="http://schemas.microsoft.com/sharepoint/v3" StaticName="ContentType" Group="_Hidden" PITarget="MicrosoftWindowsSharePointServices" PIAttribute="ContentTypeID" FromBaseType="TRUE"><FieldRefs><FieldRef Name="ContentTypeId"/></FieldRefs><DisplayPattern><MapToContentType><Column Name="ContentTypeId"/></MapToContentType></DisplayPattern></Field><Field ID="{fa564e0f-0c70-4ab9-b863-0177e6ddd247}" Type="Text" Name="Title" DisplayName="Title" Required="TRUE" SourceID="http://schemas.microsoft.com/sharepoint/v3" StaticName="Title" FromBaseType="TRUE" ColName="nvarchar1" ShowInNewForm="TRUE" ShowInEditForm="TRUE"/></Fields><XmlDocuments><XmlDocument NamespaceURI="http://schemas.microsoft.com/sharepoint/v3/contenttype/forms"><FormTemplates xmlns="http://schemas.microsoft.com/sharepoint/v3/contenttype/forms"><Display>ListForm</Display><Edit>ListForm</Edit><New>ListForm</New></FormTemplates></XmlDocument></XmlDocuments></ContentType>
+    Scope | /Lists/Test
+    Sealed | false
+    StringId | 0x01000B1208C5D23DF44B9F1AEE7373DE9D5E
     ```

--- a/docs/docs/cmd/spo/list/list-contenttype-remove.md
+++ b/docs/docs/cmd/spo/list/list-contenttype-remove.md
@@ -14,19 +14,19 @@ m365 spo list contenttype remove [options]
 : URL of the site where the list is located.
 
 `-l, --listId [listId]`
-: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: ID of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-t, --listTitle [listTitle]`
-: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Title of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-i, --id <id>`
-: ID of the content type to remove from the list
+: ID of the content type to remove from the list.
 
 `--confirm`
-: Don't prompt for confirmation
+: Don't prompt for confirmation.
 
 --8<-- "docs/cmd/_global.md"
 

--- a/docs/docs/cmd/spo/list/list-get.md
+++ b/docs/docs/cmd/spo/list/list-get.md
@@ -11,16 +11,16 @@ m365 spo list get [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: URL of the site where the list to retrieve is located
+: URL of the site where the list to retrieve is located.
 
 `-i, --id [id]`
-: ID of the list to retrieve information for. Specify either `id`, `title` or `url` but not multiple.
+: ID of the list to retrieve information for. Specify either `id`, `title`, or `url` but not multiple.
 
 `-t, --title [title]`
-: Title of the list to retrieve information for. Specify either `id`, `title` or `url` but not multiple.
+: Title of the list to retrieve information for. Specify either `id`, `title`, or `url` but not multiple.
 
 `--url [url]`
-: Server- or site-relative URL of the list. Specify either `id`, `title` or `url` but not multiple.
+: Server- or site-relative URL of the list. Specify either `id`, `title`, or `url` but not multiple.
 
 `-p, --properties [properties]`
 : Comma-separated list of properties to retrieve from the list. Will retrieve all properties possible from default response, if not specified.
@@ -203,4 +203,70 @@ m365 spo list get --title Documents --webUrl https://contoso.sharepoint.com/site
     ```csv
     AllowContentTypes,BaseTemplate,BaseType,ContentTypesEnabled,CrawlNonDefaultViews,Created,CurrentChangeToken,DefaultContentApprovalWorkflowId,DefaultItemOpenUseListSetting,Description,Direction,DisableCommenting,DisableGridEditing,DocumentTemplateUrl,DraftVersionVisibility,EnableAttachments,EnableFolderCreation,EnableMinorVersions,EnableModeration,EnableRequestSignOff,EnableVersioning,EntityTypeName,ExemptFromBlockDownloadOfNonViewableFiles,FileSavePostProcessingEnabled,ForceCheckout,HasExternalDataSource,Hidden,Id,ImagePath,ImageUrl,DefaultSensitivityLabelForLibrary,IrmEnabled,IrmExpire,IrmReject,IsApplicationList,IsCatalog,IsPrivate,ItemCount,LastItemDeletedDate,LastItemModifiedDate,LastItemUserModifiedDate,ListExperienceOptions,ListItemEntityTypeFullName,MajorVersionLimit,MajorWithMinorVersionsLimit,MultipleDataList,NoCrawl,ParentWebPath,ParentWebUrl,ParserDisabled,ServerTemplateCanCreateFolders,TemplateFeatureId,Title
     1,100,0,1,,2022-10-23T09:30:00Z,"{""StringValue"":""1;3;97d19285-b8a6-4c7f-9c6c-d6b850a6561a;638042258543870000;564169743""}",00000000-0000-0000-0000-000000000000,,,none,,,,0,1,,,,1,1,TestList,,,,,,97d19285-b8a6-4c7f-9c6c-d6b850a6561a,"{""DecodedUrl"":""/_layouts/15/images/itgen.png?rev=47""}",/_layouts/15/images/itgen.png?rev=47,,,,,,,,0,2022-11-16T19:55:37Z,2022-11-16T19:55:39Z,2022-11-16T19:55:37Z,0,SP.Data.TestListItem,50,0,,,"{""DecodedUrl"":""/""}",/,,1,00bfea71-de22-43b2-a848-c05709900100,Test
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo list get --title "Test" --webUrl "https://contoso.sharepoint.com"
+
+    Date: 2/20/2023
+
+    ## Test (97d19285-b8a6-4c7f-9c6c-d6b850a6561a)
+
+    Property | Value
+    ---------|-------
+    AllowContentTypes | true
+    BaseTemplate | 100
+    BaseType | 0
+    ContentTypesEnabled | false
+    CrawlNonDefaultViews | false
+    Created | 2022-10-23T09:30:00Z
+    CurrentChangeToken | {"StringValue":"1;3;97d19285-b8a6-4c7f-9c6c-d6b850a6561a;638042258222730000;564169620"}
+    DefaultContentApprovalWorkflowId | 00000000-0000-0000-0000-000000000000
+    DefaultItemOpenUseListSetting | false
+    Description |
+    Direction | none
+    DisableCommenting | false
+    DisableGridEditing | false
+    DocumentTemplateUrl | 
+    DraftVersionVisibility | 0
+    EnableAttachments | true
+    EnableFolderCreation | false
+    EnableMinorVersions | false
+    EnableModeration | false
+    EnableRequestSignOff | true
+    EnableVersioning | true
+    EntityTypeName | TestList
+    ExemptFromBlockDownloadOfNonViewableFiles | false
+    FileSavePostProcessingEnabled | false
+    ForceCheckout | false
+    HasExternalDataSource | false
+    Hidden | false
+    Id | 97d19285-b8a6-4c7f-9c6c-d6b850a6561a
+    ImagePath | {"DecodedUrl":"/\_layouts/15/images/itgen.png?rev=47"}
+    ImageUrl | /\_layouts/15/images/itgen.png?rev=47
+    DefaultSensitivityLabelForLibrary |
+    IrmEnabled | false
+    IrmExpire | false
+    IrmReject | false
+    IsApplicationList | false
+    IsCatalog | false
+    IsPrivate | false
+    ItemCount | 0
+    LastItemDeletedDate | 2022-11-16T19:55:37Z
+    LastItemModifiedDate | 2022-11-16T19:55:39Z
+    LastItemUserModifiedDate | 2022-11-16T19:55:37Z
+    ListExperienceOptions | 0
+    ListItemEntityTypeFullName | SP.Data.TestListItem
+    MajorVersionLimit | 50
+    MajorWithMinorVersionsLimit | 0
+    MultipleDataList | false
+    NoCrawl | false
+    ParentWebPath | {"DecodedUrl":"/"}
+    ParentWebUrl | /
+    ParserDisabled | false
+    ServerTemplateCanCreateFolders | true
+    TemplateFeatureId | 00bfea71-de22-43b2-a848-c05709900100
+    Title | Test
     ```

--- a/docs/docs/cmd/spo/list/list-list.md
+++ b/docs/docs/cmd/spo/list/list-list.md
@@ -11,13 +11,13 @@ m365 spo list list [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: URL of the site where the lists to retrieve are located
+: URL of the site where the lists to retrieve are located.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Return all lists located in site _https://contoso.sharepoint.com/sites/project-x_
+Return all lists located in in a specific site.
 
 ```sh
 m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x
@@ -114,4 +114,72 @@ m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x
     ```csv
     Id,Url
     Theme Gallery,/_catalogs/theme,66e5148c-7060-4479-88e7-636d79579148
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo list list --webUrl "https://contoso.sharepoint.com"
+
+    Date: 2/20/2023
+
+    ## _catalogs/theme (66e5148c-7060-4479-88e7-636d79579148)
+
+    Property | Value
+    ---------|-------
+    AllowContentTypes | true
+    BaseTemplate | 123
+    BaseType | 1
+    ContentTypesEnabled | false
+    CrawlNonDefaultViews | false
+    Created | 2020-01-12T01:03:13Z
+    CurrentChangeToken | {"StringValue":"1;3;66e5148c-7060-4479-88e7-636d79579148;638042267256930000;564174226"}
+    DefaultContentApprovalWorkflowId | 00000000-0000-0000-0000-000000000000
+    DefaultItemOpenUseListSetting | false
+    Description | Use the theme gallery to store themes. The themes in this gallery can be used by this site or any of its subsites.
+    Direction | none
+    DisableCommenting | false
+    DisableGridEditing | false
+    DocumentTemplateUrl | null
+    DraftVersionVisibility | 0
+    EnableAttachments | false
+    EnableFolderCreation | false
+    EnableMinorVersions | false
+    EnableModeration | false
+    EnableRequestSignOff | true
+    EnableVersioning | false
+    EntityTypeName | OData\_\_x005f\_catalogs\_x002f\_theme
+    ExemptFromBlockDownloadOfNonViewableFiles | false
+    FileSavePostProcessingEnabled | false
+    ForceCheckout | false
+    HasExternalDataSource | false
+    Hidden | true
+    Id | 66e5148c-7060-4479-88e7-636d79579148
+    ImagePath | {"DecodedUrl":"/\_layouts/15/images/itdl.png?rev=47"}
+    ImageUrl | /\_layouts/15/images/itdl.png?rev=47
+    DefaultSensitivityLabelForLibrary |
+    IrmEnabled | false
+    IrmExpire | false
+    IrmReject | false
+    IsApplicationList | false
+    IsCatalog | true
+    IsPrivate | false
+    ItemCount | 41
+    LastItemDeletedDate | 2020-01-12T01:03:13Z
+    LastItemModifiedDate | 2020-01-12T01:03:18Z
+    LastItemUserModifiedDate | 2020-01-12T01:03:18Z
+    ListExperienceOptions | 0
+    ListItemEntityTypeFullName | SP.Data.OData\_\_x005f\_catalogs\_x002f\_themeItem
+    MajorVersionLimit | 0
+    MajorWithMinorVersionsLimit | 0
+    MultipleDataList | false
+    NoCrawl | false
+    ParentWebPath | {"DecodedUrl":"/"}
+    ParentWebUrl | /
+    ParserDisabled | false
+    ServerTemplateCanCreateFolders | true
+    TemplateFeatureId | 00000000-0000-0000-0000-000000000000
+    Title | Theme Gallery
+    RootFolder | {"ServerRelativeUrl":"//\_catalogs/theme"}
+    Url | //\_catalogs/theme
     ```

--- a/docs/docs/cmd/spo/list/list-remove.md
+++ b/docs/docs/cmd/spo/list/list-remove.md
@@ -11,28 +11,28 @@ m365 spo list remove [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: URL of the site where the list to remove is located
+: URL of the site where the list to remove is located.
 
 `-i, --id [id]`
-: The ID of the list to remove. Specify either `id` or `title` but not both
+: The ID of the list to remove. Specify either `id` or `title` but not both.
 
 `-t, --title [title]`
-: Title of the list to remove. Specify either `id` or `title` but not both
+: Title of the list to remove. Specify either `id` or `title` but not both.
 
 `--confirm`
-: Don't prompt for confirming removing the list
+: Don't prompt for confirming removing the list.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Remove the list with ID _0cd891ef-afce-4e55-b836-fce03286cccf_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Remove the list with a specific ID located in a specific site
 
 ```sh
 m365 spo list remove --webUrl https://contoso.sharepoint.com/sites/project-x --id 0cd891ef-afce-4e55-b836-fce03286cccf
 ```
 
-Remove the list with title _List 1_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Remove the list with a specific title located in a specific site.
 
 ```sh
 m365 spo list remove --webUrl https://contoso.sharepoint.com/sites/project-x --title 'List 1'

--- a/docs/docs/cmd/spo/list/list-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/list/list-retentionlabel-ensure.md
@@ -51,13 +51,13 @@ A list retention label is a default label that will be applied to all new items 
 
 ## Examples
 
-Sets a retention label by name on a given list
+Sets a retention label by name on a given list.
 
 ```sh
 m365 spo list retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents' --name 'Some label'
 ```
 
-Sets a retention label by name and disables editing and deleting items on the list and all existing items for a given list
+Sets a retention label by name and disables editing and deleting items on the list and all existing items for a given list.
 
 ```sh
 m365 spo list retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'Documents' --name 'Some label' --blockEdit --blockDelete --syncToItems

--- a/docs/docs/cmd/spo/list/list-retentionlabel-get.md
+++ b/docs/docs/cmd/spo/list/list-retentionlabel-get.md
@@ -20,13 +20,13 @@ m365 spo list label get [options]
 : URL of the site where the list to get the label from is located.
 
 `-l, --listId [listId]`
-: ID of the list to get the label from. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: ID of the list to get the label from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `-t, --listTitle [listTitle]`
-: Title of the list to get the label from. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: Title of the list to get the label from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: Server- or site-relative URL of the list. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -115,4 +115,37 @@ m365 spo list retentionlabel get --listUrl 'Shared Documents' --webUrl https://c
     ```csv
     AcceptMessagesOnlyFromSendersOrMembers,AccessType,AllowAccessFromUnmanagedDevice,AutoDelete,BlockDelete,BlockEdit,ContainsSiteLabel,DisplayName,EncryptionRMSTemplateId,HasRetentionAction,IsEventTag,Notes,RequireSenderAuthenticationEnabled,ReviewerEmail,SharingCapabilities,SuperLock,TagDuration,TagId,TagName,TagRetentionBasedOn
     false,,,false,false,false,false,Label A,,false,false,,false,,,false,0,4d535433-2a7b-40b0-9dad-8f0f8f3b3841,Sensitive,
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo list retentionlabel get --listUrl "Shared Documents" --webUrl https://contoso.sharepoint.com/sites/project-x
+
+    Date: 2/20/2023
+
+    ## Label A (4d535433-2a7b-40b0-9dad-8f0f8f3b3841)
+
+    Property | Value
+    ---------|-------
+    AcceptMessagesOnlyFromSendersOrMembers | false
+    AccessType | null
+    AllowAccessFromUnmanagedDevice | null
+    AutoDelete | false
+    BlockDelete | false
+    BlockEdit | false
+    ContainsSiteLabel | false
+    DisplayName | Label A
+    EncryptionRMSTemplateId | null
+    HasRetentionAction | false
+    IsEventTag | false
+    Notes | null
+    RequireSenderAuthenticationEnabled | false
+    ReviewerEmail | null
+    SharingCapabilities | null
+    SuperLock | false
+    TagDuration | 0
+    TagId | 4d535433-2a7b-40b0-9dad-8f0f8f3b3841
+    TagName | Sensitive
+    TagRetentionBasedOn | null
     ```

--- a/docs/docs/cmd/spo/list/list-retentionlabel-remove.md
+++ b/docs/docs/cmd/spo/list/list-retentionlabel-remove.md
@@ -29,19 +29,19 @@ m365 spo list retentionlabel remove [options]
 
 ## Examples
 
-Clears the retention label on a given list by URL
+Clears the retention label on a given list by URL.
 
 ```sh
 m365 spo list retentionlabel remove --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents'
 ```
 
-Clears the retention label on a given list by title
+Clears the retention label on a given list by title.
 
 ```sh
 m365 spo list retentionlabel remove --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'Documents'
 ```
 
-Clears the retention label on a given list by ID without confirmation
+Clears the retention label on a given list by ID without confirmation.
 
 ```sh
 m365 spo list retentionlabel remove --webUrl https://contoso.sharepoint.com/sites/project-x --listId 'Documents' --confirm

--- a/docs/docs/cmd/spo/list/list-roleassignment-add.md
+++ b/docs/docs/cmd/spo/list/list-roleassignment-add.md
@@ -41,37 +41,37 @@ m365 spo list roleassignment add [options]
 
 ## Examples
 
-add role assignment to list _someList_ located in site _https://contoso.sharepoint.com/sites/project-x_for principal id _11_ and role definition id _1073741829_
+Adds role assignment to a list by title located in a specific site for given principal id and role definition id.
 
 ```sh
 m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "someList" --principalId 11 --roleDefinitionId 1073741829
 ```
 
-add role assignment to list _0CD891EF-AFCE-4E55-B836-FCE03286CCCF_ located in site _https://contoso.sharepoint.com/sites/project-x_for principal id _11_ and role definition id _1073741829_
+Adds role assignment to list by id located in a specific site for given principal id and role definition id.
 
 ```sh
 m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listId "0CD891EF-AFCE-4E55-B836-FCE03286CCCF" --principalId 11 --roleDefinitionId 1073741829
 ```
 
-add role assignment to list _sites/documents_ located in site _https://contoso.sharepoint.com/sites/project-x_for principal id _11_ and role definition id _1073741829_
+Adds role assignment to list by url located in a specific site for given principal id and role definition id.
 
 ```sh
 m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listUrl "sites/documents" --principalId 11 --roleDefinitionId 1073741829
 ```
 
-add role assignment to list _someList_ located in site _https://contoso.sharepoint.com/sites/project-x_for upn _someaccount@tenant.onmicrosoft.com_ and role definition id _1073741829_
+Adds role assignment to list by title located in a specific site for given upn and role definition id.
 
 ```sh
 m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "someList" --upn "someaccount@tenant.onmicrosoft.com" --roleDefinitionId 1073741829
 ```
 
-add role assignment to list _someList_ located in site _https://contoso.sharepoint.com/sites/project-x_for group _someGroup_ and role definition id _1073741829_
+Adds role assignment to list by title located in a specific site for given group and role definition id.
 
 ```sh
 m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "someList" --groupName "someGroup" --roleDefinitionId 1073741829
 ```
 
-add role assignment to list _someList_ located in site _https://contoso.sharepoint.com/sites/project-x_for principal id _11_ and role definition name _Full Control_
+Adds role assignment to list by title located in a specific site for given principal id and role definition name.
 
 ```sh
 m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "someList" --principalId 11 --roleDefinitionName "Full Control"

--- a/docs/docs/cmd/spo/list/list-roleassignment-remove.md
+++ b/docs/docs/cmd/spo/list/list-roleassignment-remove.md
@@ -38,19 +38,19 @@ m365 spo list roleassignment remove [options]
 
 ## Examples
 
-Remove roleassignment from list by title based on group name
+Remove roleassignment from list by title based on group name.
 
 ```sh
 m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales" --listTitle "someList" --groupName "saleGroup"
 ```
 
-Remove roleassignment from list by title based on principal Id
+Remove roleassignment from list by title based on principal Id.
 
 ```sh
 m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales" --listTitle "Events" --principalId 2
 ```
 
-Remove roleassignment from list by url based on principal Id
+Remove roleassignment from list by url based on principal Id.
 
 ```sh
 m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales" --listUrl '/sites/contoso-sales/lists/Events' --principalId 2

--- a/docs/docs/cmd/spo/list/list-roleinheritance-break.md
+++ b/docs/docs/cmd/spo/list/list-roleinheritance-break.md
@@ -14,16 +14,16 @@ m365 spo list roleinheritance break [options]
 : URL of the site where the list is located.
 
 `-i, --listId [listId]`
-: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: ID of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-t, --listTitle [listTitle]`
-: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Title of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-c, --clearExistingPermissions`
-: Flag if used clears all roles from the list
+: Flag if used clears all roles from the list.
 
 `--confirm`
 : Do not prompt for confirmation before breaking role inheritance.
@@ -36,31 +36,31 @@ By default, when breaking permissions inheritance, the list will retain existing
 
 ## Examples
 
-Break inheritance of list by title in a specific site
+Break inheritance of list by title in a specific site.
 
 ```sh
 m365 spo list roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "someList"
 ```
 
-Break inheritance of list by id in a specific site
+Break inheritance of list by id in a specific site.
 
 ```sh
 m365 spo list roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --listId "202b8199-b9de-43fd-9737-7f213f51c991"
 ```
 
-Break inheritance of list by title located in a specific site and clearing the existing permissions
+Break inheritance of list by title located in a specific site and clearing the existing permissions.
 
 ```sh
 m365 spo list roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "someList" --clearExistingPermissions
 ```
 
-Break inheritance of list by url in a specific site and clearing the existing permissions
+Break inheritance of list by url in a specific site and clearing the existing permissions.
 
 ```sh
 m365 spo list roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --listUrl '/sites/project-x/lists/events' --clearExistingPermissions
 ```
 
-Break inheritance of list with ID _202b8199-b9de-43fd-9737-7f213f51c991_ located in site _https://contoso.sharepoint.com/sites/project-x_ with clearing permissions without prompting for confirmation
+Break inheritance of list by ID located in in a specific site with clearing permissions without prompting for confirmation.
 
 ```sh
 m365 spo list roleinheritance break --webUrl "https://contoso.sharepoint.com/sites/project-x" --listId "202b8199-b9de-43fd-9737-7f213f51c991" --clearExistingPermissions --confirm

--- a/docs/docs/cmd/spo/list/list-roleinheritance-reset.md
+++ b/docs/docs/cmd/spo/list/list-roleinheritance-reset.md
@@ -14,13 +14,13 @@ m365 spo list roleinheritance reset [options]
 : URL of the site where the list is located.
 
 `-i, --listId [listId]`
-: ID of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: ID of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `-t, --listTitle [listTitle]`
-: Title of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Title of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`.
+: Server- or site-relative URL of the list. Specify either `listTitle`, `listId`, or `listUrl`.
 
 `--confirm`
 : Do not prompt for confirmation before resetting role inheritance.
@@ -29,25 +29,25 @@ m365 spo list roleinheritance reset [options]
 
 ## Examples
 
-Restores role inheritance of a specific list by id in a specific site
+Restores role inheritance of a specific list by id in a specific site.
 
 ```sh
 m365 spo list roleinheritance reset --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf
 ```
 
-Restores role inheritance of a specific list by title in a specific site
+Restores role inheritance of a specific list by title in a specific site.
 
 ```sh
 m365 spo list roleinheritance reset --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle test
 ```
 
-Restores role inheritance of a specific list by url in a specific site
+Restores role inheritance of a specific list by url in a specific site.
 
 ```sh
 m365 spo list roleinheritance reset --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl '/sites/project-x/lists/events'
 ```
 
-Restores role inheritance of list a specific list by title without prompting for confirmation
+Restores role inheritance of list a specific list by title without prompting for confirmation.
 
 ```sh
 m365 spo list roleinheritance reset --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle test --confirm

--- a/docs/docs/cmd/spo/list/list-set.md
+++ b/docs/docs/cmd/spo/list/list-set.md
@@ -14,130 +14,130 @@ m365 spo list set [options]
 : URL of the site
 
 `--id [id]`
-: ID of the list. Specify either id, title or url but not multiple.
+: ID of the list. Specify either `id`, `title`, or `url` but not multiple.
 
 `--title [title]`
-: Title of the list. Specify either id, title or url but not multiple.
+: Title of the list. Specify either `id`, `title`, or `url` but not multiple.
 
 `--url [url]`
-: Relative URL of the list. Specify either id, title or url but not multiple.
+: Relative URL of the list. Specify either `id`, `title`, or `url` but not multiple.
 
 `--newTitle [newTitle]`
-: New title for the list
+: New title for the list.
 
 `--allowDeletion [allowDeletion]`
-: Boolean value specifying whether the list can be deleted. Valid values are `true,false`
+: Boolean value specifying whether the list can be deleted. Valid values are `true`, `false`.
 
 `--allowEveryoneViewItems [allowEveryoneViewItems]`
-: Boolean value specifying whether everyone can view documents in the documentlibrary or attachments to items in the list. Valid values are `true,false`
+: Boolean value specifying whether everyone can view documents in the documentlibrary or attachments to items in the list. Valid values are `true`, `false`.
 
 `--allowMultiResponses [allowMultiResponses]`
-: Boolean value specifying whether users are allowed to give multiple responses to the survey. Valid values are `true,false`
+: Boolean value specifying whether users are allowed to give multiple responses to the survey. Valid values are `true`, `false`.
 
 `--contentTypesEnabled [contentTypesEnabled]`
-: Boolean value specifying whether content types are enabled for the list. Valid values are `true,false`
+: Boolean value specifying whether content types are enabled for the list. Valid values are `true`, `false`.
 
 `--crawlNonDefaultViews [crawlNonDefaultViews]`
-: Boolean value specifying whether to crawl non default views. Valid values are `true,false`
+: Boolean value specifying whether to crawl non default views. Valid values are `true`, `false`.
 
 `--defaultContentApprovalWorkflowId [defaultContentApprovalWorkflowId]`
-: Value that specifies the default workflow identifier for content approval on the list (GUID)
+: Value that specifies the default workflow identifier for content approval on the list (GUID).
 
 `--defaultDisplayFormUrl [defaultDisplayFormUrl]`
-: Value that specifies the location of the default display form for the list
+: Value that specifies the location of the default display form for the list.
 
 `--defaultEditFormUrl [defaultEditFormUrl]`
-: Value that specifies the URL of the edit form to use for list items in the list
+: Value that specifies the URL of the edit form to use for list items in the list.
 
 `--description [description]`
-: The description for the list
+: The description for the list.
 
 `--direction [direction]`
-: Value that specifies the reading order of the list. Valid values are NONE,LTR,RTL
+: Value that specifies the reading order of the list. Valid values are `NONE`, `LTR`, `RTL`.
 
 `--disableGridEditing [disableGridEditing]`
-: Property for assigning or retrieving grid editing on the list. Valid values are `true,false`
+: Property for assigning or retrieving grid editing on the list. Valid values are `true`, `false`.
 
 `--draftVersionVisibility [draftVersionVisibility]`
-: Value that specifies the minimum permission required to view minor versions and drafts within the list. Allowed values Reader,Author,Approver. Default Reader
+: Value that specifies the minimum permission required to view minor versions and drafts within the list. Allowed values `Reader`, `Author`, `Approver`. Default `Reader`.
 
 `--emailAlias [emailAlias]`
 : If e-mail notification is enabled, gets or sets the e-mail address to use tonotify to the owner of an item when an assignment has changed or the item has been updated.
 
 `--enableAssignToEmail [enableAssignToEmail]`
-: Boolean value specifying whether e-mail notification is enabled for the list. Valid values are `true,false`
+: Boolean value specifying whether e-mail notification is enabled for the list. Valid values are `true`, `false`.
 
 `--enableAttachments [enableAttachments]`
-: Boolean value that specifies whether attachments can be added to items in the list. Valid values are `true,false`
+: Boolean value that specifies whether attachments can be added to items in the list. Valid values are `true`, `false`.
 
 `--enableDeployWithDependentList [enableDeployWithDependentList]`
-: Boolean value that specifies whether the list can be deployed with a dependent list. Valid values are `true,false`
+: Boolean value that specifies whether the list can be deployed with a dependent list. Valid values are `true`, `false`.
 
 `--enableFolderCreation [enableFolderCreation]`
-: Boolean value that specifies whether folders can be created for the list. Valid values are `true,false`
+: Boolean value that specifies whether folders can be created for the list. Valid values are `true`, `false`.
 
 `--enableMinorVersions [enableMinorVersions]`
-: Boolean value that specifies whether minor versions are enabled when versioning is enabled for the document library. Valid values are `true,false`
+: Boolean value that specifies whether minor versions are enabled when versioning is enabled for the document library. Valid values are `true`, `false`.
 
 `--enableModeration [enableModeration]`
-: Boolean value that specifies whether Content Approval is enabled for the list. Valid values are `true,false`
+: Boolean value that specifies whether Content Approval is enabled for the list. Valid values are `true`, `false`.
 
 `--enablePeopleSelector [enablePeopleSelector]`
-: Enable user selector on event list. Valid values are `true,false`
+: Enable user selector on event list. Valid values are `true`, `false`.
 
 `--enableResourceSelector [enableResourceSelector]`
-: Enables resource selector on an event list. Valid values are `true,false`
+: Enables resource selector on an event list. Valid values are `true`, `false`.
 
 `--enableSchemaCaching [enableSchemaCaching]`
-: Boolean value specifying whether schema caching is enabled for the list. Valid values are `true,false`
+: Boolean value specifying whether schema caching is enabled for the list. Valid values are `true`, `false`.
 
 `--enableSyndication [enableSyndication]`
-: Boolean value that specifies whether RSS syndication is enabled for the list. Valid values are `true,false`
+: Boolean value that specifies whether RSS syndication is enabled for the list. Valid values are `true`, `false`.
 
 `--enableThrottling [enableThrottling]`
-: Indicates whether throttling for this list is enabled or not. Valid values are `true,false`
+: Indicates whether throttling for this list is enabled or not. Valid values are `true`, `false`.
 
 `--enableVersioning [enableVersioning]`
-: Boolean value that specifies whether versioning is enabled for the document library. Valid values are `true,false`
+: Boolean value that specifies whether versioning is enabled for the document library. Valid values are `true`, `false`.
 
 `--enforceDataValidation [enforceDataValidation]`
-: Value that indicates whether certain field properties are enforced when an item is added or updated. Valid values are `true,false`
+: Value that indicates whether certain field properties are enforced when an item is added or updated. Valid values are `true`, `false`.
 
 `--excludeFromOfflineClient [excludeFromOfflineClient]`
-: Value that indicates whether the list should be downloaded to the client during offline synchronization. Valid values are `true,false`
+: Value that indicates whether the list should be downloaded to the client during offline synchronization. Valid values are `true`, `false`.
 
 `--fetchPropertyBagForListView [fetchPropertyBagForListView]`
-: Specifies whether property bag information, as part of the list schema JSON,is retrieved when the list is being rendered on the client. Valid values are `true,false`
+: Specifies whether property bag information, as part of the list schema JSON,is retrieved when the list is being rendered on the client. Valid values are `true`, `false`.
 
 `--followable [followable]`
-: Can a list be followed in an activity feed?. Valid values are `true,false`
+: Can a list be followed in an activity feed?. Valid values are `true`, `false`.
 
 `--forceCheckout [forceCheckout]`
-: Boolean value that specifies whether forced checkout is enabled for the document library. Valid values are `true,false`
+: Boolean value that specifies whether forced checkout is enabled for the document library. Valid values are `true`, `false`.
 
 `--forceDefaultContentType [forceDefaultContentType]`
-: Specifies whether we want to return the default Document root content type. Valid values are `true,false`
+: Specifies whether we want to return the default Document root content type. Valid values are `true`, `false`.
 
 `--hidden [hidden]`
-: Boolean value that specifies whether the list is hidden. Valid values are `true,false`
+: Boolean value that specifies whether the list is hidden. Valid values are `true`, `false`.
 
 `--includedInMyFilesScope [includedInMyFilesScope]`
-: Specifies whether this list is accessible to an app principal that has been granted an OAuth scope that contains the string “myfiles” by a case-insensitive comparison when the current user is a site collection administrator of the personal site that contains the list
+: Specifies whether this list is accessible to an app principal that has been granted an OAuth scope that contains the string “myfiles” by a case-insensitive comparison when the current user is a site collection administrator of the personal site that contains the list.
 
 `--irmEnabled [irmEnabled]`
-: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) is enabled for the list
+: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) is enabled for the list.
 
 `--irmExpire [irmExpire]`
-: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) expiration is enabled for the list
+: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) expiration is enabled for the list.
 
 `--irmReject [irmReject]`
-: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) rejection is enabled for the list
+: Gets or sets a Boolean value that specifies whether Information Rights Management (IRM) rejection is enabled for the list.
 
 `--isApplicationList [isApplicationList]`
-: Indicates whether this list should be treated as a top level navigation object or not
+: Indicates whether this list should be treated as a top level navigation object or not.
 
 `--listExperienceOptions [listExperienceOptions]`
-: Gets or sets the list experience for the list. Allowed values Auto,NewExperience,ClassicExperience. Default Auto
+: Gets or sets the list experience for the list. Allowed values `Auto`, `NewExperience`, `ClassicExperience`. Default `Auto`.
 
 `--majorVersionLimit [majorVersionLimit]`
 : Gets or sets the maximum number of major versions allowed for an item in a document library that uses version control with major versions only.
@@ -146,52 +146,52 @@ m365 spo list set [options]
 : Gets or sets the maximum number of major versions that are allowed for an item in a document library that uses version control with both major and minor versions.
 
 `--multipleDataList [multipleDataList]`
-: Gets or sets a Boolean value that specifies whether the list in a Meeting Workspace sitecontains data for multiple meeting instances within the site
+: Gets or sets a Boolean value that specifies whether the list in a Meeting Workspace sitecontains data for multiple meeting instances within the site.
 
 `--navigateForFormsPages [navigateForFormsPages]`
-: Indicates whether to navigate for forms pages or use a modal dialog
+: Indicates whether to navigate for forms pages or use a modal dialog.
 
 `--needUpdateSiteClientTag [needUpdateSiteClientTag]`
 : A boolean value that determines whether to editing documents in this list should increment the ClientTag for the site. The tag is used to allow clients to cache JS/CSS/resources that are retrieved from the Content DB, including custom CSR templates.
 
 `--noCrawl [noCrawl]`
-: Gets or sets a Boolean value specifying whether crawling is enabled for the list
+: Gets or sets a Boolean value specifying whether crawling is enabled for the list.
 
 `--onQuickLaunch [onQuickLaunch]`
-: Gets or sets a Boolean value that specifies whether the list appears on the Quick Launch area of the home page
+: Gets or sets a Boolean value that specifies whether the list appears on the Quick Launch area of the home page.
 
 `--ordered [ordered]`
-: Gets or sets a Boolean value that specifies whether the option to allow users to reorder items in the list is available on the Edit View page for the list
+: Gets or sets a Boolean value that specifies whether the option to allow users to reorder items in the list is available on the Edit View page for the list.
 
 `--parserDisabled [parserDisabled]`
-: Gets or sets a Boolean value that specifies whether the parser should be disabled
+: Gets or sets a Boolean value that specifies whether the parser should be disabled.
 
 `--readOnlyUI [readOnlyUI]`
-: A boolean value that indicates whether the UI for this list should be presented in a read-only fashion. This will not affect security nor will it actually prevent changes to the list from occurring - it only affects the way the UI is displayed
+: A boolean value that indicates whether the UI for this list should be presented in a read-only fashion. This will not affect security nor will it actually prevent changes to the list from occurring - it only affects the way the UI is displayed.
 
 `--readSecurity [readSecurity]`
-: Gets or sets the Read security setting for the list. Valid values are 1 (All users have Read access to all items)|2 (Users have Read access only to items that they create)
+: Gets or sets the Read security setting for the list. Valid values are 1 (All users have Read access to all items)|2 (Users have Read access only to items that they create).
 
 `--requestAccessEnabled [requestAccessEnabled]`
-: Gets or sets a Boolean value that specifies whether the option to allow users to request access to the list is available
+: Gets or sets a Boolean value that specifies whether the option to allow users to request access to the list is available.
 
 `--restrictUserUpdates [restrictUserUpdates]`
-: A boolean value that indicates whether the this list is a restricted one or not The value can't be changed if there are existing items in the list
+: A boolean value that indicates whether the this list is a restricted one or not The value can't be changed if there are existing items in the list.
 
 `--sendToLocationName [sendToLocationName]`
 : Gets or sets a file name to use when copying an item in the list to another document library.
 
 `--sendToLocationUrl [sendToLocationUrl]`
-: Gets or sets a URL to use when copying an item in the list to another document library
+: Gets or sets a URL to use when copying an item in the list to another document library.
 
 `--showUser [showUser]`
-: Gets or sets a Boolean value that specifies whether names of users are shown in the results of the survey
+: Gets or sets a Boolean value that specifies whether names of users are shown in the results of the survey.
 
 `--templateFeatureId [templateFeatureId]`
-: The globally unique identifier (GUID) of a template feature that is associated with the list
+: The globally unique identifier (GUID) of a template feature that is associated with the list.
 
 `--useFormsForDisplay [useFormsForDisplay]`
-: Indicates whether forms should be considered for display context or not
+: Indicates whether forms should be considered for display context or not.
 
 `--validationFormula [validationFormula]`
 : Gets or sets a formula that is evaluated each time that a list item is added or updated.
@@ -200,34 +200,34 @@ m365 spo list set [options]
 : Gets or sets the message that is displayed when validation fails for a list item.
 
 `--writeSecurity [writeSecurity]`
-: Gets or sets the Write security setting for the list. Valid values are 1 (All users can modify all items)|2 (Users can modify only items that they create)|4 (Users cannot modify any list item)
+: Gets or sets the Write security setting for the list. Valid values are 1 (All users can modify all items)|2 (Users can modify only items that they create)|4 (Users cannot modify any list item).
 
 `--schemaXml [schemaXml]`
-: (deprecated) The schema in Collaborative Application Markup Language (CAML) schemas that defines the list
+: (deprecated) The schema in Collaborative Application Markup Language (CAML) schemas that defines the list.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Update the _contentTypesEnabled_ property of the list with id _3EA5A977-315E-4E25-8B0F-E4F949BF6B8F_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Update the _contentTypesEnabled_ property of the list with id located in a specific site.
 
 ```sh
 m365 spo list set --webUrl https://contoso.sharepoint.com/sites/project-x --id 3EA5A977-315E-4E25-8B0F-E4F949BF6B8F --contentTypesEnabled true
 ```
 
-Enable versioning and set the number of major versions to keep on the list with id _3EA5A977-315E-4E25-8B0F-E4F949BF6B8F_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Enable versioning and set the number of major versions to keep on the list with id located in a specific site.
 
 ```sh
 m365 spo list set --webUrl https://contoso.sharepoint.com/sites/project-x --id 3EA5A977-315E-4E25-8B0F-E4F949BF6B8F --enableVersioning true --majorVersionLimit 50
 ```
 
-Enable content types and versioning in the list with id _3EA5A977-315E-4E25-8B0F-E4F949BF6B8F_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Enable content types and versioning in the list with id located in a specific site.
 
 ```sh
 m365 spo list set --webUrl https://contoso.sharepoint.com/sites/project-x --id 3EA5A977-315E-4E25-8B0F-E4F949BF6B8F --contentTypesEnabled true --enableVersioning true --majorVersionLimit 50 --majorWithMinorVersionsLimit 100
 ```
 
-Update the Title of a list retrieved by it's original Title
+Update the title of a list retrieved by it's original title.
 
 ```sh
 m365 spo list set --webUrl https://contoso.sharepoint.com/sites/project-x --title Documents --newTitle 'Different Title'

--- a/docs/docs/cmd/spo/list/list-sitescript-get.md
+++ b/docs/docs/cmd/spo/list/list-sitescript-get.md
@@ -14,13 +14,13 @@ m365 spo list sitescript get [options]
 : URL of the site where the list to extract the site script from is located.
 
 `-l, --listId [listId]`
-: ID of the list to extract the site script from. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: ID of the list to extract the site script from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `-t, --listTitle [listTitle]`
-: Title of the list to extract the site script from. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: Title of the list to extract the site script from. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `--listUrl [listUrl]`
-: Server- or site-relative URL of the list. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: Server- or site-relative URL of the list. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -93,6 +93,38 @@ m365 spo list sitescript get --listUrl 'Shared Documents' --webUrl https://conto
 === "CSV"
 
     ```csv
+    {
+      "$schema": "https://developer.microsoft.com/json-schemas/sp/site-design-script-actions.schema.json",
+      "actions": [
+        {
+          "verb": "createSPList",
+          "listName": "Test",
+          "templateType": 100,
+          "color": "0",
+          "icon": "3",
+          "subactions": [
+            {
+              "verb": "addSPView",
+              "name": "Alle items",
+              "viewFields": [
+                "ID"
+              ],
+              "query": "",
+              "rowLimit": 30,
+              "isPaged": true,
+              "makeDefault": true,
+              "formatterJSON": "",
+              "replaceViewFields": true
+            }
+          ]
+        }
+      ]
+    }
+    ```
+
+=== "Markdown"
+
+    ```md
     {
       "$schema": "https://developer.microsoft.com/json-schemas/sp/site-design-script-actions.schema.json",
       "actions": [

--- a/docs/docs/cmd/spo/list/list-view-add.md
+++ b/docs/docs/cmd/spo/list/list-view-add.md
@@ -14,13 +14,13 @@ m365 spo list view add [options]
 : URL of the site where the list is located.
 
 `--listId [listId]`
-: ID of the list to which the view should be added. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: ID of the list to which the view should be added. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `--listTitle [listTitle]`
-: Title of the list to which the view should be added. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: Title of the list to which the view should be added. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `--listUrl [listUrl]`
-: Relative URL of the list to which the view should be added. Specify either `listId`, `listTitle` or `listUrl` but not multiple.
+: Relative URL of the list to which the view should be added. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `--title <title>`
 : Title of the view to be created for the list.
@@ -54,7 +54,7 @@ We recommend using the `paged` option. When specified, the view supports display
 Add a view called _All events_ to a list with specific title.
 
 ```sh
-m365 spo list view add --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle "My List" --title "All events" --fields "FieldName1,FieldName2,Created,Author,Modified,Editor" --paged
+m365 spo list view add --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle "Test" --title "All events" --fields "FieldName1,FieldName2,Created,Author,Modified,Editor" --paged
 ```
 
 Add a view as default view with title _All events_ to a list with a specific URL.
@@ -72,7 +72,7 @@ m365 spo list view add --webUrl https://contoso.sharepoint.com/sites/project-x -
 Add a view called _All events_ with defined filter and sorting.
 
 ```sh
-m365 spo list view add --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle "My List" --title "All events" --fields "FieldName1" --viewQuery "<OrderBy><FieldRef Name='Created' Ascending='FALSE' /></OrderBy><Where><Eq><FieldRef Name='TextFieldName' /><Value Type='Text'>Field value</Value></Eq></Where>" --paged
+m365 spo list view add --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle "Test" --title "All events" --fields "FieldName1" --viewQuery "<OrderBy><FieldRef Name='Created' Ascending='FALSE' /></OrderBy><Where><Eq><FieldRef Name='TextFieldName' /><Value Type='Text'>Field value</Value></Eq></Where>" --paged
 ```
 
 ## Response
@@ -194,4 +194,65 @@ m365 spo list view add --webUrl https://contoso.sharepoint.com/sites/project-x -
     ```csv
     Aggregations,AggregationsStatus,AssociatedContentTypeId,BaseViewId,CalendarViewStyles,ColumnWidth,ContentTypeId,CustomFormatter,CustomOrder,DefaultView,DefaultViewForContentType,EditorModified,Formats,GridLayout,Hidden,HtmlSchemaXml,Id,ImageUrl,IncludeRootFolder,ViewJoins,JSLink,ListViewXml,Method,MobileDefaultView,MobileView,ModerationType,NewDocumentTemplates,OrderedView,Paged,PersonalView,ViewProjectedFields,ViewQuery,ReadOnlyView,RequiresClientIntegration,RowLimit,Scope,ServerRelativePath,ServerRelativeUrl,StyleId,TabularView,Threaded,Title,Toolbar,ToolbarTemplateName,ViewType,ViewData,ViewType2,VisualizationInfo
     ,,,,,,"{""StringValue"":""0x""}",,,,,,,,,"<View Type=""HTML"" Url=""/Lists/Test/All events2.aspx"" Personal=""FALSE"" DisplayName=""All events"" DefaultView=""FALSE"" Name=""{0F11C3F1-E174-4A85-93A9-B4AFB7BD41B6}""><ViewFields><FieldRef Name=""Title"" /></ViewFields><Query><OrderBy><FieldRef Name=""Created"" Ascending=""FALSE"" /></OrderBy><Where><Eq><FieldRef Name=""TextFieldName"" /><Value Type=""Text"">Field value</Value></Eq></Where></Query><RowLimit Paged=""TRUE"">30</RowLimit></View>",0f11c3f1-e174-4a85-93a9-b4afb7bd41b6,,,,,"<View Type=""HTML"" Url=""/Lists/Test/All events2.aspx"" Personal=""FALSE"" DisplayName=""All events"" DefaultView=""FALSE"" Name=""{0F11C3F1-E174-4A85-93A9-B4AFB7BD41B6}"" ><Query><OrderBy><FieldRef Name=""Created"" Ascending=""FALSE"" /></OrderBy><Where><Eq><FieldRef Name=""TextFieldName"" /><Value Type=""Text"">Field value</Value></Eq></Where></Query><ViewFields><FieldRef Name=""Title"" /></ViewFields><RowLimit Paged=""TRUE"">30</RowLimit><Toolbar Type=""None""/></View>",,,,,,,1,,,"<OrderBy><FieldRef Name=""Created"" Ascending=""FALSE"" /></OrderBy><Where><Eq><FieldRef Name=""TextFieldName"" /><Value Type=""Text"">Field value</Value></Eq></Where>",,,30,0,"{""DecodedUrl"":""/Lists/Test/All events2.aspx""}",/Lists/Test/All events2.aspx,,1,,All events,,,HTML,,,
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo list view add --webUrl "https://contoso.sharepoint.com" --listTitle "Test" --title "All events" --fields "FieldName1" --viewQuery "<OrderBy><FieldRef Name='Created' Ascending='FALSE' /></OrderBy><Where><Eq><FieldRef Name='TextFieldName' /><Value Type='Text'>Field value</Value></Eq></Where>" --paged "true"
+
+    Date: 2/20/2023
+
+    ## All events (f3cade4a-d8c4-43b3-971c-9a4acc2510b8)
+
+    Property | Value
+    ---------|-------
+    Aggregations | null
+    AggregationsStatus | null
+    AssociatedContentTypeId | null
+    BaseViewId | null
+    CalendarViewStyles | null
+    ColumnWidth | null
+    ContentTypeId | {"StringValue":"0x"}
+    CustomFormatter | null
+    CustomOrder | null
+    DefaultView | false
+    DefaultViewForContentType | false
+    EditorModified | false
+    Formats | null
+    GridLayout | null
+    Hidden | false
+    HtmlSchemaXml | <View Type="HTML" Url="/Lists/Test/All events.aspx" Personal="FALSE" DisplayName="All events" DefaultView="FALSE" Name="{F3CADE4A-D8C4-43B3-971C-9A4ACC2510B8}"><ViewFields><FieldRef Name="FieldName1" /></ViewFields><Query><OrderBy><FieldRef Name="Created" Ascending="FALSE" /></OrderBy><Where><Eq><FieldRef Name="TextFieldName" /><Value Type="Text">Field value</Value></Eq></Where></Query><RowLimit Paged="TRUE">30</RowLimit></View>
+    Id | f3cade4a-d8c4-43b3-971c-9a4acc2510b8
+    ImageUrl | null
+    IncludeRootFolder | false
+    ViewJoins | null
+    JSLink | null
+    ListViewXml | <View Type="HTML" Url="/Lists/Test/All events.aspx" Personal="FALSE" DisplayName="All events" DefaultView="FALSE" Name="{F3CADE4A-D8C4-43B3-971C-9A4ACC2510B8}" ><Query><OrderBy><FieldRef Name="Created" Ascending="FALSE" /></OrderBy><Where><Eq><FieldRef Name="TextFieldName" /><Value Type="Text">Field value</Value></Eq></Where></Query><ViewFields><FieldRef Name="FieldName1" /></ViewFields><RowLimit Paged="TRUE">30</RowLimit><Toolbar Type="None"/></View>
+    Method | null
+    MobileDefaultView | false
+    MobileView | false
+    ModerationType | null
+    NewDocumentTemplates | null
+    OrderedView | false
+    Paged | true
+    PersonalView | false
+    ViewProjectedFields | null
+    ViewQuery | <OrderBy><FieldRef Name="Created" Ascending="FALSE" /></OrderBy><Where><Eq><FieldRef Name="TextFieldName" /><Value Type="Text">Field value</Value></Eq></Where>
+    ReadOnlyView | false
+    RequiresClientIntegration | false
+    RowLimit | 30
+    Scope | 0
+    ServerRelativePath | {"DecodedUrl":"/Lists/Test/All events.aspx"}
+    ServerRelativeUrl | /Lists/Test/All events.aspx
+    StyleId | null
+    TabularView | true
+    Threaded | false
+    Title | All events
+    Toolbar | null
+    ToolbarTemplateName | null
+    ViewType | HTML
+    ViewData | null
+    ViewType2 | null
+    VisualizationInfo | null
     ```

--- a/docs/docs/cmd/spo/list/list-view-field-add.md
+++ b/docs/docs/cmd/spo/list/list-view-field-add.md
@@ -11,7 +11,7 @@ m365 spo list view field add [options]
 ## Options
 
 `-u, --webUrl <webUrl>`
-: URL of the site where the list is located
+: URL of the site where the list is located.
 
 `--listId [listId]`
 : ID of the list where the view is located. Specify either `listId`, `listTitle`, or `listUrl`.
@@ -23,43 +23,43 @@ m365 spo list view field add [options]
 : Server- or site-relative URL of the list. Specify either `listId` , `listTitle` or `listUrl`.
 
 `--viewId [viewId]`
-: ID of the view to update. Specify `viewTitle` or `viewId` but not both
+: ID of the view to update. Specify `viewTitle` or `viewId` but not both.
 
 `--viewTitle [viewTitle]`
-: Title of the view to update. Specify `viewTitle` or `viewId` but not both
+: Title of the view to update. Specify `viewTitle` or `viewId` but not both.
 
 `--id [id]`
-: ID of the field to add. Specify `id` or `title` but not both
+: ID of the field to add. Specify `id` or `title` but not both.
 
 `--title [title]`
-: The **case-sensitive** internal name or display name of the field to add. Specify `id` or `title` but not both
+: The **case-sensitive** internal name or display name of the field to add. Specify `id` or `title` but not both.
 
 `--position [position]`
-: The zero-based index of the position for the field
+: The zero-based index of the position for the field.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Examples
 
-Add field with ID _330f29c5-5c4c-465f-9f4b-7903020ae1ce_ to view with ID _3d760127-982c-405e-9c93-e1f76e1a1110_ of the list with ID _1f187321-f086-4d3d-8523-517e94cc9df9_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Add field with ID to view with ID of the list with ID located in a specific site.
 
 ```sh
 m365 spo list view field add --webUrl https://contoso.sharepoint.com/sites/project-x --listId 1f187321-f086-4d3d-8523-517e94cc9df9 --viewId 3d760127-982c-405e-9c93-e1f76e1a1110 --id 330f29c5-5c4c-465f-9f4b-7903020ae1ce
 ```
 
-Add field with title _Custom field_ to view with title _All Documents_ of the list with title _Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Add field with title to view with title of the list with title _Documents_ located in a specific site.
 
 ```sh
 m365 spo list view field add --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle Documents --viewTitle 'All Documents' --title 'Custom field'
 ```
 
-Add field with title _Custom field_ at the position _0_ to view with title _My Events_ of the list with url _/sites/project-x/lists/Events_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Add field with title at the position to view with title of the list with url located in a specific site.
 
 ```sh
 m365 spo list view field add --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl '/sites/project-x/lists/Events' --viewTitle 'My Events' --title 'Custom field' --fieldPosition 0
 ```
 
-Add field with title _Custom field_ to view with title _All Documents_ of the list with site-relative URL _/Shared Documents_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Add field with title to view with title of the list with site-relative URL located in a specific site.
 
 ```sh
 m365 spo list view field add --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'Shared Documents' --viewTitle 'All Documents' --fieldTitle 'Custom field'

--- a/docs/docs/cmd/spo/list/list-view-get.md
+++ b/docs/docs/cmd/spo/list/list-view-get.md
@@ -170,3 +170,64 @@ m365 spo list view get --webUrl https://contoso.sharepoint.com/sites/project-x -
     Aggregations,AggregationsStatus,AssociatedContentTypeId,BaseViewId,CalendarViewStyles,ColumnWidth,ContentTypeId,CustomFormatter,CustomOrder,DefaultView,DefaultViewForContentType,EditorModified,Formats,GridLayout,Hidden,HtmlSchemaXml,Id,ImageUrl,IncludeRootFolder,ViewJoins,JSLink,ListViewXml,Method,MobileDefaultView,MobileView,ModerationType,NewDocumentTemplates,OrderedView,Paged,PersonalView,ViewProjectedFields,ViewQuery,ReadOnlyView,RequiresClientIntegration,RowLimit,Scope,ServerRelativePath,ServerRelativeUrl,StyleId,TabularView,Threaded,Title,Toolbar,ToolbarTemplateName,ViewType,ViewData,ViewType2,VisualizationInfo
     ,,,1,,,"{""StringValue"":""0x""}",,,,,,,,,"<View Name=""{3CD2E934-F482-4D4A-A9B8-A13B49B3D226}"" Type=""HTML"" DisplayName=""All events"" Url=""/Lists/Test/All events.aspx"" Level=""1"" BaseViewID=""1"" ContentTypeID=""0x"" ImageUrl=""/_layouts/15/images/generic.png?rev=47""><ViewFields><FieldRef Name=""Title"" /></ViewFields><Query><OrderBy><FieldRef Name=""Created"" Ascending=""FALSE"" /></OrderBy><Where><Eq><FieldRef Name=""TextFieldName"" /><Value Type=""Text"">Field value</Value></Eq></Where></Query><RowLimit Paged=""TRUE"">30</RowLimit><XslLink Default=""TRUE"">main.xsl</XslLink><JSLink>clienttemplates.js</JSLink><Toolbar Type=""Standard"" /><ParameterBindings><ParameterBinding Name=""NoAnnouncements"" Location=""Resource(wss,noXinviewofY_LIST)"" /><ParameterBinding Name=""NoAnnouncementsHowTo"" Location=""Resource(wss,noXinviewofY_DEFAULT)"" /></ParameterBindings></View>",3cd2e934-f482-4d4a-a9b8-a13b49b3d226,/_layouts/15/images/generic.png?rev=47,,,clienttemplates.js,"<View Name=""{3CD2E934-F482-4D4A-A9B8-A13B49B3D226}"" Type=""HTML"" DisplayName=""All events"" Url=""/Lists/Test/All events.aspx"" Level=""1"" BaseViewID=""1"" ContentTypeID=""0x"" ImageUrl=""/_layouts/15/images/generic.png?rev=47"" ><Query><OrderBy><FieldRef Name=""Created"" Ascending=""FALSE"" /></OrderBy><Where><Eq><FieldRef Name=""TextFieldName"" /><Value Type=""Text"">Field value</Value></Eq></Where></Query><ViewFields><FieldRef Name=""Title"" /></ViewFields><RowLimit Paged=""TRUE"">30</RowLimit><JSLink>clienttemplates.js</JSLink><XslLink Default=""TRUE"">main.xsl</XslLink><Toolbar Type=""Standard""/></View>",,,,,,,1,,,"<OrderBy><FieldRef Name=""Created"" Ascending=""FALSE"" /></OrderBy><Where><Eq><FieldRef Name=""TextFieldName"" /><Value Type=""Text"">Field value</Value></Eq></Where>",,,30,0,"{""DecodedUrl"":""/Lists/Test/All events.aspx""}",/Lists/Test/All events.aspx,,1,,All events,,,HTML,,,
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo list view get --webUrl "https://contoso.sharepoint.com" --listTitle "My List" --title "All Items"
+
+    Date: 2/20/2023
+
+    ## All Items (6275ed5c-8e4f-4e81-8060-2d9162b29952)
+
+    Property | Value
+    ---------|-------
+    Aggregations | null
+    AggregationsStatus | null
+    AssociatedContentTypeId | null
+    BaseViewId | 1
+    CalendarViewStyles | null
+    ColumnWidth | null
+    ContentTypeId | {"StringValue":"0x"}
+    CustomFormatter |
+    CustomOrder | null
+    DefaultView | true
+    DefaultViewForContentType | false
+    EditorModified | false
+    Formats | null
+    GridLayout | null
+    Hidden | false
+    HtmlSchemaXml | <View Name="{6275ED5C-8E4F-4E81-8060-2D9162B29952}" DefaultView="TRUE" MobileView="TRUE" MobileDefaultView="TRUE" Type="HTML" DisplayName="All Items" Url="/teams/AllStars/Lists/My List/AllItems.aspx" Level="1" BaseViewID="1" ContentTypeID="0x" ImageUrl="/\_layouts/15/images/generic.png?rev=47"><Query /><ViewFields><FieldRef Name="LinkTitle" /><FieldRef Name="FieldName1" /></ViewFields><Toolbar Type="Standard" /><CustomFormatter /><XslLink Default="TRUE">main.xsl</XslLink><JSLink>clienttemplates.js</JSLink><RowLimit Paged="TRUE">30</RowLimit><ParameterBindings><ParameterBinding Name="NoAnnouncements" Location="Resource(wss,noXinviewofY\_LIST)" /><ParameterBinding Name="NoAnnouncementsHowTo" Location="Resource(wss,noXinviewofY\_DEFAULT)" /></ParameterBindings></View>
+    Id | 6275ed5c-8e4f-4e81-8060-2d9162b29952
+    ImageUrl | /\_layouts/15/images/generic.png?rev=47
+    IncludeRootFolder | false
+    ViewJoins | null
+    JSLink | clienttemplates.js
+    ListViewXml | <View Name="{6275ED5C-8E4F-4E81-8060-2D9162B29952}" DefaultView="TRUE" MobileView="TRUE" MobileDefaultView="TRUE" Type="HTML" DisplayName="All Items" Url="/teams/AllStars/Lists/My List/AllItems.aspx" Level="1" BaseViewID="1" ContentTypeID="0x" ImageUrl="/\_layouts/15/images/generic.png?rev=47" ><Query /><ViewFields><FieldRef Name="LinkTitle" /><FieldRef Name="FieldName1" /></ViewFields><RowLimit Paged="TRUE">30</RowLimit><JSLink>clienttemplates.js</JSLink><XslLink Default="TRUE">main.xsl</XslLink><CustomFormatter /><Toolbar Type="Standard"/></View>
+    Method | null
+    MobileDefaultView | true
+    MobileView | true
+    ModerationType | null
+    NewDocumentTemplates | null
+    OrderedView | false
+    Paged | true
+    PersonalView | false
+    ViewProjectedFields | null
+    ViewQuery |
+    ReadOnlyView | false
+    RequiresClientIntegration | false
+    RowLimit | 30
+    Scope | 0
+    ServerRelativePath | {"DecodedUrl":"/teams/AllStars/Lists/My List/AllItems.aspx"}
+    ServerRelativeUrl | /teams/AllStars/Lists/My List/AllItems.aspx
+    StyleId | null
+    TabularView | true
+    Threaded | false
+    Title | All Items
+    Toolbar |
+    ToolbarTemplateName | null
+    ViewType | HTML
+    ViewData | null
+    ViewType2 | null
+    VisualizationInfo | null
+    ```

--- a/docs/docs/cmd/spo/list/list-view-list.md
+++ b/docs/docs/cmd/spo/list/list-view-list.md
@@ -121,3 +121,64 @@ m365 spo list view list --webUrl https://contoso.sharepoint.com/sites/project-x 
     Id,Title,DefaultView,Hidden,BaseViewId
     3cd2e934-f482-4d4a-a9b8-a13b49b3d226,All events,,,1
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo list view list --webUrl "https://contoso.sharepoint.com" --listTitle "My List"
+
+    Date: 2/20/2023
+
+    ## All Items (6275ed5c-8e4f-4e81-8060-2d9162b29952)
+
+    Property | Value
+    ---------|-------
+    Aggregations | null
+    AggregationsStatus | null
+    AssociatedContentTypeId | null
+    BaseViewId | 1
+    CalendarViewStyles | null
+    ColumnWidth | null
+    ContentTypeId | {"StringValue":"0x"}
+    CustomFormatter |
+    CustomOrder | null
+    DefaultView | true
+    DefaultViewForContentType | false
+    EditorModified | false
+    Formats | null
+    GridLayout | null
+    Hidden | false
+    HtmlSchemaXml | <View Name="{6275ED5C-8E4F-4E81-8060-2D9162B29952}" DefaultView="TRUE" MobileView="TRUE" MobileDefaultView="TRUE" Type="HTML" DisplayName="All Items" Url="/teams/AllStars/Lists/My List/AllItems.aspx" Level="1" BaseViewID="1" ContentTypeID="0x" ImageUrl="/\_layouts/15/images/generic.png?rev=47"><Query /><ViewFields><FieldRef Name="LinkTitle" /><FieldRef Name="FieldName1" /></ViewFields><Toolbar Type="Standard" /><CustomFormatter /><XslLink Default="TRUE">main.xsl</XslLink><JSLink>clienttemplates.js</JSLink><RowLimit Paged="TRUE">30</RowLimit><ParameterBindings><ParameterBinding Name="NoAnnouncements" Location="Resource(wss,noXinviewofY\_LIST)" /><ParameterBinding Name="NoAnnouncementsHowTo" Location="Resource(wss,noXinviewofY\_DEFAULT)" /></ParameterBindings></View>
+    Id | 6275ed5c-8e4f-4e81-8060-2d9162b29952
+    ImageUrl | /\_layouts/15/images/generic.png?rev=47
+    IncludeRootFolder | false
+    ViewJoins | null
+    JSLink | clienttemplates.js
+    ListViewXml | <View Name="{6275ED5C-8E4F-4E81-8060-2D9162B29952}" DefaultView="TRUE" MobileView="TRUE" MobileDefaultView="TRUE" Type="HTML" DisplayName="All Items" Url="/teams/AllStars/Lists/My List/AllItems.aspx" Level="1" BaseViewID="1" ContentTypeID="0x" ImageUrl="/\_layouts/15/images/generic.png?rev=47" ><Query /><ViewFields><FieldRef Name="LinkTitle" /><FieldRef Name="FieldName1" /></ViewFields><RowLimit Paged="TRUE">30</RowLimit><JSLink>clienttemplates.js</JSLink><XslLink Default="TRUE">main.xsl</XslLink><CustomFormatter /><Toolbar Type="Standard"/></View>
+    Method | null
+    MobileDefaultView | true
+    MobileView | true
+    ModerationType | null
+    NewDocumentTemplates | null
+    OrderedView | false
+    Paged | true
+    PersonalView | false
+    ViewProjectedFields | null
+    ViewQuery |
+    ReadOnlyView | false
+    RequiresClientIntegration | false
+    RowLimit | 30
+    Scope | 0
+    ServerRelativePath | {"DecodedUrl":"/teams/AllStars/Lists/My List/AllItems.aspx"}
+    ServerRelativeUrl | /teams/AllStars/Lists/My List/AllItems.aspx
+    StyleId | null
+    TabularView | true
+    Threaded | false
+    Title | All Items
+    Toolbar |
+    ToolbarTemplateName | null
+    ViewType | HTML
+    ViewData | null
+    ViewType2 | null
+    VisualizationInfo | null
+    ```

--- a/docs/docs/cmd/spo/list/list-webhook-add.md
+++ b/docs/docs/cmd/spo/list/list-webhook-add.md
@@ -86,3 +86,22 @@ m365 spo list webhook add --webUrl https://contoso.sharepoint.com/sites/ninja --
     clientState,expirationDateTime,id,notificationUrl,resource,resourceData
     random client state,2019-05-29T23:00:00.000Z,ef69c37d-cb0e-46d9-9758-5ebdeffd6959,https://contoso-funcions.azurewebsites.net/webhook,0987cfd9-f02c-479b-9fb4-3f0550462848,
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo list webhook add --webUrl "https://contoso.sharepoint.com/sites/ninja" --listUrl "/sites/ninja/Documents" --notificationUrl "https://contoso-funcions.azurewebsites.net/webhook" --expirationDateTime "2019-01-21"
+
+    Date: 2/20/2023
+
+    ## ef69c37d-cb0e-46d9-9758-5ebdeffd6959
+
+    Property | Value
+    ---------|-------
+    clientState | random client state
+    expirationDateTime | 2019-05-29T23:00:00.000Z
+    id | ef69c37d-cb0e-46d9-9758-5ebdeffd6959
+    notificationUrl | https://contoso-funcions.azurewebsites.net/webhook
+    resource | 0987cfd9-f02c-479b-9fb4-3f0550462848
+    resourceData | null
+    ```

--- a/docs/docs/cmd/spo/list/list-webhook-get.md
+++ b/docs/docs/cmd/spo/list/list-webhook-get.md
@@ -83,3 +83,22 @@ m365 spo list webhook get --webUrl https://contoso.sharepoint.com/sites/project-
     clientState,expirationDateTime,id,notificationUrl,resource,resourceData
     system-managed:8082D436-D8DA-458D-96AD-34C902B73F37,2022-11-16T20:25:12.2735056Z,b8838bbb-9ddb-44fb-9016-0aacb9e02b77,https://northeurope1-0.pushnp.svc.ms/notifications?token=1e263e06-4bea-4db1-9f9f-5c8f713eef76,97d19285-b8a6-4c7f-9c6c-d6b850a6561a,
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo list webhook get --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "Documents" --id "b8838bbb-9ddb-44fb-9016-0aacb9e02b77"
+
+    Date: 2/20/2023
+
+    ## b8838bbb-9ddb-44fb-9016-0aacb9e02b77
+
+    Property | Value
+    ---------|-------
+    clientState| system-managed:8082D436-D8DA-458D-96AD-34C902B73F37
+    expirationDateTime| 2022-11-16T20:25:12.2735056Z
+    id| b8838bbb-9ddb-44fb-9016-0aacb9e02b77
+    notificationUrl| https://northeurope1-0.pushnp.svc.ms/notifications?token=1e263e06-4bea-4db1-9f9f-5c8f713eef76
+    resource| 97d19285-b8a6-4c7f-9c6c-d6b850a6561a
+    resourceData| null
+    ```

--- a/docs/docs/cmd/spo/list/list-webhook-list.md
+++ b/docs/docs/cmd/spo/list/list-webhook-list.md
@@ -75,3 +75,22 @@ m365 spo list webhook list --webUrl https://contoso.sharepoint.com/sites/project
     id,clientState,expirationDateTime,resource
     b8838bbb-9ddb-44fb-9016-0aacb9e02b77,system-managed:8082D436-D8DA-458D-96AD-34C902B73F37,2022-11-16T20:25:12.2735056Z,97d19285-b8a6-4c7f-9c6c-d6b850a6561a
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo list webhook list --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "Documents"
+
+    Date: 2/20/2023
+
+    ## b8838bbb-9ddb-44fb-9016-0aacb9e02b77
+
+    Property | Value
+    ---------|-------
+    clientState| system-managed:8082D436-D8DA-458D-96AD-34C902B73F37
+    expirationDateTime| 2022-11-16T20:25:12.2735056Z
+    id| b8838bbb-9ddb-44fb-9016-0aacb9e02b77
+    notificationUrl| https://northeurope1-0.pushnp.svc.ms/notifications?token=1e263e06-4bea-4db1-9f9f-5c8f713eef76
+    resource| 97d19285-b8a6-4c7f-9c6c-d6b850a6561a
+    resourceData| null
+    ```

--- a/docs/docs/cmd/spo/listitem/listitem-add.md
+++ b/docs/docs/cmd/spo/listitem/listitem-add.md
@@ -132,3 +132,32 @@ m365 spo listitem add --listTitle "Demo List" --webUrl https://contoso.sharepoin
     FileSystemObjectType,Id,ServerRedirectedEmbedUri,ServerRedirectedEmbedUrl,ID,ContentTypeId,Title,Modified,Created,AuthorId,EditorId,OData__UIVersionString,Attachments,GUID,ComplianceAssetId,OData__vti_ItemDeclaredRecord
     0,235,,,235,0x01003CDBEB7138618C47A98D56499135D6EE0004C0F5794DEBCC4BAC981AC4AE1BD803,Test,2022-11-16T20:56:09Z,2022-11-16T20:56:09Z,10,10,1.0,,7aa8f3bd-a0a2-4974-81c8-2ac7ddc8e2d8,,
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo listitem add --contentType "Item" --listTitle "My List" --webUrl "https://contoso.sharepoint.com/sites/project-x" --Title "Test"
+
+    Date: 2/20/2023
+
+    ## Test (234)
+
+    Property | Value
+    ---------|-------
+    FileSystemObjectType | 0
+    Id | 234
+    ServerRedirectedEmbedUri | null
+    ServerRedirectedEmbedUrl |
+    ContentTypeId | 0x01003CDBEB7138618C47A98D56499135D6EE0004C0F5794DEBCC4BAC981AC4AE1BD803
+    Title | Test
+    ComplianceAssetId | null
+    FieldName1 | null
+    ID | 234
+    Modified | 2022-11-16T20:55:45Z
+    Created | 2022-11-16T20:55:45Z
+    AuthorId | 10
+    EditorId | 10
+    OData\_\_UIVersionString | 1.0
+    Attachments | false
+    GUID | 352e3855-56fa-4b68-b6be-4644d6adf204
+    ```

--- a/docs/docs/cmd/spo/listitem/listitem-attachment-list.md
+++ b/docs/docs/cmd/spo/listitem/listitem-attachment-list.md
@@ -80,3 +80,18 @@ m365 spo listitem attachment list --webUrl https://contoso.sharepoint.com/sites/
     FileName,ServerRelativeUrl
     DummyDocument.docx,/Lists/Test/Attachments/236/DummyDocument.docx
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo listitem attachment list --webUrl "https://contoso.sharepoint.com" --listTitle "Test" --itemId "236"
+
+    Date: 2/20/2023
+
+    Property | Value
+    ---------|-------
+    FileName | DummyDocument.docx
+    FileNameAsPath | {"DecodedUrl":"DummyDocument.docx"}
+    ServerRelativePath | {"DecodedUrl":"/Lists/Test/Attachments/236/DummyDocument.docx"}
+    ServerRelativeUrl | /Lists/Test/Attachments/236/DummyDocument.docx
+    ```

--- a/docs/docs/cmd/spo/listitem/listitem-get.md
+++ b/docs/docs/cmd/spo/listitem/listitem-get.md
@@ -118,6 +118,34 @@ m365 spo listitem get --listTitle "Demo List" --id 147 --webUrl https://contoso.
     0,147,,,0x010078BC2C6F12F0DB41BA554210A2BFA81600A320A11ABE6E90468525ECC747660126,Demo Item,2022-10-30T10:55:37Z,2022-10-30T10:55:22Z,10,10,3.0,,87f3138d-fac3-4126-97c0-543e55672261,
     ```
 
+=== "Markdown"
+
+    ```md
+    # spo listitem get --webUrl "https://contoso.sharepoint.com" --listTitle "My List" --id "147"
+
+    Date: 2/20/2023
+
+    ## Demo Item (147)
+
+    Property | Value
+    ---------|-------
+    FileSystemObjectType | 0
+    Id | 147
+    ServerRedirectedEmbedUri | null
+    ServerRedirectedEmbedUrl |
+    ContentTypeId | 0x010078BC2C6F12F0DB41BA554210A2BFA81600A320A11ABE6E90468525ECC747660126
+    Title | Demo Item
+    ComplianceAssetId | null
+    FieldName1 | null
+    Modified | 2022-10-30T10:55:37Z
+    Created | 2022-10-30T10:55:22Z
+    AuthorId | 10
+    EditorId | 10
+    OData\_\_UIVersionString | 3.0
+    Attachments | false
+    GUID | 87f3138d-fac3-4126-97c0-543e55672261
+    ```
+
 ### `withPermissions` response
 
 When we make use of the option `withPermissions` the response will differ. 
@@ -241,4 +269,33 @@ When we make use of the option `withPermissions` the response will differ.
     ```csv
     FileSystemObjectType,Id,ServerRedirectedEmbedUri,ServerRedirectedEmbedUrl,ContentTypeId,Title,Modified,Created,AuthorId,EditorId,OData__UIVersionString,Attachments,GUID,ComplianceAssetId,RoleAssignments
     0,147,,,0x010078BC2C6F12F0DB41BA554210A2BFA81600A320A11ABE6E90468525ECC747660126,Demo Item,2022-10-30T10:55:37Z,2022-10-30T10:55:22Z,10,10,3.0,,87f3138d-fac3-4126-97c0-543e55672261,"[{""Member"":{""Id"":3,""IsHiddenInUI"":false,""LoginName"":""Communication site Owners"",""Title"":""Communication site Owners"",""PrincipalType"":8,""AllowMembersEditMembership"":false,""AllowRequestToJoinLeave"":false,""AutoAcceptRequestToJoinLeave"":false,""Description"":null,""OnlyAllowMembersViewMembership"":false,""OwnerTitle"":""Communication site Owners"",""RequestToJoinLeaveEmailSetting"":""""},""RoleDefinitionBindings"":[{""BasePermissions"":{""High"":""2147483647"",""Low"":""4294967295""},""Description"":""Has full control."",""Hidden"":false,""Id"":1073741829,""Name"":""Full Control"",""Order"":1,""RoleTypeKind"":5,""BasePermissionsValue"":[""ViewListItems"",""AddListItems"",""EditListItems"",""DeleteListItems"",""ApproveItems"",""OpenItems"",""ViewVersions"",""DeleteVersions"",""CancelCheckout"",""ManagePersonalViews"",""ManageLists"",""ViewFormPages"",""AnonymousSearchAccessList"",""Open"",""ViewPages"",""AddAndCustomizePages"",""ApplyThemeAndBorder"",""ApplyStyleSheets"",""ViewUsageData"",""CreateSSCSite"",""ManageSubwebs"",""CreateGroups"",""ManagePermissions"",""BrowseDirectories"",""BrowseUserInfo"",""AddDelPrivateWebParts"",""UpdatePersonalWebParts"",""ManageWeb"",""AnonymousSearchAccessWebLists"",""UseClientIntegration"",""UseRemoteAPIs"",""ManageAlerts"",""CreateAlerts"",""EditMyUserInfo"",""EnumeratePermissions""],""RoleTypeKindValue"":""Administrator""}],""PrincipalId"":3}]"
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo listitem get --webUrl "https://contoso.sharepoint.com" --listTitle "My List" --id "147" --withPermissions "true"
+
+    Date: 2/20/2023
+
+    ## Demo Item (1)
+
+    Property | Value
+    ---------|-------
+    FFileSystemObjectType | 0
+    Id | 147
+    ServerRedirectedEmbedUri | null
+    ServerRedirectedEmbedUrl |
+    ContentTypeId | 0x010078BC2C6F12F0DB41BA554210A2BFA81600A320A11ABE6E90468525ECC747660126
+    Title | Demo Item
+    ComplianceAssetId | null
+    FieldName1 | null
+    Modified | 2022-10-30T10:55:37Z
+    Created | 2022-10-30T10:55:22Z
+    AuthorId | 10
+    EditorId | 10
+    OData\_\_UIVersionString | 3.0
+    Attachments | false
+    GUID | 87f3138d-fac3-4126-97c0-543e55672261
+    RoleAssignments | [{"Member":{"Id":3,"IsHiddenInUI":false,"LoginName":"Communication site Owners","Title":"Communication site Owners","PrincipalType":8,"AllowMembersEditMembership":false,"AllowRequestToJoinLeave":false,"AutoAcceptRequestToJoinLeave":false,"Description":null,"OnlyAllowMembersViewMembership":false,"OwnerTitle":"Communication site Owners","RequestToJoinLeaveEmailSetting":""},"RoleDefinitionBindings":[{"BasePermissions":{"High":"2147483647","Low":"4294967295"},"Description":"Has full control.","Hidden":false,"Id":1073741829,"Name":"Full Control","Order":1,"RoleTypeKind":5,"BasePermissionsValue":["ViewListItems","AddListItems","EditListItems","DeleteListItems","ApproveItems","OpenItems","ViewVersions","DeleteVersions","CancelCheckout","ManagePersonalViews","ManageLists","ViewFormPages","AnonymousSearchAccessList","Open","ViewPages","AddAndCustomizePages","ApplyThemeAndBorder","ApplyStyleSheets","ViewUsageData","CreateSSCSite","ManageSubwebs","CreateGroups","ManagePermissions","BrowseDirectories","BrowseUserInfo","AddDelPrivateWebParts","UpdatePersonalWebParts","ManageWeb","AnonymousSearchAccessWebLists","UseClientIntegration","UseRemoteAPIs","ManageAlerts","CreateAlerts","EditMyUserInfo","EnumeratePermissions"],"RoleTypeKindValue":"Administrator"}],"PrincipalId":3}]
     ```

--- a/docs/docs/cmd/spo/listitem/listitem-isrecord.md
+++ b/docs/docs/cmd/spo/listitem/listitem-isrecord.md
@@ -66,3 +66,9 @@ m365 spo listitem isrecord --webUrl https://contoso.sharepoint.com/sites/project
     ```csv
     false
     ```
+
+=== "Markdown"
+
+    ```md
+    false
+    ```

--- a/docs/docs/cmd/spo/listitem/listitem-list.md
+++ b/docs/docs/cmd/spo/listitem/listitem-list.md
@@ -135,3 +135,31 @@ m365 spo listitem list --listUrl /sites/project-x/documents --webUrl https://con
     FileSystemObjectType,Id,ServerRedirectedEmbedUri,ServerRedirectedEmbedUrl,ContentTypeId,Title,Modified,Created,AuthorId,EditorId,OData__UIVersionString,Attachments,GUID,ComplianceAssetId,OData__vti_ItemDeclaredRecord
     0,236,,,0x01003CDBEB7138618C47A98D56499135D6EE0004C0F5794DEBCC4BAC981AC4AE1BD803,Test,2022-11-16T21:00:03Z,2022-11-16T20:56:31Z,10,10,6.0,1,cac57513-e870-4e7a-9f23-f4ea10e14f4e,,
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo listitem list --webUrl "https://contoso.sharepoint.com" --listTitle "My List"
+
+    Date: 2/20/2023
+
+    ## Demo Item (147)
+
+    Property | Value
+    ---------|-------
+    FileSystemObjectType | 0
+    Id | 236
+    ServerRedirectedEmbedUri | null
+    ServerRedirectedEmbedUrl |
+    ContentTypeId | 0x01003CDBEB7138618C47A98D56499135D6EE0004C0F5794DEBCC4BAC981AC4AE1BD803
+    Title | Test
+    ComplianceAssetId | null
+    Modified | 2022-11-16T21:00:03Z
+    Created | 2022-11-16T20:56:31Z
+    AuthorId | 10
+    EditorId | 10
+    OData\_\_UIVersionString | 6.0
+    Attachments | false
+    GUID | cac57513-e870-4e7a-9f23-f4ea10e14f4e
+    OData__vti_ItemDeclaredRecord | null
+    ```

--- a/docs/docs/cmd/spo/listitem/listitem-record-declare.md
+++ b/docs/docs/cmd/spo/listitem/listitem-record-declare.md
@@ -84,3 +84,18 @@ m365 spo listitem record declare --webUrl https://contoso.sharepoint.com/sites/p
     SchemaVersion,LibraryVersion,ErrorInfo,TraceCorrelationId
     15.0.0.0,16.0.23102.12004,,0d4779a0-609c-5000-843d-c98e4764c937
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo listitem record declare --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "Demo List" --listItemId "1" --date "2012-03-14"
+    
+    Date: 2/20/2023
+
+    Property | Value
+    ---------|-------
+    SchemaVersion | 15.0.0.0
+    LibraryVersion | 16.0.23102.12004
+    ErrorInfo | null
+    TraceCorrelationId | 064779a0-d05b-5000-843d-c36803e58f12
+    ```

--- a/docs/docs/cmd/spo/listitem/listitem-set.md
+++ b/docs/docs/cmd/spo/listitem/listitem-set.md
@@ -129,3 +129,33 @@ m365 spo listitem set --listTitle "Demo List" --id 147 --webUrl https://contoso.
     FileSystemObjectType,Id,ServerRedirectedEmbedUri,ServerRedirectedEmbedUrl,ID,ContentTypeId,Title,Modified,Created,AuthorId,EditorId,OData__UIVersionString,Attachments,GUID,ComplianceAssetId,OData__vti_ItemDeclaredRecord
     0,236,,,236,0x01003CDBEB7138618C47A98D56499135D6EE0004C0F5794DEBCC4BAC981AC4AE1BD803,Updated Title,2022-11-16T21:10:55Z,2022-11-16T20:56:31Z,10,10,9.0,1,cac57513-e870-4e7a-9f23-f4ea10e14f4e,,
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo listitem set --listTitle "My List" --id "236" --webUrl "https://contoso.sharepoint.com" --Title "Updated Title"
+
+    Date: 2/20/2023
+
+    ## Updated Title (236)
+
+    Property | Value
+    ---------|-------
+    FileSystemObjectType | 0
+    Id | 236
+    ServerRedirectedEmbedUri | null
+    ServerRedirectedEmbedUrl |
+    ContentTypeId | 0x01003CDBEB7138618C47A98D56499135D6EE0004C0F5794DEBCC4BAC981AC4AE1BD803
+    Title | Updated Title
+    ComplianceAssetId | null
+    FieldName1 | null
+    ID | 236
+    Modified | 2022-11-16T21:10:06Z
+    Created | 2022-11-16T20:56:31Z
+    AuthorId | 10
+    EditorId | 10
+    OData\_\_UIVersionString | 7.0
+    Attachments | true
+    GUID | cac57513-e870-4e7a-9f23-f4ea10e14f4e
+    OData__vti_ItemDeclaredRecord | null
+    ```

--- a/docs/docs/cmd/spo/navigation/navigation-node-add.md
+++ b/docs/docs/cmd/spo/navigation/navigation-node-add.md
@@ -103,3 +103,25 @@ m365 spo navigation node add --webUrl https://contoso.sharepoint.com/sites/team-
     AudienceIds,CurrentLCID,Id,IsDocLib,IsExternal,IsVisible,ListTemplateType,Title,Url
     "[""7aa4a1ca-4035-4f2f-bac7-7beada59b5ba""]",1033,2032,1,1,1,0,Navigation Link,https://contoso.sharepoint.com
     ```
+
+=== "Markdown"
+
+    ```md
+    # spo navigation node get --webUrl "https://contoso.sharepoint.com/sites/team-a" --location "TopNavigationBar" --title "Navigation Link" --url "https://contoso.sharepoint.com"
+
+    Date: 2/20/2023
+
+    ## Navigation Link (2030)
+
+    Property | Value
+    ---------|-------
+    AudienceIds | ["7aa4a1ca-4035-4f2f-bac7-7beada59b5ba"]
+    CurrentLCID | 1033
+    Id | 2030
+    IsDocLib | true
+    IsExternal | false
+    IsVisible | true
+    ListTemplateType | 0
+    Title | Navigation Link
+    Url | https://contoso.sharepoint.com
+    ```


### PR DESCRIPTION
Includes md output for `spo homesite` until `spo navigation` commands. Closes #4301