### PR TITLE
Enhances `spo applicationcustomizer add`, Closes #4335 

### DIFF
--- a/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-add.md
+++ b/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-add.md
@@ -23,7 +23,7 @@ m365 spo applicationcustomizer add [options]
 : JSON string with application customizer properties
 
 `-s, --scope [scope]`
-: Scope of the application customizer. Allowed values: `Site`, `Web`. Defaults to `Site`.
+: Scope of the application customizer. Allowed values: `Site`, `Web`. Defaults to `Web`.
 
 --8<-- "docs/cmd/_global.md"
 

--- a/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-add.md
+++ b/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-add.md
@@ -23,7 +23,7 @@ m365 spo applicationcustomizer add [options]
 : JSON string with application customizer properties
 
 `-s, --scope [scope]`
-: Scope of the application customizer. Allowed values: `Site`, `Web`. Defaults to `Web`.
+: Scope of the application customizer. Allowed values: `Site`, `Web`. Defaults to `Site`.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -51,7 +51,7 @@ m365 spo applicationcustomizer add --title 'Some customizer' --clientSideCompone
 Adds an application customizer to the sales site with some properties.
 
 ```sh
-m365 spo applicationcustomizer add --title 'Some customizer' --clientSideComponentId 799883f5-7962-4384-a10a-105adaec6ffc --clientSideComponentProperties '{ "someProperty": "Some value" }' --webUrl https://contoso.sharepoint.com/sites/sales --scope 'Web'
+m365 spo applicationcustomizer add --title 'Some customizer' --clientSideComponentId 799883f5-7962-4384-a10a-105adaec6ffc --clientSideComponentProperties '{ "someProperty": "Some value" }' --webUrl https://contoso.sharepoint.com/sites/sales --scope 'Site'
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-add.md
+++ b/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-add.md
@@ -22,6 +22,9 @@ m365 spo applicationcustomizer add [options]
 `--clientSideComponentProperties [clientSideComponentProperties]`
 : JSON string with application customizer properties
 
+`-s, --scope [scope]`
+: Scope of the application customizer. Allowed values: `Site`, `Web`. Defaults to `Site`.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
@@ -48,7 +51,7 @@ m365 spo applicationcustomizer add --title 'Some customizer' --clientSideCompone
 Adds an application customizer to the sales site with some properties.
 
 ```sh
-m365 spo applicationcustomizer add --title 'Some customizer' --clientSideComponentId 799883f5-7962-4384-a10a-105adaec6ffc --clientSideComponentProperties '{ "someProperty": "Some value" }' --webUrl https://contoso.sharepoint.com/sites/sales
+m365 spo applicationcustomizer add --title 'Some customizer' --clientSideComponentId 799883f5-7962-4384-a10a-105adaec6ffc --clientSideComponentProperties '{ "someProperty": "Some value" }' --webUrl https://contoso.sharepoint.com/sites/sales --scope 'Web'
 ```
 
 ## Response

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.spec.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.spec.ts
@@ -115,7 +115,7 @@ describe(commands.APPLICATIONCUSTOMIZER_ADD, () => {
 
   it('adds the application customizer to a specific site while specifying clientSideComponentProperties', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/Web/UserCustomActions'
+      if (opts.url === 'https://contoso.sharepoint.com/_api/Site/UserCustomActions'
         && opts.data['Location'] === 'ClientSideExtension.ApplicationCustomizer'
         && opts.data['ClientSideComponentId'] === clientSideComponentId
         && opts.data['ClientSideComponentProperties'] === clientSideComponentProperties

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.spec.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.spec.ts
@@ -115,7 +115,7 @@ describe(commands.APPLICATIONCUSTOMIZER_ADD, () => {
 
   it('adds the application customizer to a specific site while specifying clientSideComponentProperties', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/Site/UserCustomActions'
+      if (opts.url === 'https://contoso.sharepoint.com/_api/Web/UserCustomActions'
         && opts.data['Location'] === 'ClientSideExtension.ApplicationCustomizer'
         && opts.data['ClientSideComponentId'] === clientSideComponentId
         && opts.data['ClientSideComponentProperties'] === clientSideComponentProperties

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.spec.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.spec.ts
@@ -18,7 +18,7 @@ describe(commands.APPLICATIONCUSTOMIZER_ADD, () => {
   const clientSideComponentId = '76d5f8c8-6228-4df8-a2da-b94cbc8115bc';
   const clientSideComponentProperties = '{"testMessage":"Test message"}';
   const customActionError = {
-    "url": "https://mathijsdev2.sharepoint.com/_api/Web/UserCustomActions",
+    "url": "https://contoso.sharepoint.com/_api/Web/UserCustomActions",
     "status": 400,
     "statusText": "Bad Request"
   };
@@ -96,7 +96,7 @@ describe(commands.APPLICATIONCUSTOMIZER_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('adds application customizer to a specific site without specifying clientSideComponentProperties', async () => {
+  it('adds the application customizer to a specific site without specifying clientSideComponentProperties', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === 'https://contoso.sharepoint.com/_api/Web/UserCustomActions'
         && opts.data['Location'] === 'ClientSideExtension.ApplicationCustomizer'
@@ -109,13 +109,13 @@ describe(commands.APPLICATIONCUSTOMIZER_ADD, () => {
       throw customActionError;
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, title: title, clientSideComponentId: clientSideComponentId } } as any);
+    await command.action(logger, { options: { webUrl: webUrl, title: title, clientSideComponentId: clientSideComponentId, scope: 'Web' } } as any);
     assert(loggerLogToStderrSpy.notCalled);
   });
 
-  it('adds application customizer to a specific site while specifying clientSideComponentProperties', async () => {
+  it('adds the application customizer to a specific site while specifying clientSideComponentProperties', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/Web/UserCustomActions'
+      if (opts.url === 'https://contoso.sharepoint.com/_api/Site/UserCustomActions'
         && opts.data['Location'] === 'ClientSideExtension.ApplicationCustomizer'
         && opts.data['ClientSideComponentId'] === clientSideComponentId
         && opts.data['ClientSideComponentProperties'] === clientSideComponentProperties
@@ -140,13 +140,18 @@ describe(commands.APPLICATIONCUSTOMIZER_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if the scope option is not a valid scope', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, title: title, clientSideComponentId: clientSideComponentId, scope: 'Invalid scope' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('fails validation if the clientSideComponentProperties option is not a valid json string', async () => {
     const actual = await command.validate({ options: { webUrl: webUrl, title: title, clientSideComponentId: clientSideComponentId, clientSideComponentProperties: 'invalid json string' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('passes validation if all options are passed', async () => {
-    const actual = await command.validate({ options: { webUrl: webUrl, title: title, clientSideComponentId: clientSideComponentId, clientSideComponentProperties: clientSideComponentProperties } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: webUrl, title: title, clientSideComponentId: clientSideComponentId, clientSideComponentProperties: clientSideComponentProperties, scope: 'Site' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 }); 

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.ts
@@ -114,10 +114,7 @@ class SpoApplicationCustomizerAddCommand extends SpoCommand {
       requestBody.ClientSideComponentProperties = args.options.clientSideComponentProperties;
     }
 
-    let scope = args.options.scope;
-    if (!scope) {
-      scope = 'Site';
-    }
+    const scope = args.options.scope || 'Web';
 
     const requestOptions: any = {
       url: `${args.options.webUrl}/_api/${scope}/UserCustomActions`,

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.ts
@@ -114,7 +114,7 @@ class SpoApplicationCustomizerAddCommand extends SpoCommand {
       requestBody.ClientSideComponentProperties = args.options.clientSideComponentProperties;
     }
 
-    const scope = args.options.scope || 'Web';
+    const scope = args.options.scope || 'Site';
 
     const requestOptions: any = {
       url: `${args.options.webUrl}/_api/${scope}/UserCustomActions`,


### PR DESCRIPTION
This PR enhances `spo applicationcustomizer add`, adding the `scope` option.

Also replaced the `executeCommandWithOutput`.

 Closes #4335 