### PR TITLE
Fixes 'spo list add' command. Closes #4546

### DIFF
--- a/docs/docs/cmd/spo/list/list-add.md
+++ b/docs/docs/cmd/spo/list/list-add.md
@@ -13,7 +13,7 @@ m365 spo list add [options]
 `-t, --title <title>`
 : Title of the list to add
 
-`--baseTemplate <baseTemplate>`
+`--baseTemplate [baseTemplate]`
 : The list definition type on which the list is based. Allowed values `Announcements,Contacts,CustomGrid,DataSources,DiscussionBoard,DocumentLibrary,Events,GanttTasks,GenericList,IssuesTracking,Links,NoCodeWorkflows,PictureLibrary,Survey,Tasks,WebPageLibrary,WorkflowHistory,WorkflowProcess,XmlForm`. Default `GenericList`
 
 `-u, --webUrl <webUrl>`

--- a/src/m365/spo/commands/list/list-add.spec.ts
+++ b/src/m365/spo/commands/list/list-add.spec.ts
@@ -97,6 +97,22 @@ describe(commands.LIST_ADD, () => {
     assert.strictEqual(actual, expected);
   });
 
+  it('sets default baseTemplate for list', async () => {
+    const expected = 100;
+    let actual = '';
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if ((opts.url as string).indexOf(`/_api/web/lists`) > -1) {
+        actual = opts.data.BaseTemplate;
+        return Promise.resolve({ ErrorMessage: null });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, { options: { title: 'List 1', webUrl: 'https://contoso.sharepoint.com/sites/project-x' } });
+    assert.strictEqual(actual, expected);
+  });
+
   it('sets specified description for list', async () => {
     const expected = 'List 1 description';
     let actual = '';

--- a/src/m365/spo/commands/list/list-add.ts
+++ b/src/m365/spo/commands/list/list-add.ts
@@ -15,7 +15,7 @@ interface CommandArgs {
 
 interface Options extends GlobalOptions {
   title: string;
-  baseTemplate: string;
+  baseTemplate?: string;
   webUrl: string;
   description?: string;
   templateFeatureId?: string;
@@ -192,6 +192,7 @@ class SpoListAddCommand extends SpoCommand {
       const telemetryProps: any = {};
       // add properties with identifiable data
       [
+        'baseTemplate',
         'description',
         'templateFeatureId',
         'schemaXml',
@@ -245,7 +246,7 @@ class SpoListAddCommand extends SpoCommand {
         option: '-t, --title <title>'
       },
       {
-        option: '--baseTemplate <baseTemplate>',
+        option: '--baseTemplate [baseTemplate]',
         autocomplete: this.listTemplateTypeMap
       },
       {
@@ -489,9 +490,11 @@ class SpoListAddCommand extends SpoCommand {
           return isValidSharePointUrl;
         }
 
-        const template: ListTemplateType = ListTemplateType[(args.options.baseTemplate.trim() as keyof typeof ListTemplateType)];
-        if (!template) {
-          return `${args.options.baseTemplate} is not a valid baseTemplate value`;
+        if (args.options.baseTemplate) {
+          const template: ListTemplateType = ListTemplateType[(args.options.baseTemplate.trim() as keyof typeof ListTemplateType)];
+          if (!template) {
+            return `${args.options.baseTemplate} is not a valid baseTemplate value`;
+          }
         }
 
         if (args.options.templateFeatureId &&
@@ -603,7 +606,7 @@ class SpoListAddCommand extends SpoCommand {
   private mapRequestBody(options: Options): any {
     const requestBody: any = {
       Title: options.title,
-      BaseTemplate: ListTemplateType[(options.baseTemplate.trim() as keyof typeof ListTemplateType)].valueOf()
+      BaseTemplate: options.baseTemplate ? ListTemplateType[(options.baseTemplate.trim() as keyof typeof ListTemplateType)].valueOf() : ListTemplateType.GenericList
     };
 
     if (options.description) {


### PR DESCRIPTION
Fixes 'spo list add' command. Closes #4546
If we do not specify any value for option `baseTemplate`, then it should take the Default `GenericList`.