### PR TITLE
Fixes incorrect option name used in the examples

### DIFF
--- a/docs/docs/cmd/aad/user/user-set.md
+++ b/docs/docs/cmd/aad/user/user-set.md
@@ -74,7 +74,7 @@ m365 aad user set --objectId 1caf7dcd-7e83-4c3a-94f7-932a1299c844 --accountEnabl
 Reset password of a given user by userPrincipalName and require the user to change the password on the next sign in
 
 ```sh
-m365 aad user set --userPrincipalName steve@contoso.onmicrosoft.com --resetPassword --password 6NLUId79Lc24 --forceChangePasswordNextSignIn
+m365 aad user set --userPrincipalName steve@contoso.onmicrosoft.com --resetPassword --newPassword 6NLUId79Lc24 --forceChangePasswordNextSignIn
 ```
 
 Change password of the currently logged in user


### PR DESCRIPTION
Not related to an issue. Fixes an incorrect option name that was used in the examples of `aad user set`