### PR TITLE
Adds command `spo listitem batch set`

### DIFF
--- a/docs/docs/cmd/spo/listitem/listitem-batch-set.md
+++ b/docs/docs/cmd/spo/listitem/listitem-batch-set.md
@@ -33,6 +33,15 @@ m365 spo listitem batch set [options]
 
 --8<-- "docs/cmd/_global.md"
 
+## Remarks
+
+A sample CSV can be found below. The first line of the CSV-file should contain the internal column names that you wish to set.
+
+```csv
+ID,ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField,LookupList,LookupListMulti
+5,Item,Title Update,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa,john@contoso.com,john@contoso.com;doe@contoso.com,"https://bing.com, URL",5,2,2;3
+```
+
 ## Examples
 
 Updates a batch of items to a list retrieved by title in a specific site
@@ -51,15 +60,6 @@ Updates a batch of items to a list defined by server-relative URL in a specific 
 
 ```sh
 m365 spo listitem batch set --filePath "C:\Path\To\Csv\CsvFile.csv" --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl "/sites/project-x/lists/Demo List" --systemUpdate
-```
-
-## Remarks
-
-A sample CSV can be found below. The first line of the CSV-file should contain the internal column names that you wish to set.
-
-```csv
-ID,ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField,LookupList,LookupListMulti
-5,Item,Title Update,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa,john@contoso.com,john@contoso.com;doe@contoso.com,"https://bing.com, URL",5,2,2;3
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/listitem/listitem-batch-set.md
+++ b/docs/docs/cmd/spo/listitem/listitem-batch-set.md
@@ -1,0 +1,67 @@
+# spo listitem batch set
+
+Updates list items in a batch
+
+## Usage
+
+```sh
+m365 spo listitem batch set [options]
+```
+
+## Options
+
+`-p, --filePath <filePath>`
+: The absolute or relative path to a flat file containing the list items.
+
+`-s, --systemUpdate`
+: Update the item without updating the modified date and modified by fields.
+
+`-u, --webUrl <webUrl>`
+: URL of the site.
+
+`-l, --listId [listId]`
+: ID of the list. Specify either `listTitle`, `listId` or `listUrl`, but not multiple.
+
+`-t, --listTitle [listTitle]`
+: Title of the list. Specify either `listTitle`, `listId` or `listUrl`, but not multiple.
+
+`--listUrl [listUrl]`
+: Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`, but not multiple.
+
+`--idColumn [idColumn]`
+: Name of the column in the csv containing the IDs of the items to set. Defaults to `ID`
+
+--8<-- "docs/cmd/_global.md"
+
+## Examples
+
+Updates a batch of items to a list retrieved by title in a specific site
+
+```sh
+m365 spo listitem batch set --filePath "C:\Path\To\Csv\CsvFile.csv" --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle "Demo List"
+```
+
+Updates a batch of items to a list retrieved by Id in a specific site with a specific `idColumn`
+
+```sh
+m365 spo listitem batch set --filePath "C:\Path\To\Csv\CsvFile.csv" --webUrl https://contoso.sharepoint.com/sites/project-x --listId fe54c47b-22e4-4cab-8a10-3fc54003fb4c --idColumn id
+```
+
+Updates a batch of items to a list defined by server-relative URL in a specific site without updating the modified details
+
+```sh
+m365 spo listitem batch set --filePath "C:\Path\To\Csv\CsvFile.csv" --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl "/sites/project-x/lists/Demo List" --systemUpdate
+```
+
+## Remarks
+
+A sample CSV can be found below. The first line of the CSV-file should contain the internal column names that you wish to set.
+
+```csv
+ID,ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField,LookupList,LookupListMulti
+5,Item,Title Update,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa,15,15;16,"https://bing.com, URL",5,2,2;3
+```
+
+## Response
+
+The command won't return a response on success.

--- a/docs/docs/cmd/spo/listitem/listitem-batch-set.md
+++ b/docs/docs/cmd/spo/listitem/listitem-batch-set.md
@@ -13,9 +13,6 @@ m365 spo listitem batch set [options]
 `-p, --filePath <filePath>`
 : The absolute or relative path to a flat file containing the list items.
 
-`-s, --systemUpdate`
-: Update the item without updating the modified date and modified by fields.
-
 `-u, --webUrl <webUrl>`
 : URL of the site.
 
@@ -29,7 +26,10 @@ m365 spo listitem batch set [options]
 : Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`, but not multiple.
 
 `--idColumn [idColumn]`
-: Name of the column in the csv containing the IDs of the items to set. Defaults to `ID`
+: Name of the column in the csv containing the IDs of the items to set. Defaults to `ID`.
+
+`-s, --systemUpdate`
+: Update the item without updating the modified date and modified by fields.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -59,7 +59,7 @@ A sample CSV can be found below. The first line of the CSV-file should contain t
 
 ```csv
 ID,ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField,LookupList,LookupListMulti
-5,Item,Title Update,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa,15,15;16,"https://bing.com, URL",5,2,2;3
+5,Item,Title Update,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa,john@contoso.com,john@contoso.com;doe@contoso.com,"https://bing.com, URL",5,2,2;3
 ```
 
 ## Response

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -568,6 +568,7 @@ nav:
         - listitem remove: cmd/spo/listitem/listitem-remove.md
         - listitem attachment list: cmd/spo/listitem/listitem-attachment-list.md
         - listitem batch add: cmd/spo/listitem/listitem-batch-add.md
+        - listitem batch set: cmd/spo/listitem/listitem-batch-set.md
         - listitem retentionlabel ensure: cmd/spo/listitem/listitem-retentionlabel-ensure.md
         - listitem retentionlabel remove: cmd/spo/listitem/listitem-retentionlabel-remove.md
         - listitem roleassignment add: cmd/spo/listitem/listitem-roleassignment-add.md

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -157,6 +157,7 @@ export default {
   LISTITEM_ADD: `${prefix} listitem add`,
   LISTITEM_ATTACHMENT_LIST: `${prefix} listitem attachment list`,
   LISTITEM_BATCH_ADD: `${prefix} listitem batch add`,
+  LISTITEM_BATCH_SET: `${prefix} listitem batch set`,
   LISTITEM_GET: `${prefix} listitem get`,
   LISTITEM_ISRECORD: `${prefix} listitem isrecord`,
   LISTITEM_LIST: `${prefix} listitem list`,

--- a/src/m365/spo/commands/listitem/listitem-batch-set.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-set.spec.ts
@@ -11,17 +11,26 @@ import { CommandInfo } from '../../../../cli/CommandInfo';
 import Command, { CommandError } from '../../../../Command';
 import commands from '../../commands';
 import { Logger } from '../../../../cli/Logger';
+import { spo } from '../../../../utils/spo';
+import { urlUtil } from '../../../../utils/urlUtil';
+import { formatting } from '../../../../utils/formatting';
+import { odata } from '../../../../utils/odata';
 const command: Command = require('./listitem-batch-set');
 
 describe(commands.LISTITEM_BATCH_SET, () => {
   const filePath = 'C:\\Path\\To\\CSV\\CsvFile.csv';
   const webUrl = 'https://contoso.sharepoint.com/sites/project-x';
+  const idColumn = 'Id';
   const listId = 'f2978459-4e2a-4307-b57c-0c90eb4e5d6a';
   const listTitle = 'Random List';
   const listUrl = '/sites/project-x/lists/random-list';
-  const csvContentHeaders = `ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField`;
-  const csvContentLine = `Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",5`;
+  const csvContentHeaders = `Id,ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField,LookupField,LookupFieldMulti`;
+  const csvContentLine = `10,Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",5,1,1;2`;
   const csvContent = `${csvContentHeaders}\n${csvContentLine}`;
+  const fieldsResponse = [{ 'InternalName': 'ContentType', 'TypeAsString': 'Computed' }, { 'InternalName': 'Title', 'TypeAsString': 'Text' }, { 'InternalName': 'SingleChoiceField', 'TypeAsString': 'Choice' }, { 'InternalName': 'MultiChoiceField', 'TypeAsString': 'MultiChoice' }, { 'InternalName': 'SingleMetadataField', 'TypeAsString': 'TaxonomyFieldType' }, { 'InternalName': 'MultiMetadataField', 'TypeAsString': 'TaxonomyFieldTypeMulti' }, { 'InternalName': 'SinglePeopleField', 'TypeAsString': 'User' }, { 'InternalName': 'MultiPeopleField', 'TypeAsString': 'UserMulti' }, { 'InternalName': 'CustomHyperlink', 'TypeAsString': 'URL' }, { 'InternalName': 'NumberField', 'TypeAsString': 'Number' }, { 'InternalName': 'LookupField', 'TypeAsString': 'Lookup' }, { 'InternalName': 'LookupFieldMulti', 'TypeAsString': 'LookupMulti' }];
+  const filterFields = ["InternalName eq 'ContentType'", "InternalName eq 'Title'", "InternalName eq 'SingleChoiceField'", "InternalName eq 'MultiChoiceField'", "InternalName eq 'SingleMetadataField'", "InternalName eq 'MultiMetadataField'", "InternalName eq 'SinglePeopleField'", "InternalName eq 'MultiPeopleField'", "InternalName eq 'CustomHyperlink'", "InternalName eq 'NumberField'", "InternalName eq 'LookupField'", "InternalName eq 'LookupFieldMulti'"];
+  const batchCsomResponse = [{ 'SchemaVersion': '15.0.0.0', 'LibraryVersion': '16.0.23408.12001', 'ErrorInfo': null, 'TraceCorrelationId': '9c7d99a0-9005-6000-4c2b-7d8f8a647714' }];
+  const listResponse = { Id: listId };
 
   let commandInfo: CommandInfo;
   let log: any[];
@@ -48,13 +57,27 @@ describe(commands.LISTITEM_BATCH_SET, () => {
         log.push(msg);
       }
     };
+    sinon.stub(spo, 'getRequestDigest').callsFake(async () => ({
+      FormDigestValue: 'ABC',
+      FormDigestTimeoutSeconds: 1800,
+      FormDigestExpiresAt: new Date(),
+      WebFullUrl: webUrl
+    }));
+    sinon.stub(spo, 'getCurrentWebIdentity').callsFake(async () => ({
+      'objectIdentity': '04e9249b-1edd-40da-9ec9-c3f19b2db1bd|25a633e6-3138-49c0-8be8-8bd3260a0431:site:339fb67e-4573-4eee-91b8-7e4fdb1a38d7:web:2c82aec1-21d2-4a1a-ad95-15bb7a4b66aa',
+      'serverRelativeUrl': '/sites/project-x'
+    }));
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      request.post,
       fs.existsSync,
-      fs.readFileSync
+      fs.readFileSync,
+      odata.getAllItems,
+      request.get,
+      request.post,
+      spo.getCurrentWebIdentity,
+      spo.getRequestDigest
     ]);
   });
 
@@ -75,70 +98,197 @@ describe(commands.LISTITEM_BATCH_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('adds items in batch to a sharepoint list retrieved by id', async () => {
+  it('updates single item in batch to a sharepoint list retrieved by listUrl', async () => {
+    const listServerRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, listUrl);
+
     sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
-    sinon.stub(request, 'post').callsFake(async (opts: any) => {
-      if (opts.url === `${webUrl}/_api/$batch`) {
-        return;
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')?$select=Id`) {
+        return listResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `${webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/fields?$select=InternalName,TypeAsString&$filter=${filterFields.join(' or ')}`) {
+        return fieldsResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
+        return JSON.stringify(batchCsomResponse);
       }
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, verbose: true } } as any);
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, idColumn: idColumn, systemUpdate: true, verbose: true } } as any);
+    assert(postStub.called);
   });
 
-  it('adds items in batch to a sharepoint list retrieved by title', async () => {
+  it('system updates single item in batch to a sharepoint list retrieved by id', async () => {
     sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
-    sinon.stub(request, 'post').callsFake(async (opts: any) => {
-      if (opts.url === `${webUrl}/_api/$batch`) {
-        return;
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `${webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/fields?$select=InternalName,TypeAsString&$filter=${filterFields.join(' or ')}`) {
+        return fieldsResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
+        return JSON.stringify(batchCsomResponse);
       }
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listTitle: listTitle, verbose: true } } as any);
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, idColumn: idColumn, systemUpdate: true, verbose: true } } as any);
+    assert(postStub.called);
   });
 
-  it('adds 150 items in batch to a sharepoint list retrieved by url', async () => {
+  it('updates items in multiple batches to a sharepoint list retrieved by title', async () => {
+    let amountOfExecutions = 0;
     let csvContent150Items = csvContent;
     for (let i = 1; i < 150; i++) {
       csvContent150Items += `\n${csvContentLine}`;
     }
-    let amountOfRequestsInBody = 0;
     sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent150Items);
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `${webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/fields?$select=InternalName,TypeAsString&$filter=${filterFields.join(' or ')}`) {
+        return fieldsResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitle)}')?$select=Id`) {
+        return listResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
     sinon.stub(request, 'post').callsFake(async (opts: any) => {
-      if (opts.url === `${webUrl}/_api/$batch`) {
-        amountOfRequestsInBody += opts.data.match(/POST/g).length;
-        return;
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
+        amountOfExecutions++;
+        return JSON.stringify(batchCsomResponse);
       }
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, verbose: true } } as any);
-    assert.strictEqual(amountOfRequestsInBody, 150);
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, idColumn: idColumn, verbose: true } } as any);
+    assert.strictEqual(amountOfExecutions, 3);
   });
 
-  it('throws an error when batch api URL fails', async () => {
-    const errorMessage = 'SharePoint REST Service Exception';
+  it('throws an error when a wrong value is entered (text instead of number)', async () => {
+    const csvContentLine = `10,Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",'TEXT',1,1;2`;
+    const csvContent = `${csvContentHeaders}\n${csvContentLine}`;
+    const batchCsomResponseError = [{ 'SchemaVersion': '15.0.0.0', 'LibraryVersion': '16.0.23408.12001', 'ErrorInfo': { 'ErrorMessage': 'Only numbers can go here.', 'ErrorValue': '362,NumberField', 'TraceCorrelationId': '4d7f99a0-3064-6000-40b7-61b9fc6fcd53', 'ErrorCode': -2130575155, 'ErrorTypeName': 'Microsoft.SharePoint.SPFieldValueException' }, 'TraceCorrelationId': '4d7f99a0-3064-6000-40b7-61b9fc6fcd53' }];
     sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `${webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/fields?$select=InternalName,TypeAsString&$filter=${filterFields.join(' or ')}`) {
+        return fieldsResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
     sinon.stub(request, 'post').callsFake(async (opts: any) => {
-      if (opts.url === `${webUrl}/_api/$batch`) {
-        throw errorMessage;
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
+        return JSON.stringify(batchCsomResponseError);
       }
       throw 'Invalid request';
     });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, idColumn: idColumn, verbose: true } } as any), new CommandError(`${batchCsomResponseError[0].ErrorInfo.ErrorMessage} - ${batchCsomResponseError[0].ErrorInfo.ErrorValue}`));
+  });
+
+  it('throws an error when field specified in the csv does not exist on the list', async () => {
+    const fieldsThatDontExist = ['NonExistingColumn1', 'NonExistingColumn2'];
+    const errorMessage = `Following fields specified in the csv do not exist on the list: ${fieldsThatDontExist.join(', ')}`;
+    const csvContentHeadersError = csvContentHeaders + `,${fieldsThatDontExist.join(',')}`;
+    const csvContentLineError = csvContentLine + ',Value 1,Value2';
+    const csvContentError = `${csvContentHeadersError}\n${csvContentLineError}`;
+    const jsonContent: any[] = formatting.parseCsvToJson(csvContentError);
+
+    const objectKeys = Object.keys(jsonContent[0]);
+    const index = objectKeys.indexOf(idColumn, 0);
+    if (index > -1) {
+      objectKeys.splice(index, 1);
+    }
+
+    const filterFields: string[] = [];
+    objectKeys.map(objectKey => {
+      filterFields.push(`InternalName eq '${objectKey}'`);
+    });
+
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContentError);
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `${webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/fields?$select=InternalName,TypeAsString&$filter=${filterFields.join(' or ')}`) {
+        return fieldsResponse;
+      }
+
+      throw 'Invalid request';
+    });
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, idColumn: idColumn, verbose: true } } as any), new CommandError(errorMessage));
+  });
+
+  it('throws an error when list by url is not found', async () => {
+    const listServerRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, listUrl);
+    const errorMessage = `File Not Found.`;
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')?$select=Id`) {
+        throw errorMessage;
+      }
+
+      throw 'Invalid request';
+    });
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, idColumn: idColumn, verbose: true } } as any), new CommandError(errorMessage));
+  });
+
+  it('throws an error when list by title is not found', async () => {
+    const errorMessage = `List '${listTitle}' does not exist at site with URL 'https://mathijsdev2.sharepoint.com'.`;
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitle)}')?$select=Id`) {
+        throw errorMessage;
+      }
+
+      throw 'Invalid request';
+    });
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listTitle: listTitle, idColumn: idColumn, verbose: true } } as any), new CommandError(errorMessage));
+  });
+
+  it('throws an error when specified idColumn does not exist in csv', async () => {
+    const tempIdColumn = 'id';
+    const errorMessage = `The specified value for idColumn does not exist in the array. Specified idColumn is '${tempIdColumn || 'ID'}'. Please specify the correct value.`;
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, idColumn: tempIdColumn, verbose: true } } as any), new CommandError(errorMessage));
+  });
+
+  it('throws an error when idColumn is not specified and ID does not exist in csv', async () => {
+    const errorMessage = `The specified value for idColumn does not exist in the array. Specified idColumn is 'ID'. Please specify the correct value.`;
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
 
     await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, verbose: true } } as any), new CommandError(errorMessage));
   });
 
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
-    const actual = await command.validate({ options: { webUrl: 'foo', filePath: filePath, listId: listId } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'invalid', filePath: filePath, listId: listId } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if listId option is not a valid GUID', async () => {
     sinon.stub(fs, 'existsSync').callsFake(_ => true);
-    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: 'foo' } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
@@ -148,9 +298,9 @@ describe(commands.LISTITEM_BATCH_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('passes validation if filePath exists and listId is a valid guid', async () => {
+  it('passes validation if filePath exists, listId is a valid guid and idColumn is a valid idColumn', async () => {
     sinon.stub(fs, 'existsSync').callsFake(_ => true);
-    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: listId } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: listId, idColumn: idColumn } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 });

--- a/src/m365/spo/commands/listitem/listitem-batch-set.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-set.spec.ts
@@ -24,13 +24,16 @@ describe(commands.LISTITEM_BATCH_SET, () => {
   const listId = 'f2978459-4e2a-4307-b57c-0c90eb4e5d6a';
   const listTitle = 'Random List';
   const listUrl = '/sites/project-x/lists/random-list';
+  const mail1 = 'adamb@contoso.com';
+  const mail2 = 'markh@contoso.com';
   const csvContentHeaders = `Id,ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField,LookupField,LookupFieldMulti`;
-  const csvContentLine = `10,Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",5,1,1;2`;
+  const csvContentLine = `10,Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,${mail2},${mail2};${mail1},"https://bing.com, URL",5,1,1;2`;
   const csvContent = `${csvContentHeaders}\n${csvContentLine}`;
   const fieldsResponse = [{ 'InternalName': 'ContentType', 'TypeAsString': 'Computed' }, { 'InternalName': 'Title', 'TypeAsString': 'Text' }, { 'InternalName': 'SingleChoiceField', 'TypeAsString': 'Choice' }, { 'InternalName': 'MultiChoiceField', 'TypeAsString': 'MultiChoice' }, { 'InternalName': 'SingleMetadataField', 'TypeAsString': 'TaxonomyFieldType' }, { 'InternalName': 'MultiMetadataField', 'TypeAsString': 'TaxonomyFieldTypeMulti' }, { 'InternalName': 'SinglePeopleField', 'TypeAsString': 'User' }, { 'InternalName': 'MultiPeopleField', 'TypeAsString': 'UserMulti' }, { 'InternalName': 'CustomHyperlink', 'TypeAsString': 'URL' }, { 'InternalName': 'NumberField', 'TypeAsString': 'Number' }, { 'InternalName': 'LookupField', 'TypeAsString': 'Lookup' }, { 'InternalName': 'LookupFieldMulti', 'TypeAsString': 'LookupMulti' }];
   const filterFields = ["InternalName eq 'ContentType'", "InternalName eq 'Title'", "InternalName eq 'SingleChoiceField'", "InternalName eq 'MultiChoiceField'", "InternalName eq 'SingleMetadataField'", "InternalName eq 'MultiMetadataField'", "InternalName eq 'SinglePeopleField'", "InternalName eq 'MultiPeopleField'", "InternalName eq 'CustomHyperlink'", "InternalName eq 'NumberField'", "InternalName eq 'LookupField'", "InternalName eq 'LookupFieldMulti'"];
   const batchCsomResponse = [{ 'SchemaVersion': '15.0.0.0', 'LibraryVersion': '16.0.23408.12001', 'ErrorInfo': null, 'TraceCorrelationId': '9c7d99a0-9005-6000-4c2b-7d8f8a647714' }];
   const listResponse = { Id: listId };
+
 
   let commandInfo: CommandInfo;
   let log: any[];
@@ -123,6 +126,13 @@ describe(commands.LISTITEM_BATCH_SET, () => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
         return JSON.stringify(batchCsomResponse);
       }
+      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail1}')?$select=Id`) {
+        return { id: 10 };
+      }
+      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail2}')?$select=Id`) {
+        return { id: 11 };
+      }
+
       throw 'Invalid request';
     });
 
@@ -143,6 +153,12 @@ describe(commands.LISTITEM_BATCH_SET, () => {
     const postStub = sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
         return JSON.stringify(batchCsomResponse);
+      }
+      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail1}')?$select=Id`) {
+        return { id: 10 };
+      }
+      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail2}')?$select=Id`) {
+        return { id: 11 };
       }
       throw 'Invalid request';
     });
@@ -179,6 +195,12 @@ describe(commands.LISTITEM_BATCH_SET, () => {
         amountOfExecutions++;
         return JSON.stringify(batchCsomResponse);
       }
+      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail1}')?$select=Id`) {
+        return { id: 10 };
+      }
+      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail2}')?$select=Id`) {
+        return { id: 11 };
+      }
       throw 'Invalid request';
     });
 
@@ -187,7 +209,7 @@ describe(commands.LISTITEM_BATCH_SET, () => {
   });
 
   it('throws an error when a wrong value is entered (text instead of number)', async () => {
-    const csvContentLine = `10,Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",'TEXT',1,1;2`;
+    const csvContentLine = `10,Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,${mail1},${mail1};${mail2},"https://bing.com, URL",'TEXT',1,1;2`;
     const csvContent = `${csvContentHeaders}\n${csvContentLine}`;
     const batchCsomResponseError = [{ 'SchemaVersion': '15.0.0.0', 'LibraryVersion': '16.0.23408.12001', 'ErrorInfo': { 'ErrorMessage': 'Only numbers can go here.', 'ErrorValue': '362,NumberField', 'TraceCorrelationId': '4d7f99a0-3064-6000-40b7-61b9fc6fcd53', 'ErrorCode': -2130575155, 'ErrorTypeName': 'Microsoft.SharePoint.SPFieldValueException' }, 'TraceCorrelationId': '4d7f99a0-3064-6000-40b7-61b9fc6fcd53' }];
     sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
@@ -202,6 +224,12 @@ describe(commands.LISTITEM_BATCH_SET, () => {
     sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
         return JSON.stringify(batchCsomResponseError);
+      }
+      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail1}')?$select=Id`) {
+        return { id: 10 };
+      }
+      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail2}')?$select=Id`) {
+        return { id: 11 };
       }
       throw 'Invalid request';
     });

--- a/src/m365/spo/commands/listitem/listitem-batch-set.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-set.spec.ts
@@ -1,0 +1,156 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as sinon from 'sinon';
+import { telemetry } from '../../../../telemetry';
+import auth from '../../../../Auth';
+import { pid } from '../../../../utils/pid';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import request from '../../../../request';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import Command, { CommandError } from '../../../../Command';
+import commands from '../../commands';
+import { Logger } from '../../../../cli/Logger';
+const command: Command = require('./listitem-batch-set');
+
+describe(commands.LISTITEM_BATCH_SET, () => {
+  const filePath = 'C:\\Path\\To\\CSV\\CsvFile.csv';
+  const webUrl = 'https://contoso.sharepoint.com/sites/project-x';
+  const listId = 'f2978459-4e2a-4307-b57c-0c90eb4e5d6a';
+  const listTitle = 'Random List';
+  const listUrl = '/sites/project-x/lists/random-list';
+  const csvContentHeaders = `ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField`;
+  const csvContentLine = `Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",5`;
+  const csvContent = `${csvContentHeaders}\n${csvContentLine}`;
+
+  let commandInfo: CommandInfo;
+  let log: any[];
+  let logger: Logger;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.post,
+      fs.existsSync,
+      fs.readFileSync
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      telemetry.trackEvent,
+      pid.getProcessName
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.LISTITEM_BATCH_SET);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('adds items in batch to a sharepoint list retrieved by id', async () => {
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, verbose: true } } as any);
+  });
+
+  it('adds items in batch to a sharepoint list retrieved by title', async () => {
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listTitle: listTitle, verbose: true } } as any);
+  });
+
+  it('adds 150 items in batch to a sharepoint list retrieved by url', async () => {
+    let csvContent150Items = csvContent;
+    for (let i = 1; i < 150; i++) {
+      csvContent150Items += `\n${csvContentLine}`;
+    }
+    let amountOfRequestsInBody = 0;
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent150Items);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        amountOfRequestsInBody += opts.data.match(/POST/g).length;
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, verbose: true } } as any);
+    assert.strictEqual(amountOfRequestsInBody, 150);
+  });
+
+  it('throws an error when batch api URL fails', async () => {
+    const errorMessage = 'SharePoint REST Service Exception';
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        throw errorMessage;
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, verbose: true } } as any), new CommandError(errorMessage));
+  });
+
+  it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'foo', filePath: filePath, listId: listId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if listId option is not a valid GUID', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: 'foo' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if csv file does not exist', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(_ => false);
+    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: listId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if filePath exists and listId is a valid guid', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(_ => true);
+    const actual = await command.validate({ options: { webUrl: webUrl, filePath: filePath, listId: listId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+});

--- a/src/m365/spo/commands/listitem/listitem-batch-set.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-set.spec.ts
@@ -29,8 +29,13 @@ describe(commands.LISTITEM_BATCH_SET, () => {
   const csvContentHeaders = `Id,ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField,LookupField,LookupFieldMulti`;
   const csvContentLine = `10,Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,${mail2},${mail2};${mail1},"https://bing.com, URL",5,1,1;2`;
   const csvContent = `${csvContentHeaders}\n${csvContentLine}`;
+  const csvContentHeadersWithoutUserFields = `Id,ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,CustomHyperlink,NumberField,LookupField,LookupFieldMulti`;
+  const csvContentLineWithoutUserValues = `10,Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,"https://bing.com, URL",5,1,1;2`;
+  const csvContentWithoutUsers = `${csvContentHeadersWithoutUserFields}\n${csvContentLineWithoutUserValues}`;
   const fieldsResponse = [{ 'InternalName': 'ContentType', 'TypeAsString': 'Computed' }, { 'InternalName': 'Title', 'TypeAsString': 'Text' }, { 'InternalName': 'SingleChoiceField', 'TypeAsString': 'Choice' }, { 'InternalName': 'MultiChoiceField', 'TypeAsString': 'MultiChoice' }, { 'InternalName': 'SingleMetadataField', 'TypeAsString': 'TaxonomyFieldType' }, { 'InternalName': 'MultiMetadataField', 'TypeAsString': 'TaxonomyFieldTypeMulti' }, { 'InternalName': 'SinglePeopleField', 'TypeAsString': 'User' }, { 'InternalName': 'MultiPeopleField', 'TypeAsString': 'UserMulti' }, { 'InternalName': 'CustomHyperlink', 'TypeAsString': 'URL' }, { 'InternalName': 'NumberField', 'TypeAsString': 'Number' }, { 'InternalName': 'LookupField', 'TypeAsString': 'Lookup' }, { 'InternalName': 'LookupFieldMulti', 'TypeAsString': 'LookupMulti' }];
   const filterFields = ["InternalName eq 'ContentType'", "InternalName eq 'Title'", "InternalName eq 'SingleChoiceField'", "InternalName eq 'MultiChoiceField'", "InternalName eq 'SingleMetadataField'", "InternalName eq 'MultiMetadataField'", "InternalName eq 'SinglePeopleField'", "InternalName eq 'MultiPeopleField'", "InternalName eq 'CustomHyperlink'", "InternalName eq 'NumberField'", "InternalName eq 'LookupField'", "InternalName eq 'LookupFieldMulti'"];
+  const fieldsResponseWithoutUserFields = [{ 'InternalName': 'ContentType', 'TypeAsString': 'Computed' }, { 'InternalName': 'Title', 'TypeAsString': 'Text' }, { 'InternalName': 'SingleChoiceField', 'TypeAsString': 'Choice' }, { 'InternalName': 'MultiChoiceField', 'TypeAsString': 'MultiChoice' }, { 'InternalName': 'SingleMetadataField', 'TypeAsString': 'TaxonomyFieldType' }, { 'InternalName': 'MultiMetadataField', 'TypeAsString': 'TaxonomyFieldTypeMulti' }, { 'InternalName': 'CustomHyperlink', 'TypeAsString': 'URL' }, { 'InternalName': 'NumberField', 'TypeAsString': 'Number' }, { 'InternalName': 'LookupField', 'TypeAsString': 'Lookup' }, { 'InternalName': 'LookupFieldMulti', 'TypeAsString': 'LookupMulti' }];
+  const filterFieldsWithoutUserFields = ["InternalName eq 'ContentType'", "InternalName eq 'Title'", "InternalName eq 'SingleChoiceField'", "InternalName eq 'MultiChoiceField'", "InternalName eq 'SingleMetadataField'", "InternalName eq 'MultiMetadataField'", "InternalName eq 'CustomHyperlink'", "InternalName eq 'NumberField'", "InternalName eq 'LookupField'", "InternalName eq 'LookupFieldMulti'"];
   const batchCsomResponse = [{ 'SchemaVersion': '15.0.0.0', 'LibraryVersion': '16.0.23408.12001', 'ErrorInfo': null, 'TraceCorrelationId': '9c7d99a0-9005-6000-4c2b-7d8f8a647714' }];
   const listResponse = { Id: listId };
 
@@ -140,11 +145,11 @@ describe(commands.LISTITEM_BATCH_SET, () => {
     assert(postStub.called);
   });
 
-  it('system updates single item in batch to a sharepoint list retrieved by id', async () => {
-    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+  it('system updates single item in batch to a sharepoint list retrieved by id without user fields', async () => {
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContentWithoutUsers);
     sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
-      if (url === `${webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/fields?$select=InternalName,TypeAsString&$filter=${filterFields.join(' or ')}`) {
-        return fieldsResponse;
+      if (url === `${webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/fields?$select=InternalName,TypeAsString&$filter=${filterFieldsWithoutUserFields.join(' or ')}`) {
+        return fieldsResponseWithoutUserFields;
       }
 
       throw 'Invalid request';
@@ -153,12 +158,6 @@ describe(commands.LISTITEM_BATCH_SET, () => {
     const postStub = sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
         return JSON.stringify(batchCsomResponse);
-      }
-      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail1}')?$select=Id`) {
-        return { id: 10 };
-      }
-      if (opts.url === `${webUrl}/_api/web/ensureUser('${mail2}')?$select=Id`) {
-        return { id: 11 };
       }
       throw 'Invalid request';
     });

--- a/src/m365/spo/commands/listitem/listitem-batch-set.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-set.ts
@@ -16,6 +16,11 @@ interface FieldDetails {
   TypeAsString: string;
 }
 
+interface UserDetail {
+  email: string;
+  id: number;
+}
+
 interface CommandArgs {
   options: Options;
 }
@@ -45,7 +50,6 @@ class SpoListItemBatchSetCommand extends SpoCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
-    this.#initTypes();
     this.#initOptionSets();
   }
 
@@ -67,9 +71,6 @@ class SpoListItemBatchSetCommand extends SpoCommand {
         option: '-p, --filePath <filePath>'
       },
       {
-        option: '-s, --systemUpdate'
-      },
-      {
         option: '-u, --webUrl <webUrl>'
       },
       {
@@ -83,6 +84,9 @@ class SpoListItemBatchSetCommand extends SpoCommand {
       },
       {
         option: '--idColumn [idColumn]'
+      },
+      {
+        option: '-s, --systemUpdate'
       }
     );
   }
@@ -109,17 +113,6 @@ class SpoListItemBatchSetCommand extends SpoCommand {
     );
   }
 
-  #initTypes(): void {
-    this.types.string.push(
-      'webUrl',
-      'filePath',
-      'idColumn',
-      'listId',
-      'listTitle',
-      'listUrl'
-    );
-  }
-
   #initOptionSets(): void {
     this.optionSets.push({ options: ['listId', 'listTitle', 'listUrl'] });
   }
@@ -140,6 +133,9 @@ class SpoListItemBatchSetCommand extends SpoCommand {
 
       const listId = await this.getListId(args.options, logger);
       const fields = await this.getListFields(args.options, listId, jsonContent, idColumn, logger);
+      const userFields = fields.filter(field => field.TypeAsString === 'UserMulti' || field.TypeAsString === 'User');
+      const resolvedUsers = await this.getUsersFromCsv(args.options.webUrl, jsonContent, userFields);
+
       const formDigestValue = (await spo.getRequestDigest(args.options.webUrl)).FormDigestValue;
       const objectIdentity = (await spo.getCurrentWebIdentity(args.options.webUrl, formDigestValue)).objectIdentity;
       let objectPaths = [], actions = [], index = 1;
@@ -147,7 +143,7 @@ class SpoListItemBatchSetCommand extends SpoCommand {
       for await (const [batchIndex, row] of jsonContent.entries()) {
         objectPaths.push(`<Identity Id="${index}" Name="${objectIdentity}:list:${listId}:item:${row[idColumn]},1" />`);
 
-        const [actionString, updatedIndex] = this.mapActions(index, row, fields, args.options.systemUpdate);
+        const [actionString, updatedIndex] = this.mapActions(index, row, fields, resolvedUsers, args.options.systemUpdate);
         index = updatedIndex;
         actions.push(actionString);
 
@@ -194,15 +190,19 @@ class SpoListItemBatchSetCommand extends SpoCommand {
     }
   }
 
-  private mapActions(index: number, row: any, fields: FieldDetails[], systemUpdate?: boolean): [string, number] {
+  private mapActions(index: number, row: any, fields: FieldDetails[], users: UserDetail[], systemUpdate?: boolean): [string, number] {
     const objectPathId = index;
     let actionString = '';
 
     fields.forEach((field: FieldDetails) => {
       switch (field.TypeAsString) {
+        case 'User':
+          const userDetail = users.find(us => us.email === row[field.InternalName])!;
+          actionString += `<Method Name="ParseAndSetFieldValue" Id="${index += 1}" ObjectPathId="${objectPathId}"><Parameters><Parameter Type="String">${field.InternalName}</Parameter><Parameter Type="String">${userDetail.id}</Parameter></Parameters></Method>`;
         case 'UserMulti':
           const userMultiString: string[] = row[field.InternalName].split(';').map((element: string) => {
-            return `<Object TypeId="{c956ab54-16bd-4c18-89d2-996f57282a6f}"><Property Name="Email" Type="Null" /><Property Name="LookupId" Type="Int32">${element}</Property><Property Name="LookupValue" Type="Null" /></Object>`;
+            const userDetail = users.find(us => us.email === element)!;
+            return `<Object TypeId="{c956ab54-16bd-4c18-89d2-996f57282a6f}"><Property Name="Email" Type="Null" /><Property Name="LookupId" Type="Int32">${userDetail.id}</Property><Property Name="LookupValue" Type="Null" /></Object>`;
           });
           actionString += `<Method Name="SetFieldValue" Id="${index += 1}" ObjectPathId="${objectPathId}"><Parameters><Parameter Type="String">${field.InternalName}</Parameter><Parameter Type="Array">${userMultiString.join('')}</Parameter></Parameters></Method>`;
           break;
@@ -257,25 +257,25 @@ class SpoListItemBatchSetCommand extends SpoCommand {
   }
 
   private async getListId(options: Options, logger: Logger): Promise<string> {
+    if (options.listId) {
+      return options.listId;
+    }
+
     if (this.verbose) {
       logger.logToStderr('Retrieving list id');
     }
 
     let listUrl = `${options.webUrl}/_api/web`;
-    if (options.listId) {
-      return options.listId;
-    }
-    else if (options.listTitle) {
+    if (options.listTitle) {
       listUrl += `/lists/getByTitle('${formatting.encodeQueryParameter(options.listTitle)}')`;
     }
-    else if (options.listUrl) {
-      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(options.webUrl, options.listUrl);
+    else {
+      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(options.webUrl, options.listUrl!);
       listUrl += `/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
     }
-    listUrl += '?$select=Id';
 
     const requestOptions: CliRequestOptions = {
-      url: listUrl,
+      url: `${listUrl}?$select=Id`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },
@@ -284,6 +284,55 @@ class SpoListItemBatchSetCommand extends SpoCommand {
 
     const listResult = await request.get<{ Id: string }>(requestOptions);
     return listResult.Id;
+  }
+
+  private async getUsersFromCsv(webUrl: string, jsonContent: any[], userFields: FieldDetails[]): Promise<UserDetail[]> {
+    const userFieldValues: UserDetail[] = [];
+    if (userFields.length === 0) {
+      return userFieldValues;
+    }
+    const emailsToResolve = this.getEmailsToEnsure(jsonContent, userFields);
+    for await (const email of emailsToResolve) {
+      const requestOptions: CliRequestOptions = {
+        url: `${webUrl}/_api/web/ensureUser('${email}')?$select=Id`,
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json'
+        },
+        responseType: 'json'
+      };
+
+      const response = await request.post<{ Id: number }>(requestOptions);
+      userFieldValues.push({ email: email, id: response.Id });
+    }
+    return userFieldValues;
+  }
+
+  private getEmailsToEnsure(jsonContent: any[], userFields: FieldDetails[]): string[] {
+    const emailsToResolve: string[] = [];
+    userFields.forEach((userField: FieldDetails) => {
+      jsonContent.forEach(row => {
+        const fieldValue = row[userField.InternalName];
+        if (fieldValue !== undefined) {
+          if (userField.TypeAsString === 'User') {
+            this.checkIfMailHasToBeAdded(emailsToResolve, fieldValue);
+          }
+          else {
+            const emailsSplitted = fieldValue.split(';');
+            emailsSplitted.forEach((email: string) => {
+              this.checkIfMailHasToBeAdded(emailsToResolve, email);
+            });
+          }
+        }
+      });
+    });
+    return emailsToResolve;
+  }
+
+  private checkIfMailHasToBeAdded(emailsToResolve: string[], value: string): void {
+    if (!emailsToResolve.some(email => email === value)) {
+      emailsToResolve.push(value);
+    }
   }
 }
 

--- a/src/m365/spo/commands/listitem/listitem-batch-set.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-set.ts
@@ -1,0 +1,227 @@
+import * as fs from 'fs';
+import { Logger } from '../../../../cli/Logger';
+import config from '../../../../config';
+import GlobalOptions from '../../../../GlobalOptions';
+import request, { CliRequestOptions } from '../../../../request';
+import { formatting } from '../../../../utils/formatting';
+import { spo } from '../../../../utils/spo';
+import { urlUtil } from '../../../../utils/urlUtil';
+import { validation } from '../../../../utils/validation';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+import { ListInstance } from '../list/ListInstance';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  filePath: string;
+  webUrl: string;
+  listId?: string;
+  listTitle?: string;
+  listUrl?: string;
+  systemUpdate?: boolean;
+}
+
+class SpoListItemBatchSetCommand extends SpoCommand {
+  public get name(): string {
+    return commands.LISTITEM_BATCH_SET;
+  }
+
+  public get description(): string {
+    return 'Updates list items in a batch';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initTypes();
+    this.#initOptionSets();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        listId: typeof args.options.listId !== 'undefined',
+        listTitle: typeof args.options.listTitle !== 'undefined',
+        listUrl: typeof args.options.listUrl !== 'undefined',
+        systemUpdate: !!args.options.systemUpdate
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-p, --filePath <filePath>'
+      },
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-l, --listId [listId]'
+      },
+      {
+        option: '-t, --listTitle [listTitle]'
+      },
+      {
+        option: '--listUrl [listUrl]'
+      },
+      {
+        option: '--systemUpdate'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+        if (isValidSharePointUrl !== true) {
+          return isValidSharePointUrl;
+        }
+
+        if (args.options.listId &&
+          !validation.isValidGuid(args.options.listId)) {
+          return `${args.options.listId} in option listId is not a valid GUID`;
+        }
+
+        if (!fs.existsSync(args.options.filePath)) {
+          return `File with path ${args.options.filePath} does not exist`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  #initTypes(): void {
+    this.types.string.push(
+      'webUrl',
+      'filePath',
+      'listId',
+      'listTitle',
+      'listUrl'
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['listId', 'listTitle', 'listUrl'] });
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      if (this.verbose) {
+        logger.logToStderr(`Starting to create batch items from csv at path ${args.options.filePath}`);
+      }
+      const csvContent = fs.readFileSync(args.options.filePath, 'utf8');
+      const jsonContent: any[] = formatting.parseCsvToJson(csvContent);
+      // check if ID Column exists
+      if ('ID' in jsonContent[0] === false && 'id' in jsonContent[0] === false && 'Id' in jsonContent[0] === false) {
+        throw 'Please make sure that the CSV has a column with the name ID';
+      }
+
+      const idColumn = 'ID' in jsonContent[0] ? "ID" : 'Id' in jsonContent[0] ? "Id" : "id";
+
+      const formDigestValue = (await spo.getRequestDigest(args.options.webUrl)).FormDigestValue;
+      const objectIdentity = (await spo.getCurrentWebIdentity(args.options.webUrl, formDigestValue)).objectIdentity;
+      const listId = await this.getListId(args.options);
+
+      let objectPaths = [];
+      let actions = [];
+      let index = 1;
+
+      for await (const [batchIndex, row] of jsonContent.entries()) {
+        objectPaths.push(`<Identity Id="${index}" Name="${objectIdentity}:list:${listId}:item:${row[idColumn]},1" />`);
+
+        const [actionString, updatedIndex] = this.mapActions(index, row, args.options.systemUpdate);
+        index = updatedIndex;
+        actions.push(actionString);
+
+        if (objectPaths.length === 50) {
+          if (this.verbose) {
+            logger.logToStderr(`Writing away batch of items, currently at: ${batchIndex + 1}/${jsonContent.length}.`);
+          }
+
+          await this.sendBatchRequest(args.options.webUrl, this.getRequestBody(objectPaths, actions));
+          objectPaths = [];
+          actions = [];
+        }
+      }
+
+      if (objectPaths.length) {
+        if (this.verbose) {
+          logger.logToStderr(`Writing away ${objectPaths.length} items.`);
+        }
+
+        await this.sendBatchRequest(args.options.webUrl, this.getRequestBody(objectPaths, actions));
+      }
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+
+  private getRequestBody(objectPaths: string[], actions: string[]): string {
+    return `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions>${actions.join('')}</Actions><ObjectPaths>${objectPaths.join('')}</ObjectPaths></Request>`;
+  }
+
+  private async sendBatchRequest(webUrl: string, requestBody: string): Promise<void> {
+    const requestOptions: CliRequestOptions = {
+      url: `${webUrl}/_vti_bin/client.svc/ProcessQuery`,
+      headers: {
+        'Content-Type': 'text/xml'
+      },
+      data: requestBody
+    };
+
+    await request.post(requestOptions);
+  }
+
+  private mapActions(index: number, row: any, systemUpdate?: boolean): [string, number] {
+    const objectPathId = index;
+    let actionString = '';
+    const excludeOptions = ['ID', 'id', 'Id'];
+
+    Object.keys(row).forEach(key => {
+      if (excludeOptions.indexOf(key) === -1) {
+        actionString += `<Method Name="ParseAndSetFieldValue" Id="${index++}" ObjectPathId="${objectPathId}"><Parameters><Parameter Type="String">${key}</Parameter><Parameter Type="String">${(<any>row)[key].toString()}</Parameter></Parameters></Method>`;
+      }
+    });
+
+    actionString += `<Method Name="${systemUpdate ? 'System' : ''}Update" Id="${index++}" ObjectPathId="${objectPathId}"/>`;
+    return [actionString, index];
+  }
+
+  private async getListId(options: Options): Promise<string> {
+    let listUrl = `${options.webUrl}/_api/web`;
+    if (options.listId) {
+      return options.listId;
+    }
+    else if (options.listTitle) {
+      listUrl += `/lists/getByTitle('${formatting.encodeQueryParameter(options.listTitle)}')`;
+    }
+    else if (options.listUrl) {
+      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(options.webUrl, options.listUrl);
+      listUrl += `/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
+    }
+    listUrl += '?$select=Id';
+
+    const requestOptions: CliRequestOptions = {
+      url: listUrl,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const listInstance = await request.get<ListInstance>(requestOptions);
+    return listInstance.Id;
+  }
+}
+
+module.exports = new SpoListItemBatchSetCommand();

--- a/src/m365/spo/commands/listitem/listitem-batch-set.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-set.ts
@@ -124,7 +124,7 @@ class SpoListItemBatchSetCommand extends SpoCommand {
       }
 
       const csvContent = fs.readFileSync(args.options.filePath, 'utf8');
-      const jsonContent: any[] = formatting.parseCsvToJson(csvContent, '"', ";");
+      const jsonContent: any[] = formatting.parseCsvToJson(csvContent);
       const amountOfRows = jsonContent.length;
       const idColumn = args.options.idColumn || 'ID';
 

--- a/src/m365/spo/commands/listitem/listitem-batch-set.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-set.ts
@@ -124,9 +124,7 @@ class SpoListItemBatchSetCommand extends SpoCommand {
       }
 
       const csvContent = fs.readFileSync(args.options.filePath, 'utf8');
-      const jsonContent: any[] = formatting.parseCsvToJson(csvContent, '"', ";");
-      logger.log(jsonContent);
-      return;
+      const jsonContent: any[] = formatting.parseCsvToJson(csvContent);
       const amountOfRows = jsonContent.length;
       const idColumn = args.options.idColumn || 'ID';
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -67,7 +67,7 @@ export const formatting = {
 
     const heads = match(lines[0]);
 
-    return lines.slice(1).map(line => {
+    return lines.slice(1).filter(text => text !== '').map(line => {
       return match(line).reduce((acc, cur, i) => {
         const val = cur;
         const numValue = parseInt(val);

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -67,16 +67,14 @@ export const formatting = {
 
     const heads = match(lines[0]);
 
-    return lines.slice(1)
-      //.filter(text => text !== '')
-      .map(line => {
-        return match(line).reduce((acc, cur, i) => {
-          const val = cur;
-          const numValue = parseInt(val);
-          const key = heads[i];
-          return { ...acc, [key]: isNaN(numValue) || numValue.toString() !== val ? val : numValue };
-        }, {});
-      });
+    return lines.slice(1).filter(text => text !== '').map(line => {
+      return match(line).reduce((acc, cur, i) => {
+        const val = cur;
+        const numValue = parseInt(val);
+        const key = heads[i];
+        return { ...acc, [key]: isNaN(numValue) || numValue.toString() !== val ? val : numValue };
+      }, {});
+    });
   },
 
   encodeQueryParameter(value: string): string {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -67,14 +67,16 @@ export const formatting = {
 
     const heads = match(lines[0]);
 
-    return lines.slice(1).filter(text => text !== '').map(line => {
-      return match(line).reduce((acc, cur, i) => {
-        const val = cur;
-        const numValue = parseInt(val);
-        const key = heads[i];
-        return { ...acc, [key]: isNaN(numValue) || numValue.toString() !== val ? val : numValue };
-      }, {});
-    });
+    return lines.slice(1)
+      //.filter(text => text !== '')
+      .map(line => {
+        return match(line).reduce((acc, cur, i) => {
+          const val = cur;
+          const numValue = parseInt(val);
+          const key = heads[i];
+          return { ...acc, [key]: isNaN(numValue) || numValue.toString() !== val ? val : numValue };
+        }, {});
+      });
   },
 
   encodeQueryParameter(value: string): string {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -73,7 +73,7 @@ export const formatting = {
         const obj: any = {};
         heads.forEach((key, index) => {
           const value = parseInt(lineMatch[index]);
-          if (isNaN(value)) {
+          if (isNaN(value) || value.toString() !== lineMatch[index]) {
             obj[key] = lineMatch[index];
           }
           else {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -62,19 +62,26 @@ export const formatting = {
     const lines: string[] = s.split('\n');
 
     const match = (line: string): string[] => [...line.matchAll(regex)]
-      .map(m => m[2])  // we only want the second capture group
-      .slice(0, -1);   // cut off blank match at the end
+      .map(m => m[2]);  // we only want the second capture group
 
-    const heads = match(lines[0]);
+    const heads = match(lines[0]).slice(0, -1);
 
-    return lines.slice(1).filter(text => text !== '').map(line => {
-      return match(line).reduce((acc, cur, i) => {
-        const val = cur;
-        const numValue = parseInt(val);
-        const key = heads[i];
-        return { ...acc, [key]: isNaN(numValue) || numValue.toString() !== val ? val : numValue };
-      }, {});
-    });
+    return lines.slice(1)
+      .filter(text => text !== '')
+      .map(line => {
+        const lineMatch: string[] = match(line);
+        const obj: any = {};
+        heads.forEach((key, index) => {
+          const value = parseInt(lineMatch[index]);
+          if (isNaN(value)) {
+            obj[key] = lineMatch[index];
+          }
+          else {
+            obj[key] = parseInt(lineMatch[index]);
+          }
+        });
+        return obj;
+      });
   },
 
   encodeQueryParameter(value: string): string {


### PR DESCRIPTION
Closes #4549 

So a little more information about the PR, as it's quite a big one 😄 
The script will do the following steps:
- Read the csv content & parse it to JSON
- Checks if the idColumn specified by the user exists in the csv, if not --> throw an error
- Get the list id
- Get the fields of the list and check if they all match a field in the list. If not --> throw an error that fields in the csv cannot be resolved. This differs from the `spo batch listitem add`, but is probably an enhancement for there + is also needed because we need the field type to set lookup fields / multiple user fields
- Get the formDigest + objectIdentity (needed for CSOM-call)
- Loop over all the rows in the csv and create batch requests.
      - If amount of items in the array contains 50, we will send a batch request.
- If more items still exist or items were less than 50, we will send another request.

I think that this is the base explanation of the code.

Some things that differ from the `spo listitem batch add`: 
- We get the fields for the field types `Lookup`, `LookupMulti` and `UserMulti`
- In `spo listitem batch add`, we are currently specifying a user field by e-mail. This is no longer possible and we will have to use the lookup id from the user from the siteusers list in the csv. In the future, this could be enhanced.
- Same goes with the lookup list. We will also have to mention the lookup id of the listitem

I think that the rest of the CSV stayed the exact same.

HF reviewing! 😄 It took me a lot of time to write & research 😄 