### PR TITLE
Adds missing telemetry option `confirm` in `aad user license remove` and removes unnecessary telemetry option `confirm` in `aad user recyclebinitem restore`

### DIFF
--- a/src/m365/aad/commands/user/user-license-remove.ts
+++ b/src/m365/aad/commands/user/user-license-remove.ts
@@ -41,7 +41,8 @@ class AadUserLicenseRemoveCommand extends GraphCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined'
+        userName: typeof args.options.userName !== 'undefined',
+        confirm: !!args.options.confirm
       });
     });
   }

--- a/src/m365/aad/commands/user/user-recyclebinitem-restore.ts
+++ b/src/m365/aad/commands/user/user-recyclebinitem-restore.ts
@@ -26,17 +26,8 @@ class AadUserRecycleBinItemRestoreCommand extends GraphCommand {
   constructor() {
     super();
 
-    this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        confirm: !!args.options.confirm
-      });
-    });
   }
 
   #initOptions(): void {


### PR DESCRIPTION
When looking at the new commands i noticed the `confirm` telemetry option was missing in the command `aad user license remove` and noticed there is an unnecessary `confirm` telemetry option in the command `aad user recyclebinitem restore`.

Seems too little to create an issue for