### PR TITLE
Unnecessary telemetry option `confirm` in `aad user recyclebinitem restore`

### DIFF
--- a/src/m365/aad/commands/user/user-recyclebinitem-restore.ts
+++ b/src/m365/aad/commands/user/user-recyclebinitem-restore.ts
@@ -26,17 +26,8 @@ class AadUserRecycleBinItemRestoreCommand extends GraphCommand {
   constructor() {
     super();
 
-    this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        confirm: !!args.options.confirm
-      });
-    });
   }
 
   #initOptions(): void {


### PR DESCRIPTION
When looking at the new commands i noticed there is an unnecessary `confirm` telemetry option in the command `aad user recyclebinitem restore`.

Seems too little to create an issue for