### PR TITLE
Fixes broken discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
       alt="GitHub" />
   </a>
 
-  <a href="https://discord.com/invite/7rfW4kg6B5">
+  <a href="https://discord.gg/35HTFJ544b">
     <img src="https://img.shields.io/badge/Discord-Join-7289da?style=flat-square"
       alt="Discord" />
   </a>

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -42,11 +42,11 @@ The project is built and managed publicly on GitHub at [https://github.com/pnp/c
 
 ### Community Discord server
 
-We also have a [community Discord server](https://discord.com/invite/7rfW4kg6B5) where you can hang out, share, collaborate, and discuss more about the CLI for Microsoft 365!
+We also have a [community Discord server](https://discord.gg/35HTFJ544b) where you can hang out, share, collaborate, and discuss more about the CLI for Microsoft 365!
 
 <br/>
 <p align="center">
-  <a href="https://discord.com/invite/7rfW4kg6B5">
+  <a href="https://discord.gg/35HTFJ544b">
     <img src="https://img.shields.io/badge/Discord-invite/7rfW4kg6B5-7289da?style=for-the-badge"
       alt="Discord" />
   </a>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1007,7 +1007,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/pnp/cli-microsoft365
     - icon: fontawesome/brands/discord
-      link: https://discord.com/invite/7rfW4kg6B5
+      link: https://discord.gg/35HTFJ544b
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/climicrosoft365
     - icon: fontawesome/brands/youtube

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <a href="https://discord.com/invite/7rfW4kg6B5" class="cli-announcement">
+  <a href="https://discord.gg/35HTFJ544b" class="cli-announcement">
     Join our brand new <strong>community Discord server</strong>
     <span class="twemoji discord">
       {% include ".icons/fontawesome/brands/discord.svg" %}


### PR DESCRIPTION
Not related to an issue.

It looks like our Discord invite link has disappeared. This PR changes the links in our docs and readme to the new invite link.

@pnp/cli-for-microsoft-365-maintainers let's try to get this PR live ASAP 😄 