### PR TITLE
Update gitignore for Docusaurus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,21 @@ commands.json
 
 # VS env folder
 .vs/
+
+# Docs
+docs/node_modules
+
+docs/build
+
+docs/.docusaurus
+docs/.cache-loader
+
+docs/.DS_Store
+docs/.env.local
+docs/.env.development.local
+docs/.env.test.local
+docs/.env.production.local
+
+docs/npm-debug.log*
+docs/yarn-debug.log*
+docs/yarn-error.log*


### PR DESCRIPTION
Not related to an issue

During the migration process, when we switch from the `docs-migration` branch to `main`, all the Docusaurus files that were ignored in the `docs-migration` branch will appear in your working directory that is targeting `main`. This can be a bit inconvenient to remove every time, so with this change, I can exclude these files from appearing in `main` as well.