### PR TITLE
Adds `assetId` option to `retentionlabel ensure` commands, Closes #4387

### DIFF
--- a/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-ensure.md
@@ -22,11 +22,16 @@ m365 spo file retentionlabel ensure [options]
 `--name <name>`
 : Name of the retention label to apply to the file.
 
+`-a, --assetId [assetId]`
+: A Compliance Asset Id to set on the item after it's labeled. See below for more information.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
 You can also use [spo listitem retentionlabel remove](./../../../cmd/spo//listitem/listitem-retentionlabel-remove.md) for removing the retentionlabel from a listitem.
+
+The `--assetId` option has to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created.
 
 ## Examples
 
@@ -39,7 +44,13 @@ m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/site
 Applies a retention label to a file based on the label name and the fileId
 
 ```sh
-m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8'  --name 'Some label'
+m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8' --name 'Some label'
+```
+
+Applies a event-based retention label to a file and updates the Asset Id field
+
+```sh
+m365 spo file retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --fileId '26541f96-017c-4189-a604-599e083533b8' --name 'Some label' --assetId 'XYZ'
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.md
+++ b/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.md
@@ -31,11 +31,18 @@ m365 spo listitem retentionlabel ensure [options]
 `-i, --id [id]`
 : The id of the retention label. Specify either `name` or `id`.
 
+`-a, --assetId [assetId]`
+: A Compliance Asset Id to set on the item after it's labeled. See below for more information.
+
 --8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+The `--assetId` option has to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created.
 
 ## Examples
 
-Applies the retention label _Some label_ to a list item in a given site based on the list id and label name
+Applies a retention label to a list item in a given site based on the list id and label name
 
 ```sh
 m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listId 0cd891ef-afce-4e55-b836-fce03286cccf --listItemId 1 --name 'Some label'
@@ -47,10 +54,16 @@ Applies a retention label to a list item in a given site based on the list title
 m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'List 1' --listItemId 1 --id '7a621a91-063b-461b-aff6-d713d5fb23eb'
 ```
 
-Applies the retention label _Some label_ to a list item in a given site based on the server relative list url
+Applies a retention label to a list item in a given site based on the server relative list url
 
 ```sh
 m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/lists/TestList --listItemId 1 --name 'Some label'
+```
+
+Applies a retention label to a list item in a given site based on the server relative list url and updates the Asset Id field
+
+```sh
+m365 spo listitem retentionlabel ensure --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/lists/TestList --listItemId 1 --name 'Some label' --assetId 'XYZ'
 ```
 
 ## Response

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.spec.ts
@@ -31,7 +31,7 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
       "DisplayName": "",
       "EncryptionRMSTemplateId": null,
       "HasRetentionAction": true,
-      "IsEventTag": false,
+      "IsEventTag": true,
       "MultiStageReviewerEmail": null,
       "NextStageComplianceTag": null,
       "Notes": null,
@@ -173,10 +173,10 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
     assert(actual);
   });
 
-  it('applies a retentionlabel based on listId and name', async () => {
+  it('applies a retentionlabel based on listId and name without assetId', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/items(1)/SetComplianceTag()`
-        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":false,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
+        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":true,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
         return;
       }
 
@@ -195,11 +195,28 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
     assert(loggerLogStderrSpy.notCalled);
   });
 
-  it('applies a retentionlabel based on listId and id (debug)', async () => {
+  it('applies a retentionlabel based on listId, id and with assetId (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
+      const test = `https://contoso.sharepoint.com/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/items(1)/SetComplianceTag()`;
+      Cli.log(test);
       if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')/items(1)/SetComplianceTag()`
-        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":false,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
+        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":true,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
         return;
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${listId}')/items(${1})/ValidateUpdateListItem()`) {
+        return {
+          "value": [
+            {
+              "ErrorCode": 0,
+              "ErrorMessage": null,
+              "FieldName": "ComplianceAssetId",
+              "FieldValue": "XYZ",
+              "HasException": false,
+              "ItemId": 1
+            }
+          ]
+        };
       }
 
       throw 'Invalid request';
@@ -211,16 +228,32 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
         listId: listId,
         webUrl: webUrl,
         listItemId: 1,
-        id: labelId
+        id: labelId,
+        assetId: 'XYZ'
       }
     }));
   });
 
-  it('applies a retentionlabel based on listTitle and id (debug)', async () => {
+  it('applies a retentionlabel based on listTitle, id and assetId (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `https://contoso.sharepoint.com/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitle)}')/items(1)/SetComplianceTag()`
-        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":false,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
+        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":true,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
         return;
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitle)}')/items(${1})/ValidateUpdateListItem()`) {
+        return {
+          "value": [
+            {
+              "ErrorCode": 0,
+              "ErrorMessage": null,
+              "FieldName": "ComplianceAssetId",
+              "FieldValue": "XYZ",
+              "HasException": false,
+              "ItemId": 1
+            }
+          ]
+        };
       }
 
       throw 'Invalid request';
@@ -232,16 +265,33 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
         listTitle: listTitle,
         webUrl: webUrl,
         listItemId: 1,
-        id: labelId
+        id: labelId,
+        assetId: 'XYZ'
       }
     }));
   });
 
-  it('applies a retentionlabel based on listUrl and id (debug)', async () => {
+  it('applies a retentionlabel based on listUrl, id and assetId (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `https://contoso.sharepoint.com/_api/web/GetList(@listUrl)/items(1)/SetComplianceTag()?@listUrl='${formatting.encodeQueryParameter(listUrl)}'`
-        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":false,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
+        && JSON.stringify(opts.data) === '{"complianceTag":"Some label","isTagPolicyHold":true,"isTagPolicyRecord":false,"isEventBasedTag":true,"isTagSuperLock":false,"isUnlockedAsDefault":false}') {
         return;
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetList(@listUrl)/items(${1})/ValidateUpdateListItem()?@listUrl='${formatting.encodeQueryParameter(listUrl)}'`) {
+        return {
+          "value": [
+            {
+              "ErrorCode": 0,
+              "ErrorMessage": null,
+              "FieldName": "ComplianceAssetId",
+              "FieldValue": "XYZ",
+              "HasException": false,
+              "ItemId": 1,
+              assetId: 'XYZ'
+            }
+          ]
+        };
       }
 
       throw 'Invalid request';

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
-import request from '../../../../request';
+import request, { CliRequestOptions } from '../../../../request';
 import { formatting } from '../../../../utils/formatting';
 import { urlUtil } from '../../../../utils/urlUtil';
 import { validation } from '../../../../utils/validation';
@@ -26,6 +26,7 @@ export interface Options extends GlobalOptions {
   listItemId: string;
   name?: string;
   id?: string;
+  assetId?: string;
 }
 
 class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
@@ -53,7 +54,8 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
         listTitle: typeof args.options.listTitle !== 'undefined',
         listUrl: typeof args.options.listUrl !== 'undefined',
         name: typeof args.options.name !== 'undefined',
-        id: typeof args.options.id !== 'undefined'
+        id: typeof args.options.id !== 'undefined',
+        assetId: typeof args.options.assetId !== 'undefined'
       });
     });
   }
@@ -80,6 +82,9 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
       },
       {
         option: '-i, --id [id]'
+      },
+      {
+        option: '-a, --assetId [assetId]'
       }
     );
   }
@@ -120,6 +125,10 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const labelInformation = await this.getLabelInformation(args.options, logger);
+
+      if (args.options.assetId) {
+        await this.applyAssetId(args.options, logger);
+      }
       await this.applyLabel(args.options, labelInformation, logger);
     }
     catch (err: any) {
@@ -186,6 +195,36 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
         'accept': 'application/json;odata=nometadata'
       },
       data: labelInformation,
+      responseType: 'json'
+    };
+
+    await request.post(requestOptions);
+  }
+
+  async applyAssetId(options: GlobalOptions, logger: Logger): Promise<void> {
+    if (this.verbose) {
+      logger.logToStderr(`Applying the asset Id ${options.assetId}...`);
+    }
+    let requestUrl = `${options.webUrl}/_api/web`;
+
+    if (options.listId) {
+      requestUrl += `/lists(guid'${formatting.encodeQueryParameter(options.listId)}')/items(${options.listItemId})/ValidateUpdateListItem()`;
+    }
+    else if (options.listTitle) {
+      requestUrl += `/lists/getByTitle('${formatting.encodeQueryParameter(options.listTitle)}')/items(${options.listItemId})/ValidateUpdateListItem()`;
+    }
+    else if (options.listUrl) {
+      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(options.webUrl, options.listUrl);
+      requestUrl += `/GetList(@listUrl)/items(${options.listItemId})/ValidateUpdateListItem()?@listUrl='${formatting.encodeQueryParameter(listServerRelativeUrl)}'`;
+    }
+    const requestBody = { "formValues": [{ "FieldName": "ComplianceAssetId", "FieldValue": options.assetId }] };
+
+    const requestOptions: CliRequestOptions = {
+      url: requestUrl,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      data: requestBody,
       responseType: 'json'
     };
 


### PR DESCRIPTION
This PR adds the `assetId` option to `retentionlabel ensure` commands.

Also reworked the 2 commands so they don't use `executeCommandWithOutput` anymore

Closes #4387

This PR is a new request from previous closed PR #4524