### PR TITLE
Fix 'listitem <verb>' commands to handle errors that are returned when updating fields. Closes #4375

### DIFF
--- a/docs/docs/cmd/spo/listitem/listitem-add.md
+++ b/docs/docs/cmd/spo/listitem/listitem-add.md
@@ -30,6 +30,11 @@ m365 spo listitem add [options]
 
 --8<-- "docs/cmd/_global.md"
 
+## Remarks
+
+!!! tip "When using DateTime fields"
+    When creating a list item with a DateTime field, use the timezone and the format that the site expects, based on its regional settings. Alternatively, a format which works on all regions is the following: `yyyy-MM-dd HH:mm:ss`. However, you should use the local timezone in all situations. UTC date/time or ISO 8601 formatted date/time is not supported.
+
 ## Examples
 
 Add an item with Title _Demo Item_ and content type name _Item_ to list with title _Demo List_ in site _https://contoso.sharepoint.com/sites/project-x_
@@ -77,7 +82,13 @@ m365 spo listitem add --contentType Item --listUrl /sites/project-x/Documents --
 Add an item with a specific Title and multi-choice value
 
 ```sh
-m365 spo listitem add --listTitle "Demo List" --webUrl https://contoso.sharepoint.com/sites/project-x --Title "Demo Hyperlink Field" --MultiChoiceField "Choice 1;#Choice 2;#Choice 3"
+m365 spo listitem add --listTitle "Demo List" --webUrl https://contoso.sharepoint.com/sites/project-x --Title "Demo multi-choice Field" --MultiChoiceField "Choice 1;#Choice 2;#Choice 3"
+```
+
+Add an item with a specific Title and DateTime value
+
+```sh
+m365 spo listitem add --listTitle "Demo List" --webUrl https://contoso.sharepoint.com/sites/project-x --Title "Demo DateTime Field" --SomeDateTimeField "2023-01-16 15:30:00"
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/listitem/listitem-batch-add.md
+++ b/docs/docs/cmd/spo/listitem/listitem-batch-add.md
@@ -52,9 +52,12 @@ m365 spo listitem batch add --filePath "C:\Path\To\Csv\CsvFile.csv" --webUrl htt
 A sample CSV can be found below. The first line of the CSV-file should contain the internal column names that you wish to set.
 
 ```csv
-ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField
-Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|john.doe@contoso.com'}]","https://bing.com, URL",5
+ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField,DateTimeField
+Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|john.doe@contoso.com'}]","https://bing.com, URL",5,2023-01-01 10:00:00
 ```
+
+!!! tip "When using DateTime fields"
+    When creating list items with a DateTime field, use the timezone and the format that the site expects, based on its regional settings. Alternatively, a format which works on all regions is the following: `yyyy-MM-dd HH:mm:ss`. However, you should use the local timezone in all situations. UTC date/time or ISO 8601 formatted date/time is not supported.
 
 ## Response
 

--- a/docs/docs/cmd/spo/listitem/listitem-set.md
+++ b/docs/docs/cmd/spo/listitem/listitem-set.md
@@ -33,6 +33,11 @@ m365 spo listitem set [options]
 
 --8<-- "docs/cmd/_global.md"
 
+## Remarks
+
+!!! tip "When using DateTime fields"
+    When updating a list item with a DateTime field, use the timezone and the format that the site expects, based on its regional settings. Alternatively, a format which works on all regions is the following: `yyyy-MM-dd HH:mm:ss`. However, you should use the local timezone in all situations. UTC date/time or ISO 8601 formatted date/time is not supported.
+
 ## Examples
 
 Update an item with id _147_ with title _Demo Item_ and content type name _Item_ in list with title _Demo List_ in site _https://contoso.sharepoint.com/sites/project-x_
@@ -74,7 +79,13 @@ m365 spo listitem set --listUrl '/sites/project-x/lists/Demo List' --id 147 --we
 Update an item with a specific Title and multi-choice value
 
 ```sh
-m365 spo listitem set --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x --Title "Demo Hyperlink Field" --MultiChoiceField "Choice 1;#Choice 2;#Choice 3"
+m365 spo listitem set --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x --Title "Demo multi-choice Field" --MultiChoiceField "Choice 1;#Choice 2;#Choice 3"
+```
+
+Update an item with a specific Title and DateTime value
+
+```sh
+m365 spo listitem set --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x --Title "Demo DateTime Field" --SomeDateTimeField "2023-01-16 15:30:00"
 ```
 
 ## Response

--- a/src/m365/spo/commands/listitem/ListItemFieldValueResult.ts
+++ b/src/m365/spo/commands/listitem/ListItemFieldValueResult.ts
@@ -1,0 +1,7 @@
+export interface ListItemFieldValueResult {
+  ErrorMessage: string;
+  HasException: boolean;
+  ItemId: number;
+  FieldName: string;
+  FieldValue: any;
+}

--- a/src/m365/spo/commands/listitem/listitem-add.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-add.spec.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { telemetry } from '../../../../telemetry';
@@ -38,8 +39,8 @@ describe(commands.LISTITEM_ADD, () => {
         const bodyString = JSON.stringify(opts.data);
         const ctMatch = bodyString.match(/\"?FieldName\"?:\s*\"?ContentType\"?,\s*\"?FieldValue\"?:\s*\"?(\w*)\"?/i);
         actualContentType = ctMatch ? ctMatch[1] : "";
-        if (bodyString.indexOf("fail adding me") > -1) { return Promise.resolve({ value: [] }); }
-        return { value: [{ FieldName: "Id", FieldValue: expectedId }] };
+        if (bodyString.indexOf("fail adding me") > -1) { return Promise.resolve({ value: [{ ErrorMessage: 'failed updating', 'FieldName': 'Title', 'HasException': true }] }); }
+        return { value: [{ FieldName: "Id", FieldValue: expectedId, HasException: false }] };
       }
     }
     if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/AddValidateUpdateItemUsingPath()`) {
@@ -204,7 +205,7 @@ describe(commands.LISTITEM_ADD, () => {
       Title: "fail adding me"
     };
 
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError("Item didn't add successfully"));
+    await assert.rejects(command.action(logger, { options: options } as any), new CommandError(`The item was not created successfully due to the following errors: ${os.EOL}- Title - failed updating`));
     assert.strictEqual(actualId, 0);
   });
 

--- a/src/m365/spo/commands/listitem/listitem-batch-add.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-add.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as sinon from 'sinon';
 import { telemetry } from '../../../../telemetry';
 import auth from '../../../../Auth';
@@ -23,6 +24,11 @@ describe(commands.LISTITEM_BATCH_ADD, () => {
   const csvContentHeaders = `ContentType,Title,SingleChoiceField,MultiChoiceField,SingleMetadataField,MultiMetadataField,SinglePeopleField,MultiPeopleField,CustomHyperlink,NumberField`;
   const csvContentLine = `Item,Title A,Choice 1,Choice 1;#Choice 2,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;,Engineering|4a3cc5f3-a4a6-433e-a07a-746978ff1760;Finance|f994a4ac-cf34-448e-a22c-2b35fd9bbffa;,[{'Key':'i:0#.f|membership|markh@contoso.com'}],"[{'Key':'i:0#.f|membership|markh@contoso.com'},{'Key':'i:0#.f|membership|adamb@contoso.com'}]","https://bing.com, URL",5`;
   const csvContent = `${csvContentHeaders}\n${csvContentLine}`;
+
+  //#region Mock Responses
+  const mockBatchFailedResponse = "--batchresponse_18052adb-c218-412b-bd1c-c324b0f428f6\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 200 OK\r\nCONTENT-TYPE: application/json;odata=nometadata;streaming=true;charset=utf-8\r\n\r\n{\"value\":[{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"ContentType\",\"FieldValue\":\"Item\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Title\",\"FieldValue\":\"Title A\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"SomeDateTime\",\"FieldValue\":\"2023-01-01 00:00:00\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Id\",\"FieldValue\":\"31\",\"HasException\":false,\"ItemId\":0}]}\r\n--batchresponse_18052adb-c218-412b-bd1c-c324b0f428f6\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 200 OK\r\nCONTENT-TYPE: application/json;odata=nometadata;streaming=true;charset=utf-8\r\n\r\n{\"value\":[{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"ContentType\",\"FieldValue\":\"Item\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Title\",\"FieldValue\":\"Title B\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":-2146232832,\"ErrorMessage\":\"You must specify a valid date within the range of 1/1/1900 and 12/31/8900.\",\"FieldName\":\"SomeDateTime\",\"FieldValue\":\"2023-01-01T00:00:00Z\",\"HasException\":true,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Id\",\"FieldValue\":\"0\",\"HasException\":false,\"ItemId\":0}]}\r\n--batchresponse_18052adb-c218-412b-bd1c-c324b0f428f6\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 200 OK\r\nCONTENT-TYPE: application/json;odata=nometadata;streaming=true;charset=utf-8\r\n\r\n{\"value\":[{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"ContentType\",\"FieldValue\":\"Item\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Title\",\"FieldValue\":\"Title C\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":-2146232832,\"ErrorMessage\":\"You must specify a valid date within the range of 1/1/1900 and 12/31/8900.\",\"FieldName\":\"SomeDateTime\",\"FieldValue\":\"2023-01-01T00:00:00Z\",\"HasException\":true,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Id\",\"FieldValue\":\"0\",\"HasException\":false,\"ItemId\":0}]}\r\n--batchresponse_18052adb-c218-412b-bd1c-c324b0f428f6\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 200 OK\r\nCONTENT-TYPE: application/json;odata=nometadata;streaming=true;charset=utf-8\r\n\r\n{\"value\":[{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Id\",\"FieldValue\":\"0\",\"HasException\":false,\"ItemId\":0}]}\r\n--batchresponse_18052adb-c218-412b-bd1c-c324b0f428f6--\r\n";
+  const mockBatchSuccessfulResponse = "--batchresponse_50b4ef4d-f4df-491f-b89f-640b23d9954e\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 200 OK\r\nCONTENT-TYPE: application/json;odata=nometadata;streaming=true;charset=utf-8\r\n\r\n{\"value\":[{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"ContentType\",\"FieldValue\":\"Item\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Title\",\"FieldValue\":\"Title A\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"SomeDateTime\",\"FieldValue\":\"2023-01-01 00:00:00\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Id\",\"FieldValue\":\"32\",\"HasException\":false,\"ItemId\":0}]}\r\n--batchresponse_50b4ef4d-f4df-491f-b89f-640b23d9954e\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 200 OK\r\nCONTENT-TYPE: application/json;odata=nometadata;streaming=true;charset=utf-8\r\n\r\n{\"value\":[{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"ContentType\",\"FieldValue\":\"Item\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Title\",\"FieldValue\":\"Title B\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"SomeDateTime\",\"FieldValue\":\"2023-01-01 00:00:00\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Id\",\"FieldValue\":\"33\",\"HasException\":false,\"ItemId\":0}]}\r\n--batchresponse_50b4ef4d-f4df-491f-b89f-640b23d9954e\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 200 OK\r\nCONTENT-TYPE: application/json;odata=nometadata;streaming=true;charset=utf-8\r\n\r\n{\"value\":[{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"ContentType\",\"FieldValue\":\"Item\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Title\",\"FieldValue\":\"Title C\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"SomeDateTime\",\"FieldValue\":\"2023-01-01 00:00:00\",\"HasException\":false,\"ItemId\":0},{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Id\",\"FieldValue\":\"34\",\"HasException\":false,\"ItemId\":0}]}\r\n--batchresponse_50b4ef4d-f4df-491f-b89f-640b23d9954e\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 200 OK\r\nCONTENT-TYPE: application/json;odata=nometadata;streaming=true;charset=utf-8\r\n\r\n{\"value\":[{\"ErrorCode\":0,\"ErrorMessage\":null,\"FieldName\":\"Id\",\"FieldValue\":\"0\",\"HasException\":false,\"ItemId\":0}]}\r\n--batchresponse_50b4ef4d-f4df-491f-b89f-640b23d9954e--\r\n";
+  //#endregion
 
   let commandInfo: CommandInfo;
   let log: any[];
@@ -82,7 +88,7 @@ describe(commands.LISTITEM_BATCH_ADD, () => {
     sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
     sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `${webUrl}/_api/$batch`) {
-        return;
+        return Promise.resolve(mockBatchSuccessfulResponse);
       }
       throw 'Invalid request';
     });
@@ -94,7 +100,7 @@ describe(commands.LISTITEM_BATCH_ADD, () => {
     sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
     sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `${webUrl}/_api/$batch`) {
-        return;
+        return Promise.resolve(mockBatchSuccessfulResponse);
       }
       throw 'Invalid request';
     });
@@ -112,7 +118,7 @@ describe(commands.LISTITEM_BATCH_ADD, () => {
     sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `${webUrl}/_api/$batch`) {
         amountOfRequestsInBody += opts.data.match(/POST/g).length;
-        return;
+        return Promise.resolve(mockBatchSuccessfulResponse);
       }
       throw 'Invalid request';
     });
@@ -127,6 +133,19 @@ describe(commands.LISTITEM_BATCH_ADD, () => {
     sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `${webUrl}/_api/$batch`) {
         throw errorMessage;
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, verbose: true } } as any), new CommandError(errorMessage));
+  });
+
+  it('throws an error when batch api returns partly unsuccessful results', async () => {
+    const errorMessage = `Some items were not created successfully due to the following errors: ${os.EOL}- Line 3: SomeDateTime - You must specify a valid date within the range of 1/1/1900 and 12/31/8900.${os.EOL}- Line 4: SomeDateTime - You must specify a valid date within the range of 1/1/1900 and 12/31/8900.`;
+    sinon.stub(fs, 'readFileSync').callsFake(_ => csvContent);
+    sinon.stub(request, 'post').callsFake(async (opts: any) => {
+      if (opts.url === `${webUrl}/_api/$batch`) {
+        return Promise.resolve(mockBatchFailedResponse);
       }
       throw 'Invalid request';
     });

--- a/src/m365/spo/commands/listitem/listitem-set.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-set.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as os from 'os';
 import { telemetry } from '../../../../telemetry';
 import auth from '../../../../Auth';
 import { Cli } from '../../../../cli/Cli';
@@ -39,7 +40,7 @@ describe(commands.LISTITEM_SET, () => {
         const bodyString = JSON.stringify(opts.data);
         const ctMatch = bodyString.match(/\"?FieldName\"?:\s*\"?ContentType\"?,\s*\"?FieldValue\"?:\s*\"?(\w*)\"?/i);
         actualContentType = ctMatch ? ctMatch[1] : "";
-        if (bodyString.indexOf("fail updating me") > -1) { return Promise.resolve({ value: [{ ErrorMessage: 'failed updating' }] }); }
+        if (bodyString.indexOf("fail updating me") > -1) { return Promise.resolve({ value: [{ ErrorMessage: 'failed updating', 'FieldName': 'Title', 'HasException': true }] }); }
         return { value: [{ ItemId: expectedId }] };
       }
     }
@@ -260,7 +261,7 @@ describe(commands.LISTITEM_SET, () => {
       Title: "fail updating me"
     };
 
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError("Item didn't update successfully"));
+    await assert.rejects(command.action(logger, { options: options } as any), new CommandError(`The item was not updated successfully due to the following errors: ${os.EOL}- Title - failed updating`));
     assert.strictEqual(actualId, 0);
   });
 
@@ -349,7 +350,6 @@ describe(commands.LISTITEM_SET, () => {
 
     await assert.rejects(command.action(logger, { options: options } as any), new CommandError("Specified content type 'Unexpected content type' doesn't exist on the target list"));
   });
-
 
   it('successfully updates the listitem when the systemUpdate parameter is specified', async () => {
     sinon.stub(request, 'get').callsFake(getFakes);

--- a/src/m365/spo/commands/listitem/listitem-set.ts
+++ b/src/m365/spo/commands/listitem/listitem-set.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import { Logger } from '../../../../cli/Logger';
 import config from '../../../../config';
 import GlobalOptions from '../../../../GlobalOptions';
@@ -9,6 +10,7 @@ import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import { ListItemInstance } from './ListItemInstance';
+import { ListItemFieldValueResult } from './ListItemFieldValueResult';
 
 interface CommandArgs {
   options: Options;
@@ -290,14 +292,12 @@ class SpoListItemSetCommand extends SpoCommand {
       }
       else {
         // Response is from /ValidateUpdateListItem POST call, perform get on updated item to get all field values
-        const returnedData: any = response.value;
+        const fieldValues: ListItemFieldValueResult[] = response.value;
+        if (fieldValues.some(f => f.HasException)) {
+          throw `The item was not updated successfully due to the following errors: ${os.EOL}${fieldValues.filter(f => f.HasException).map(f => { return `- ${f.FieldName} - ${f.ErrorMessage}`; }).join(os.EOL)}`;
+        }
 
-        if (!returnedData[0].ItemId) {
-          throw `Item didn't update successfully`;
-        }
-        else {
-          itemId = returnedData[0].ItemId;
-        }
+        itemId = fieldValues[0].ItemId;
       }
 
       const requestOptionsItems: CliRequestOptions = {


### PR DESCRIPTION
Closes #4375

Fix 'listitem <verb>' commands to handle errors that are returned when updating fields. 

- Shows API errors about fields that could not be updated to the user.
- Adds explanations on adding/setting values in DateTime fields.

## Updated Commands

- `spo listitem add` : The errors given by SharePoint in the `AddValidateUpdateItemUsingPath` request should be returned to the user.
- `spo listitem set` : The errors given by SharePoint in the `ValidateUpdateListItem` request should be returned to the user.
- `spo listitem batch add` : The errors given by SharePoint in the `AddValidateUpdateItemUsingPath` batch-request should be returned to the user. The batching should be broken off when an error occurs. (failfast)
- The documentation of the commands should explain to use the date time format of the site locale or `yyyy-HH-mm HH:mm:ss`.

I'm especially interested in the reviewers opinion on the change in the listitem batch add command. There was no response parsing and validation as of yet, which meant that items in the CSV that caused errors would not be added to the list. I implemented that in such a way that the command throws immediately after the first batch that has issues. (Fail-fast) So if 1000 items should be created, and the first batch fails, the next batches are not posted.
