### PR TITLE
Fixes issue when using trailing slash on folderUrl. Closes #4658

### DIFF
--- a/src/m365/file/commands/file-list.spec.ts
+++ b/src/m365/file/commands/file-list.spec.ts
@@ -1882,7 +1882,7 @@ describe(commands.LIST, () => {
     await command.action(logger, {
       options: {
         webUrl: 'https://contoso.sharepoint.com/',
-        folderUrl: 'DemoDocs'
+        folderUrl: 'DemoDocs/'
       }
     });
     assert(loggerLogSpy.calledWith([

--- a/src/m365/file/commands/file-list.ts
+++ b/src/m365/file/commands/file-list.ts
@@ -68,7 +68,13 @@ class FileListCommand extends GraphCommand {
     if (!webUrl.endsWith('/')) {
       webUrl += '/';
     }
-    const folderUrl: URL = new URL(args.options.folderUrl, webUrl);
+
+    let folderUrlValue: string = args.options.folderUrl;
+    if (folderUrlValue.endsWith('/')) {
+      folderUrlValue = folderUrlValue.slice(0, -1);
+    }
+
+    const folderUrl: URL = new URL(folderUrlValue, webUrl);
     let driveId: string = '';
 
     try {


### PR DESCRIPTION
Closes #4658

Fixes issue when using trailing slash on folderUrl. 