### PR TITLE
Adds new command 'spo tenant commandset add'. Closes #4680

### DIFF
--- a/docs/docs/cmd/spo/tenant/tenant-commandset-add.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-commandset-add.mdx
@@ -1,0 +1,183 @@
+import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# spo tenant commandset add
+
+Add a ListView Command Set as a tenant-wide extension.
+
+## Usage
+
+```sh
+m365 spo tenant commandset add [options]
+```
+
+## Options
+
+```md defintion-list
+`-t, --title <title>`
+: The title of the ListView Command Set.
+
+`-l, --listType <listType>`
+: The list or library type to register the ListView Command Set on. Allowed values `List` or `Library`.
+
+`-i, --clientSideComponentId <clientSideComponentId>`
+: The Client Side Component Id (GUID) of the ListView Command Set.
+
+`-p, --clientSideComponentProperties [clientSideComponentProperties]`
+: The Client Side Component properties of the ListView Command Set.
+
+`-w, --webTemplate [webTemplate]`
+: Optionally add a web template (e.g. STS#3, SITEPAGEPUBLISHING#0, etc) as a filter for what kind of sites the ListView Command Set is registered on.
+
+`--location [location]`
+: The location of the ListView Command Set. Allowed values `ContextMenu`, `CommandBar` or `Both`. Defaults to `CommandBar`.
+```
+
+<Global />
+
+## Remarks
+
+Running this command from the Windows Command Shell (cmd.exe) or PowerShell for Windows OS XP, 7, 8, 8.1 without bash installed might require additional formatting for command options that have JSON, XML, or JavaScript values because the command shell treats quotes differently. For example, this is how commandset user custom action can be created from the Windows cmd.exe:
+
+```sh
+m365 spo tenant commandset add --title "YourAppCustomizer" --clientSideComponentId b41916e7-e69d-467f-b37f-ff8ecf8f99f2 --clientSideComponentProperties '{\"testMessage\":\"Test message\"}'
+```
+
+Note, how the clientSideComponentProperties option has escaped double quotes `'{\"testMessage\":\"Test message\"}'` compared to execution from bash `'{"testMessage":"Test message"}'`.
+
+:::caution Escaping JSON in PowerShell
+
+When using the `--clientSideComponentProperties` option it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../../user-guide/using-cli.mdx#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../../user-guide/using-cli.mdx#passing-complex-content-into-cli-options) instead.
+
+:::
+
+:::info
+
+To use this command, you need to be a SharePoint Admin.
+
+:::
+
+## Examples
+
+Adds a ListView Command Set that's deployed tenant wide to CommandBars of Lists.
+
+```sh
+m365 spo tenant commandset add --title "Some customizer" --clientSideComponentId  799883f5-7962-4384-a10a-105adaec6ffc --listType List
+```
+
+Adds a ListView Command Set that is configured to the context menu of communication site libraries.
+
+```sh
+m365 spo tenant commandset  add --title "Some customizer" --clientSideComponentId  799883f5-7962-4384-a10a-105adaec6ffc --webTemplate "SITEPAGEPUBLISHING#0" --listType Library --location ContextMenu
+```
+
+## Response
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ```json
+  {
+    "FileSystemObjectType": 0,
+    "Id": 4,
+    "ServerRedirectedEmbedUri": null,
+    "ServerRedirectedEmbedUrl": "",
+    "ID": 4,
+    "ContentTypeId": "0x00693E2C487575B448BD420C12CEAE7EFE",
+    "Title": "Some ListView Command Set",
+    "Modified": "2023-01-11T15:47:38Z",
+    "Created": "2023-01-11T15:47:38Z",
+    "AuthorId": 9,
+    "EditorId": 9,
+    "OData__UIVersionString": "1.0",
+    "Attachments": false,
+    "GUID": "14125658-a9bc-4ddf-9c75-1b5767c9a337",
+    "ComplianceAssetId": null,
+    "TenantWideExtensionComponentId": "7096cded-b83d-4eab-96f0-df477ed7c0bc",
+    "TenantWideExtensionComponentProperties": "{\"testMessage\":\"Test message\"}",
+    "TenantWideExtensionWebTemplate": null,
+    "TenantWideExtensionListTemplate": 101,
+    "TenantWideExtensionLocation": "ClientSideExtension.ListViewCommandSet.ContextMenu",
+    "TenantWideExtensionSequence": 0,
+    "TenantWideExtensionHostProperties": null,
+    "TenantWideExtensionDisabled": false
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="Text">
+
+  ```text
+  Attachments                           : false
+  AuthorId                              : 9
+  ComplianceAssetId                     : null
+  ContentTypeId                         : 0x00693E2C487575B448BD420C12CEAE7EFE
+  Created                               : 2023-01-11T15:47:38Z
+  EditorId                              : 9
+  FileSystemObjectType                  : 0
+  GUID                                  : 14125658-a9bc-4ddf-9c75-1b5767c9a337
+  Id                                    : 4
+  ID                                    : 4
+  Modified                              : 2023-01-11T15:47:38Z
+  OData__UIVersionString                : 1.0
+  ServerRedirectedEmbedUri              : null
+  ServerRedirectedEmbedUrl              :
+  TenantWideExtensionComponentId        : 7096cded-b83d-4eab-96f0-df477ed7c0bc
+  TenantWideExtensionComponentProperties: {"testMessage":"Test message"}
+  TenantWideExtensionDisabled           : false
+  TenantWideExtensionHostProperties     : null
+  TenantWideExtensionListTemplate       : 101
+  TenantWideExtensionLocation           : ClientSideExtension.ListViewCommandSet.ContextMenu
+  TenantWideExtensionSequence           : 0
+  TenantWideExtensionWebTemplate        : null
+  Title                                 : Some ListView Command Set
+  ```
+
+  </TabItem>
+  <TabItem value="CSV">
+
+  ```csv
+  FileSystemObjectType,Id,ServerRedirectedEmbedUri,ServerRedirectedEmbedUrl,ID,ContentTypeId,Title,Modified,Created,AuthorId,EditorId,OData__UIVersionString,Attachments,GUID,ComplianceAssetId,TenantWideExtensionComponentId,TenantWideExtensionComponentProperties,TenantWideExtensionWebTemplate,TenantWideExtensionListTemplate,TenantWideExtensionLocation,TenantWideExtensionSequence,TenantWideExtensionHostProperties,TenantWideExtensionDisabled
+  0,4,,,4,0x00693E2C487575B448BD420C12CEAE7EFE,Some ListView Command Set,2023-01-11T15:47:38Z,2023-01-11T15:47:38Z,9,9,1.0,,14125658-a9bc-4ddf-9c75-1b5767c9a337,,7096cded-b83d-4eab-96f0-df477ed7c0bc,"{""testMessage"":""Test message""}",,101,ClientSideExtension.ListViewCommandSet.ContextMenu,0,,
+  ```
+
+  </TabItem>
+  <TabItem value="Markdown">
+
+  ```md
+  # spo listitem add --webUrl "https://contoso.sharepoint.com/sites/appcatalog" --listUrl "/sites/appcatalog/Lists/TenantWideExtensions" --Title "Some ListView Command Set" --TenantWideExtensionComponentId "7096cded-b83d-4eab-96f0-df477ed7c0bc" --TenantWideExtensionLocation "ClientSideExtension.ListViewCommandSet.ContextMenu" --TenantWideExtensionSequence "0" --TenantWideExtensionListTemplate "101" --TenantWideExtensionComponentProperties "{"testMessage":"Test message"}" --TenantWideExtensionWebTemplate "" --TenantWideExtensionDisabled "false" --verbose "false" --debug "false" --_ ""
+
+  Date: 1/13/2023
+
+  ## Some ListView Command Set (4)
+
+  Property | Value
+  ---------|-------
+  FileSystemObjectType | 0
+  Id | 4
+  ServerRedirectedEmbedUri | null
+  ServerRedirectedEmbedUrl |
+  ID | 4
+  ContentTypeId | 0x00693E2C487575B448BD420C12CEAE7EFE
+  Title | Some customizer
+  Modified | 2023-01-11T15:47:38Z
+  Created | 2023-01-11T15:47:38Z
+  AuthorId | 9
+  EditorId | 9
+  OData\_\_UIVersionString | 1.0
+  Attachments | false
+  GUID | 14125658-a9bc-4ddf-9c75-1b5767c9a337
+  ComplianceAssetId | null
+  TenantWideExtensionComponentId | 7096cded-b83d-4eab-96f0-df477ed7c0bc
+  TenantWideExtensionComponentProperties | {"testMessage":"Test message"}
+  TenantWideExtensionWebTemplate | null
+  TenantWideExtensionListTemplate | 101
+  TenantWideExtensionLocation | ClientSideExtension.ListViewCommandSet.ContextMenu
+  TenantWideExtensionSequence | 0
+  TenantWideExtensionHostProperties | null
+  TenantWideExtensionDisabled | false
+  ```
+
+  </TabItem>
+</Tabs>

--- a/docs/src/config/sidebars.js
+++ b/docs/src/config/sidebars.js
@@ -3279,6 +3279,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              label: 'tenant commandset add',
+              id: 'cmd/spo/tenant/tenant-commandset-add'
+            },
+            {
+              type: 'doc',
               label: 'tenant commandset remove',
               id: 'cmd/spo/tenant/tenant-commandset-remove'
             },

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -294,6 +294,7 @@ export default {
   TENANT_APPLICATIONCUSTOMIZER_GET: `${prefix} tenant applicationcustomizer get`,
   TENANT_APPLICATIONCUSTOMIZER_LIST: `${prefix} tenant applicationcustomizer list`,
   TENANT_APPLICATIONCUSTOMIZER_REMOVE: `${prefix} tenant applicationcustomizer remove`,
+  TENANT_COMMANDSET_ADD: `${prefix} tenant commandset add`,
   TENANT_COMMANDSET_REMOVE: `${prefix} tenant commandset remove`,
   TENANT_COMMANDSET_SET: `${prefix} tenant commandset set`,
   TENANT_RECYCLEBINITEM_LIST: `${prefix} tenant recyclebinitem list`,

--- a/src/m365/spo/commands/tenant/Solution.ts
+++ b/src/m365/spo/commands/tenant/Solution.ts
@@ -1,0 +1,4 @@
+export interface Solution {
+  ContainsTenantWideExtension: boolean;
+  SkipFeatureDeployment: boolean;
+}

--- a/src/m365/spo/commands/tenant/tenant-commandset-add.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-add.spec.ts
@@ -1,0 +1,329 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+import { pid } from '../../../../utils/pid';
+import { session } from '../../../../utils/session';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+import * as spoTenantAppCatalogUrlGetCommand from './tenant-appcatalogurl-get';
+import * as spoListItemListCommand from '../listitem/listitem-list';
+import * as spoListItemAddCommand from '../listitem/listitem-add';
+import { urlUtil } from '../../../../utils/urlUtil';
+const command: Command = require('./tenant-commandset-add');
+
+describe(commands.TENANT_COMMANDSET_ADD, () => {
+  const clientSideComponentId = '9748c81b-d72e-4048-886a-e98649543743';
+  const clientSideComponentProperties = '{ "someProperty": "Some value" }';
+  const customizerTitle = 'Some Command Set';
+  const webTemplate = 'GROUP#0';
+  const webUrl = 'https://contoso.sharepoint.com';
+  const appCatalogUrl = `${webUrl}/sites/apps`;
+  const solutionId = 'ac555cb1-e5ac-409e-86dc-61e6651b1e66';
+  const clientComponentManifest = "{\"id\":\"6b2a54c5-3317-49eb-8621-1bbb76263629\",\"alias\":\"HelloWorldCommandSet\",\"componentType\":\"Extension\",\"extensionType\":\"ListViewCommandSet\",\"version\":\"0.0.1\",\"manifestVersion\":2,\"loaderConfig\":{\"internalModuleBaseUrls\":[\"HTTPS://SPCLIENTSIDEASSETLIBRARY/\"],\"entryModuleId\":\"hello-world-command-set\",\"scriptResources\":{\"hello-world-command-set\":{\"type\":\"path\",\"path\":\"hello-world-command-set_b47769f9eca3d3b6c4d5.js\"},\"HelloWorldCommandSetStrings\":{\"type\":\"path\",\"path\":\"HelloWorldCommandSetStrings_en-us_72ca11838ac9bae2790a8692c260e1ac.js\"},\"@microsoft/sp-application-base\":{\"type\":\"component\",\"id\":\"4df9bb86-ab0a-4aab-ab5f-48bf167048fb\",\"version\":\"1.15.2\"},\"@microsoft/sp-core-library\":{\"type\":\"component\",\"id\":\"7263c7d0-1d6a-45ec-8d85-d4d1d234171b\",\"version\":\"1.15.2\"}}},\"mpnId\":\"Undefined-1.15.2\",\"clientComponentDeveloper\":\"\"}";
+  const solution = { "FileSystemObjectType": 0, "Id": 40, "ServerRedirectedEmbedUri": null, "ServerRedirectedEmbedUrl": "", "ClientComponentId": clientSideComponentId, "ClientComponentManifest": clientComponentManifest, "SolutionId": solutionId, "Created": "2022-11-03T11:25:17", "Modified": "2022-11-03T11:26:03" };
+  const solutionResponse = [solution];
+  const application = { "FileSystemObjectType": 0, "Id": 31, "ServerRedirectedEmbedUri": null, "ServerRedirectedEmbedUrl": "", "SkipFeatureDeployment": true, "ContainsTenantWideExtension": true, "Modified": "2022-11-03T11:26:03", "CheckoutUserId": null, "EditorId": 9 };
+  const applicationResponse = [application];
+
+  let log: string[];
+  let logger: Logger;
+  let commandInfo: CommandInfo;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    sinon.stub(session, 'getId').callsFake(() => '');
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      Cli.executeCommand,
+      Cli.executeCommandWithOutput
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.TENANT_COMMANDSET_ADD), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('adds a tenant-wide ListView Command Set for lists', async () => {
+    let executeCommandCalled = false;
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify(applicationResponse) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'executeCommand').callsFake(async (command): Promise<void> => {
+      if (command === spoListItemAddCommand) {
+        executeCommandCalled = true;
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { clientSideComponentId: clientSideComponentId, listType: 'List', title: customizerTitle, verbose: true } });
+    assert.strictEqual(executeCommandCalled, true);
+  });
+
+  it('adds a tenant-wide ListView Command Set for libraries', async () => {
+    let executeCommandCalled = false;
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify(applicationResponse) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'executeCommand').callsFake(async (command): Promise<void> => {
+      if (command === spoListItemAddCommand) {
+        executeCommandCalled = true;
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { clientSideComponentId: clientSideComponentId, listType: 'Library', location: 'ContextMenu', title: customizerTitle, verbose: true } });
+    assert.strictEqual(executeCommandCalled, true);
+  });
+
+  it('adds a tenant-wide ListView Command Set for the SitePages library', async () => {
+    let executeCommandCalled = false;
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify(applicationResponse) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'executeCommand').callsFake(async (command): Promise<void> => {
+      if (command === spoListItemAddCommand) {
+        executeCommandCalled = true;
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { clientSideComponentId: clientSideComponentId, listType: 'SitePages', location: 'CommandBar', title: customizerTitle, verbose: true } });
+    assert.strictEqual(executeCommandCalled, true);
+  });
+
+  it('adds a tenant-wide ListView Command Set to a specific webtemplate and location including clientSideComponentProperties', async () => {
+    let executeCommandCalled = false;
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify(applicationResponse) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'executeCommand').callsFake(async (command): Promise<void> => {
+      if (command === spoListItemAddCommand) {
+        executeCommandCalled = true;
+        return;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { clientSideComponentId: clientSideComponentId, listType: 'Library', title: customizerTitle, webTemplate: webTemplate, location: 'Both', clientSideComponentProperties: clientSideComponentProperties, verbose: true } });
+    assert.strictEqual(executeCommandCalled, true);
+  });
+
+  it('throws an error when no app catalog is found', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': null };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { title: customizerTitle, clientSideComponentId: clientSideComponentId, verbose: true } }),
+      new CommandError('Cannot add tenant-wide ListView Command Set as app catalog cannot be found'));
+  });
+
+  it('throws an error when specific client side component is not found in manifest list', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify([]) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { title: customizerTitle, clientSideComponentId: clientSideComponentId, verbose: true } }),
+      new CommandError('No component found with the specified clientSideComponentId found in the component manifest list. Make sure that the application is added to the application catalog'));
+  });
+
+  it('throws an error when the manifest of a specific client side component is not of type ListView Command Set', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          const faultyClientComponentManifest = "{\"id\":\"6b2a54c5-3317-49eb-8621-1bbb76263629\",\"alias\":\"HelloWorldCommandSet\",\"componentType\":\"Extension\",\"extensionType\":\"FormCustomizer\",\"version\":\"0.0.1\",\"manifestVersion\":2,\"loaderConfig\":{\"internalModuleBaseUrls\":[\"HTTPS://SPCLIENTSIDEASSETLIBRARY/\"],\"entryModuleId\":\"hello-world-command-set\",\"scriptResources\":{\"hello-world-command-set\":{\"type\":\"path\",\"path\":\"hello-world-command-set_b47769f9eca3d3b6c4d5.js\"},\"HelloWorldCommandSetStrings\":{\"type\":\"path\",\"path\":\"HelloWorldCommandSetStrings_en-us_72ca11838ac9bae2790a8692c260e1ac.js\"},\"@microsoft/sp-application-base\":{\"type\":\"component\",\"id\":\"4df9bb86-ab0a-4aab-ab5f-48bf167048fb\",\"version\":\"1.15.2\"},\"@microsoft/sp-core-library\":{\"type\":\"component\",\"id\":\"7263c7d0-1d6a-45ec-8d85-d4d1d234171b\",\"version\":\"1.15.2\"}}},\"mpnId\":\"Undefined-1.15.2\",\"clientComponentDeveloper\":\"\"}";
+          const solutionDuplicate = { ...solution };
+          solutionDuplicate.ClientComponentManifest = faultyClientComponentManifest;
+          return { 'stdout': JSON.stringify([solutionDuplicate]) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { title: customizerTitle, clientSideComponentId: clientSideComponentId, verbose: true } }),
+      new CommandError(`The extension type of this component is not of type 'ListViewCommandSet' but of type 'FormCustomizer'`));
+  });
+
+  it('throws an error when solution is not found in app catalog', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify([]) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { title: customizerTitle, clientSideComponentId: clientSideComponentId, verbose: true } }),
+      new CommandError(`No component found with the solution id ${solutionId}. Make sure that the solution is available in the app catalog`));
+  });
+
+  it('throws an error when solution does not contain extension that can be deployed tenant-wide', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          const faultyApplication = { ...application };
+          faultyApplication.ContainsTenantWideExtension = false;
+          return { 'stdout': JSON.stringify([faultyApplication]) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { title: customizerTitle, clientSideComponentId: clientSideComponentId, verbose: true } }),
+      new CommandError(`The solution does not contain an extension that can be deployed to all sites. Make sure that you've entered the correct component Id.`));
+  });
+
+  it('throws an error when solution is not deployed globally', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          const faultyApplication = { ...application };
+          faultyApplication.SkipFeatureDeployment = false;
+          return { 'stdout': JSON.stringify([faultyApplication]) };
+        }
+      }
+      if (command === spoTenantAppCatalogUrlGetCommand) {
+        return { 'stdout': appCatalogUrl };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { title: customizerTitle, clientSideComponentId: clientSideComponentId, verbose: true } }),
+      new CommandError(`The solution has not been deployed to all sites. Make sure to deploy this solution to all sites.`));
+  });
+
+  it('fails validation if clientSideComponentId is not a valid Guid', async () => {
+    const actual = await command.validate({ options: { title: customizerTitle, listType: 'List', clientSideComponentId: 'foo' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if location value is not valid', async () => {
+    const actual = await command.validate({ options: { title: customizerTitle, listType: 'List', clientSideComponentId: clientSideComponentId, location: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if listType value is not valid', async () => {
+    const actual = await command.validate({ options: { title: customizerTitle, listType: 'invalid', clientSideComponentId: clientSideComponentId, location: 'Both' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when all properties are specified', async () => {
+    const actual = await command.validate({ options: { title: customizerTitle, clientSideComponentId: clientSideComponentId, listType: 'List', location: 'Both', webTemplate: webTemplate, clientSideComponentProperties: clientSideComponentProperties } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+});


### PR DESCRIPTION
Closes #4680

Adds new command 'spo tenant commandset add'. 

**Note:** 
I'm reusing some code from `spo tenant applicationcustomizer add` here. Including calling other commands. We'll update the code of these commands to move that to util classes in a different issue.