### PR TITLE
Add config key to disable spinner. Closes #4692

### DIFF
--- a/docs/docs/_clisettings.md
+++ b/docs/docs/_clisettings.md
@@ -18,3 +18,4 @@ Setting name|Definition|Default value
 `printErrorsAsPlainText`|When output mode is set to `json`, print error messages as plain-text rather than JSON|`true`
 `prompt`|Prompts for missing values in required options|`false`
 `showHelpOnFailure`|Automatically display help when executing a command failed|`true`
+`showSpinner`|Display spinner when executing commands|`true`

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -195,9 +195,11 @@ export class Cli {
     const cli = Cli.getInstance();
     const parentCommandName: string | undefined = cli.currentCommandName;
     cli.currentCommandName = command.getCommandName(cli.currentCommandName);
+    const showSpinner = cli.getSettingWithDefaultValue<boolean>(settingsNames.showSpinner, true);
+
     // don't show spinner if running tests
     /* c8 ignore next 3 */
-    if (typeof global.it === 'undefined') {
+    if (showSpinner && typeof global.it === 'undefined') {
       cli.spinner.start();
     }
 
@@ -214,7 +216,7 @@ export class Cli {
       cli.currentCommandName = parentCommandName;
 
       /* c8 ignore next 3 */
-      if (cli.spinner.isSpinning) {
+      if (showSpinner && cli.spinner.isSpinning) {
         cli.spinner.stop();
       }
     }
@@ -899,9 +901,12 @@ export class Cli {
   }
 
   public static log(message?: any, ...optionalParams: any[]): void {
+    const cli = Cli.getInstance();
+    const showSpinner = cli.getSettingWithDefaultValue<boolean>(settingsNames.showSpinner, true);
+
     /* c8 ignore next 3 */
-    if (Cli.getInstance().spinner.isSpinning) {
-      Cli.getInstance().spinner.stop();
+    if (showSpinner && cli.spinner.isSpinning) {
+      cli.spinner.stop();
     }
 
     if (message) {
@@ -913,12 +918,15 @@ export class Cli {
   }
 
   private static error(message?: any, ...optionalParams: any[]): void {
+    const cli = Cli.getInstance();
+    const showSpinner = cli.getSettingWithDefaultValue<boolean>(settingsNames.showSpinner, true);
+
     /* c8 ignore next 3 */
-    if (Cli.getInstance().spinner.isSpinning) {
-      Cli.getInstance().spinner.stop();
+    if (showSpinner && cli.spinner.isSpinning) {
+      cli.spinner.stop();
     }
 
-    const errorOutput: string = Cli.getInstance().getSettingWithDefaultValue(settingsNames.errorOutput, 'stderr');
+    const errorOutput: string = cli.getSettingWithDefaultValue(settingsNames.errorOutput, 'stderr');
     if (errorOutput === 'stdout') {
       console.log(message, ...optionalParams);
     }
@@ -929,19 +937,21 @@ export class Cli {
 
   public static async prompt<T>(options: any): Promise<T> {
     const inquirer: Inquirer = require('inquirer');
-    const spinnerSpinning = Cli.getInstance().spinner.isSpinning;
+    const cli = Cli.getInstance();
+    const spinnerSpinning = cli.spinner.isSpinning;
+    const showSpinner = cli.getSettingWithDefaultValue<boolean>(settingsNames.showSpinner, true);
 
     /* c8 ignore next 3 */
-    if (spinnerSpinning) {
-      Cli.getInstance().spinner.stop();
+    if (showSpinner && spinnerSpinning) {
+      cli.spinner.stop();
     }
 
     const response = await inquirer.prompt(options) as T;
 
     // Restart the spinner if it was running before the prompt
     /* c8 ignore next 3 */
-    if (spinnerSpinning) {
-      Cli.getInstance().spinner.start();
+    if (showSpinner && spinnerSpinning) {
+      cli.spinner.start();
     }
 
     return response;

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -93,6 +93,7 @@ class CliConfigSetCommand extends AnonymousCommand {
       case settingsNames.printErrorsAsPlainText:
       case settingsNames.prompt:
       case settingsNames.showHelpOnFailure:
+      case settingsNames.showSpinner:
         value = args.options.value === 'true';
         break;
       default:

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -12,7 +12,8 @@ const settingsNames = {
   output: 'output',
   printErrorsAsPlainText: 'printErrorsAsPlainText',
   prompt: 'prompt',
-  showHelpOnFailure: 'showHelpOnFailure'
+  showHelpOnFailure: 'showHelpOnFailure',
+  showSpinner: 'showSpinner'
 };
 
 export { settingsNames };


### PR DESCRIPTION
Closes #4692

Add config key to disable spinner. 
This fixes an issue with running the CLI on Azure Functions, as the Function runtime treats output to the `stderr` stream as exceptions.