### PR TITLE
Adds support for non-public clouds. Closes #1931

### DIFF
--- a/docs/docs/cmd/login.md
+++ b/docs/docs/cmd/login.md
@@ -37,6 +37,9 @@ m365 login [options]
 `--tenant [tenant]`
 : ID of the tenant from which accounts should be able to authenticate. Use `common` or `organization` if the app is multitenant. If not specified, use the tenant specified in the `CLIMICROSOFT365_TENANT` environment variable. If the environment variable is not defined, use `common` as the tenant identifier
 
+`--cloud [cloud]`
+: Cloud to connect to. Allowed values `Public`, `USGov`, `USGovHigh`, `USGovDoD` and `China`. Default `Public`
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
@@ -45,8 +48,6 @@ Using the `login` command you can log in to Microsoft 365.
 
 By default, the `login` command uses device code OAuth flow to log in to Microsoft 365. Alternatively, you can authenticate using a user name and password or certificate, which are convenient for CI/CD scenarios, but which come with their own [limitations](../user-guide/connecting-office-365.md).
 
-When logging in to Microsoft 365, the `login` command stores in memory the access token and the refresh token. Both tokens are cleared from memory after exiting the CLI or by calling the [logout](logout.md) command.
-
 When logging in to Microsoft 365 using the user name and password, next to the access and refresh token, the CLI for Microsoft 365 will store the user credentials so that it can automatically re-authenticate if necessary. Similarly to the tokens, the credentials are removed by re-authenticating using the device code or by calling the [logout](logout.md) command.
 
 When logging in to Microsoft 365 using a certificate, the CLI for Microsoft 365 will store the contents of the certificate so that it can automatically re-authenticate if necessary. The contents of the certificate are removed by re-authenticating using the device code or by calling the [logout](logout.md) command.  
@@ -54,6 +55,8 @@ When logging in to Microsoft 365 using a certificate, the CLI for Microsoft 365 
 To log in to Microsoft 365 using a certificate or secret, you will typically [create a custom Azure AD application](../user-guide/using-own-identity.md). To use this application with the CLI for Microsoft 365, you will set the `CLIMICROSOFT365_AADAPPID` environment variable to the application's ID and the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Azure AD tenant, where you created the Azure AD application. Also, please make sure to read about [the caveats when using the certificate login option](../user-guide/cli-certificate-caveats.md).
 
 Managed identity in Azure Cloud Shell is the identity of the user. It is neither system- nor user-assigned and it can't be configured. To log in to Microsoft 365 using managed identity in Azure Cloud Shell, set `authType` to `identity` and don't specify the `userName` option.
+
+When connecting to clouds other than `Public`, you'll need to use an Azure AD application registered in a directory provisioned in that cloud. If you try to login using the default Azure AD application, login will fail.
 
 ## Examples
 

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import 'node-forge';
 import * as open from 'open';
 import * as sinon from 'sinon';
-import { Auth, AuthType, CertificateType, InteractiveAuthorizationCodeResponse, InteractiveAuthorizationErrorResponse, Service } from './Auth';
+import { Auth, AuthType, CertificateType, CloudType, InteractiveAuthorizationCodeResponse, InteractiveAuthorizationErrorResponse, Service } from './Auth';
 import { FileTokenStorage } from './auth/FileTokenStorage';
 import { TokenStorage } from './auth/TokenStorage';
 import authServer from './AuthServer';
@@ -129,6 +129,10 @@ describe('Auth', () => {
     openStub.restore();
     clipboardStub.restore();
     getSettingWithDefaultValueStub.restore();
+  });
+
+  after(() => {
+    auth.service.cloudType = CloudType.Public;
   });
 
   it('returns existing access token if still valid', (done) => {
@@ -2145,5 +2149,29 @@ describe('Auth', () => {
     }, (err) => {
       done(err);
     });
+  });
+
+  it('configures cloud for auth to AzureChina for China cloud', () => {
+    auth.service.cloudType = CloudType.China;
+    const actual: msal.Configuration = (auth as any).getAuthClientConfiguration(logger, false);
+    assert.strictEqual(actual.auth.azureCloudOptions?.azureCloudInstance, msal.AzureCloudInstance.AzureChina);
+  });
+
+  it('configures cloud for auth to AzureUsGovernment for USGov cloud', () => {
+    auth.service.cloudType = CloudType.USGov;
+    const actual: msal.Configuration = (auth as any).getAuthClientConfiguration(logger, false);
+    assert.strictEqual(actual.auth.azureCloudOptions?.azureCloudInstance, msal.AzureCloudInstance.AzureUsGovernment);
+  });
+
+  it('configures cloud for auth to AzureUsGovernment for USGovHigh cloud', () => {
+    auth.service.cloudType = CloudType.USGovHigh;
+    const actual: msal.Configuration = (auth as any).getAuthClientConfiguration(logger, false);
+    assert.strictEqual(actual.auth.azureCloudOptions?.azureCloudInstance, msal.AzureCloudInstance.AzureUsGovernment);
+  });
+
+  it('configures cloud for auth to AzureUsGovernment for USGovDoD cloud', () => {
+    auth.service.cloudType = CloudType.USGovDoD;
+    const actual: msal.Configuration = (auth as any).getAuthClientConfiguration(logger, false);
+    assert.strictEqual(actual.auth.azureCloudOptions?.azureCloudInstance, msal.AzureCloudInstance.AzureUsGovernment);
   });
 });

--- a/src/AuthServer.ts
+++ b/src/AuthServer.ts
@@ -4,7 +4,7 @@ import { AddressInfo } from 'net';
 import * as open from 'open';
 import { ParsedUrlQuery } from 'querystring';
 import * as url from "url";
-import { InteractiveAuthorizationCodeResponse, Service, InteractiveAuthorizationErrorResponse } from './Auth';
+import { Auth, InteractiveAuthorizationCodeResponse, Service, InteractiveAuthorizationErrorResponse } from './Auth';
 import { Logger } from './cli/Logger';
 
 export class AuthServer {
@@ -43,7 +43,7 @@ export class AuthServer {
     const requestState = Math.random().toString(16).substr(2, 20);
     const address = this.httpServer.address() as AddressInfo;
     this.generatedServerUrl = `http://localhost:${address.port}`;
-    const url = `https://login.microsoftonline.com/${this.service.tenant}/oauth2/authorize?response_type=code&client_id=${this.service.appId}&redirect_uri=${this.generatedServerUrl}&state=${requestState}&resource=${this.resource}&prompt=select_account`;
+    const url = `${Auth.getEndpointForResource('https://login.microsoftonline.com', this.service.cloudType)}/${this.service.tenant}/oauth2/authorize?response_type=code&client_id=${this.service.appId}&redirect_uri=${this.generatedServerUrl}&state=${requestState}&resource=${this.resource}&prompt=select_account`;
     if (this.debug) {
       this.logger.logToStderr('Redirect URL:');
       this.logger.logToStderr(url);

--- a/src/auth/FileTokenStorage.spec.ts
+++ b/src/auth/FileTokenStorage.spec.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { AuthType, CertificateType, Service } from '../Auth';
+import { AuthType, CertificateType, CloudType, Service } from '../Auth';
 import { sinonUtil } from '../utils/sinonUtil';
 import { FileTokenStorage } from './FileTokenStorage';
 
@@ -44,6 +44,7 @@ describe('FileTokenStorage', () => {
       accessTokens: {},
       appId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
       tenant: 'common',
+      cloudType: CloudType.Public,
       authType: AuthType.DeviceCode,
       certificateType: CertificateType.Unknown,
       connected: false,
@@ -69,6 +70,7 @@ describe('FileTokenStorage', () => {
       accessTokens: {},
       appId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
       tenant: 'common',
+      cloudType: CloudType.Public,
       authType: AuthType.DeviceCode,
       certificateType: CertificateType.Unknown,
       connected: false,
@@ -95,6 +97,7 @@ describe('FileTokenStorage', () => {
       accessTokens: {},
       appId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
       tenant: 'common',
+      cloudType: CloudType.Public,
       authType: AuthType.DeviceCode,
       certificateType: CertificateType.Unknown,
       connected: false,
@@ -122,6 +125,7 @@ describe('FileTokenStorage', () => {
       accessTokens: {},
       appId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
       tenant: 'common',
+      cloudType: CloudType.Public,
       authType: AuthType.DeviceCode,
       certificateType: CertificateType.Unknown,
       connected: false,
@@ -149,6 +153,7 @@ describe('FileTokenStorage', () => {
       accessTokens: {},
       appId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
       tenant: 'common',
+      cloudType: CloudType.Public,
       authType: AuthType.DeviceCode,
       certificateType: CertificateType.Unknown,
       connected: false,
@@ -176,6 +181,7 @@ describe('FileTokenStorage', () => {
       accessTokens: {},
       appId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
       tenant: 'common',
+      cloudType: CloudType.Public,
       authType: AuthType.DeviceCode,
       certificateType: CertificateType.Unknown,
       connected: false,

--- a/src/m365/base/AzmgmtCommand.spec.ts
+++ b/src/m365/base/AzmgmtCommand.spec.ts
@@ -1,4 +1,9 @@
 import * as assert from 'assert';
+import * as sinon from 'sinon';
+import auth, { CloudType } from '../../Auth';
+import { CommandError } from '../../Command';
+import { telemetry } from '../../telemetry';
+import { sinonUtil } from '../../utils/sinonUtil';
 import AzmgmtCommand from './AzmgmtCommand';
 
 class MockCommand extends AzmgmtCommand {
@@ -18,8 +23,55 @@ class MockCommand extends AzmgmtCommand {
 }
 
 describe('AzmgmtCommand', () => {
+  const cmd = new MockCommand();
+  const cloudError = new CommandError(`Power Automate commands only support the public cloud at the moment. We'll add support for other clouds in the future. Sorry for the inconvenience.`);
+
+  before(() => {
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      telemetry.trackEvent
+    ]);
+  });
+
   it('defines correct resource', () => {
-    const cmd = new MockCommand();
     assert.strictEqual((cmd as any).resource, 'https://management.azure.com/');
+  });
+
+  it(`doesn't throw error when not connected`, () => {
+    auth.service.connected = false;
+    (cmd as any).initAction({ options: {} }, {});
+  });
+
+  it('throws error when connected to USGov cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGov;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to USGovHigh cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGovHigh;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to USGovDoD cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGovDoD;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to China cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.China;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it(`doesn't throw error when connected to public cloud`, () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.Public;
+    assert.doesNotThrow(() => (cmd as any).initAction({ options: {} }, {}));
   });
 });

--- a/src/m365/base/AzmgmtCommand.ts
+++ b/src/m365/base/AzmgmtCommand.ts
@@ -1,7 +1,22 @@
-import Command from '../../Command';
+import auth, { CloudType } from '../../Auth';
+import { Logger } from '../../cli/Logger';
+import Command, { CommandArgs, CommandError } from '../../Command';
 
 export default abstract class AzmgmtCommand extends Command {
   protected get resource(): string {
     return 'https://management.azure.com/';
+  }
+
+  protected initAction(args: CommandArgs, logger: Logger): void {
+    super.initAction(args, logger);
+
+    if (!auth.service.connected) {
+      // we fail no login in the base command command class
+      return;
+    }
+
+    if (auth.service.cloudType !== CloudType.Public) {
+      throw new CommandError(`Power Automate commands only support the public cloud at the moment. We'll add support for other clouds in the future. Sorry for the inconvenience.`);
+    }
   }
 }

--- a/src/m365/base/PowerAppsCommand.spec.ts
+++ b/src/m365/base/PowerAppsCommand.spec.ts
@@ -1,4 +1,9 @@
 import * as assert from 'assert';
+import * as sinon from 'sinon';
+import auth, { CloudType } from '../../Auth';
+import { CommandError } from '../../Command';
+import { telemetry } from '../../telemetry';
+import { sinonUtil } from '../../utils/sinonUtil';
 import PowerAppsCommand from './PowerAppsCommand';
 
 class MockCommand extends PowerAppsCommand {
@@ -18,8 +23,56 @@ class MockCommand extends PowerAppsCommand {
 }
 
 describe('PowerAppsCommand', () => {
+  const cmd = new MockCommand();
+  const cloudError = new CommandError(`Power Apps commands only support the public cloud at the moment. We'll add support for other clouds in the future. Sorry for the inconvenience.`);
+
+  before(() => {
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      telemetry.trackEvent
+    ]);
+  });
+
   it('returns correct resource', () => {
     const command = new MockCommand();
     assert.strictEqual((command as any).resource, 'https://api.powerapps.com');
+  });
+
+  it(`doesn't throw error when not connected`, () => {
+    auth.service.connected = false;
+    (cmd as any).initAction({ options: {} }, {});
+  });
+
+  it('throws error when connected to USGov cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGov;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to USGovHigh cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGovHigh;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to USGovDoD cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGovDoD;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to China cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.China;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it(`doesn't throw error when connected to public cloud`, () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.Public;
+    assert.doesNotThrow(() => (cmd as any).initAction({ options: {} }, {}));
   });
 });

--- a/src/m365/base/PowerAppsCommand.ts
+++ b/src/m365/base/PowerAppsCommand.ts
@@ -1,7 +1,22 @@
-import Command from '../../Command';
+import auth, { CloudType } from '../../Auth';
+import { Logger } from '../../cli/Logger';
+import Command, { CommandArgs, CommandError } from '../../Command';
 
 export default abstract class PowerAppsCommand extends Command {
   protected get resource(): string {
     return 'https://api.powerapps.com';
+  }
+
+  protected initAction(args: CommandArgs, logger: Logger): void {
+    super.initAction(args, logger);
+
+    if (!auth.service.connected) {
+      // we fail no login in the base command command class
+      return;
+    }
+
+    if (auth.service.cloudType !== CloudType.Public) {
+      throw new CommandError(`Power Apps commands only support the public cloud at the moment. We'll add support for other clouds in the future. Sorry for the inconvenience.`);
+    }
   }
 }

--- a/src/m365/base/PowerPlatformCommand.spec.ts
+++ b/src/m365/base/PowerPlatformCommand.spec.ts
@@ -1,4 +1,9 @@
 import * as assert from 'assert';
+import * as sinon from 'sinon';
+import auth, { CloudType } from '../../Auth';
+import { CommandError } from '../../Command';
+import { telemetry } from '../../telemetry';
+import { sinonUtil } from '../../utils/sinonUtil';
 import PowerPlatformCommand from './PowerPlatformCommand';
 
 class MockCommand extends PowerPlatformCommand {
@@ -18,8 +23,56 @@ class MockCommand extends PowerPlatformCommand {
 }
 
 describe('PowerPlatformCommand', () => {
+  const cmd = new MockCommand();
+  const cloudError = new CommandError(`Power Platform commands only support the public cloud at the moment. We'll add support for other clouds in the future. Sorry for the inconvenience.`);
+
+  before(() => {
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      telemetry.trackEvent
+    ]);
+  });
+
   it('returns correct bapi resource', () => {
     const command = new MockCommand();
     assert.strictEqual((command as any).resource, 'https://api.bap.microsoft.com');
+  });
+
+  it(`doesn't throw error when not connected`, () => {
+    auth.service.connected = false;
+    (cmd as any).initAction({ options: {} }, {});
+  });
+
+  it('throws error when connected to USGov cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGov;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to USGovHigh cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGovHigh;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to USGovDoD cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.USGovDoD;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it('throws error when connected to China cloud', () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.China;
+    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+  });
+
+  it(`doesn't throw error when connected to public cloud`, () => {
+    auth.service.connected = true;
+    auth.service.cloudType = CloudType.Public;
+    assert.doesNotThrow(() => (cmd as any).initAction({ options: {} }, {}));
   });
 });

--- a/src/m365/base/PowerPlatformCommand.ts
+++ b/src/m365/base/PowerPlatformCommand.ts
@@ -1,7 +1,23 @@
-import Command from '../../Command';
+import auth, { CloudType } from '../../Auth';
+import { Logger } from '../../cli/Logger';
+import Command, { CommandArgs, CommandError } from '../../Command';
+
 
 export default abstract class PowerPlatformCommand extends Command {
   protected get resource(): string {
     return 'https://api.bap.microsoft.com';
+  }
+
+  protected initAction(args: CommandArgs, logger: Logger): void {
+    super.initAction(args, logger);
+
+    if (!auth.service.connected) {
+      // we fail no login in the base command command class
+      return;
+    }
+
+    if (auth.service.cloudType !== CloudType.Public) {
+      throw new CommandError(`Power Platform commands only support the public cloud at the moment. We'll add support for other clouds in the future. Sorry for the inconvenience.`);
+    }
   }
 }

--- a/src/m365/commands/status.spec.ts
+++ b/src/m365/commands/status.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import auth, { AuthType } from '../../Auth';
+import auth, { AuthType, CloudType } from '../../Auth';
 import { Logger } from '../../cli/Logger';
 import Command, { CommandError } from '../../Command';
 import { telemetry } from '../../telemetry';
@@ -111,6 +111,7 @@ describe(commands.STATUS, () => {
     auth.service.authType = AuthType.DeviceCode;
     auth.service.appId = '8dd76117-ab8e-472c-b5c1-a50e13b457cd';
     auth.service.tenant = 'common';
+    auth.service.cloudType = CloudType.Public;
     sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve(''));
     sinon.stub(accessToken, 'getUserNameFromAccessToken').callsFake(() => { return 'admin@contoso.onmicrosoft.com'; });
     await command.action(logger, { options: {} });
@@ -118,7 +119,8 @@ describe(commands.STATUS, () => {
       connectedAs: 'admin@contoso.onmicrosoft.com',
       authType: 'DeviceCode',
       appId: '8dd76117-ab8e-472c-b5c1-a50e13b457cd',
-      appTenant: 'common'
+      appTenant: 'common',
+      cloudType: 'Public'
     }));
   });
 
@@ -127,6 +129,7 @@ describe(commands.STATUS, () => {
     auth.service.authType = AuthType.DeviceCode;
     auth.service.appId = '8dd76117-ab8e-472c-b5c1-a50e13b457cd';
     auth.service.tenant = 'common';
+    auth.service.cloudType = CloudType.Public;
     sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve(''));
     sinon.stub(accessToken, 'getUserNameFromAccessToken').callsFake(() => { return 'admin@contoso.onmicrosoft.com'; });
     auth.service.accessTokens = {
@@ -141,7 +144,8 @@ describe(commands.STATUS, () => {
       authType: 'DeviceCode',
       appId: '8dd76117-ab8e-472c-b5c1-a50e13b457cd',
       appTenant: 'common',
-      accessTokens: '{\n  "https://graph.microsoft.com": {\n    "expiresOn": "123",\n    "accessToken": "abc"\n  }\n}'
+      accessTokens: '{\n  "https://graph.microsoft.com": {\n    "expiresOn": "123",\n    "accessToken": "abc"\n  }\n}',
+      cloudType: 'Public'
     }));
   });
 
@@ -150,6 +154,7 @@ describe(commands.STATUS, () => {
     auth.service.authType = AuthType.DeviceCode;
     auth.service.appId = '8dd76117-ab8e-472c-b5c1-a50e13b457cd';
     auth.service.tenant = 'common';
+    auth.service.cloudType = CloudType.Public;
     sinon.stub(auth, 'ensureAccessToken').callsFake(() => Promise.resolve(''));
     auth.service.accessTokens = {
       'https://graph.microsoft.com': {
@@ -164,7 +169,8 @@ describe(commands.STATUS, () => {
       authType: 'DeviceCode',
       appId: '8dd76117-ab8e-472c-b5c1-a50e13b457cd',
       appTenant: 'common',
-      accessTokens: '{\n  "https://graph.microsoft.com": {\n    "expiresOn": "123",\n    "accessToken": "abc"\n  }\n}'
+      accessTokens: '{\n  "https://graph.microsoft.com": {\n    "expiresOn": "123",\n    "accessToken": "abc"\n  }\n}',
+      cloudType: 'Public'
     }));
   });
 

--- a/src/m365/commands/status.ts
+++ b/src/m365/commands/status.ts
@@ -1,4 +1,4 @@
-import auth, { AuthType } from '../../Auth';
+import auth, { AuthType, CloudType } from '../../Auth';
 import { Logger } from '../../cli/Logger';
 import Command, { CommandArgs, CommandError } from '../../Command';
 import { accessToken } from '../../utils/accessToken';
@@ -26,14 +26,15 @@ class StatusCommand extends Command {
         auth.service.logout();
         throw new CommandError(`Your login has expired. Sign in again to continue. ${err.message}`);
       }
-      
+
       if (this.debug) {
         logger.logToStderr({
           connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
           authType: AuthType[auth.service.authType],
           appId: auth.service.appId,
           appTenant: auth.service.tenant,
-          accessTokens: JSON.stringify(auth.service.accessTokens, null, 2)
+          accessTokens: JSON.stringify(auth.service.accessTokens, null, 2),
+          cloudType: CloudType[auth.service.cloudType]
         });
       }
       else {
@@ -41,7 +42,8 @@ class StatusCommand extends Command {
           connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
           authType: AuthType[auth.service.authType],
           appId: auth.service.appId,
-          appTenant: auth.service.tenant
+          appTenant: auth.service.tenant,
+          cloudType: CloudType[auth.service.cloudType]
         });
       }
     }

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { ClientRequest } from 'http';
 import * as https from 'https';
 import * as sinon from 'sinon';
-import auth from './Auth';
+import auth, { CloudType } from './Auth';
 import { Logger } from './cli/Logger';
 import _request, { CliRequestOptions } from './request';
 import { sinonUtil } from './utils/sinonUtil';
@@ -740,5 +740,57 @@ describe('Request', () => {
       }, (err: any) => {
         done(err);
       });
+  });
+
+  it(`updates the URL for the China cloud`, async () => {
+    let url;
+    auth.service.cloudType = CloudType.China;
+    sinon.stub(_request as any, 'req').callsFake(options => {
+      url = options.url;
+      return Promise.resolve({ data: {} });
+    });
+    await _request.execute({
+      url: 'https://graph.microsoft.com/v1.0/me'
+    });
+    assert.strictEqual(url, 'https://microsoftgraph.chinacloudapi.cn/v1.0/me');
+  });
+
+  it(`updates the URL for the USGov cloud`, async () => {
+    let url;
+    auth.service.cloudType = CloudType.USGov;
+    sinon.stub(_request as any, 'req').callsFake(options => {
+      url = options.url;
+      return Promise.resolve({ data: {} });
+    });
+    await _request.execute({
+      url: 'https://graph.microsoft.com/v1.0/me'
+    });
+    assert.strictEqual(url, 'https://graph.microsoft.com/v1.0/me');
+  });
+
+  it(`updates the URL for the USGovDoD cloud`, async () => {
+    let url;
+    auth.service.cloudType = CloudType.USGovDoD;
+    sinon.stub(_request as any, 'req').callsFake(options => {
+      url = options.url;
+      return Promise.resolve({ data: {} });
+    });
+    await _request.execute({
+      url: 'https://graph.microsoft.com/v1.0/me'
+    });
+    assert.strictEqual(url, 'https://dod-graph.microsoft.us/v1.0/me');
+  });
+
+  it(`updates the URL for the USGovHigh cloud`, async () => {
+    let url;
+    auth.service.cloudType = CloudType.USGovHigh;
+    sinon.stub(_request as any, 'req').callsFake(options => {
+      url = options.url;
+      return Promise.resolve({ data: {} });
+    });
+    await _request.execute({
+      url: 'https://graph.microsoft.com/v1.0/me'
+    });
+    assert.strictEqual(url, 'https://graph.microsoft.us/v1.0/me');
   });
 });

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,6 @@
 import Axios, { AxiosError, AxiosInstance, AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { Stream } from 'stream';
-import auth, { Auth } from './Auth';
+import auth, { Auth, CloudType } from './Auth';
 import { Logger } from './cli/Logger';
 import { formatting } from './utils/formatting';
 const packageJSON = require('../package.json');
@@ -154,6 +154,8 @@ class Request {
       return Promise.reject('Logger not set on the request object');
     }
 
+    this.updateRequestForCloudType(options, auth.service.cloudType);
+
     return new Promise<TResponse>((_resolve: (res: TResponse) => void, _reject: (error: any) => void): void => {
       ((): Promise<string> => {
         if (options.headers && options.headers['x-anonymous']) {
@@ -211,6 +213,13 @@ class Request {
           }
         });
     });
+  }
+
+  private updateRequestForCloudType(options: AxiosRequestConfig, cloudType: CloudType): void {
+    const url = new URL(options.url!);
+    const hostname = `${url.protocol}//${url.hostname}`;
+    const cloudUrl: string = Auth.getEndpointForResource(hostname, cloudType);
+    options.url = options.url!.replace(hostname, cloudUrl);
   }
 }
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,0 +1,7 @@
+export const misc = {
+  getEnums(en: any): string[] {
+    return Object
+      .keys(en)
+      .filter(k => isNaN(parseInt(k)));
+  }
+};


### PR DESCRIPTION
Adds support for non-public clouds. Closes #1931

Like discussed in #1931, in this PR we start with support for non-public clouds on all commands except Power Platform, Power Apps and Power Automate. Because support for non-public clouds on these APIs isn't trivial due to lack of documentation, we'll focus on it separately, based on customer demand.