### PR TITLE
Status logs upon successful login. Closes #4747

### DIFF
--- a/docs/docs/cmd/login.mdx
+++ b/docs/docs/cmd/login.mdx
@@ -183,7 +183,8 @@ m365 login --authType secret --secret topSeCr3t@007
     "connectedAs": "john.doe@contoso.onmicrosoft.com",
     "authType": "DeviceCode",
     "appId": "31359c7f-bd7e-475c-86db-fdb8c937548e",
-    "appTenant": "common"
+    "appTenant": "common",
+    "cloudType": "Public"
   }
   ```
 
@@ -198,7 +199,8 @@ m365 login --authType secret --secret topSeCr3t@007
   appId      : 31359c7f-bd7e-475c-86db-fdb8c937548e
   appTenant  : common
   authType   : DeviceCode
-  connectedAs: john.doe@contoso.onmicrosoft.com
+  connectedAs: john.doe@contoso.onmicrosoft.com,
+  cloudType  : Public
   ```
 
   </TabItem>
@@ -209,8 +211,8 @@ m365 login --authType secret --secret topSeCr3t@007
   ```
   Upon successful login:
   ```csv
-  connectedAs,authType,appId,appTenant
-  john.doe@contoso.onmicrosoft.com,DeviceCode,31359c7f-bd7e-475c-86db-fdb8c937548e,common
+  connectedAs,authType,appId,appTenant,cloudType
+  john.doe@contoso.onmicrosoft.com,DeviceCode,31359c7f-bd7e-475c-86db-fdb8c937548e,common,Public
   ```
 
   </TabItem>
@@ -233,6 +235,7 @@ m365 login --authType secret --secret topSeCr3t@007
   authType | DeviceCode
   appId | 31359c7f-bd7e-475c-86db-fdb8c937548e
   appTenant | common
+  cloudType | Public
   ```
 
   </TabItem>

--- a/docs/docs/cmd/login.mdx
+++ b/docs/docs/cmd/login.mdx
@@ -177,12 +177,28 @@ m365 login --authType secret --secret topSeCr3t@007
   ```json
   To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code CQBMTLEFC to authenticate.
   ```
+  Upon successful login:
+  ```json
+  {
+    "connectedAs": "john.doe@contoso.onmicrosoft.com",
+    "authType": "DeviceCode",
+    "appId": "31359c7f-bd7e-475c-86db-fdb8c937548e",
+    "appTenant": "common"
+  }
+  ```
 
   </TabItem>
   <TabItem value="Text">
 
   ```text
   To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code CQBMTLEFC to authenticate.
+  ```
+  Upon successful login:
+  ```text
+  appId      : 31359c7f-bd7e-475c-86db-fdb8c937548e
+  appTenant  : common
+  authType   : DeviceCode
+  connectedAs: john.doe@contoso.onmicrosoft.com
   ```
 
   </TabItem>
@@ -191,12 +207,32 @@ m365 login --authType secret --secret topSeCr3t@007
   ```csv
   To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code CQBMTLEFC to authenticate.
   ```
+  Upon successful login:
+  ```csv
+  connectedAs,authType,appId,appTenant
+  john.doe@contoso.onmicrosoft.com,DeviceCode,31359c7f-bd7e-475c-86db-fdb8c937548e,common
+  ```
 
   </TabItem>
   <TabItem value="Markdown">
 
   ```md
   To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code CQBMTLEFC to authenticate.
+  ```
+  Upon successful login:
+  ```md
+  # status
+
+  Date: 7/2/2023
+
+
+
+  Property | Value
+  ---------|-------
+  connectedAs | john.doe@contoso.onmicrosoft.com
+  authType | DeviceCode
+  appId | 31359c7f-bd7e-475c-86db-fdb8c937548e
+  appTenant | common
   ```
 
   </TabItem>

--- a/docs/docs/cmd/status.mdx
+++ b/docs/docs/cmd/status.mdx
@@ -38,7 +38,8 @@ m365 status
     "connectedAs": "john.doe@contoso.onmicrosoft.com",
     "authType": "DeviceCode",
     "appId": "31359c7f-bd7e-475c-86db-fdb8c937548e",
-    "appTenant": "common"
+    "appTenant": "common",
+    "cloudType": "Public"
   }
   ```
 
@@ -50,14 +51,15 @@ m365 status
   appTenant  : common
   authType   : DeviceCode
   connectedAs: john.doe@contoso.onmicrosoft.com
+  cloudType  : Public
   ```
 
   </TabItem>
   <TabItem value="CSV">
 
   ```csv
-  connectedAs,authType,appId,appTenant
-  john.doe@contoso.onmicrosoft.com,DeviceCode,31359c7f-bd7e-475c-86db-fdb8c937548e,common
+  connectedAs,authType,appId,appTenant,cloudType
+  john.doe@contoso.onmicrosoft.com,DeviceCode,31359c7f-bd7e-475c-86db-fdb8c937548e,common,Public
   ```
 
   </TabItem>
@@ -76,6 +78,7 @@ m365 status
   authType | DeviceCode
   appId | 31359c7f-bd7e-475c-86db-fdb8c937548e
   appTenant | common
+  cloudType | Public
   ```
 
   </TabItem>

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -210,7 +210,8 @@ class LoginCommand extends Command {
           authType: AuthType[auth.service.authType],
           appId: auth.service.appId,
           appTenant: auth.service.tenant,
-          accessToken: JSON.stringify(auth.service.accessTokens, null, 2)
+          accessToken: JSON.stringify(auth.service.accessTokens, null, 2),
+          cloudType: CloudType[auth.service.cloudType]
         });
       }
       else {
@@ -218,7 +219,8 @@ class LoginCommand extends Command {
           connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
           authType: AuthType[auth.service.authType],
           appId: auth.service.appId,
-          appTenant: auth.service.tenant
+          appTenant: auth.service.tenant,
+          cloudType: CloudType[auth.service.cloudType]
         });
       }
     };

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -6,6 +6,7 @@ import Command, {
 } from '../../Command';
 import config from '../../config';
 import GlobalOptions from '../../GlobalOptions';
+import { accessToken } from '../../utils/accessToken';
 import { misc } from '../../utils/misc';
 import commands from './commands';
 
@@ -201,6 +202,24 @@ class LoginCommand extends Command {
         }
 
         throw new CommandError(error.message);
+      }
+
+      if (this.debug) {
+        logger.logToStderr({
+          connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
+          authType: AuthType[auth.service.authType],
+          appId: auth.service.appId,
+          appTenant: auth.service.tenant,
+          accessToken: JSON.stringify(auth.service.accessTokens, null, 2)
+        });
+      }
+      else {
+        logger.logToStderr({
+          connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
+          authType: AuthType[auth.service.authType],
+          appId: auth.service.appId,
+          appTenant: auth.service.tenant
+        });
       }
     };
 


### PR DESCRIPTION
Extends the `login` command to show the same information as the `status` command after a successful login.

Closes #4747
