### PR TITLE
docs: Fixes svg logo not showing up on Safari (Mendable component) 

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -15,13 +15,19 @@
   #my-component-root *, #headlessui-portal-root * {
     font-size: 102%;
   }  
+  svg.ms-w-12 {
+    width: 2rem !important;
+  }
+  svg.ms-h-12 {
+    height: 2rem !important;
+  }
 </style>
 <div id="my-component-root" class="mendable-search"></div>
 
 <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
 <script src="https://unpkg.com/@babel/standalone@7.12.13/babel.min.js"></script>
-<script src="https://unpkg.com/@mendable/search@0.0.80/dist/umd/mendable.min.js"></script>
+<script src="https://unpkg.com/@mendable/search@0.0.84/dist/umd/mendable.min.js"></script>
 
 {% raw %}
 <script type="text/babel">


### PR DESCRIPTION
This fixes the SVG logo not showing up on Safari in the Mendable component. Also, upgraded to our new release which contains other improvements and fixes.