### PR TITLE
Fix issue with some tests where tests were interrupting when `prompt` config value is `true`. Closes #4763

### DIFF
--- a/src/m365/aad/commands/user/user-hibp.spec.ts
+++ b/src/m365/aad/commands/user/user-hibp.spec.ts
@@ -64,11 +64,6 @@ describe(commands.USER_HIBP, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if userName and apiKey is not specified', async () => {
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('fails validation if the userName is not a valid UPN', async () => {
     const actual = await command.validate({ options: { userName: 'invalid', apiKey: 'key' } }, commandInfo);
     assert.notStrictEqual(actual, true);
@@ -195,7 +190,8 @@ describe(commands.USER_HIBP, () => {
   it('fails validation if the userName is not a valid UPN.', async () => {
     const actual = await command.validate({
       options: {
-        userName: "no-an-email"
+        userName: "no-an-email",
+        apiKey: "2975xc539c304xf797f665x43f8x557x"
       }
     }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/outlook/commands/message/message-get.spec.ts
+++ b/src/m365/outlook/commands/message/message-get.spec.ts
@@ -246,11 +246,6 @@ describe(commands.MESSAGE_GET, () => {
       new CommandError(`Graph error occured`));
   });
 
-  it('fails validation if id is empty', async () => {
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('passes validation if id is filled in', async () => {
     const actual = await command.validate({ options: { id: messageId } }, commandInfo);
     assert.equal(actual, true);

--- a/src/m365/pa/commands/pcf/pcf-init.spec.ts
+++ b/src/m365/pa/commands/pcf/pcf-init.spec.ts
@@ -135,21 +135,6 @@ describe(commands.PCF_INIT, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation when the name option isn\'t specified', async () => {
-    const actual = await command.validate({ options: { namespace: 'Example.Namespace', template: 'Field' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when the namespace option isn\'t specified', async () => {
-    const actual = await command.validate({ options: { name: 'Example1Name', template: 'Field' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when the template option isn\'t specified', async () => {
-    const actual = await command.validate({ options: { name: 'Example1Name', namespace: 'Example1.Namespace' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('fails validation when unsupported template specified', async () => {
     const actual = await command.validate({ options: { name: 'Example1Name', namespace: 'Example1.Namespace', template: 'abc' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/pa/commands/solution/solution-init.spec.ts
+++ b/src/m365/pa/commands/solution/solution-init.spec.ts
@@ -129,16 +129,6 @@ describe(commands.SOLUTION_INIT, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation when the publisherName option isn\'t specified', async () => {
-    const actual = await command.validate({ options: { publisherPrefix: 'prefix' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation when the publisherPrefix option isn\'t specified', async () => {
-    const actual = await command.validate({ options: { publisherName: 'ExamplePublisher' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('fails validation when the length of publisherPrefix is less than 2', async () => {
     const actual = await command.validate({ options: { publisherName: 'ExamplePublisher', publisherPrefix: 'p' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/pa/commands/solution/solution-reference-add.spec.ts
+++ b/src/m365/pa/commands/solution/solution-reference-add.spec.ts
@@ -108,13 +108,6 @@ describe(commands.SOLUTION_REFERENCE_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation when the path option isn\'t specified', async () => {
-    sinon.stub(fs, 'readdirSync').callsFake(() => ['file1.cdsproj'] as any);
-
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('fails validation when the specified path option doesn\'t exist', async () => {
     sinon.stub(fs, 'readdirSync').callsFake(() => ['file1.cdsproj'] as any);
     sinon.stub(fs, 'existsSync').callsFake(() => false);


### PR DESCRIPTION
### Fixed the issue in some tests when `prompt` config is `true`

Fixed the issue in some tests since tests were prompting for values which shouldn't be the case. There were prompts happening when cli config `prompt` were `true`. Closes #4763 

 ### Linked Issue

Closes #4763 

 ### Other Information
Before you review the PR, ensure to run the command `m365 cli config set --key prompt --value true`. 
