### PR TITLE
Extend `spfx doctor` with `json` output

### DIFF
--- a/src/m365/spfx/commands/spfx-doctor.spec.ts
+++ b/src/m365/spfx/commands/spfx-doctor.spec.ts
@@ -898,7 +898,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { output: 'json' } });
-    const gulpCliFix = (loggerLogSpy.lastCall.args[0] as any[]).findLast(y => y.check === 'gulp-cli');
+    const gulpCliFix = (loggerLogSpy.lastCall.args[0] as any[]).filter(y => y.check === 'gulp-cli')[(loggerLogSpy.lastCall.args[0] as any[]).filter(y => y.check === 'gulp-cli').length - 1];
     assert.strictEqual(gulpCliFix.fix, 'npm i -g gulp-cli@2');
   });
 

--- a/src/m365/spfx/commands/spfx-doctor.spec.ts
+++ b/src/m365/spfx/commands/spfx-doctor.spec.ts
@@ -20,6 +20,7 @@ describe(commands.DOCTOR, () => {
   let sandbox: SinonSandbox;
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let loggerLogSpyStderr: sinon.SinonSpy;
   let commandInfo: CommandInfo;
 
   const packageVersionResponse = (name: string, version: string): string => {
@@ -56,6 +57,7 @@ describe(commands.DOCTOR, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
+    loggerLogSpyStderr = sinon.spy(logger, 'logToStderr');
     sinon.stub(process, 'platform').value('linux');
   });
 
@@ -107,11 +109,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.22.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.22.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.11 project when all requirements met (debug)', async () => {
@@ -139,11 +141,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { debug: true } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.11 generator installed locally when all requirements met (debug)', async () => {
@@ -175,11 +177,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { debug: true } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.11 generator installed globally when all requirements met', async () => {
@@ -211,11 +213,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.11 generator installed locally when all requirements met', async () => {
@@ -247,11 +249,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.10 project when all requirements met', async () => {
@@ -279,11 +281,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.10 project when all requirements met (debug)', async () => {
@@ -311,11 +313,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { debug: true } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.10 generator installed locally when all requirements met', async () => {
@@ -347,11 +349,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.10 generator installed locally when all requirements met (debug)', async () => {
@@ -383,11 +385,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { debug: true } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.10 generator installed globally when all requirements met', async () => {
@@ -419,11 +421,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('passes all checks for SPFx v1.11 generator installed globally, SPFx version specified through args, when all requirements met', async () => {
@@ -455,11 +457,11 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { spfxVersion: '1.11.0' } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.11.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')), 'Invalid Node version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')), 'Invalid yo version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')), 'Invalid gulp-cli version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')), 'Invalid typescript reported');
   });
 
   it('fails with error when SPFx not found', async () => {
@@ -479,8 +481,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('SharePoint Framework not found'));
-    assert(loggerLogSpy.calledWith(getStatus(1, 'SharePoint Framework')), 'SharePoint Framework found');
-    assert(!loggerLogSpy.calledWith('Recommended fixes:'), 'Fixes provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'SharePoint Framework')), 'SharePoint Framework found');
+    assert(!loggerLogSpyStderr.calledWith('Recommended fixes:'), 'Fixes provided');
   });
 
   it('fails with error when SPFx not found (debug)', async () => {
@@ -500,8 +502,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await assert.rejects(command.action(logger, { options: { debug: true } } as any), new CommandError('SharePoint Framework not found'));
-    assert(loggerLogSpy.calledWith(getStatus(1, 'SharePoint Framework')), 'SharePoint Framework found');
-    assert(!loggerLogSpy.calledWith('Recommended fixes:'), 'Fixes provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'SharePoint Framework')), 'SharePoint Framework found');
+    assert(!loggerLogSpyStderr.calledWith('Recommended fixes:'), 'Fixes provided');
   });
 
   it('fails with error when SPFx not found, version passed explicitly', async () => {
@@ -521,8 +523,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { spfxVersion: '1.11.0' } });
-    assert(loggerLogSpy.calledWith(`${getStatus(1, 'SharePoint Framework')} v1.11.0 not found`), 'SharePoint Framework found');
-    assert(loggerLogSpy.calledWith('Recommended fixes:'), 'Fixes provided');
+    assert(loggerLogSpyStderr.calledWith(`${getStatus(1, 'SharePoint Framework')} v1.11.0 not found`), 'SharePoint Framework found');
+    assert(loggerLogSpyStderr.calledWith('Recommended fixes:'), 'Fixes provided');
   });
 
   it('passes SPO compatibility check for SPFx v1.11.0', async () => {
@@ -539,7 +541,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { env: 'spo' } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Supported in SPO')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Supported in SPO')));
   });
 
   it('passes SPO compatibility check for SPFx v1.10.0', async () => {
@@ -556,7 +558,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { env: 'spo' } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Supported in SPO')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Supported in SPO')));
   });
 
   it('passes SP2019 compatibility check for SPFx v1.4.1', async () => {
@@ -573,13 +575,23 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { env: 'sp2019' } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Supported in SP2019')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Supported in SP2019')));
   });
 
-  it('fails validation if output does not equal text or json.', async () => {
+  it('fails validation if output is equal to csv', async () => {
     const actual = await command.validate({
       options: {
         output: 'csv'
+      }
+    }, commandInfo);
+
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if output is equal to md', async () => {
+    const actual = await command.validate({
+      options: {
+        output: 'md'
       }
     }, commandInfo);
 
@@ -600,8 +612,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await assert.rejects(command.action(logger, { options: { env: 'sp2019' } } as any), new CommandError('SharePoint Framework v1.5.0 is not supported in SP2019'));
-    assert(loggerLogSpy.calledWith(getStatus(1, 'Not supported in SP2019')));
-    assert(loggerLogSpy.calledWith('- Use SharePoint Framework v1.4.1'), 'No fix provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'Not supported in SP2019')));
+    assert(loggerLogSpyStderr.calledWith('- Use SharePoint Framework v1.4.1'), 'No fix provided');
   });
 
   it('passes SP2016 compatibility check for SPFx v1.1.0', async () => {
@@ -618,7 +630,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: { env: 'sp2016' } });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Supported in SP2016')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Supported in SP2016')));
   });
 
   it('fails SP2016 compatibility check for SPFx v1.2.0', async () => {
@@ -635,8 +647,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await assert.rejects(command.action(logger, { options: { env: 'sp2016' } } as any), new CommandError('SharePoint Framework v1.2.0 is not supported in SP2016'));
-    assert(loggerLogSpy.calledWith(getStatus(1, 'Not supported in SP2016')));
-    assert(loggerLogSpy.calledWith('- Use SharePoint Framework v1.1'), 'No fix provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'Not supported in SP2016')));
+    assert(loggerLogSpyStderr.calledWith('- Use SharePoint Framework v1.1'), 'No fix provided');
   });
 
   it('passes Node check when version meets single range prerequisite', async () => {
@@ -655,7 +667,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v10.18.0')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v10.18.0')));
   });
 
   it('passes Node check when version meets double range prerequisite', async () => {
@@ -674,7 +686,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'Node v8.0.0')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'Node v8.0.0')));
   });
 
   it('fails Node check when version does not meet single range prerequisite', async () => {
@@ -693,8 +705,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(1, 'Node v12.0.0 found, v^10 required')));
-    assert(loggerLogSpy.calledWith('- Install Node.js v10'), 'No fix provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'Node v12.0.0 found, v^10 required')));
+    assert(loggerLogSpyStderr.calledWith('- Install Node.js v10'), 'No fix provided');
   });
 
   it('fails Node check when version does not meet double range prerequisite', async () => {
@@ -713,8 +725,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(1, 'Node v12.0.0 found, v^8 || ^10 required')));
-    assert(loggerLogSpy.calledWith('- Install Node.js v10'), 'No fix provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'Node v12.0.0 found, v^8 || ^10 required')));
+    assert(loggerLogSpyStderr.calledWith('- Install Node.js v10'), 'No fix provided');
   });
 
   it('fails with friendly error message when npm not found', async () => {
@@ -725,8 +737,8 @@ describe(commands.DOCTOR, () => {
       return {} as child_process.ChildProcess;
     });
 
-    await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('npm not found'));
-    assert(!loggerLogSpy.calledWith('Recommended fixes:'), 'Fixes provided');
+    await assert.rejects(command.action(logger, { options: { output: 'text' } } as any), new CommandError('npm not found'));
+    assert(loggerLogSpyStderr.calledWith('Recommended fixes:'));
   });
 
   it('determines the current version from .yo-rc.json when spfxVersion not passed', async () => {
@@ -814,7 +826,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'yo v3.1.1')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'yo v3.1.1')));
   });
 
   it('fails yo check when yo not found', async () => {
@@ -833,8 +845,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(1, 'yo not found')));
-    assert(loggerLogSpy.calledWith('- npm i -g yo@3'), 'No fix provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'yo not found')));
+    assert(loggerLogSpyStderr.calledWith('- npm i -g yo@3'), 'No fix provided');
   });
 
   it('passes gulp-cli check when gulp-cli found', async () => {
@@ -857,7 +869,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'gulp-cli v2.3.0')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'gulp-cli v2.3.0')));
   });
 
   it('fails gulp-cli check when gulp-cli not found', async () => {
@@ -877,8 +889,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(1, 'gulp-cli not found')));
-    assert(loggerLogSpy.calledWith('- npm i -g gulp-cli@2'), 'No fix provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'gulp-cli not found')));
+    assert(loggerLogSpyStderr.calledWith('- npm i -g gulp-cli@2'), 'No fix provided');
   });
 
   it('fails gulp-cli check when gulp-cli not found and logs error as last option using json as output', async () => {
@@ -921,8 +933,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(1, 'gulp should be removed')));
-    assert(loggerLogSpy.calledWith('- npm un -g gulp'), 'No fix provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'gulp should be removed')));
+    assert(loggerLogSpyStderr.calledWith('- npm un -g gulp'), 'No fix provided');
   });
 
   it('passes typescript check when typescript not found', async () => {
@@ -944,7 +956,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'bundled typescript used')));
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'bundled typescript used')));
   });
 
   it('fails typescript check when typescript found', async () => {
@@ -966,8 +978,8 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(1, 'typescript v3.7.5 installed in the project')));
-    assert(loggerLogSpy.calledWith('- npm un typescript'), 'No fix provided');
+    assert(loggerLogSpyStderr.calledWith(getStatus(1, 'typescript v3.7.5 installed in the project')));
+    assert(loggerLogSpyStderr.calledWith('- npm un typescript'), 'No fix provided');
   });
 
   it('returns error when used with an unsupported version of spfx', async () => {
@@ -1011,7 +1023,7 @@ describe(commands.DOCTOR, () => {
     });
 
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
+    assert(loggerLogSpyStderr.calledWith(getStatus(0, 'SharePoint Framework v1.10.0')), 'Invalid SharePoint Framework version reported');
   });
 
   it('supports specifying environment', () => {

--- a/src/m365/spfx/commands/spfx-doctor.ts
+++ b/src/m365/spfx/commands/spfx-doctor.ts
@@ -705,7 +705,9 @@ class SpfxDoctorCommand extends BaseProjectCommand {
       this.handleRejectedPromise(err);
     }
     finally {
-      logger.log(this.resultsObject);
+      if (args.options.output === 'json') {
+        logger.log(this.resultsObject);
+      }
     }
   }
 


### PR DESCRIPTION
Closes #4212 

@waldekmastykarz I still believe that we would also have to change the `logger.log()` messages to `logger.logToStdErr()` messages, or the `json` output from the `logger.log` messages would look very bad.