### PR TITLE
Adds testing on Node@20

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -56,6 +56,9 @@ jobs:
           - os: ubuntu-latest
             nodeRun: 16
             nodeBuild: 18
+          - os: ubuntu-latest
+            nodeRun: 20
+            nodeBuild: 18
 
     steps:
       - name: Configure pagefile

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -58,6 +58,9 @@ jobs:
           - os: ubuntu-latest
             nodeRun: 16
             nodeBuild: 18
+          - os: ubuntu-latest
+            nodeRun: 20
+            nodeBuild: 18
 
     steps:
       - name: Configure pagefile

--- a/src/m365/base/ContextCommand.spec.ts
+++ b/src/m365/base/ContextCommand.spec.ts
@@ -59,7 +59,15 @@ describe('ContextCommand', () => {
     sinon.stub(fs, 'existsSync').callsFake(() => true);
     sinon.stub(fs, 'readFileSync').callsFake(() => '{');
 
-    assert.throws(() => cmd.mockSaveContextInfo(contextInfo), new CommandError('Error reading .m365rc.json: SyntaxError: Unexpected end of JSON input. Please add context info to .m365rc.json manually.'));
+    let errorMessage;
+    try {
+      JSON.parse('{');
+    }
+    catch (err: any) {
+      errorMessage = err;
+    }
+
+    assert.throws(() => cmd.mockSaveContextInfo(contextInfo), new CommandError(`Error reading .m365rc.json: ${errorMessage}. Please add context info to .m365rc.json manually.`));
   });
 
   it(`logs an error if the content can't be written to the .m365rc.json file`, () => {

--- a/src/m365/context/commands/context-init.spec.ts
+++ b/src/m365/context/commands/context-init.spec.ts
@@ -98,7 +98,15 @@ describe(commands.INIT, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { verbose: true } }), new CommandError('Error reading .m365rc.json: SyntaxError: Unexpected end of JSON input. Please add context info to .m365rc.json manually.'));
+    let errorMessage;
+    try {
+      JSON.parse('{');
+    }
+    catch (err: any) {
+      errorMessage = err;
+    }
+
+    await assert.rejects(command.action(logger, { options: { verbose: true } }), new CommandError(`Error reading .m365rc.json: ${errorMessage}. Please add context info to .m365rc.json manually.`));
   });
 
   it(`logs an error if the content can't be written to the .m365rc.json file`, async () => {

--- a/src/m365/spo/commands/page/page-text-add.spec.ts
+++ b/src/m365/spo/commands/page/page-text-add.spec.ts
@@ -1007,6 +1007,14 @@ describe(commands.PAGE_TEXT_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
+    let errorMessage;
+    try {
+      JSON.parse('{"controlType&qu');
+    }
+    catch (err: any) {
+      errorMessage = err.message;
+    }
+
     await assert.rejects(command.action(logger,
       {
         options: {
@@ -1016,7 +1024,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
           section: 1,
           column: 1
         }
-      }), new CommandError("Unexpected end of JSON input"));
+      }), new CommandError(errorMessage));
   });
 
   it('supports verbose mode', () => {

--- a/src/m365/spo/commands/storageentity/storageentity-list.spec.ts
+++ b/src/m365/spo/commands/storageentity/storageentity-list.spec.ts
@@ -203,7 +203,15 @@ describe(commands.STORAGEENTITY_LIST, () => {
       return Promise.reject('Invalid request');
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } } as any), new CommandError('Unexpected token a in JSON at position 0'));
+    let errorMessage;
+    try {
+      JSON.parse('a');
+    }
+    catch (err: any) {
+      errorMessage = err.message;
+    }
+
+    await assert.rejects(command.action(logger, { options: { debug: true, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } } as any), new CommandError(`${errorMessage}`));
   });
 
   it('requires app catalog URL', () => {


### PR DESCRIPTION
Had to update some tests that were using `JSON.parse(` because the error messages seems to be different in Node@20.

---

Closes #4788