### PR TITLE
Add 'm365 docs' command. Closes #3958

### DIFF
--- a/docs/docs/cmd/docs.md
+++ b/docs/docs/cmd/docs.md
@@ -14,7 +14,7 @@ m365 docs [options]
 
 ## Remarks
 
-If config setting `autoOpenLinksInBrowser` is configured to true, the command will automatically open the CLI for Microsoft 365 docs webpage in the default browser. [cli config set](../cmd/cli/config/config-set.md)
+Configure `autoOpenLinksInBrowser` using [cli config set](../cmd/cli/config/config-set.md) to automatically open the webpage in the default browser
 
 ## Examples
 
@@ -30,26 +30,22 @@ m365 docs
 
     ```json
     "https://pnp.github.io/cli-microsoft365/"
-    "Use a web browser to open the CLI for Microsoft 365 docs webpage URL"
     ```
 
 === "Text"
 
     ```text
     https://pnp.github.io/cli-microsoft365/
-    Use a web browser to open the CLI for Microsoft 365 docs webpage URL
     ```
 
 === "CSV"
 
     ```csv
     https://pnp.github.io/cli-microsoft365/
-    Use a web browser to open the CLI for Microsoft 365 docs webpage URL
     ```
 
 === "Markdown"
 
     ```md
     https://pnp.github.io/cli-microsoft365/
-    Use a web browser to open the CLI for Microsoft 365 docs webpage URL
     ```

--- a/docs/docs/cmd/docs.md
+++ b/docs/docs/cmd/docs.md
@@ -1,0 +1,55 @@
+# docs
+
+Returns the CLI for Microsoft 365 docs webpage URL
+
+## Usage
+
+```sh
+m365 docs [options]
+```
+
+## Options
+
+--8<-- "docs/cmd/_global.md"
+
+## Remarks
+
+If config setting `autoOpenLinksInBrowser` is configured to true, the command will automatically open the CLI for Microsoft 365 docs webpage in the default browser. [cli config set](../cmd/cli/config/config-set.md)
+
+## Examples
+
+Returns the CLI for Microsoft 365 docs webpage URL
+
+```sh
+m365 docs
+```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    "https://pnp.github.io/cli-microsoft365/"
+    "Use a web browser to open the CLI for Microsoft 365 docs webpage URL"
+    ```
+
+=== "Text"
+
+    ```text
+    https://pnp.github.io/cli-microsoft365/
+    Use a web browser to open the CLI for Microsoft 365 docs webpage URL
+    ```
+
+=== "CSV"
+
+    ```csv
+    https://pnp.github.io/cli-microsoft365/
+    Use a web browser to open the CLI for Microsoft 365 docs webpage URL
+    ```
+
+=== "Markdown"
+
+    ```md
+    https://pnp.github.io/cli-microsoft365/
+    Use a web browser to open the CLI for Microsoft 365 docs webpage URL
+    ```

--- a/docs/docs/cmd/docs.md
+++ b/docs/docs/cmd/docs.md
@@ -14,7 +14,7 @@ m365 docs [options]
 
 ## Remarks
 
-Configure `autoOpenLinksInBrowser` using [cli config set](../cmd/cli/config/config-set.md) to automatically open the webpage in the default browser
+Configure `autoOpenLinksInBrowser` using [cli config set](../cmd/cli/config/config-set.md) to automatically open the webpage in the default browser.
 
 ## Examples
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
     - Use CLI programmatically: user-guide/use-cli-api.md
     - Use CLI for Microsoft 365 context: user-guide/using-cli-context.md
   - Commands:
+    - cmd/docs.md
     - cmd/login.md
     - cmd/logout.md
     - cmd/request.md

--- a/src/m365/commands/commands.ts
+++ b/src/m365/commands/commands.ts
@@ -1,4 +1,5 @@
 export default {
+  DOCS: 'docs',
   LOGIN: `login`,
   LOGOUT: `logout`,
   REQUEST: `request`,

--- a/src/m365/commands/docs.spec.ts
+++ b/src/m365/commands/docs.spec.ts
@@ -7,6 +7,7 @@ import * as open from 'open';
 import { telemetry } from '../../telemetry';
 import { pid } from '../../utils/pid';
 import { session } from '../../utils/session';
+import { sinonUtil } from '../../utils/sinonUtil';
 import { Cli } from '../../cli/Cli';
 const packageJSON = require('../../../package.json');
 const command: Command = require('./docs');
@@ -46,9 +47,11 @@ describe(commands.DOCS, () => {
   });
 
   afterEach(() => {
-    loggerLogSpy.restore();
-    getSettingWithDefaultValueStub.restore();
-    openStub.restore();
+    sinonUtil.restore([
+      loggerLogSpy,
+      getSettingWithDefaultValueStub,
+      openStub
+    ]);
   });
 
   after(() => {

--- a/src/m365/commands/docs.spec.ts
+++ b/src/m365/commands/docs.spec.ts
@@ -47,18 +47,18 @@ describe(commands.DOCS, () => {
   });
 
   afterEach(() => {
-    loggerLogSpy.restore();
-    getSettingWithDefaultValueStub.restore();
-    openStub.restore();
-    sinon.restore();
-  });
-
-  after(() => {
     sinonUtil.restore([
       telemetry.trackEvent,
       pid.getProcessName,
-      session.getId
+      session.getId,
+      loggerLogSpy,
+      getSettingWithDefaultValueStub,
+      openStub
     ]);
+  });
+
+  after(() => {
+    sinon.restore();
   });
 
   it('has correct name', () => {

--- a/src/m365/commands/docs.spec.ts
+++ b/src/m365/commands/docs.spec.ts
@@ -7,7 +7,6 @@ import * as open from 'open';
 import { telemetry } from '../../telemetry';
 import { pid } from '../../utils/pid';
 import { session } from '../../utils/session';
-import { sinonUtil } from '../../utils/sinonUtil';
 import { Cli } from '../../cli/Cli';
 const packageJSON = require('../../../package.json');
 const command: Command = require('./docs');
@@ -47,14 +46,9 @@ describe(commands.DOCS, () => {
   });
 
   afterEach(() => {
-    sinonUtil.restore([
-      telemetry.trackEvent,
-      pid.getProcessName,
-      session.getId,
-      loggerLogSpy,
-      getSettingWithDefaultValueStub,
-      openStub
-    ]);
+    loggerLogSpy.restore();
+    getSettingWithDefaultValueStub.restore();
+    openStub.restore();
   });
 
   after(() => {

--- a/src/m365/commands/docs.spec.ts
+++ b/src/m365/commands/docs.spec.ts
@@ -42,7 +42,7 @@ describe(commands.DOCS, () => {
     };
     loggerLogSpy = sinon.spy(logger, 'log');
     (command as any)._open = open;
-    openStub = sinon.stub(command as any, '_open').callsFake(() => Promise.resolve(null));
+    openStub = sinon.stub(command as any, '_open').resolves();
     getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').returns(false);
   });
 
@@ -50,6 +50,7 @@ describe(commands.DOCS, () => {
     loggerLogSpy.restore();
     getSettingWithDefaultValueStub.restore();
     openStub.restore();
+    sinon.restore();
   });
 
   after(() => {
@@ -70,7 +71,7 @@ describe(commands.DOCS, () => {
 
   it('should log a message and return if autoOpenLinksInBrowser is false', async () => {
     await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith(`Use a web browser to open the CLI for Microsoft 365 docs webpage URL`));
+    assert(loggerLogSpy.calledWith(packageJSON.homepage));
   });
 
   it('should open the CLI for Microsoft 365 docs webpage URL using "open" if autoOpenLinksInBrowser is true', async () => {

--- a/src/m365/commands/docs.spec.ts
+++ b/src/m365/commands/docs.spec.ts
@@ -1,0 +1,82 @@
+import Command from '../../Command';
+import commands from './commands';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { Logger } from '../../cli/Logger';
+import * as open from 'open';
+import { telemetry } from '../../telemetry';
+import { pid } from '../../utils/pid';
+import { session } from '../../utils/session';
+import { sinonUtil } from '../../utils/sinonUtil';
+import { Cli } from '../../cli/Cli';
+const packageJSON = require('../../../package.json');
+const command: Command = require('./docs');
+
+describe(commands.DOCS, () => {
+  let log: any[];
+  let logger: Logger;
+  let cli: Cli;
+  let loggerLogSpy: sinon.SinonSpy;
+  let getSettingWithDefaultValueStub: sinon.SinonStub;
+  let openStub: sinon.SinonStub;
+
+  before(() => {
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    sinon.stub(session, 'getId').callsFake(() => '');
+  });
+
+  beforeEach(() => {
+    log = [];
+    cli = Cli.getInstance();
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+    (command as any)._open = open;
+    openStub = sinon.stub(command as any, '_open').callsFake(() => Promise.resolve(null));
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').returns(false);
+  });
+
+  afterEach(() => {
+    loggerLogSpy.restore();
+    getSettingWithDefaultValueStub.restore();
+    openStub.restore();
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      telemetry.trackEvent,
+      pid.getProcessName,
+      session.getId
+    ]);
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.DOCS);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('should log a message and return if autoOpenLinksInBrowser is false', async () => {
+    await command.action(logger, { options: {} });
+    assert(loggerLogSpy.calledWith(`Use a web browser to open the CLI for Microsoft 365 docs webpage URL`));
+  });
+
+  it('should open the CLI for Microsoft 365 docs webpage URL using "open" if autoOpenLinksInBrowser is true', async () => {
+    getSettingWithDefaultValueStub.restore();
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').returns(true);
+    await command.action(logger, { options: {} });
+    assert(openStub.calledWith(packageJSON.homepage), 'open should have been called with the CLI for Microsoft 365 docs webpage URL');
+  });
+});

--- a/src/m365/commands/docs.ts
+++ b/src/m365/commands/docs.ts
@@ -1,0 +1,39 @@
+import AnonymousCommand from '../base/AnonymousCommand';
+import { Cli } from '../../cli/Cli';
+import commands from './commands';
+import { Logger } from '../../cli/Logger';
+import type * as open from 'open';
+import { settingsNames } from '../../settingsNames';
+const packageJSON = require('../../../package.json');
+
+class DocsCommand extends AnonymousCommand {
+  private _open: typeof open | undefined;
+
+  public get name(): string {
+    return commands.DOCS;
+  }
+
+  public get description(): string {
+    return 'Returns the CLI for Microsoft 365 docs webpage URL';
+  }
+
+  public async commandAction(logger: Logger): Promise<void> {
+    logger.log(packageJSON.homepage);
+
+    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) === false) {
+      logger.log(`Use a web browser to open the CLI for Microsoft 365 docs webpage URL`);
+      return;
+    }
+
+    // _open is never set before hitting this line, but this check
+    // is implemented so that we can support lazy loading
+    // but also stub it for testing
+    /* c8 ignore next 3 */
+    if (!this._open) {
+      this._open = require('open');
+    }
+    await (this._open as typeof open)(packageJSON.homepage);
+  }
+}
+
+module.exports = new DocsCommand();

--- a/src/m365/commands/docs.ts
+++ b/src/m365/commands/docs.ts
@@ -21,7 +21,6 @@ class DocsCommand extends AnonymousCommand {
     logger.log(packageJSON.homepage);
 
     if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) === false) {
-      logger.log(`Use a web browser to open the CLI for Microsoft 365 docs webpage URL`);
       return;
     }
 
@@ -32,7 +31,7 @@ class DocsCommand extends AnonymousCommand {
     if (!this._open) {
       this._open = require('open');
     }
-    await (this._open as typeof open)(packageJSON.homepage);
+    await this._open!(packageJSON.homepage);
   }
 }
 


### PR DESCRIPTION

> -  The specifications are implemented in the command, and any discussion in the thread is not included. https://github.com/pnp/cli-microsoft365/issues/3958#issuecomment-1312685887
> - The 'open' package is used, it requires a centralized workaround to work correctly on Windows. https://github.com/pnp/cli-microsoft365/issues/3958#issuecomment-1527894667
> - The command is not tied to a specific Microsoft 365 service, so it is placed in the 'm365 commands' folder instead of creating a new service folder.

