### PR TITLE
Extends 'spo term get' command with support for getting term on site-level from tenant term sets as well as sitecollection termsets. Closes #4834

### DIFF
--- a/docs/docs/cmd/spo/term/term-get.md
+++ b/docs/docs/cmd/spo/term/term-get.md
@@ -10,23 +10,26 @@ m365 spo term get [options]
 
 ## Options
 
+`-u, --webUrl [webUrl]`
+: If specified, allows you to get a term from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.
+
 `-i, --id [id]`
-: ID of the term to retrieve. Specify `name` or `id` but not both
+: ID of the term to retrieve. Specify `name` or `id` but not both.
 
 `-n, --name [name]`
-: Name of the term to retrieve. Specify `name` or `id` but not both
+: Name of the term to retrieve. Specify `name` or `id` but not both.
 
 `--termGroupId [termGroupId]`
-: ID of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both
+: ID of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.
 
 `--termGroupName [termGroupName]`
-: Name of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both
+: Name of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.
 
 `--termSetId [termSetId]`
-: ID of the term set to which the term belongs. Specify `termSetId` or `termSetName` but not both
+: ID of the term set to which the term belongs. Specify `termSetId` or `termSetName` but not both.
 
 `--termSetName [termSetName]`
-: Name of the term set to which the term belongs. Specify `termSetId` or `termSetName` but not both
+: Name of the term set to which the term belongs. Specify `termSetId` or `termSetName` but not both.
 
 --8<-- "docs/cmd/_global.md"
 
@@ -35,24 +38,122 @@ m365 spo term get [options]
 When retrieving term by its ID, it's sufficient to specify just the ID. When retrieving it by its name however, you need to specify the parent term group and term set using either their names or IDs.
 
 !!! important
-    To use this command you have to have permissions to access the tenant admin site.
+    To use this command without the --webUrl option you have to have permissions to access the tenant admin site.
     
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. You need be a site visitor or more. It allows you to get a term from the tenant term store as well as a term from the sitecollection term store.
+
 ## Examples
 
-Get information about a taxonomy term using its ID
+Get information about a taxonomy term using its ID from the specified sitecollection.
+
+```sh
+m365 spo term get --webUrl https://contoso.sharepoint.com/sites/project-x --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb
+```
+
+Get information about a taxonomy term using its ID.
 
 ```sh
 m365 spo term get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb
 ```
 
-Get information about a taxonomy term using its name, retrieving the parent term group and term set using their names
+Get information about a taxonomy term using its name, retrieving the parent term group and term set using their names.
 
 ```sh
 m365 spo term get --name IT --termGroupName People --termSetName Department
 ```
 
-Get information about a taxonomy term using its name, retrieving the parent term group and term set using their IDs
+Get information about a taxonomy term using its name, retrieving the parent term group and term set using their IDs.
 
 ```sh
 m365 spo term get --name IT --termGroupId 5c928151-c140-4d48-aab9-54da901c7fef --termSetId 8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f
 ```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    {
+      "CreatedDate": "2021-07-07T09:42:02.283Z",
+      "Id": "2b5c71a6-d72b-49a8-a3bf-d80636d85b44",
+      "LastModifiedDate": "2021-07-07T09:42:02.283Z",
+      "Name": "IT",
+      "CustomProperties": {},
+      "CustomSortOrder": null,
+      "IsAvailableForTagging": true,
+      "Owner": "NT Service\\SPTimerV4",
+      "Description": "",
+      "IsDeprecated": false,
+      "IsKeyword": false,
+      "IsPinned": false,
+      "IsPinnedRoot": false,
+      "IsReused": false,
+      "IsRoot": true,
+      "IsSourceTerm": true,
+      "LocalCustomProperties": {},
+      "MergedTermIds": [],
+      "PathOfTerm": "IT",
+      "TermsCount": 1
+    }
+    ```
+
+=== "Text"
+
+    ```text
+    CreatedDate          : 2021-07-07T09:42:02.283Z
+    CustomProperties     : {}
+    CustomSortOrder      : null
+    Description          :
+    Id                   : 2b5c71a6-d72b-49a8-a3bf-d80636d85b44
+    IsAvailableForTagging: true
+    IsDeprecated         : false
+    IsKeyword            : false
+    IsPinned             : false
+    IsPinnedRoot         : false
+    IsReused             : false
+    IsRoot               : true
+    IsSourceTerm         : true
+    LastModifiedDate     : 2021-07-07T09:42:02.283Z
+    LocalCustomProperties: {}
+    MergedTermIds        : []
+    Name                 : IT
+    Owner                : NT Service\SPTimerV4
+    PathOfTerm           : IT
+    TermsCount           : 1
+    ```
+
+=== "CSV"
+
+    ```csv
+    CreatedDate,Id,LastModifiedDate,Name,IsAvailableForTagging,Owner,Description,IsDeprecated,IsKeyword,IsPinned,IsPinnedRoot,IsReused,IsRoot,IsSourceTerm,PathOfTerm,TermsCount
+    2021-07-07T09:42:02.283Z,2b5c71a6-d72b-49a8-a3bf-d80636d85b44,2021-07-07T09:42:02.283Z,IT,1,NT Service\SPTimerV4,,,,,,,1,1,IT,1
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo term get --termGroupName "People" --termSetName "Department" --name "IT"
+
+    Date: 5/8/2023
+
+    ## IT (2b5c71a6-d72b-49a8-a3bf-d80636d85b44)
+
+    Property | Value
+    ---------|-------
+    CreatedDate | 2021-07-07T09:42:02.283Z
+    Id | 2b5c71a6-d72b-49a8-a3bf-d80636d85b44
+    LastModifiedDate | 2021-07-07T09:42:02.283Z
+    Name | IT
+    IsAvailableForTagging | true
+    Owner | NT Service\SPTimerV4
+    Description |
+    IsDeprecated | false
+    IsKeyword | false
+    IsPinned | false
+    IsPinnedRoot | false
+    IsReused | false
+    IsRoot | true
+    IsSourceTerm | true
+    PathOfTerm | IT
+    TermsCount | 1
+    ```

--- a/src/m365/spo/commands/term/term-get.spec.ts
+++ b/src/m365/spo/commands/term/term-get.spec.ts
@@ -18,6 +18,7 @@ import { formatting } from '../../../../utils/formatting';
 const command: Command = require('./term-get');
 
 describe(commands.TERM_GET, () => {
+  const webUrl = 'https://contoso.sharepoint.com';
   const termId = '334d792b-0026-4486-a593-a2031b564104';
   const termName = 'IT';
   const termGroupId = '5c928151-c140-4d48-aab9-54da901c7fef';
@@ -128,6 +129,22 @@ describe(commands.TERM_GET, () => {
     });
 
     await command.action(logger, { options: { id: termId } });
+    assert(loggerLogSpy.calledWith(formattedResponse));
+  });
+
+  it('gets taxonomy term by id from the specified sitecollection', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === 'https://contoso.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
+        opts.headers &&
+        opts.headers['X-RequestDigest'] &&
+        opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="14" ObjectPathId="13" /><ObjectIdentityQuery Id="15" ObjectPathId="13" /><Query Id="16" ObjectPathId="13"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="6" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="7" ParentId="6" Name="GetDefaultSiteCollectionTermStore" /><Method Id="13" ParentId="7" Name="GetTerm"><Parameters><Parameter Type="Guid">{${termId}}</Parameter></Parameters></Method></ObjectPaths></Request>`) {
+        return JSON.stringify(csomResponseById);
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { webUrl: webUrl, id: termId } });
     assert(loggerLogSpy.calledWith(formattedResponse));
   });
 
@@ -360,4 +377,13 @@ describe(commands.TERM_GET, () => {
     await assert.rejects(command.action(logger, { options: { name: termName, termGroupName: termGroupName, termSetName: termSetName } } as any), new CommandError('getRequestDigest error'));
   });
 
+  it('fails validation when webUrl is not a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'invalid', id: termId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the webUrl is a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, id: termId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
 });


### PR DESCRIPTION
Extends `spo term get` command with support for getting term on site-level from tenant term sets as well as sitecollection termsets. Closes #4834