### PR TITLE
Extends 'spo term set get' command with support for getting a tenant term set as well as a sitecollection term set on site-level. Closes #4836

### DIFF
--- a/docs/docs/cmd/spo/term/term-set-get.md
+++ b/docs/docs/cmd/spo/term/term-set-get.md
@@ -10,35 +10,119 @@ m365 spo term set get [options]
 
 ## Options
 
+`-u, --webUrl [webUrl]`
+: If specified, allows you to get a term set from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.
+
 `-i, --id [id]`
-: ID of the term set to retrieve. Specify `name` or `id` but not both
+: ID of the term set to retrieve. Specify `name` or `id` but not both.
 
 `-n, --name [name]`
-: Name of the term set to retrieve. Specify `name` or `id` but not both
+: Name of the term set to retrieve. Specify `name` or `id` but not both.
 
 `--termGroupId [termGroupId]`
-: ID of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both
+: ID of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.
 
 `--termGroupName [termGroupName]`
-: Name of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both
+: Name of the term group to which the term set belongs. Specify `termGroupId` or `termGroupName` but not both.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
 !!! important
-    To use this command you have to have permissions to access the tenant admin site.
+    To use this command without the --webUrl option you have to have permissions to access the tenant admin site.
+
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. You need be a site visitor or more. It allows you to get a term set from the tenant term store as well as a term set from the sitecollection term store.
 
 ## Examples
 
-Get information about a taxonomy term set using its ID
+Get information about a taxonomy term set using its ID.
 
 ```sh
 m365 spo term set get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termGroupName PnPTermSets
 ```
 
-Get information about a taxonomy term set using its name
+Get information about a taxonomy term set using its name.
 
 ```sh
-m365 spo term set get --name PnPTermSets --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb
+m365 spo term set get --name PnP-Organizations --termGroupId 0a099ee9-e231-4ae9-a5b6-d7f94a0d241d
 ```
+
+Get information about a taxonomy term set using its ID from the specified sitecollection.
+
+```sh
+m365 spo term set get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --termGroupName PnPTermSets --webUrl https://contoso.sharepoint.com/sites/project-x
+```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    {
+      "CreatedDate": "2019-09-03T06:41:32.110Z",
+      "Id": "0e8f395e-ff58-4d45-9ff7-e331ab728beb",
+      "LastModifiedDate": "2019-09-03T06:41:32.260Z",
+      "Name": "PnP-Organizations",
+      "CustomProperties": {
+        "SearchCenterNavVer": "15"
+      },
+      "CustomSortOrder": null,
+      "IsAvailableForTagging": true,
+      "Owner": "",
+      "Contact": "",
+      "Description": "",
+      "IsOpenForTermCreation": true,
+      "Names": {
+        "1033": "PnP-Organizations"
+      },
+      "Stakeholders": []
+    }
+    ```
+
+=== "Text"
+
+    ```text
+    Contact              :
+    CreatedDate          : 2019-09-03T06:41:32.110Z
+    CustomProperties     : {"SearchCenterNavVer":"15"}
+    CustomSortOrder      : null
+    Description          :
+    Id                   : 0e8f395e-ff58-4d45-9ff7-e331ab728beb
+    IsAvailableForTagging: true
+    IsOpenForTermCreation: true
+    LastModifiedDate     : 2019-09-03T06:41:32.260Z
+    Name                 : PnP-Organizations
+    Names                : {"1033":"PnP-Organizations"}
+    Owner                :
+    Stakeholders         : []
+    ```
+
+=== "CSV"
+
+    ```csv
+    CreatedDate,Id,LastModifiedDate,Name,IsAvailableForTagging,Owner,Contact,Description,IsOpenForTermCreation
+    2019-09-03T06:41:32.110Z,0e8f395e-ff58-4d45-9ff7-e331ab728beb,2019-09-03T06:41:32.260Z,PnP-Organizations,1,,,,1
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo term set get --name "PnP-Organizations" --termGroupName "PnPTermSets"
+
+    Date: 5/9/2023
+
+    ## PnP-Organizations (0e8f395e-ff58-4d45-9ff7-e331ab728beb)
+
+    Property | Value
+    ---------|-------
+    CreatedDate | 2019-09-03T06:41:32.110Z
+    Id | 0e8f395e-ff58-4d45-9ff7-e331ab728beb
+    LastModifiedDate | 2019-09-03T06:41:32.260Z
+    Name | PnP-Organizations
+    IsAvailableForTagging | true
+    Owner |
+    Contact |
+    Description |
+    IsOpenForTermCreation | true
+    ```

--- a/src/m365/spo/commands/term/term-set-get.spec.ts
+++ b/src/m365/spo/commands/term/term-set-get.spec.ts
@@ -16,6 +16,102 @@ import commands from '../../commands';
 const command: Command = require('./term-set-get');
 
 describe(commands.TERM_SET_GET, () => {
+  const webUrl = 'https://contoso.sharepoint.com';
+  const id = '7a167c47-2b37-41d0-94d0-e962c1a4f2ed';
+  const name = 'PnP-CollabFooter-SharedLinks';
+  const termGroupId = '0e8f395e-ff58-4d45-9ff7-e331ab728beb';
+  const termGroupName = 'PnPTermSets';
+  const getTermSetResponse = [
+    {
+      "SchemaVersion": "15.0.0.0",
+      "LibraryVersion": "16.0.8112.1218",
+      "ErrorInfo": null,
+      "TraceCorrelationId": "2994929e-20f1-0000-2cdb-e577d70db169"
+    },
+    55,
+    {
+      "IsNull": false
+    },
+    56,
+    {
+      "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
+    },
+    58,
+    {
+      "IsNull": false
+    },
+    59,
+    {
+      "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
+    },
+    61,
+    {
+      "IsNull": false
+    },
+    63,
+    {
+      "IsNull": false
+    },
+    64,
+    {
+      "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+s="
+    },
+    66,
+    {
+      "IsNull": false
+    },
+    68,
+    {
+      "IsNull": false
+    },
+    69,
+    {
+      "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt"
+    },
+    70,
+    {
+      "_ObjectType_": "SP.Taxonomy.TermSet",
+      "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt",
+      "CreatedDate": "\/Date(1536839573337)\/",
+      "Id": "\/Guid(7a167c47-2b37-41d0-94d0-e962c1a4f2ed)\/",
+      "LastModifiedDate": "\/Date(1536840826883)\/",
+      "Name": "PnP-CollabFooter-SharedLinks",
+      "CustomProperties": {
+        "_Sys_Nav_IsNavigationTermSet": "True"
+      },
+      "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
+      "IsAvailableForTagging": true,
+      "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
+      "Contact": "",
+      "Description": "",
+      "IsOpenForTermCreation": false,
+      "Names": {
+        "1033": "PnP-CollabFooter-SharedLinks"
+      },
+      "Stakeholders": []
+    }
+  ];
+
+  const termSetGetResponse = {
+    "CreatedDate": "2018-09-13T11:52:53.337Z",
+    "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed",
+    "LastModifiedDate": "2018-09-13T12:13:46.883Z",
+    "Name": "PnP-CollabFooter-SharedLinks",
+    "CustomProperties": {
+      "_Sys_Nav_IsNavigationTermSet": "True"
+    },
+    "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
+    "IsAvailableForTagging": true,
+    "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
+    "Contact": "",
+    "Description": "",
+    "IsOpenForTermCreation": false,
+    "Names": {
+      "1033": "PnP-CollabFooter-SharedLinks"
+    },
+    "Stakeholders": []
+  };
+
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -80,411 +176,83 @@ describe(commands.TERM_SET_GET, () => {
   });
 
   it('gets taxonomy term set by id, term group by id', async () => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><ObjectPath Id="68" ObjectPathId="67" /><ObjectIdentityQuery Id="69" ObjectPathId="67" /><Query Id="70" ObjectPathId="67"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetById"><Parameters><Parameter Type="Guid">{0e8f395e-ff58-4d45-9ff7-e331ab728beb}</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /><Method Id="67" ParentId="65" Name="GetById"><Parameters><Parameter Type="Guid">{7a167c47-2b37-41d0-94d0-e962c1a4f2ed}</Parameter></Parameters></Method></ObjectPaths></Request>`) {
-        return Promise.resolve(JSON.stringify([
-          {
-            "SchemaVersion": "15.0.0.0",
-            "LibraryVersion": "16.0.8112.1218",
-            "ErrorInfo": null,
-            "TraceCorrelationId": "2994929e-20f1-0000-2cdb-e577d70db169"
-          },
-          55,
-          {
-            "IsNull": false
-          },
-          56,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
-          },
-          58,
-          {
-            "IsNull": false
-          },
-          59,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
-          },
-          61,
-          {
-            "IsNull": false
-          },
-          63,
-          {
-            "IsNull": false
-          },
-          64,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+s="
-          },
-          66,
-          {
-            "IsNull": false
-          },
-          68,
-          {
-            "IsNull": false
-          },
-          69,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt"
-          },
-          70,
-          {
-            "_ObjectType_": "SP.Taxonomy.TermSet",
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt",
-            "CreatedDate": "\/Date(1536839573337)\/",
-            "Id": "\/Guid(7a167c47-2b37-41d0-94d0-e962c1a4f2ed)\/",
-            "LastModifiedDate": "\/Date(1536840826883)\/",
-            "Name": "PnP-CollabFooter-SharedLinks",
-            "CustomProperties": {
-              "_Sys_Nav_IsNavigationTermSet": "True"
-            },
-            "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
-            "IsAvailableForTagging": true,
-            "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
-            "Contact": "",
-            "Description": "",
-            "IsOpenForTermCreation": false,
-            "Names": {
-              "1033": "PnP-CollabFooter-SharedLinks"
-            },
-            "Stakeholders": []
-          }
-        ]));
+        return JSON.stringify(getTermSetResponse);
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
-    await command.action(logger, { options: { id: '7a167c47-2b37-41d0-94d0-e962c1a4f2ed', termGroupId: '0e8f395e-ff58-4d45-9ff7-e331ab728beb' } });
-    assert(loggerLogSpy.calledWith({
-      "CreatedDate": "2018-09-13T11:52:53.337Z",
-      "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed",
-      "LastModifiedDate": "2018-09-13T12:13:46.883Z",
-      "Name": "PnP-CollabFooter-SharedLinks",
-      "CustomProperties": {
-        "_Sys_Nav_IsNavigationTermSet": "True"
-      },
-      "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
-      "IsAvailableForTagging": true,
-      "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
-      "Contact": "",
-      "Description": "",
-      "IsOpenForTermCreation": false,
-      "Names": {
-        "1033": "PnP-CollabFooter-SharedLinks"
-      },
-      "Stakeholders": []
-    }));
+
+    await command.action(logger, { options: { id: id, termGroupId: termGroupId } });
+    assert(loggerLogSpy.calledWith(termSetGetResponse));
   });
 
-  it('gets taxonomy term set by name, term group by id (debug)', async () => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+  it('gets taxonomy term set by name, term group by id', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><ObjectPath Id="68" ObjectPathId="67" /><ObjectIdentityQuery Id="69" ObjectPathId="67" /><Query Id="70" ObjectPathId="67"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetById"><Parameters><Parameter Type="Guid">{0e8f395e-ff58-4d45-9ff7-e331ab728beb}</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /><Method Id="67" ParentId="65" Name="GetByName"><Parameters><Parameter Type="String">PnP-CollabFooter-SharedLinks</Parameter></Parameters></Method></ObjectPaths></Request>`) {
-        return Promise.resolve(JSON.stringify([
-          {
-            "SchemaVersion": "15.0.0.0",
-            "LibraryVersion": "16.0.8112.1218",
-            "ErrorInfo": null,
-            "TraceCorrelationId": "2994929e-20f1-0000-2cdb-e577d70db169"
-          },
-          55,
-          {
-            "IsNull": false
-          },
-          56,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
-          },
-          58,
-          {
-            "IsNull": false
-          },
-          59,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
-          },
-          61,
-          {
-            "IsNull": false
-          },
-          63,
-          {
-            "IsNull": false
-          },
-          64,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+s="
-          },
-          66,
-          {
-            "IsNull": false
-          },
-          68,
-          {
-            "IsNull": false
-          },
-          69,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt"
-          },
-          70,
-          {
-            "_ObjectType_": "SP.Taxonomy.TermSet",
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt",
-            "CreatedDate": "\/Date(1536839573337)\/",
-            "Id": "\/Guid(7a167c47-2b37-41d0-94d0-e962c1a4f2ed)\/",
-            "LastModifiedDate": "\/Date(1536840826883)\/",
-            "Name": "PnP-CollabFooter-SharedLinks",
-            "CustomProperties": {
-              "_Sys_Nav_IsNavigationTermSet": "True"
-            },
-            "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
-            "IsAvailableForTagging": true,
-            "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
-            "Contact": "",
-            "Description": "",
-            "IsOpenForTermCreation": false,
-            "Names": {
-              "1033": "PnP-CollabFooter-SharedLinks"
-            },
-            "Stakeholders": []
-          }
-        ]));
+        return JSON.stringify(getTermSetResponse);
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
-    await command.action(logger, { options: { debug: true, name: 'PnP-CollabFooter-SharedLinks', termGroupId: '0e8f395e-ff58-4d45-9ff7-e331ab728beb' } });
-    assert(loggerLogSpy.calledWith({
-      "CreatedDate": "2018-09-13T11:52:53.337Z",
-      "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed",
-      "LastModifiedDate": "2018-09-13T12:13:46.883Z",
-      "Name": "PnP-CollabFooter-SharedLinks",
-      "CustomProperties": {
-        "_Sys_Nav_IsNavigationTermSet": "True"
-      },
-      "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
-      "IsAvailableForTagging": true,
-      "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
-      "Contact": "",
-      "Description": "",
-      "IsOpenForTermCreation": false,
-      "Names": {
-        "1033": "PnP-CollabFooter-SharedLinks"
-      },
-      "Stakeholders": []
-    }));
+
+    await command.action(logger, { options: { name: name, termGroupId: termGroupId, debug: true } });
+    assert(loggerLogSpy.calledWith(termSetGetResponse));
   });
 
   it('gets taxonomy term set by id, term group by name', async () => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><ObjectPath Id="68" ObjectPathId="67" /><ObjectIdentityQuery Id="69" ObjectPathId="67" /><Query Id="70" ObjectPathId="67"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetByName"><Parameters><Parameter Type="String">PnPTermSets</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /><Method Id="67" ParentId="65" Name="GetById"><Parameters><Parameter Type="Guid">{7a167c47-2b37-41d0-94d0-e962c1a4f2ed}</Parameter></Parameters></Method></ObjectPaths></Request>`) {
-        return Promise.resolve(JSON.stringify([
-          {
-            "SchemaVersion": "15.0.0.0",
-            "LibraryVersion": "16.0.8112.1218",
-            "ErrorInfo": null,
-            "TraceCorrelationId": "2994929e-20f1-0000-2cdb-e577d70db169"
-          },
-          55,
-          {
-            "IsNull": false
-          },
-          56,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
-          },
-          58,
-          {
-            "IsNull": false
-          },
-          59,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
-          },
-          61,
-          {
-            "IsNull": false
-          },
-          63,
-          {
-            "IsNull": false
-          },
-          64,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+s="
-          },
-          66,
-          {
-            "IsNull": false
-          },
-          68,
-          {
-            "IsNull": false
-          },
-          69,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt"
-          },
-          70,
-          {
-            "_ObjectType_": "SP.Taxonomy.TermSet",
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt",
-            "CreatedDate": "\/Date(1536839573337)\/",
-            "Id": "\/Guid(7a167c47-2b37-41d0-94d0-e962c1a4f2ed)\/",
-            "LastModifiedDate": "\/Date(1536840826883)\/",
-            "Name": "PnP-CollabFooter-SharedLinks",
-            "CustomProperties": {
-              "_Sys_Nav_IsNavigationTermSet": "True"
-            },
-            "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
-            "IsAvailableForTagging": true,
-            "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
-            "Contact": "",
-            "Description": "",
-            "IsOpenForTermCreation": false,
-            "Names": {
-              "1033": "PnP-CollabFooter-SharedLinks"
-            },
-            "Stakeholders": []
-          }
-        ]));
+        return JSON.stringify(getTermSetResponse);
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
-    await command.action(logger, { options: { id: '7a167c47-2b37-41d0-94d0-e962c1a4f2ed', termGroupName: 'PnPTermSets' } });
-    assert(loggerLogSpy.calledWith({
-      "CreatedDate": "2018-09-13T11:52:53.337Z",
-      "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed",
-      "LastModifiedDate": "2018-09-13T12:13:46.883Z",
-      "Name": "PnP-CollabFooter-SharedLinks",
-      "CustomProperties": {
-        "_Sys_Nav_IsNavigationTermSet": "True"
-      },
-      "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
-      "IsAvailableForTagging": true,
-      "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
-      "Contact": "",
-      "Description": "",
-      "IsOpenForTermCreation": false,
-      "Names": {
-        "1033": "PnP-CollabFooter-SharedLinks"
-      },
-      "Stakeholders": []
-    }));
+
+    await command.action(logger, { options: { id: id, termGroupName: termGroupName } });
+    assert(loggerLogSpy.calledWith(termSetGetResponse));
   });
 
   it('gets taxonomy term set by name, term group by name', async () => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><ObjectPath Id="68" ObjectPathId="67" /><ObjectIdentityQuery Id="69" ObjectPathId="67" /><Query Id="70" ObjectPathId="67"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetByName"><Parameters><Parameter Type="String">PnPTermSets</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /><Method Id="67" ParentId="65" Name="GetByName"><Parameters><Parameter Type="String">PnP-CollabFooter-SharedLinks</Parameter></Parameters></Method></ObjectPaths></Request>`) {
-        return Promise.resolve(JSON.stringify([
-          {
-            "SchemaVersion": "15.0.0.0",
-            "LibraryVersion": "16.0.8112.1218",
-            "ErrorInfo": null,
-            "TraceCorrelationId": "2994929e-20f1-0000-2cdb-e577d70db169"
-          },
-          55,
-          {
-            "IsNull": false
-          },
-          56,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
-          },
-          58,
-          {
-            "IsNull": false
-          },
-          59,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
-          },
-          61,
-          {
-            "IsNull": false
-          },
-          63,
-          {
-            "IsNull": false
-          },
-          64,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+s="
-          },
-          66,
-          {
-            "IsNull": false
-          },
-          68,
-          {
-            "IsNull": false
-          },
-          69,
-          {
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt"
-          },
-          70,
-          {
-            "_ObjectType_": "SP.Taxonomy.TermSet",
-            "_ObjectIdentity_": "2994929e-20f1-0000-2cdb-e577d70db169|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt",
-            "CreatedDate": "\/Date(1536839573337)\/",
-            "Id": "\/Guid(7a167c47-2b37-41d0-94d0-e962c1a4f2ed)\/",
-            "LastModifiedDate": "\/Date(1536840826883)\/",
-            "Name": "PnP-CollabFooter-SharedLinks",
-            "CustomProperties": {
-              "_Sys_Nav_IsNavigationTermSet": "True"
-            },
-            "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
-            "IsAvailableForTagging": true,
-            "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
-            "Contact": "",
-            "Description": "",
-            "IsOpenForTermCreation": false,
-            "Names": {
-              "1033": "PnP-CollabFooter-SharedLinks"
-            },
-            "Stakeholders": []
-          }
-        ]));
+        return JSON.stringify(getTermSetResponse);
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
-    await command.action(logger, { options: { name: 'PnP-CollabFooter-SharedLinks', termGroupName: 'PnPTermSets' } });
-    assert(loggerLogSpy.calledWith({
-      "CreatedDate": "2018-09-13T11:52:53.337Z",
-      "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed",
-      "LastModifiedDate": "2018-09-13T12:13:46.883Z",
-      "Name": "PnP-CollabFooter-SharedLinks",
-      "CustomProperties": {
-        "_Sys_Nav_IsNavigationTermSet": "True"
-      },
-      "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
-      "IsAvailableForTagging": true,
-      "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
-      "Contact": "",
-      "Description": "",
-      "IsOpenForTermCreation": false,
-      "Names": {
-        "1033": "PnP-CollabFooter-SharedLinks"
-      },
-      "Stakeholders": []
-    }));
+
+    await command.action(logger, { options: { name: name, termGroupName: termGroupName } });
+    assert(loggerLogSpy.calledWith(termSetGetResponse));
+  });
+
+  it('gets taxonomy term set by name, term group by name from the specified sitecollection', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === 'https://contoso.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
+        opts.headers &&
+        opts.headers['X-RequestDigest'] &&
+        opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><ObjectPath Id="68" ObjectPathId="67" /><ObjectIdentityQuery Id="69" ObjectPathId="67" /><Query Id="70" ObjectPathId="67"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetByName"><Parameters><Parameter Type="String">PnPTermSets</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /><Method Id="67" ParentId="65" Name="GetByName"><Parameters><Parameter Type="String">PnP-CollabFooter-SharedLinks</Parameter></Parameters></Method></ObjectPaths></Request>`) {
+        return JSON.stringify(getTermSetResponse);
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { name: name, termGroupName: termGroupName, webUrl: webUrl } });
+    assert(loggerLogSpy.calledWith(termSetGetResponse));
   });
 
   it('escapes XML in term group name', async () => {
@@ -567,7 +335,8 @@ describe(commands.TERM_SET_GET, () => {
 
       return Promise.reject('Invalid request');
     });
-    await command.action(logger, { options: { name: 'PnP-CollabFooter-SharedLinks', termGroupName: 'PnPTermSets>' } });
+
+    await command.action(logger, { options: { name: name, termGroupName: 'PnPTermSets>' } });
     assert(loggerLogSpy.calledWith({
       "CreatedDate": "2018-09-13T11:52:53.337Z",
       "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed",
@@ -669,7 +438,8 @@ describe(commands.TERM_SET_GET, () => {
 
       return Promise.reject('Invalid request');
     });
-    await command.action(logger, { options: { name: 'PnP-CollabFooter-SharedLinks>', termGroupName: 'PnPTermSets' } });
+
+    await command.action(logger, { options: { name: 'PnP-CollabFooter-SharedLinks>', termGroupName: termGroupName } });
     assert(loggerLogSpy.calledWith({
       "CreatedDate": "2018-09-13T11:52:53.337Z",
       "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed",
@@ -723,8 +493,8 @@ describe(commands.TERM_SET_GET, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'PnP-CollabFooter-SharedLinks',
-        termGroupName: 'PnPTermSets'
+        name: name,
+        termGroupName: termGroupName
       }
     } as any), new CommandError('Specified argument was out of the range of valid values.\r\nParameter name: index'));
   });
@@ -761,8 +531,8 @@ describe(commands.TERM_SET_GET, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'PnP-CollabFooter-SharedLinks',
-        termGroupName: 'PnPTermSets'
+        name: name,
+        termGroupName: termGroupName
       }
     } as any), new CommandError('Specified argument was out of the range of valid values.\r\nParameter name: index'));
   });
@@ -782,52 +552,62 @@ describe(commands.TERM_SET_GET, () => {
   });
 
   it('fails validation if neither id nor name specified', async () => {
-    const actual = await command.validate({ options: { termGroupName: 'PnPTermSets' } }, commandInfo);
+    const actual = await command.validate({ options: { termGroupName: termGroupName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if both id and name specified', async () => {
-    const actual = await command.validate({ options: { id: '9e54299e-208a-4000-8546-cc4139091b26', name: 'PnP-CollabFooter-SharedLinks', termGroupName: 'PnPTermSets' } }, commandInfo);
+    const actual = await command.validate({ options: { id: id, name: name, termGroupName: termGroupName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: 'invalid', termGroupName: 'PnPTermSets' } }, commandInfo);
+    const actual = await command.validate({ options: { id: 'invalid', termGroupName: termGroupName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if neither termGroupId nor termGroupName specified', async () => {
-    const actual = await command.validate({ options: { id: '9e54299e-208a-4000-8546-cc4139091b26' } }, commandInfo);
+    const actual = await command.validate({ options: { id: id } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if both termGroupId and termGroupName specified', async () => {
-    const actual = await command.validate({ options: { id: '9e54299e-208a-4000-8546-cc4139091b26', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27', termGroupName: 'PnPTermSets' } }, commandInfo);
+    const actual = await command.validate({ options: { id: id, termGroupId: termGroupId, termGroupName: termGroupName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if termGroupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: '9e54299e-208a-4000-8546-cc4139091b26', termGroupId: 'invalid' } }, commandInfo);
+    const actual = await command.validate({ options: { id: id, termGroupId: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('passes validation when id and termGroupName specified', async () => {
-    const actual = await command.validate({ options: { id: '9e54299e-208a-4000-8546-cc4139091b26', termGroupName: 'PnPTermSets' } }, commandInfo);
+    const actual = await command.validate({ options: { id: id, termGroupName: termGroupName } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation when name and termGroupName specified', async () => {
-    const actual = await command.validate({ options: { name: 'People', termGroupName: 'PnPTermSets' } }, commandInfo);
+    const actual = await command.validate({ options: { name: 'People', termGroupName: termGroupName } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation when id and termGroupId specified', async () => {
-    const actual = await command.validate({ options: { id: '9e54299e-208a-4000-8546-cc4139091b26', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27' } }, commandInfo);
+    const actual = await command.validate({ options: { id: id, termGroupId: termGroupId } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation when name and termGroupId specified', async () => {
-    const actual = await command.validate({ options: { name: 'PnP-CollabFooter-SharedLinks', termGroupId: '9e54299e-208a-4000-8546-cc4139091b26' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupId: termGroupId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation when webUrl is not a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'invalid', id: id, termGroupId: termGroupId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the webUrl is a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, id: id, termGroupId: termGroupId } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
@@ -837,8 +617,8 @@ describe(commands.TERM_SET_GET, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'PnP-CollabFooter-SharedLinks',
-        termGroupName: 'PnPTermSets'
+        name: name,
+        termGroupName: termGroupName
       }
     } as any), new CommandError('getRequestDigest error'));
   });

--- a/src/m365/spo/commands/term/term-set-get.ts
+++ b/src/m365/spo/commands/term/term-set-get.ts
@@ -14,6 +14,7 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
+  webUrl?: string;
   id?: string;
   name?: string;
   termGroupId?: string;
@@ -41,6 +42,7 @@ class SpoTermSetGetCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
+        webUrl: typeof args.options.webUrl !== 'undefined',
         id: typeof args.options.id !== 'undefined',
         name: typeof args.options.name !== 'undefined',
         termGroupId: typeof args.options.termGroupId !== 'undefined',
@@ -51,6 +53,9 @@ class SpoTermSetGetCommand extends SpoCommand {
 
   #initOptions(): void {
     this.options.unshift(
+      {
+        option: '-u, --webUrl [webUrl]'
+      },
       {
         option: '-i, --id [id]'
       },
@@ -69,6 +74,13 @@ class SpoTermSetGetCommand extends SpoCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
+        if (args.options.webUrl) {
+          const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+          if (isValidSharePointUrl !== true) {
+            return isValidSharePointUrl;
+          }
+        }
+
         if (args.options.id) {
           if (!validation.isValidGuid(args.options.id)) {
             return `${args.options.id} is not a valid GUID`;
@@ -95,8 +107,8 @@ class SpoTermSetGetCommand extends SpoCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const spoAdminUrl: string = await spo.getSpoAdminUrl(logger, this.debug);
-      const res: ContextInfo = await spo.getRequestDigest(spoAdminUrl);
+      const spoWebUrl: string = args.options.webUrl ? args.options.webUrl : await spo.getSpoAdminUrl(logger, this.debug);
+      const res: ContextInfo = await spo.getRequestDigest(spoWebUrl);
       if (this.verbose) {
         logger.logToStderr(`Retrieving taxonomy term set...`);
       }
@@ -105,7 +117,7 @@ class SpoTermSetGetCommand extends SpoCommand {
       const termSetQuery: string = args.options.id ? `<Method Id="67" ParentId="65" Name="GetById"><Parameters><Parameter Type="Guid">{${args.options.id}}</Parameter></Parameters></Method>` : `<Method Id="67" ParentId="65" Name="GetByName"><Parameters><Parameter Type="String">${formatting.escapeXml(args.options.name)}</Parameter></Parameters></Method>`;
 
       const requestOptions: any = {
-        url: `${spoAdminUrl}/_vti_bin/client.svc/ProcessQuery`,
+        url: `${spoWebUrl}/_vti_bin/client.svc/ProcessQuery`,
         headers: {
           'X-RequestDigest': res.FormDigestValue
         },


### PR DESCRIPTION
Extends `spo term set get` command with support for getting a tenant term set as well as a sitecollection term set on site-level. Closes #4836