### PR TITLE
Extends 'spo term add' command with support for adding a site-level term or a tenant-level term without SPO Admin privileges. Closes #4837

### DIFF
--- a/docs/docs/cmd/spo/term/term-add.md
+++ b/docs/docs/cmd/spo/term/term-add.md
@@ -13,6 +13,9 @@ m365 spo term add [options]
 `-n, --name <name>`
 : Name of the term to add
 
+`-u, --webUrl [webUrl]`
+: If specified, allows you to add a term to the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.
+
 `--termSetId [termSetId]`
 : ID of the term set in which to create the term. Specify `termSetId` or `termSetName` but not both
 
@@ -48,36 +51,134 @@ m365 spo term add [options]
     When using the `--customProperties` and/or `--localCustomProperties` options it's possible to enter a JSON string. In PowerShell 5 to 7.2 [specific escaping rules](./../../../user-guide/using-cli.md#escaping-double-quotes-in-powershell) apply due to an issue. Remember that you can also use [file tokens](./../../../user-guide/using-cli.md#passing-complex-content-into-cli-options) instead.
 
 !!! important
-    To use this command you have to have permissions to access the tenant admin site.
+    To use this command without the `--webUrl` option you have to have permissions to access the tenant admin site.
+
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. It allows you to add a term to a term set in the tenant term store if you are listed as a term store administrator. It allows you to add terms to a term set in the sitecollection term store if you are a site owner.
 
 ## Examples
 
-Add taxonomy term with the specified name to the term group and term set specified by their names
+Add taxonomy term with the specified name to the term group and term set specified by their names.
 
 ```sh
 m365 spo term add --name IT --termSetName Department --termGroupName People
 ```
 
-Add taxonomy term with the specified name to the term group and term set specified by their IDs
+Add taxonomy term with the specified name to the term group and term set specified by their IDs.
 
 ```sh
 m365 spo term add --name IT --termSetId 8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f --termGroupId 5c928151-c140-4d48-aab9-54da901c7fef
 ```
 
-Add taxonomy term with the specified name and ID
+Add taxonomy term with the specified name and ID.
 
 ```sh
 m365 spo term add --name IT --id 5c928151-c140-4d48-aab9-54da901c7fef --termSetName Department --termGroupName People
 ```
 
-Add taxonomy term with custom properties
+Add taxonomy term to the specified sitecollection with the specified name and ID.
+
+```sh
+m365 spo term add --name IT --id 5c928151-c140-4d48-aab9-54da901c7fef --termSetName Department --termGroupName People --webUrl https://contoso.sharepoint.com/sites/project-x
+```
+
+Add taxonomy term with custom properties.
 
 ```sh
 m365 spo term add --name IT --termSetName Department --termGroupName People --customProperties '{"Property": "Value"}'
 ```
 
-Add taxonomy term below the specified term
+Add taxonomy term below the specified term.
 
 ```sh
 m365 spo term add --name IT --parentTermId 5c928151-c140-4d48-aab9-54da901c7fef --termGroupName People
 ```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    {
+      "CreatedDate": "2023-05-10T06:21:33.873Z",
+      "Id": "346f49b0-3d1c-4ed3-b590-df303294cc16",
+      "LastModifiedDate": "2023-05-10T06:21:33.873Z",
+      "Name": "IT",
+      "CustomProperties": {},
+      "CustomSortOrder": null,
+      "IsAvailableForTagging": true,
+      "Owner": "i:0#.f|membership|john.doe@contoso.onmicrosoft.com",
+      "Description": "",
+      "IsDeprecated": false,
+      "IsKeyword": false,
+      "IsPinned": false,
+      "IsPinnedRoot": false,
+      "IsReused": false,
+      "IsRoot": true,
+      "IsSourceTerm": true,
+      "LocalCustomProperties": {},
+      "MergedTermIds": [],
+      "PathOfTerm": "IT",
+      "TermsCount": 0
+    }
+    ```
+
+=== "Text"
+
+    ```text
+    CreatedDate          : 2023-05-10T06:22:34.686Z
+    CustomProperties     : {}
+    CustomSortOrder      : null
+    Description          :
+    Id                   : 53156df9-5485-4724-9f4f-6670a3d41f88
+    IsAvailableForTagging: true
+    IsDeprecated         : false
+    IsKeyword            : false
+    IsPinned             : false
+    IsPinnedRoot         : false
+    IsReused             : false
+    IsRoot               : true
+    IsSourceTerm         : true
+    LastModifiedDate     : 2023-05-10T06:22:34.686Z
+    LocalCustomProperties: {}
+    MergedTermIds        : []
+    Name                 : IT
+    Owner                : i:0#.f|membership|john.doe@contoso.onmicrosoft.com
+    PathOfTerm           : IT
+    TermsCount           : 0
+    ```
+
+=== "CSV"
+
+    ```csv
+    CreatedDate,Id,LastModifiedDate,Name,IsAvailableForTagging,Owner,Description,IsDeprecated,IsKeyword,IsPinned,IsPinnedRoot,IsReused,IsRoot,IsSourceTerm,PathOfTerm,TermsCount
+    2023-05-10T06:23:13.490Z,0f1e0630-9f45-42d1-a64e-e82fe76826da,2023-05-10T06:23:13.490Z,IT,1,i:0#.f|membership|john.doe@contoso.onmicrosoft.com,,,,,,,1,1,IT,0
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo term add --termGroupName "People" --termSetName "Department" --name "IT"
+
+    Date: 5/10/2023
+
+    ## IT (6e72d493-000d-4517-aa3e-2afb3a3d4bc8)
+
+    Property | Value
+    ---------|-------
+    CreatedDate | 2023-05-10T06:23:49.970Z
+    Id | 6e72d493-000d-4517-aa3e-2afb3a3d4bc8
+    LastModifiedDate | 2023-05-10T06:23:49.970Z
+    Name | IT
+    IsAvailableForTagging | true
+    Owner | i:0#.f\|membership\|john.doe@contoso.onmicrosoft.com
+    Description |
+    IsDeprecated | false
+    IsKeyword | false
+    IsPinned | false
+    IsPinnedRoot | false
+    IsReused | false
+    IsRoot | true
+    IsSourceTerm | true
+    PathOfTerm | IT
+    TermsCount | 0
+    ```

--- a/src/m365/spo/commands/term/term-add.spec.ts
+++ b/src/m365/spo/commands/term/term-add.spec.ts
@@ -16,6 +16,97 @@ import commands from '../../commands';
 const command: Command = require('./term-add');
 
 describe(commands.TERM_ADD, () => {
+  const webUrl = 'https://contoso.sharepoint.com';
+  const id = '9e54299e-208a-4000-8546-cc4139091b26';
+  const name = 'IT';
+  const termGroupId = '9e54299e-208a-4000-8546-cc4139091b27';
+  const termGroupName = 'People';
+  const termSetId = '9e54299e-208a-4000-8546-cc4139091b28';
+  const parentTermId = '9e54299e-208a-4000-8546-cc4139091b29';
+  const termSetName = 'Department';
+  const addTermResponse = [
+    {
+      "SchemaVersion": "15.0.0.0",
+      "LibraryVersion": "16.0.8210.1205",
+      "ErrorInfo": null,
+      "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6"
+    },
+    4,
+    {
+      "IsNull": false
+    },
+    5,
+    {
+      "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
+    },
+    7,
+    {
+      "IsNull": false
+    },
+    8,
+    {
+      "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw=="
+    },
+    10,
+    {
+      "IsNull": false
+    },
+    12,
+    {
+      "IsNull": false
+    },
+    13,
+    {
+      "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8="
+    },
+    15,
+    {
+      "IsNull": false
+    },
+    17,
+    {
+      "IsNull": false
+    },
+    18,
+    {
+      "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv"
+    },
+    20,
+    {
+      "IsNull": false
+    },
+    21,
+    {
+      "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g=="
+    },
+    22,
+    {
+      "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0
+    }];
+
+  const termAddResponse = {
+    "CreatedDate": "2018-10-22T19:11:43.669Z",
+    "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de",
+    "LastModifiedDate": "2018-10-22T19:11:43.669Z",
+    "Name": "IT",
+    "CustomProperties": {},
+    "CustomSortOrder": null,
+    "IsAvailableForTagging": true,
+    "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com",
+    "Description": "",
+    "IsDeprecated": false,
+    "IsKeyword": false,
+    "IsPinned": false,
+    "IsPinnedRoot": false,
+    "IsReused": false,
+    "IsRoot": true,
+    "IsSourceTerm": true,
+    "LocalCustomProperties": {},
+    "MergedTermIds": [],
+    "PathOfTerm": "IT",
+    "TermsCount": 0
+  };
+
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -79,55 +170,71 @@ describe(commands.TERM_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('adds term with the specified name to the term set and term group specified by name', async () => {
+  it('adds term to the specified sitecollection with the specified name to the term set and term group specified by name', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
       }
 
       return Promise.reject('Invalid request');
     });
-    await command.action(logger, { options: { name: 'IT', termSetName: 'Department', termGroupName: 'People' } });
-    assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
+
+    await command.action(logger, { options: { webUrl: webUrl, name: name, termSetName: termSetName, termGroupName: termGroupName } });
+    assert(loggerLogSpy.calledWith(termAddResponse));
+  });
+
+  it('adds term with the specified name to the term set and term group specified by name', async () => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
+        if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
+          return Promise.resolve(JSON.stringify(addTermResponse));
+        }
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, { options: { name: name, termSetName: termSetName, termGroupName: termGroupName } });
+    assert(loggerLogSpy.calledWith(termAddResponse));
   });
 
   it('adds term with the specified name and id to the term set and term group specified by id', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetById"><Parameters><Parameter Type="Guid">{5c928151-c140-4d48-aab9-54da901c7fef}</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetById"><Parameters><Parameter Type="Guid">{8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f}</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{47fdacfe-ff64-4a05-b611-e84e767f04de}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
       }
 
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT', id: '47fdacfe-ff64-4a05-b611-e84e767f04de', termSetId: '8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f', termGroupId: '5c928151-c140-4d48-aab9-54da901c7fef' } });
-    assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
+    await command.action(logger, { options: { name: name, id: '47fdacfe-ff64-4a05-b611-e84e767f04de', termSetId: '8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f', termGroupId: '5c928151-c140-4d48-aab9-54da901c7fef' } });
+    assert(loggerLogSpy.calledWith(termAddResponse));
   });
 
   it('adds term with the specified name and id below the specified term', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetById"><Parameters><Parameter Type="Guid">{5c928151-c140-4d48-aab9-54da901c7fef}</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="6" Name="GetTerm"><Parameters><Parameter Type="Guid">{8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f}</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{47fdacfe-ff64-4a05-b611-e84e767f04de}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
       }
 
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT', id: '47fdacfe-ff64-4a05-b611-e84e767f04de', parentTermId: '8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f', termGroupId: '5c928151-c140-4d48-aab9-54da901c7fef' } });
-    assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
+    await command.action(logger, { options: { name: name, id: '47fdacfe-ff64-4a05-b611-e84e767f04de', parentTermId: '8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f', termGroupId: '5c928151-c140-4d48-aab9-54da901c7fef' } });
+    assert(loggerLogSpy.calledWith(termAddResponse));
   });
 
   it('adds term with description', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
 
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="SetDescription" Id="127" ObjectPathId="117"><Parameters><Parameter Type="String">IT term</Parameter><Parameter Type="Int32">1033</Parameter></Parameters></Method><Method Name="CommitAll" Id="131" ObjectPathId="109" /></Actions><ObjectPaths><Identity Id="117" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" /><Identity Id="109" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" /></ObjectPaths></Request>`) > -1) {
@@ -142,15 +249,15 @@ describe(commands.TERM_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { debug: true, name: 'IT', description: 'IT term', termSetName: 'Department', termGroupName: 'People' } });
+    await command.action(logger, { options: { debug: true, name: name, description: 'IT term', termSetName: termSetName, termGroupName: termGroupName } });
     assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "IT term", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
   });
 
   it('adds term with local and custom local properties', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
 
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="SetCustomProperty" Id="127" ObjectPathId="117"><Parameters><Parameter Type="String">Prop1</Parameter><Parameter Type="String">Value1</Parameter></Parameters></Method><Method Name="SetLocalCustomProperty" Id="128" ObjectPathId="117"><Parameters><Parameter Type="String">LocalProp1</Parameter><Parameter Type="String">LocalValue1</Parameter></Parameters></Method><Method Name="CommitAll" Id="131" ObjectPathId="109" /></Actions><ObjectPaths><Identity Id="117" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" /><Identity Id="109" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" /></ObjectPaths></Request>`) > -1) {
@@ -165,13 +272,13 @@ describe(commands.TERM_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT', customProperties: '{"Prop1": "Value1"}', localCustomProperties: '{"LocalProp1": "LocalValue1"}', termSetName: 'Department', termGroupName: 'People' } });
+    await command.action(logger, { options: { name: name, customProperties: '{"Prop1": "Value1"}', localCustomProperties: '{"LocalProp1": "LocalValue1"}', termSetName: termSetName, termGroupName: termGroupName } });
     assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": { "Prop1": "Value1" }, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": { "LocalProp1": "LocalValue1" }, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
   });
 
   it('correctly handles error when retrieving the term store', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
           return Promise.resolve(JSON.stringify([
             {
@@ -186,12 +293,12 @@ describe(commands.TERM_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await assert.rejects(command.action(logger, { options: { name: 'IT', termSetName: 'Department', termGroupName: 'People' } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: { name: name, termSetName: termSetName, termGroupName: termGroupName } } as any), new CommandError('An error has occurred'));
   });
 
   it('correctly handles error when the term group specified by id doesn\'t exist', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetById"><Parameters><Parameter Type="Guid">{5c928151-c140-4d48-aab9-54da901c7fef}</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetById"><Parameters><Parameter Type="Guid">{8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f}</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{47fdacfe-ff64-4a05-b611-e84e767f04de}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
           return Promise.resolve(JSON.stringify([
             {
@@ -208,7 +315,7 @@ describe(commands.TERM_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'IT',
+        name: name,
         id: '47fdacfe-ff64-4a05-b611-e84e767f04de',
         termSetId: '8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f',
         termGroupId: '5c928151-c140-4d48-aab9-54da901c7fef'
@@ -218,7 +325,7 @@ describe(commands.TERM_ADD, () => {
 
   it('correctly handles error when the term group specified by name doesn\'t exist', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
           return Promise.resolve(JSON.stringify([
             {
@@ -233,13 +340,13 @@ describe(commands.TERM_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await assert.rejects(command.action(logger, { options: { name: 'IT', termSetName: 'Department', termGroupName: 'People' } } as any), new CommandError('Specified argument was out of the range of valid values.\r\nParameter name: index'));
+    await assert.rejects(command.action(logger, { options: { name: name, termSetName: termSetName, termGroupName: termGroupName } } as any), new CommandError('Specified argument was out of the range of valid values.\r\nParameter name: index'));
 
   });
 
   it('correctly handles error when the term set specified by name doesn\'t exist', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
           return Promise.resolve(JSON.stringify([
             {
@@ -256,16 +363,16 @@ describe(commands.TERM_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'IT',
-        termSetName: 'Department',
-        termGroupName: 'People'
+        name: name,
+        termSetName: termSetName,
+        termGroupName: termGroupName
       }
     } as any), new CommandError('Specified argument was out of the range of valid values.\r\nParameter name: index'));
   });
 
   it('correctly handles error when the term set specified by id doesn\'t exist', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetById"><Parameters><Parameter Type="Guid">{5c928151-c140-4d48-aab9-54da901c7fef}</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetById"><Parameters><Parameter Type="Guid">{8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f}</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{47fdacfe-ff64-4a05-b611-e84e767f04de}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
           return Promise.resolve(JSON.stringify([
             {
@@ -282,7 +389,7 @@ describe(commands.TERM_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'IT',
+        name: name,
         id: '47fdacfe-ff64-4a05-b611-e84e767f04de',
         termSetId: '8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f',
         termGroupId: '5c928151-c140-4d48-aab9-54da901c7fef'
@@ -292,7 +399,7 @@ describe(commands.TERM_ADD, () => {
 
   it('correctly handles error when the specified name already exists', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
           return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1221", "ErrorInfo": { "ErrorMessage": "There is already a term with the same default label and parent term.", "ErrorValue": null, "TraceCorrelationId": "5c419b9e-5074-0000-3292-b5fe42f75fd1", "ErrorCode": -1, "ErrorTypeName": "Microsoft.SharePoint.Taxonomy.TermStoreOperationException" }, "TraceCorrelationId": "5c419b9e-5074-0000-3292-b5fe42f75fd1" }]));
         }
@@ -303,16 +410,16 @@ describe(commands.TERM_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'IT',
-        termSetName: 'Department',
-        termGroupName: 'People'
+        name: name,
+        termSetName: termSetName,
+        termGroupName: termGroupName
       }
     } as any), new CommandError('There is already a term with the same default label and parent term.'));
   });
 
   it('correctly handles error when the specified id already exists', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetById"><Parameters><Parameter Type="Guid">{5c928151-c140-4d48-aab9-54da901c7fef}</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetById"><Parameters><Parameter Type="Guid">{8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f}</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{47fdacfe-ff64-4a05-b611-e84e767f04de}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
           return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1221", "ErrorInfo": { "ErrorMessage": "Failed to read from or write to database. Refresh and try again. If the problem persists, please contact the administrator.", "ErrorValue": null, "TraceCorrelationId": "8f419b9e-b042-0000-37ae-164c0c311c0a", "ErrorCode": -1, "ErrorTypeName": "Microsoft.SharePoint.Taxonomy.TermStoreOperationException" }, "TraceCorrelationId": "8f419b9e-b042-0000-37ae-164c0c311c0a" }]));
         }
@@ -323,7 +430,7 @@ describe(commands.TERM_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'IT',
+        name: name,
         id: '47fdacfe-ff64-4a05-b611-e84e767f04de',
         termSetId: '8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f',
         termGroupId: '5c928151-c140-4d48-aab9-54da901c7fef'
@@ -333,9 +440,9 @@ describe(commands.TERM_ADD, () => {
 
   it('correctly handles error when setting the description', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
 
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="SetDescription" Id="127" ObjectPathId="117"><Parameters><Parameter Type="String">IT term</Parameter><Parameter Type="Int32">1033</Parameter></Parameters></Method><Method Name="CommitAll" Id="131" ObjectPathId="109" /></Actions><ObjectPaths><Identity Id="117" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" /><Identity Id="109" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" /></ObjectPaths></Request>`) > -1) {
@@ -354,19 +461,19 @@ describe(commands.TERM_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'IT',
+        name: name,
         description: 'IT term',
-        termSetName: 'Department',
-        termGroupName: 'People'
+        termSetName: termSetName,
+        termGroupName: termGroupName
       }
     } as any), new CommandError('An error has occurred'));
   });
 
   it('correctly handles error when setting custom properties', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
 
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="SetCustomProperty" Id="127" ObjectPathId="117"><Parameters><Parameter Type="String">Prop1</Parameter><Parameter Type="String">Value1</Parameter></Parameters></Method><Method Name="SetLocalCustomProperty" Id="128" ObjectPathId="117"><Parameters><Parameter Type="String">LocalProp1</Parameter><Parameter Type="String">LocalValue1</Parameter></Parameters></Method><Method Name="CommitAll" Id="131" ObjectPathId="109" /></Actions><ObjectPaths><Identity Id="117" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" /><Identity Id="109" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" /></ObjectPaths></Request>`) > -1) {
@@ -385,20 +492,20 @@ describe(commands.TERM_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'IT',
+        name: name,
         customProperties: '{"Prop1": "Value1"}',
         localCustomProperties: '{"LocalProp1": "LocalValue1"}',
-        termSetName: 'Department',
-        termGroupName: 'People'
+        termSetName: termSetName,
+        termGroupName: termGroupName
       }
     } as any), new CommandError('An error has occurred'));
   });
 
   it('correctly handles error when setting local custom properties', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
 
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="SetCustomProperty" Id="127" ObjectPathId="117"><Parameters><Parameter Type="String">Prop1</Parameter><Parameter Type="String">Value1</Parameter></Parameters></Method><Method Name="SetLocalCustomProperty" Id="128" ObjectPathId="117"><Parameters><Parameter Type="String">LocalProp1</Parameter><Parameter Type="String">LocalValue1</Parameter></Parameters></Method><Method Name="CommitAll" Id="131" ObjectPathId="109" /></Actions><ObjectPaths><Identity Id="117" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" /><Identity Id="109" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" /></ObjectPaths></Request>`) > -1) {
@@ -417,48 +524,48 @@ describe(commands.TERM_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        name: 'IT',
+        name: name,
         customProperties: '{"Prop1": "Value1"}',
         localCustomProperties: '{"LocalProp1": "LocalValue1"}',
-        termSetName: 'Department',
-        termGroupName: 'People'
+        termSetName: termSetName,
+        termGroupName: termGroupName
       }
     } as any), new CommandError('An error has occurred'));
   });
 
   it('correctly escapes XML in term group name', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People&gt;</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
       }
 
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT', termSetName: 'Department', termGroupName: 'People>' } });
-    assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
+    await command.action(logger, { options: { name: name, termSetName: termSetName, termGroupName: 'People>' } });
+    assert(loggerLogSpy.calledWith(termAddResponse));
   });
 
   it('correctly escapes XML in term set name', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department&gt;</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
       }
 
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT', termSetName: 'Department>', termGroupName: 'People' } });
-    assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
+    await command.action(logger, { options: { name: name, termSetName: 'Department>', termGroupName: termGroupName } });
+    assert(loggerLogSpy.calledWith(termAddResponse));
   });
 
   it('correctly escapes XML in term name', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT&gt;</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
           return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT>", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
         }
@@ -467,15 +574,15 @@ describe(commands.TERM_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT>', termSetName: 'Department', termGroupName: 'People' } });
+    await command.action(logger, { options: { name: 'IT>', termSetName: termSetName, termGroupName: termGroupName } });
     assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT>", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
   });
 
   it('correctly escapes XML in term description', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
 
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="SetDescription" Id="127" ObjectPathId="117"><Parameters><Parameter Type="String">IT term&gt;</Parameter><Parameter Type="Int32">1033</Parameter></Parameters></Method><Method Name="CommitAll" Id="131" ObjectPathId="109" /></Actions><ObjectPaths><Identity Id="117" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" /><Identity Id="109" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" /></ObjectPaths></Request>`) > -1) {
@@ -490,15 +597,15 @@ describe(commands.TERM_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT', description: 'IT term>', termSetName: 'Department', termGroupName: 'People' } });
+    await command.action(logger, { options: { name: name, description: 'IT term>', termSetName: termSetName, termGroupName: termGroupName } });
     assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "IT term>", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
   });
 
   it('correctly escapes XML in term custom properties', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
 
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="SetCustomProperty" Id="127" ObjectPathId="117"><Parameters><Parameter Type="String">Prop1&gt;</Parameter><Parameter Type="String">Value1&gt;</Parameter></Parameters></Method><Method Name="SetLocalCustomProperty" Id="128" ObjectPathId="117"><Parameters><Parameter Type="String">LocalProp1</Parameter><Parameter Type="String">LocalValue1</Parameter></Parameters></Method><Method Name="CommitAll" Id="131" ObjectPathId="109" /></Actions><ObjectPaths><Identity Id="117" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" /><Identity Id="109" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" /></ObjectPaths></Request>`) > -1) {
@@ -513,15 +620,15 @@ describe(commands.TERM_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT', customProperties: '{"Prop1>": "Value1>"}', localCustomProperties: '{"LocalProp1": "LocalValue1"}', termSetName: 'Department', termGroupName: 'People' } });
+    await command.action(logger, { options: { name: name, customProperties: '{"Prop1>": "Value1>"}', localCustomProperties: '{"LocalProp1": "LocalValue1"}', termSetName: termSetName, termGroupName: termGroupName } });
     assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": { "Prop1>": "Value1>" }, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": { "LocalProp1": "LocalValue1" }, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
   });
 
   it('correctly escapes XML in term local custom properties', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery') {
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><ObjectPath Id="12" ObjectPathId="11" /><ObjectIdentityQuery Id="13" ObjectPathId="11" /><ObjectPath Id="15" ObjectPathId="14" /><ObjectPath Id="17" ObjectPathId="16" /><ObjectIdentityQuery Id="18" ObjectPathId="16" /><ObjectPath Id="20" ObjectPathId="19" /><ObjectIdentityQuery Id="21" ObjectPathId="19" /><Query Id="22" ObjectPathId="19"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /><Method Id="11" ParentId="9" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method><Property Id="14" ParentId="11" Name="TermSets" /><Method Id="16" ParentId="14" Name="GetByName"><Parameters><Parameter Type="String">Department</Parameter></Parameters></Method><Method Id="19" ParentId="16" Name="CreateTerm"><Parameters><Parameter Type="String">IT</Parameter><Parameter Type="Int32">1033</Parameter><Parameter Type="Guid">{`) > -1 && opts.data.indexOf(`}</Parameter></Parameters></Method></ObjectPaths></Request>`) > -1) {
-          return Promise.resolve(JSON.stringify([{ "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8210.1205", "ErrorInfo": null, "TraceCorrelationId": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6" }, 4, { "IsNull": false }, 5, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:ss:" }, 7, { "IsNull": false }, 8, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" }, 10, { "IsNull": false }, 12, { "IsNull": false }, 13, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:gr:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+8=" }, 15, { "IsNull": false }, 17, { "IsNull": false }, 18, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:se:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv" }, 20, { "IsNull": false }, 21, { "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" }, 22, { "_ObjectType_": "SP.Taxonomy.Term", "_ObjectIdentity_": "d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==", "CreatedDate": "/Date(1540235503669)/", "Id": "/Guid(47fdacfe-ff64-4a05-b611-e84e767f04de)/", "LastModifiedDate": "/Date(1540235503669)/", "Name": "IT", "CustomProperties": {}, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": {}, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }]));
+          return Promise.resolve(JSON.stringify(addTermResponse));
         }
 
         if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="SetCustomProperty" Id="127" ObjectPathId="117"><Parameters><Parameter Type="String">Prop1</Parameter><Parameter Type="String">Value1</Parameter></Parameters></Method><Method Name="SetLocalCustomProperty" Id="128" ObjectPathId="117"><Parameters><Parameter Type="String">LocalProp1&gt;</Parameter><Parameter Type="String">LocalValue1&gt;</Parameter></Parameters></Method><Method Name="CommitAll" Id="131" ObjectPathId="109" /></Actions><ObjectPaths><Identity Id="117" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:te:MvRe/3xHkEqrmEXxmJ7Lx1GBklxAwUhNqrlU2pAcf+/qydiOUnAdTKTXucEL/+pv/qz9R2T/BUq2EehOdn8E3g==" /><Identity Id="109" Name="d7f59a9e-a0f5-0000-37ae-17ef5f03c2e6|fec14c62-7c3b-481b-851b-c80d7802b224:st:MvRe/3xHkEqrmEXxmJ7Lxw==" /></ObjectPaths></Request>`) > -1) {
@@ -536,92 +643,102 @@ describe(commands.TERM_ADD, () => {
       return Promise.reject('Invalid request');
     });
 
-    await command.action(logger, { options: { name: 'IT', customProperties: '{"Prop1": "Value1"}', localCustomProperties: '{"LocalProp1>": "LocalValue1>"}', termSetName: 'Department', termGroupName: 'People' } });
+    await command.action(logger, { options: { name: name, customProperties: '{"Prop1": "Value1"}', localCustomProperties: '{"LocalProp1>": "LocalValue1>"}', termSetName: termSetName, termGroupName: termGroupName } });
     assert(loggerLogSpy.calledWith({ "CreatedDate": "2018-10-22T19:11:43.669Z", "Id": "47fdacfe-ff64-4a05-b611-e84e767f04de", "LastModifiedDate": "2018-10-22T19:11:43.669Z", "Name": "IT", "CustomProperties": { "Prop1": "Value1" }, "CustomSortOrder": null, "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@contoso.onmicrosoft.com", "Description": "", "IsDeprecated": false, "IsKeyword": false, "IsPinned": false, "IsPinnedRoot": false, "IsReused": false, "IsRoot": true, "IsSourceTerm": true, "LocalCustomProperties": { "LocalProp1>": "LocalValue1>" }, "MergedTermIds": [], "PathOfTerm": "IT", "TermsCount": 0 }));
   });
 
   it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { termGroupName: 'PnPTermSets', name: 'PnP-Organizations', id: 'invalid' } }, commandInfo);
+    const actual = await command.validate({ options: { termGroupName: termGroupName, name: name, id: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if neither termGroupId nor termGroupName specified', async () => {
-    const actual = await command.validate({ options: { name: 'PnP-Organizations' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if both termGroupId and termGroupName specified', async () => {
-    const actual = await command.validate({ options: { name: 'PnP-Organizations', termGroupName: 'PnPTermSets', termGroupId: 'aca21974-139c-44fd-813c-6bbe6f25e658' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupName: termGroupName, termGroupId: termGroupId } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if termGroupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupId: 'invalid', termSetName: 'Department' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupId: 'invalid', termSetName: termSetName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if neither termSetId nor termSetName specified', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupId: termGroupId } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if both termSetId and termSetName specified', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27', termSetId: '9e54299e-208a-4000-8546-cc4139091b28', termSetName: 'Department' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupId: termGroupId, termSetId: termSetId, termSetName: termSetName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if both parentTermId and termSetName specified', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27', parentTermId: '9e54299e-208a-4000-8546-cc4139091b28', termSetName: 'Department' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupId: termGroupId, parentTermId: parentTermId, termSetName: termSetName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if both parentTermId and termSetId specified', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27', parentTermId: '9e54299e-208a-4000-8546-cc4139091b28', termSetId: '9e54299e-208a-4000-8546-cc4139091b29' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupId: termGroupId, parentTermId: parentTermId, termSetId: '9e54299e-208a-4000-8546-cc4139091b29' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if both parentTermId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27', parentTermId: 'invalid' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupId: termGroupId, parentTermId: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if termSetId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27', termSetId: 'invalid' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupId: termGroupId, termSetId: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if custom properties is not a valid JSON string', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupName: 'People', termSetName: 'Department', customProperties: 'invalid' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupName: termGroupName, termSetName: termSetName, customProperties: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('fails validation if local custom properties is not a valid JSON string', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupName: 'People', termSetName: 'Department', localCustomProperties: 'invalid' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupName: termGroupName, termSetName: termSetName, localCustomProperties: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation when webUrl is not a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'invalid', name: name, termGroupName: termGroupName, termSetName: termSetName } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the webUrl is a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, name: name, termGroupName: termGroupName, termSetName: termSetName } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
   it('passes validation when id, termSetId and termGroupId specified', async () => {
-    const actual = await command.validate({ options: { name: 'IT', id: '9e54299e-208a-4000-8546-cc4139091b26', termGroupId: '9e54299e-208a-4000-8546-cc4139091b27', termSetId: '9e54299e-208a-4000-8546-cc4139091b28' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, id: id, termGroupId: termGroupId, termSetId: termSetId } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation when id, termSetName and termGroupName specified', async () => {
-    const actual = await command.validate({ options: { name: 'IT', id: '9e54299e-208a-4000-8546-cc4139091b26', termGroupName: 'People', termSetName: 'Department' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, id: id, termGroupName: termGroupName, termSetName: termSetName } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation when id, parentTermId and termGroupName specified', async () => {
-    const actual = await command.validate({ options: { name: 'IT', id: '9e54299e-208a-4000-8546-cc4139091b26', termGroupName: 'People', parentTermId: '9e54299e-208a-4000-8546-cc4139091b26' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, id: id, termGroupName: termGroupName, parentTermId: parentTermId } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation when custom properties is a valid JSON string', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupName: 'People', termSetName: 'Department', customProperties: '{}' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupName: termGroupName, termSetName: termSetName, customProperties: '{}' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation when local custom properties is a valid JSON string', async () => {
-    const actual = await command.validate({ options: { name: 'IT', termGroupName: 'People', termSetName: 'Department', localCustomProperties: '{}' } }, commandInfo);
+    const actual = await command.validate({ options: { name: name, termGroupName: termGroupName, termSetName: termSetName, localCustomProperties: '{}' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 });


### PR DESCRIPTION
Extends `spo term add` command with support for adding a site-level term or a tenant-level term without SPO Admin privileges. Closes #4837