### PR TITLE
Shows clean error for `@me` tokens when using application permissions, Closes #4818

### DIFF
--- a/src/Command.spec.ts
+++ b/src/Command.spec.ts
@@ -595,7 +595,6 @@ describe('Command', () => {
     };
     const command = new MockCommand3();
     sinon.stub(accessToken, 'isAppOnlyAccessToken').callsFake(() => { return true; });
-    sinon.stub(accessToken, 'getUserIdFromAccessToken').callsFake(() => { return ''; });
 
     await assert.rejects(command.action(logger, { options: { option1: '@meId' } }), new CommandError(`It's not possible to use @meId with application permissions`));
   });
@@ -607,7 +606,6 @@ describe('Command', () => {
     };
     const command = new MockCommand3();
     sinon.stub(accessToken, 'isAppOnlyAccessToken').callsFake(() => { return true; });
-    sinon.stub(accessToken, 'getUserIdFromAccessToken').callsFake(() => { return ''; });
 
     await assert.rejects(command.action(logger, { options: { option1: '@meUsername' } }), new CommandError(`It's not possible to use @meUsername with application permissions`));
   });

--- a/src/Command.spec.ts
+++ b/src/Command.spec.ts
@@ -156,7 +156,9 @@ describe('Command', () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      process.exit
+      process.exit,
+      accessToken.isAppOnlyAccessToken,
+      accessToken.getUserIdFromAccessToken
     ]);
     auth.service.connected = false;
   });
@@ -584,5 +586,29 @@ describe('Command', () => {
 
     await command.action(logger, { options: { option1: '@MeUsername ' } });
     assert.deepStrictEqual(commandCommandActionSpy.lastCall.args[1].options.option1, 'admin@contoso.onmicrosoft.com');
+  });
+
+  it('handles @meid with application permissions', async () => {
+    auth.service.accessTokens[auth.defaultResource] = {
+      expiresOn: '',
+      accessToken: ''
+    };
+    const command = new MockCommand3();
+    sinon.stub(accessToken, 'isAppOnlyAccessToken').callsFake(() => { return true; });
+    sinon.stub(accessToken, 'getUserIdFromAccessToken').callsFake(() => { return ''; });
+
+    await assert.rejects(command.action(logger, { options: { option1: '@meId' } }), new CommandError(`It's not possible to use @meId with application permissions`));
+  });
+
+  it('handles @meusername with application permissions', async () => {
+    auth.service.accessTokens[auth.defaultResource] = {
+      expiresOn: '',
+      accessToken: ''
+    };
+    const command = new MockCommand3();
+    sinon.stub(accessToken, 'isAppOnlyAccessToken').callsFake(() => { return true; });
+    sinon.stub(accessToken, 'getUserIdFromAccessToken').callsFake(() => { return ''; });
+
+    await assert.rejects(command.action(logger, { options: { option1: '@meUsername' } }), new CommandError(`It's not possible to use @meUsername with application permissions`));
   });
 });

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -530,6 +530,12 @@ export default abstract class Command {
       }
 
       const lowerCaseValue = value.toLowerCase().trim();
+      if (lowerCaseValue === '@meid' || lowerCaseValue === '@meusername') {
+        const isAppOnlyAccessToken = accessToken.isAppOnlyAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken);
+        if (isAppOnlyAccessToken) {
+          throw `It's not possible to use ${value} with application permissions`;
+        }
+      }
       if (lowerCaseValue === '@meid') {
         args.options[option] = accessToken.getUserIdFromAccessToken(token);
       }


### PR DESCRIPTION
Closes #4818