### PR TITLE
Extends 'spo term group list' command with support for listing tenant term groups as well as sitecollection term groups on site-level. Closes #4832

### DIFF
--- a/docs/docs/cmd/spo/term/term-group-list.md
+++ b/docs/docs/cmd/spo/term/term-group-list.md
@@ -10,17 +10,85 @@ m365 spo term group list [options]
 
 ## Options
 
+`-u, --webUrl [webUrl]`
+: If specified, allows you to list term groups from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.
+
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
 !!! important
-    To use this command you have to have permissions to access the tenant admin site.
+    To use this command without the --webUrl option you have to have permissions to access the tenant admin site.
+
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. You need be a site visitor or more. It allows you to list term groups from the tenant term store as well as term groups from the sitecollection term store.
 
 ## Examples
 
-List taxonomy term groups
+List taxonomy term groups.
 
 ```sh
 m365 spo term group list
 ```
+
+List taxonomy term groups from the specified sitecollection.
+
+```sh
+m365 spo term group list --webUrl https://contoso.sharepoint.com/sites/project-x
+```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    [
+      {
+        "_ObjectType_": "SP.Taxonomy.TermGroup",
+        "_ObjectIdentity_": "5522b1a0-b01a-2000-4160-d04eee2e977f|fec14c62-7c3b-481b-851b-c80d7802b224:gr:aCf0Cz4D9UOS7+b/OlUY5XrNqUp10tpPhLK4MIXc7g8=",
+        "CreatedDate": "2019-09-03T06:41:32.070Z",
+        "Id": "4aa9cd7a-d275-4fda-84b2-b83085dcee0f",
+        "LastModifiedDate": "2019-09-03T06:41:32.070Z",
+        "Name": "People",
+        "Description": "",
+        "IsSiteCollectionGroup": false,
+        "IsSystemGroup": false
+      }
+    ]
+    ```
+
+=== "Text"
+
+    ```text
+    Id                                    Name
+    ------------------------------------  -----------------------------------------------------------
+    4aa9cd7a-d275-4fda-84b2-b83085dcee0f  People
+    ```
+
+=== "CSV"
+
+    ```csv
+      _ObjectType_,_ObjectIdentity_,CreatedDate,Id,LastModifiedDate,Name,Description,IsSiteCollectionGroup,IsSystemGroup
+      SP.Taxonomy.TermGroup,7522b1a0-804d-2000-41be-bba084eae72f|fec14c62-7c3b-481b-851b-c80d7802b224:gr:aCf0Cz4D9UOS7+b/OlUY5XrNqUp10tpPhLK4MIXc7g8=,2019-09-03T06:41:32.070Z,4aa9cd7a-d275-4fda-84b2-b83085dcee0f,2019-09-03T06:41:32.070Z,People,,,
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo term group list
+
+    Date: 5/9/2023
+
+    ## People (4aa9cd7a-d275-4fda-84b2-b83085dcee0f)
+
+    Property | Value
+    ---------|-------
+    \_ObjectType\_ | SP.Taxonomy.TermGroup
+    \_ObjectIdentity\_ | 8c22b1a0-200f-2000-3976-694ba2bf8a01\|fec14c62-7c3b-481b-851b-c80d7802b224:gr:aCf0Cz4D9UOS7+b/OlUY5XrNqUp10tpPhLK4MIXc7g8=
+    CreatedDate | 2019-09-03T06:41:32.070Z
+    Id | 4aa9cd7a-d275-4fda-84b2-b83085dcee0f
+    LastModifiedDate | 2019-09-03T06:41:32.070Z
+    Name | People
+    Description |
+    IsSiteCollectionGroup | false
+    IsSystemGroup | false
+    ```

--- a/src/m365/spo/commands/term/term-group-list.spec.ts
+++ b/src/m365/spo/commands/term/term-group-list.spec.ts
@@ -2,6 +2,8 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { telemetry } from '../../../../telemetry';
 import auth from '../../../../Auth';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
 import config from '../../../../config';
@@ -17,6 +19,7 @@ describe(commands.TERM_GROUP_LIST, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
@@ -31,6 +34,7 @@ describe(commands.TERM_GROUP_LIST, () => {
     }));
     auth.service.connected = true;
     auth.service.spoUrl = 'https://contoso.sharepoint.com';
+    commandInfo = Cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
@@ -79,9 +83,9 @@ describe(commands.TERM_GROUP_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['Id', 'Name']);
   });
 
-  it('lists taxonomy term groups (debug)', async () => {
+  it('lists taxonomy term groups', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><Query Id="11" ObjectPathId="9"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /></ObjectPaths></Request>`) {
@@ -325,9 +329,255 @@ describe(commands.TERM_GROUP_LIST, () => {
     }]));
   });
 
+  it('lists taxonomy term groups from the specified sitecollection', async () => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === 'https://contoso.sharepoint.com/sites/project-x/_vti_bin/client.svc/ProcessQuery' &&
+        opts.headers &&
+        opts.headers['X-RequestDigest'] &&
+        opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><Query Id="11" ObjectPathId="9"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /></ObjectPaths></Request>`) {
+        return Promise.resolve(JSON.stringify([
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.8105.1215",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9"
+          },
+          4,
+          {
+            "IsNull": false
+          },
+          5,
+          {
+            "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
+          },
+          7,
+          {
+            "IsNull": false
+          },
+          8,
+          {
+            "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
+          },
+          10,
+          {
+            "IsNull": false
+          },
+          11,
+          {
+            "_ObjectType_": "SP.Taxonomy.TermGroupCollection",
+            "_Child_Items_": [
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUQElpjbqF1pFvtTv+GIkLe8=",
+                "CreatedDate": "\/Date(1529479401033)\/",
+                "Id": "\/Guid(36a62501-17ea-455a-bed4-eff862242def)\/",
+                "LastModifiedDate": "\/Date(1529479401033)\/",
+                "Name": "People",
+                "Description": "",
+                "IsSiteCollectionGroup": false,
+                "IsSystemGroup": false
+              },
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+s=",
+                "CreatedDate": "\/Date(1536839573117)\/",
+                "Id": "\/Guid(0e8f395e-ff58-4d45-9ff7-e331ab728beb)\/",
+                "LastModifiedDate": "\/Date(1536839573117)\/",
+                "Name": "PnPTermSets",
+                "Description": "",
+                "IsSiteCollectionGroup": false,
+                "IsSystemGroup": false
+              },
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUTdqe9gByDZKkEZiltR3nIc=",
+                "CreatedDate": "\/Date(1529479401063)\/",
+                "Id": "\/Guid(d87b6a37-c801-4a36-9046-6296d4779c87)\/",
+                "LastModifiedDate": "\/Date(1529479401063)\/",
+                "Name": "Search Dictionaries",
+                "Description": "",
+                "IsSiteCollectionGroup": false,
+                "IsSystemGroup": false
+              },
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUdrlarEXoGtNuzIB3A5zZDo=",
+                "CreatedDate": "\/Date(1529479400770)\/",
+                "Id": "\/Guid(b16ae5da-a017-4d6b-bb32-01dc0e73643a)\/",
+                "LastModifiedDate": "\/Date(1529479400770)\/",
+                "Name": "Site Collection - contoso.sharepoint.com-search",
+                "Description": "",
+                "IsSiteCollectionGroup": true,
+                "IsSystemGroup": false
+              },
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUQZhmdVzct1Fj6MAalJ1aHc=",
+                "CreatedDate": "\/Date(1529495406027)\/",
+                "Id": "\/Guid(d5996106-7273-45dd-8fa3-006a52756877)\/",
+                "LastModifiedDate": "\/Date(1529495406027)\/",
+                "Name": "Site Collection - contoso.sharepoint.com-sites-Analytics",
+                "Description": "",
+                "IsSiteCollectionGroup": true,
+                "IsSystemGroup": false
+              },
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUeAa0tV1fe9PpxZBXc21aYc=",
+                "CreatedDate": "\/Date(1536754831887)\/",
+                "Id": "\/Guid(d5d21ae0-7d75-4fef-a716-415dcdb56987)\/",
+                "LastModifiedDate": "\/Date(1536754831887)\/",
+                "Name": "Site Collection - contoso.sharepoint.com-sites-hr",
+                "Description": "",
+                "IsSiteCollectionGroup": true,
+                "IsSystemGroup": false
+              },
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUVSux4Ka74dLrn8bmCVuTp0=",
+                "CreatedDate": "\/Date(1536754843060)\/",
+                "Id": "\/Guid(82c7ae54-ef9a-4b87-ae7f-1b98256e4e9d)\/",
+                "LastModifiedDate": "\/Date(1536754843060)\/",
+                "Name": "Site Collection - contoso.sharepoint.com-sites-Marketing",
+                "Description": "",
+                "IsSiteCollectionGroup": true,
+                "IsSystemGroup": false
+              },
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpURC8Oohu2K5FoLzWJkLCzM0=",
+                "CreatedDate": "\/Date(1536754304210)\/",
+                "Id": "\/Guid(883abc10-d86e-45ae-a0bc-d62642c2cccd)\/",
+                "LastModifiedDate": "\/Date(1536754304210)\/",
+                "Name": "Site Collection - contoso.sharepoint.com-sites-portal",
+                "Description": "",
+                "IsSiteCollectionGroup": true,
+                "IsSystemGroup": false
+              },
+              {
+                "_ObjectType_": "SP.Taxonomy.TermGroup",
+                "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUYWJl\u002fqvH5hPrfM1Rk4nNTU=",
+                "CreatedDate": "\/Date(1529479155453)\/",
+                "Id": "\/Guid(fa978985-1faf-4f98-adf3-35464e273535)\/",
+                "LastModifiedDate": "\/Date(1529479155453)\/",
+                "Name": "System",
+                "Description": "These term sets are used by the system itself.",
+                "IsSiteCollectionGroup": false,
+                "IsSystemGroup": true
+              }
+            ]
+          }
+        ]));
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/project-x' } });
+
+    assert(loggerLogSpy.calledWith([{
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpUQElpjbqF1pFvtTv+GIkLe8=",
+      "CreatedDate": "2018-06-20T07:23:21.033Z",
+      "Id": "36a62501-17ea-455a-bed4-eff862242def",
+      "LastModifiedDate": "2018-06-20T07:23:21.033Z",
+      "Name": "People",
+      "Description": "",
+      "IsSiteCollectionGroup": false,
+      "IsSystemGroup": false
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpUV45jw5Y/0VNn/fjMatyi+s=",
+      "CreatedDate": "2018-09-13T11:52:53.117Z",
+      "Id": "0e8f395e-ff58-4d45-9ff7-e331ab728beb",
+      "LastModifiedDate": "2018-09-13T11:52:53.117Z",
+      "Name": "PnPTermSets",
+      "Description": "",
+      "IsSiteCollectionGroup": false,
+      "IsSystemGroup": false
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpUTdqe9gByDZKkEZiltR3nIc=",
+      "CreatedDate": "2018-06-20T07:23:21.063Z",
+      "Id": "d87b6a37-c801-4a36-9046-6296d4779c87",
+      "LastModifiedDate": "2018-06-20T07:23:21.063Z",
+      "Name": "Search Dictionaries",
+      "Description": "",
+      "IsSiteCollectionGroup": false,
+      "IsSystemGroup": false
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpUdrlarEXoGtNuzIB3A5zZDo=",
+      "CreatedDate": "2018-06-20T07:23:20.770Z",
+      "Id": "b16ae5da-a017-4d6b-bb32-01dc0e73643a",
+      "LastModifiedDate": "2018-06-20T07:23:20.770Z",
+      "Name": "Site Collection - contoso.sharepoint.com-search",
+      "Description": "",
+      "IsSiteCollectionGroup": true,
+      "IsSystemGroup": false
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpUQZhmdVzct1Fj6MAalJ1aHc=",
+      "CreatedDate": "2018-06-20T11:50:06.027Z",
+      "Id": "d5996106-7273-45dd-8fa3-006a52756877",
+      "LastModifiedDate": "2018-06-20T11:50:06.027Z",
+      "Name": "Site Collection - contoso.sharepoint.com-sites-Analytics",
+      "Description": "",
+      "IsSiteCollectionGroup": true,
+      "IsSystemGroup": false
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpUeAa0tV1fe9PpxZBXc21aYc=",
+      "CreatedDate": "2018-09-12T12:20:31.887Z",
+      "Id": "d5d21ae0-7d75-4fef-a716-415dcdb56987",
+      "LastModifiedDate": "2018-09-12T12:20:31.887Z",
+      "Name": "Site Collection - contoso.sharepoint.com-sites-hr",
+      "Description": "",
+      "IsSiteCollectionGroup": true,
+      "IsSystemGroup": false
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpUVSux4Ka74dLrn8bmCVuTp0=",
+      "CreatedDate": "2018-09-12T12:20:43.060Z",
+      "Id": "82c7ae54-ef9a-4b87-ae7f-1b98256e4e9d",
+      "LastModifiedDate": "2018-09-12T12:20:43.060Z",
+      "Name": "Site Collection - contoso.sharepoint.com-sites-Marketing",
+      "Description": "",
+      "IsSiteCollectionGroup": true,
+      "IsSystemGroup": false
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpURC8Oohu2K5FoLzWJkLCzM0=",
+      "CreatedDate": "2018-09-12T12:11:44.210Z",
+      "Id": "883abc10-d86e-45ae-a0bc-d62642c2cccd",
+      "LastModifiedDate": "2018-09-12T12:11:44.210Z",
+      "Name": "Site Collection - contoso.sharepoint.com-sites-portal",
+      "Description": "",
+      "IsSiteCollectionGroup": true,
+      "IsSystemGroup": false
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermGroup",
+      "_ObjectIdentity_": "40bc8e9e-c0f3-0000-2b65-64d3c82fb3d9|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh/fzgFZGpUYWJl/qvH5hPrfM1Rk4nNTU=",
+      "CreatedDate": "2018-06-20T07:19:15.453Z",
+      "Id": "fa978985-1faf-4f98-adf3-35464e273535",
+      "LastModifiedDate": "2018-06-20T07:19:15.453Z",
+      "Name": "System",
+      "Description": "These term sets are used by the system itself.",
+      "IsSiteCollectionGroup": false,
+      "IsSystemGroup": true
+    }]));
+  });
+
   it('lists taxonomy term groups with all properties when output is JSON', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><Query Id="11" ObjectPathId="9"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /></ObjectPaths></Request>`) {
@@ -474,7 +724,7 @@ describe(commands.TERM_GROUP_LIST, () => {
 
   it('correctly handles no term groups found', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><ObjectPath Id="10" ObjectPathId="9" /><Query Id="11" ObjectPathId="9"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /><Property Id="9" ParentId="6" Name="Groups" /></ObjectPaths></Request>`) {
@@ -536,5 +786,15 @@ describe(commands.TERM_GROUP_LIST, () => {
     sinon.stub(spo, 'getRequestDigest').callsFake(() => Promise.reject('getRequestDigest error'));
 
     await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('getRequestDigest error'));
+  });
+
+  it('fails validation when webUrl is not a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'abc' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the webUrl is a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com/sites/project-x' } }, commandInfo);
+    assert.strictEqual(actual, true);
   });
 });


### PR DESCRIPTION
Extends `spo term group list` command with support for listing tenant term groups as well as sitecollection term groups on site-level. Closes #4832