### PR TITLE
Extends 'spo term set list' command with support for listing tenant term sets as well as sitecollection term sets on site-level. Closes #4833

### DIFF
--- a/docs/docs/cmd/spo/term/term-set-list.md
+++ b/docs/docs/cmd/spo/term/term-set-list.md
@@ -10,29 +10,109 @@ m365 spo term set list [options]
 
 ## Options
 
+`-u, --webUrl [webUrl]`
+: If specified, allows you to list term sets from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.
+
 `--termGroupId [termGroupId]`
-: ID of the term group from which to retrieve term sets. Specify `termGroupName` or `termGroupId` but not both
+: ID of the term group from which to retrieve term sets. Specify `termGroupName` or `termGroupId` but not both.
 
 `--termGroupName [termGroupName]`
-: Name of the term group from which to retrieve term sets. Specify `termGroupName` or `termGroupId` but not both
+: Name of the term group from which to retrieve term sets. Specify `termGroupName` or `termGroupId` but not both.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
 !!! important
-    To use this command you have to have permissions to access the tenant admin site.
+    To use this command without the --webUrl option you have to have permissions to access the tenant admin site.
+
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. You need be a site visitor or more. It allows you to list term sets from the tenant term store as well as term sets from the sitecollection term store.
 
 ## Examples
 
-List taxonomy term sets from the term group with the given name
+List taxonomy term sets from the term group with the given name.
 
 ```sh
 m365 spo term set list --termGroupName PnPTermSets
 ```
 
-List taxonomy term sets from the term group with the given ID
+List taxonomy term sets from the term group with the given ID.
 
 ```sh
 m365 spo term set list --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb
 ```
+
+List taxonomy term sets from the specified sitecollection, from the term group with the given name.
+
+```sh
+m365 spo term set list --termGroupName PnPTermSets
+```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    [
+      {
+        "_ObjectType_": "SP.Taxonomy.TermSet",
+        "_ObjectIdentity_": "676eb2a0-80e7-2000-3976-610eb3f5a91e|fec14c62-7c3b-481b-851b-c80d7802b224:se:aCf0Cz4D9UOS7+b/OlUY5XrNqUp10tpPhLK4MIXc7g/qydiOUnAdTKTXucEL/+pv",
+        "CreatedDate": "2019-09-03T06:41:32.110Z",
+        "Id": "8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f",
+        "LastModifiedDate": "2019-09-03T06:41:32.260Z",
+        "Name": "Department",
+        "CustomProperties": {
+          "SearchCenterNavVer": "15"
+        },
+        "CustomSortOrder": null,
+        "IsAvailableForTagging": true,
+        "Owner": "",
+        "Contact": "",
+        "Description": "",
+        "IsOpenForTermCreation": true,
+        "Names": {
+          "1033": "Department"
+        },
+        "Stakeholders": []
+      }
+    ]
+    ```
+
+=== "Text"
+
+    ```text
+    Id                                    Name
+    ------------------------------------  ----------
+    8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f  Department
+    ```
+
+=== "CSV"
+
+    ```csv
+    _ObjectType_,_ObjectIdentity_,CreatedDate,Id,LastModifiedDate,Name,IsAvailableForTagging,Owner,Contact,Description,IsOpenForTermCreation
+    SP.Taxonomy.TermSet,7c6eb2a0-20fe-2000-47f1-69774ac909f5|fec14c62-7c3b-481b-851b-c80d7802b224:se:aCf0Cz4D9UOS7+b/OlUY5XrNqUp10tpPhLK4MIXc7g/qydiOUnAdTKTXucEL/+pv,2019-09-03T06:41:32.110Z,8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f,2019-09-03T06:41:32.260Z,Department,1,,,,1
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo term set list --termGroupName "PnPTermSets"
+
+    Date: 5/13/2023
+
+    ## Department (8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f)
+
+    Property | Value
+    ---------|-------
+    \_ObjectType\_ | SP.Taxonomy.TermSet
+    \_ObjectIdentity\_ | 826eb2a0-405f-2000-41be-bfe56d4cdc73\|fec14c62-7c3b-481b-851b-c80d7802b224:se:aCf0Cz4D9UOS7+b/OlUY5XrNqUp10tpPhLK4MIXc7g/qydiOUnAdTKTXucEL/+pv
+    CreatedDate | 2019-09-03T06:41:32.110Z
+    Id | 8ed8c9ea-7052-4c1d-a4d7-b9c10bffea6f
+    LastModifiedDate | 2019-09-03T06:41:32.260Z
+    Name | Department
+    IsAvailableForTagging | true
+    Owner |
+    Contact |
+    Description |
+    IsOpenForTermCreation | true
+    ```

--- a/docs/docs/cmd/spo/term/term-set-list.md
+++ b/docs/docs/cmd/spo/term/term-set-list.md
@@ -26,7 +26,7 @@ m365 spo term set list [options]
 !!! important
     To use this command without the --webUrl option you have to have permissions to access the tenant admin site.
 
-When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. You need be a site visitor or more. It allows you to list term sets from the tenant term store as well as term sets from the sitecollection term store.
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Administrator role. You need to be a site visitor or more. It allows you to list term sets from the tenant term store as well as term sets from the sitecollection term store.
 
 ## Examples
 
@@ -45,7 +45,7 @@ m365 spo term set list --termGroupId 0e8f395e-ff58-4d45-9ff7-e331ab728beb
 List taxonomy term sets from the specified sitecollection, from the term group with the given name.
 
 ```sh
-m365 spo term set list --termGroupName PnPTermSets
+m365 spo term set list --termGroupName PnPTermSets --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
 ## Response

--- a/src/m365/spo/commands/term/term-set-list.spec.ts
+++ b/src/m365/spo/commands/term/term-set-list.spec.ts
@@ -83,9 +83,9 @@ describe(commands.TERM_SET_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['Id', 'Name']);
   });
 
-  it('lists taxonomy term sets from the term group specified using id (debug)', async () => {
+  it('lists taxonomy term sets from the term group specified using id', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><Query Id="67" ObjectPathId="65"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetById"><Parameters><Parameter Type="Guid">{0e8f395e-ff58-4d45-9ff7-e331ab728beb}</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /></ObjectPaths></Request>`) {
@@ -134,6 +134,7 @@ describe(commands.TERM_SET_LIST, () => {
 
       return Promise.reject('Invalid request');
     });
+
     await command.action(logger, { options: { debug: true, termGroupId: '0e8f395e-ff58-4d45-9ff7-e331ab728beb' } });
     assert(loggerLogSpy.calledWith([{
       "_ObjectType_": "SP.Taxonomy.TermSet",
@@ -179,7 +180,7 @@ describe(commands.TERM_SET_LIST, () => {
 
   it('lists taxonomy term sets from the term group specified using name', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><Query Id="67" ObjectPathId="65"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetByName"><Parameters><Parameter Type="String">PnPTermSets</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /></ObjectPaths></Request>`) {
@@ -228,7 +229,103 @@ describe(commands.TERM_SET_LIST, () => {
 
       return Promise.reject('Invalid request');
     });
+
     await command.action(logger, { options: { termGroupName: 'PnPTermSets' } });
+    assert(loggerLogSpy.calledWith([{
+      "_ObjectType_": "SP.Taxonomy.TermSet",
+      "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh/fzgFZGpUV45jw5Y/0VNn/fjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt",
+      "CreatedDate": "2018-09-13T11:52:53.337Z",
+      "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed",
+      "LastModifiedDate": "2018-09-13T12:13:46.883Z",
+      "Name": "PnP-CollabFooter-SharedLinks",
+      "CustomProperties": {
+        "_Sys_Nav_IsNavigationTermSet": "True"
+      },
+      "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f",
+      "IsAvailableForTagging": true,
+      "Owner": "i:0#.f|membership|admin@m365x035040.onmicrosoft.com",
+      "Contact": "",
+      "Description": "",
+      "IsOpenForTermCreation": false,
+      "Names": {
+        "1033": "PnP-CollabFooter-SharedLinks"
+      },
+      "Stakeholders": []
+    },
+    {
+      "_ObjectType_": "SP.Taxonomy.TermSet",
+      "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh/fzgFZGpUV45jw5Y/0VNn/fjMatyi+ts4nkUgBOoQZGDcrxallG7",
+      "CreatedDate": "2018-09-13T11:52:55.147Z",
+      "Id": "1479e26c-1380-41a8-9183-72bc5a9651bb",
+      "LastModifiedDate": "2018-09-13T12:13:47.383Z",
+      "Name": "PnP-Organizations",
+      "CustomProperties": {},
+      "CustomSortOrder": "02cf219e-8ce9-4e85-ac04-a913a44a5d2b:247543b6-45f2-4232-b9e8-66c5bf53c31e:ffc3608f-1250-4d28-b388-381fad8d4602",
+      "IsAvailableForTagging": true,
+      "Owner": "i:0#.f|membership|admin@m365x035040.onmicrosoft.com",
+      "Contact": "",
+      "Description": "",
+      "IsOpenForTermCreation": false,
+      "Names": {
+        "1033": "PnP-Organizations"
+      },
+      "Stakeholders": []
+    }]));
+  });
+
+  it('lists taxonomy term sets from the specified site collection with specified term group using name', async () => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === 'https://contoso.sharepoint.com/sites/project-x/_vti_bin/client.svc/ProcessQuery' &&
+        opts.headers &&
+        opts.headers['X-RequestDigest'] &&
+        opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><Query Id="67" ObjectPathId="65"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetByName"><Parameters><Parameter Type="String">PnPTermSets</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /></ObjectPaths></Request>`) {
+        return Promise.resolve(JSON.stringify([
+          {
+            "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8112.1217", "ErrorInfo": null, "TraceCorrelationId": "ec3f929e-2007-0000-2cdb-ebdf7451c224"
+          }, 55, {
+            "IsNull": false
+          }, 56, {
+            "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
+          }, 58, {
+            "IsNull": false
+          }, 59, {
+            "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
+          }, 61, {
+            "IsNull": false
+          }, 63, {
+            "IsNull": false
+          }, 64, {
+            "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+s="
+          }, 66, {
+            "IsNull": false
+          }, 67, {
+            "_ObjectType_": "SP.Taxonomy.TermSetCollection", "_Child_Items_": [
+              {
+                "_ObjectType_": "SP.Taxonomy.TermSet", "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt", "CreatedDate": "\/Date(1536839573337)\/", "Id": "\/Guid(7a167c47-2b37-41d0-94d0-e962c1a4f2ed)\/", "LastModifiedDate": "\/Date(1536840826883)\/", "Name": "PnP-CollabFooter-SharedLinks", "CustomProperties": {
+                  "_Sys_Nav_IsNavigationTermSet": "True"
+                }, "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f", "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@m365x035040.onmicrosoft.com", "Contact": "", "Description": "", "IsOpenForTermCreation": false, "Names": {
+                  "1033": "PnP-CollabFooter-SharedLinks"
+                }, "Stakeholders": [
+
+                ]
+              }, {
+                "_ObjectType_": "SP.Taxonomy.TermSet", "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+ts4nkUgBOoQZGDcrxallG7", "CreatedDate": "\/Date(1536839575147)\/", "Id": "\/Guid(1479e26c-1380-41a8-9183-72bc5a9651bb)\/", "LastModifiedDate": "\/Date(1536840827383)\/", "Name": "PnP-Organizations", "CustomProperties": {
+
+                }, "CustomSortOrder": "02cf219e-8ce9-4e85-ac04-a913a44a5d2b:247543b6-45f2-4232-b9e8-66c5bf53c31e:ffc3608f-1250-4d28-b388-381fad8d4602", "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@m365x035040.onmicrosoft.com", "Contact": "", "Description": "", "IsOpenForTermCreation": false, "Names": {
+                  "1033": "PnP-Organizations"
+                }, "Stakeholders": [
+
+                ]
+              }
+            ]
+          }
+        ]));
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/project-x', termGroupName: 'PnPTermSets' } });
     assert(loggerLogSpy.calledWith([{
       "_ObjectType_": "SP.Taxonomy.TermSet",
       "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh/fzgFZGpUV45jw5Y/0VNn/fjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt",
@@ -273,7 +370,7 @@ describe(commands.TERM_SET_LIST, () => {
 
   it('escapes XML in term group name', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><Query Id="67" ObjectPathId="65"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetByName"><Parameters><Parameter Type="String">PnPTermSets&gt;</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /></ObjectPaths></Request>`) {
@@ -322,6 +419,7 @@ describe(commands.TERM_SET_LIST, () => {
 
       return Promise.reject('Invalid request');
     });
+
     await command.action(logger, { options: { termGroupName: 'PnPTermSets>' } });
     assert(loggerLogSpy.calledWith([{
       "_ObjectType_": "SP.Taxonomy.TermSet",
@@ -367,7 +465,7 @@ describe(commands.TERM_SET_LIST, () => {
 
   it('lists taxonomy term sets with all properties when output is JSON', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><Query Id="67" ObjectPathId="65"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetByName"><Parameters><Parameter Type="String">PnPTermSets</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /></ObjectPaths></Request>`) {
@@ -416,13 +514,14 @@ describe(commands.TERM_SET_LIST, () => {
 
       return Promise.reject('Invalid request');
     });
+
     await command.action(logger, { options: { output: 'json', termGroupName: 'PnPTermSets' } });
     assert(loggerLogSpy.calledWith([{ "_ObjectType_": "SP.Taxonomy.TermSet", "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+tHfBZ6NyvQQZTQ6WLBpPLt", "CreatedDate": "2018-09-13T11:52:53.337Z", "Id": "7a167c47-2b37-41d0-94d0-e962c1a4f2ed", "LastModifiedDate": "2018-09-13T12:13:46.883Z", "Name": "PnP-CollabFooter-SharedLinks", "CustomProperties": { "_Sys_Nav_IsNavigationTermSet": "True" }, "CustomSortOrder": "a359ee29-cf72-4235-a4ef-1ed96bf4eaea:60d165e6-8cb1-4c20-8fad-80067c4ca767:da7bfb84-008b-48ff-b61f-bfe40da2602f", "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@m365x035040.onmicrosoft.com", "Contact": "", "Description": "", "IsOpenForTermCreation": false, "Names": { "1033": "PnP-CollabFooter-SharedLinks" }, "Stakeholders": [] }, { "_ObjectType_": "SP.Taxonomy.TermSet", "_ObjectIdentity_": "ec3f929e-2007-0000-2cdb-ebdf7451c224|fec14c62-7c3b-481b-851b-c80d7802b224:se:YU1+cBy9wUuh\u002ffzgFZGpUV45jw5Y\u002f0VNn\u002ffjMatyi+ts4nkUgBOoQZGDcrxallG7", "CreatedDate": "2018-09-13T11:52:55.147Z", "Id": "1479e26c-1380-41a8-9183-72bc5a9651bb", "LastModifiedDate": "2018-09-13T12:13:47.383Z", "Name": "PnP-Organizations", "CustomProperties": {}, "CustomSortOrder": "02cf219e-8ce9-4e85-ac04-a913a44a5d2b:247543b6-45f2-4232-b9e8-66c5bf53c31e:ffc3608f-1250-4d28-b388-381fad8d4602", "IsAvailableForTagging": true, "Owner": "i:0#.f|membership|admin@m365x035040.onmicrosoft.com", "Contact": "", "Description": "", "IsOpenForTermCreation": false, "Names": { "1033": "PnP-Organizations" }, "Stakeholders": [] }]));
   });
 
   it('correctly handles no term sets found', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="55" ObjectPathId="54" /><ObjectIdentityQuery Id="56" ObjectPathId="54" /><ObjectPath Id="58" ObjectPathId="57" /><ObjectIdentityQuery Id="59" ObjectPathId="57" /><ObjectPath Id="61" ObjectPathId="60" /><ObjectPath Id="63" ObjectPathId="62" /><ObjectIdentityQuery Id="64" ObjectPathId="62" /><ObjectPath Id="66" ObjectPathId="65" /><Query Id="67" ObjectPathId="65"><Query SelectAllProperties="false"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></ChildItemQuery></Query></Actions><ObjectPaths><StaticMethod Id="54" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="57" ParentId="54" Name="GetDefaultSiteCollectionTermStore" /><Property Id="60" ParentId="57" Name="Groups" /><Method Id="62" ParentId="60" Name="GetById"><Parameters><Parameter Type="Guid">{0e8f395e-ff58-4d45-9ff7-e331ab728beb}</Parameter></Parameters></Method><Property Id="65" ParentId="62" Name="TermSets" /></ObjectPaths></Request>`) {
@@ -463,6 +562,7 @@ describe(commands.TERM_SET_LIST, () => {
 
       return Promise.reject('Invalid request');
     });
+
     await command.action(logger, { options: { termGroupId: '0e8f395e-ff58-4d45-9ff7-e331ab728beb' } });
   });
 
@@ -521,6 +621,16 @@ describe(commands.TERM_SET_LIST, () => {
   it('fails validation if id is not a valid GUID', async () => {
     const actual = await command.validate({ options: { termGroupId: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when webUrl is not a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'abc', termGroupId: '0e8f395e-ff58-4d45-9ff7-e331ab728beb' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the webUrl is a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com/sites/project-x', termGroupId: '0e8f395e-ff58-4d45-9ff7-e331ab728beb' } }, commandInfo);
+    assert.strictEqual(actual, true);
   });
 
   it('passes validation when id specified', async () => {


### PR DESCRIPTION
Extends `spo term set list` command with support for listing tenant term sets as well as sitecollection term sets on site-level. Closes #4833