### PR TITLE
Extends 'spo term group get' command with support for getting a tenant term group as well as a sitecollection term group on site-level. Closes #4835

### DIFF
--- a/docs/docs/cmd/spo/term/term-group-get.md
+++ b/docs/docs/cmd/spo/term/term-group-get.md
@@ -26,7 +26,7 @@ m365 spo term group get [options]
 !!! important
     To use this command without the `--webUrl` option you have to have permissions to access the tenant admin site.
 
-When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. You need be a site visitor or more. It allows you to get a term group from the tenant term store as well as a term group from the sitecollection term store.
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Administrator role. You need to be a site visitor or more. It allows you to get a term group from the tenant term store as well as a term group from the sitecollection term store.
 
 ## Examples
 
@@ -42,7 +42,7 @@ Get information about a taxonomy term group using its name.
 m365 spo term group get --name PnPTermSets
 ```
 
-Get information about a taxonomy term group using its ID from the specified sitecollection.
+Get information about a taxonomy term group from the specified sitecollection using its ID.
 
 ```sh
 m365 spo term group get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --webUrl https://contoso.sharepoint.com/sites/project-x

--- a/docs/docs/cmd/spo/term/term-group-get.md
+++ b/docs/docs/cmd/spo/term/term-group-get.md
@@ -10,29 +10,95 @@ m365 spo term group get [options]
 
 ## Options
 
+`-u, --webUrl [webUrl]`
+: If specified, allows you to get a term group from the tenant term store as well as the sitecollection specific term store. Defaults to the tenant admin site.
+
 `-i, --id [id]`
-: ID of the term group to retrieve. Specify `name` or `id` but not both
+: ID of the term group to retrieve. Specify `name` or `id` but not both.
 
 `-n, --name [name]`
-: Name of the term group to retrieve. Specify `name` or `id` but not both
+: Name of the term group to retrieve. Specify `name` or `id` but not both.
 
 --8<-- "docs/cmd/_global.md"
 
 ## Remarks
 
 !!! important
-    To use this command you have to have permissions to access the tenant admin site.
+    To use this command without the `--webUrl` option you have to have permissions to access the tenant admin site.
+
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. You need be a site visitor or more. It allows you to get a term group from the tenant term store as well as a term group from the sitecollection term store.
 
 ## Examples
 
-Get information about a taxonomy term group using its ID
+Get information about a taxonomy term group using its ID.
 
 ```sh
 m365 spo term group get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb
 ```
 
-Get information about a taxonomy term group using its name
+Get information about a taxonomy term group using its name.
 
 ```sh
 m365 spo term group get --name PnPTermSets
 ```
+
+Get information about a taxonomy term group using its ID from the specified sitecollection.
+
+```sh
+m365 spo term group get --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb --webUrl https://contoso.sharepoint.com/sites/project-x
+```
+
+## Response
+
+=== "JSON"
+
+    ```json
+    {
+      "CreatedDate": "2019-09-03T06:41:32.070Z",
+      "Id": "0e8f395e-ff58-4d45-9ff7-e331ab728beb",
+      "LastModifiedDate": "2019-09-03T06:41:32.070Z",
+      "Name": "PnPTermSets",
+      "Description": "",
+      "IsSiteCollectionGroup": false,
+      "IsSystemGroup": false
+    }
+    ```
+
+=== "Text"
+
+    ```text
+    CreatedDate          : 2019-09-03T06:41:32.070Z
+    Description          :
+    Id                   : 0e8f395e-ff58-4d45-9ff7-e331ab728beb
+    IsSiteCollectionGroup: false
+    IsSystemGroup        : false
+    LastModifiedDate     : 2019-09-03T06:41:32.070Z
+    Name                 : PnPTermSets
+    ```
+
+=== "CSV"
+
+    ```csv
+    CreatedDate,Id,LastModifiedDate,Name,Description,IsSiteCollectionGroup,IsSystemGroup
+    2019-09-03T06:41:32.070Z,0e8f395e-ff58-4d45-9ff7-e331ab728beb,2019-09-03T06:41:32.070Z,PnPTermSets,,,
+    ```
+
+=== "Markdown"
+
+    ```md
+    # spo term group get --id "0e8f395e-ff58-4d45-9ff7-e331ab728beb"
+
+    Date: 5/14/2023
+
+    ## PnPTermSets (0e8f395e-ff58-4d45-9ff7-e331ab728beb)
+
+    Property | Value
+    ---------|-------
+    CreatedDate | 2019-09-03T06:41:32.070Z
+    Id | 0e8f395e-ff58-4d45-9ff7-e331ab728beb
+    LastModifiedDate | 2019-09-03T06:41:32.070Z
+    Name | PnPTermSets
+    Description |
+    IsSiteCollectionGroup | false
+    IsSystemGroup | false
+    ```

--- a/src/m365/spo/commands/term/term-group-get.spec.ts
+++ b/src/m365/spo/commands/term/term-group-get.spec.ts
@@ -81,7 +81,7 @@ describe(commands.TERM_GROUP_GET, () => {
 
   it('gets taxonomy term group by id', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="25" ObjectPathId="24" /><ObjectIdentityQuery Id="26" ObjectPathId="24" /><ObjectPath Id="28" ObjectPathId="27" /><ObjectIdentityQuery Id="29" ObjectPathId="27" /><ObjectPath Id="31" ObjectPathId="30" /><ObjectPath Id="33" ObjectPathId="32" /><ObjectIdentityQuery Id="34" ObjectPathId="32" /><Query Id="35" ObjectPathId="32"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="24" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="27" ParentId="24" Name="GetDefaultSiteCollectionTermStore" /><Property Id="30" ParentId="27" Name="Groups" /><Method Id="32" ParentId="30" Name="GetById"><Parameters><Parameter Type="Guid">{36a62501-17ea-455a-bed4-eff862242def}</Parameter></Parameters></Method></ObjectPaths></Request>`) {
@@ -149,9 +149,79 @@ describe(commands.TERM_GROUP_GET, () => {
     }));
   });
 
+  it('gets taxonomy term group from specified sitecollection by id', async () => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === 'https://contoso.sharepoint.com/sites/project-x/_vti_bin/client.svc/ProcessQuery' &&
+        opts.headers &&
+        opts.headers['X-RequestDigest'] &&
+        opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="25" ObjectPathId="24" /><ObjectIdentityQuery Id="26" ObjectPathId="24" /><ObjectPath Id="28" ObjectPathId="27" /><ObjectIdentityQuery Id="29" ObjectPathId="27" /><ObjectPath Id="31" ObjectPathId="30" /><ObjectPath Id="33" ObjectPathId="32" /><ObjectIdentityQuery Id="34" ObjectPathId="32" /><Query Id="35" ObjectPathId="32"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="24" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="27" ParentId="24" Name="GetDefaultSiteCollectionTermStore" /><Property Id="30" ParentId="27" Name="Groups" /><Method Id="32" ParentId="30" Name="GetById"><Parameters><Parameter Type="Guid">{36a62501-17ea-455a-bed4-eff862242def}</Parameter></Parameters></Method></ObjectPaths></Request>`) {
+        return Promise.resolve(JSON.stringify([
+          {
+            "SchemaVersion": "15.0.0.0",
+            "LibraryVersion": "16.0.8105.1217",
+            "ErrorInfo": null,
+            "TraceCorrelationId": "aa58909e-60c1-0000-29c7-003b321d02d1"
+          },
+          25,
+          {
+            "IsNull": false
+          },
+          26,
+          {
+            "_ObjectIdentity_": "aa58909e-60c1-0000-29c7-003b321d02d1|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
+          },
+          28,
+          {
+            "IsNull": false
+          },
+          29,
+          {
+            "_ObjectIdentity_": "aa58909e-60c1-0000-29c7-003b321d02d1|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
+          },
+          31,
+          {
+            "IsNull": false
+          },
+          33,
+          {
+            "IsNull": false
+          },
+          34,
+          {
+            "_ObjectIdentity_": "aa58909e-60c1-0000-29c7-003b321d02d1|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUQElpjbqF1pFvtTv+GIkLe8="
+          },
+          35,
+          {
+            "_ObjectType_": "SP.Taxonomy.TermGroup",
+            "_ObjectIdentity_": "aa58909e-60c1-0000-29c7-003b321d02d1|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUQElpjbqF1pFvtTv+GIkLe8=",
+            "CreatedDate": "\/Date(1529479401033)\/",
+            "Id": "\/Guid(36a62501-17ea-455a-bed4-eff862242def)\/",
+            "LastModifiedDate": "\/Date(1529479401033)\/",
+            "Name": "People",
+            "Description": "",
+            "IsSiteCollectionGroup": false,
+            "IsSystemGroup": false
+          }
+        ]));
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/project-x', id: '36a62501-17ea-455a-bed4-eff862242def' } });
+    assert(loggerLogSpy.calledWith({
+      "CreatedDate": "2018-06-20T07:23:21.033Z",
+      "Id": "36a62501-17ea-455a-bed4-eff862242def",
+      "LastModifiedDate": "2018-06-20T07:23:21.033Z",
+      "Name": "People",
+      "Description": "",
+      "IsSiteCollectionGroup": false,
+      "IsSystemGroup": false
+    }));
+  });
+
   it('gets taxonomy term group by name', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="25" ObjectPathId="24" /><ObjectIdentityQuery Id="26" ObjectPathId="24" /><ObjectPath Id="28" ObjectPathId="27" /><ObjectIdentityQuery Id="29" ObjectPathId="27" /><ObjectPath Id="31" ObjectPathId="30" /><ObjectPath Id="33" ObjectPathId="32" /><ObjectIdentityQuery Id="34" ObjectPathId="32" /><Query Id="35" ObjectPathId="32"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="24" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="27" ParentId="24" Name="GetDefaultSiteCollectionTermStore" /><Property Id="30" ParentId="27" Name="Groups" /><Method Id="32" ParentId="30" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method></ObjectPaths></Request>`) {
@@ -221,7 +291,7 @@ describe(commands.TERM_GROUP_GET, () => {
 
   it('correctly handles term group not found via id', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="25" ObjectPathId="24" /><ObjectIdentityQuery Id="26" ObjectPathId="24" /><ObjectPath Id="28" ObjectPathId="27" /><ObjectIdentityQuery Id="29" ObjectPathId="27" /><ObjectPath Id="31" ObjectPathId="30" /><ObjectPath Id="33" ObjectPathId="32" /><ObjectIdentityQuery Id="34" ObjectPathId="32" /><Query Id="35" ObjectPathId="32"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="24" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="27" ParentId="24" Name="GetDefaultSiteCollectionTermStore" /><Property Id="30" ParentId="27" Name="Groups" /><Method Id="32" ParentId="30" Name="GetById"><Parameters><Parameter Type="Guid">{36a62501-17ea-455a-bed4-eff862242def}</Parameter></Parameters></Method></ObjectPaths></Request>`) {
@@ -246,7 +316,7 @@ describe(commands.TERM_GROUP_GET, () => {
 
   it('correctly handles term group not found via name', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
+      if (opts.url === 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery' &&
         opts.headers &&
         opts.headers['X-RequestDigest'] &&
         opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="25" ObjectPathId="24" /><ObjectIdentityQuery Id="26" ObjectPathId="24" /><ObjectPath Id="28" ObjectPathId="27" /><ObjectIdentityQuery Id="29" ObjectPathId="27" /><ObjectPath Id="31" ObjectPathId="30" /><ObjectPath Id="33" ObjectPathId="32" /><ObjectIdentityQuery Id="34" ObjectPathId="32" /><Query Id="35" ObjectPathId="32"><Query SelectAllProperties="true"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="24" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="27" ParentId="24" Name="GetDefaultSiteCollectionTermStore" /><Property Id="30" ParentId="27" Name="Groups" /><Method Id="32" ParentId="30" Name="GetByName"><Parameters><Parameter Type="String">People</Parameter></Parameters></Method></ObjectPaths></Request>`) {
@@ -292,6 +362,16 @@ describe(commands.TERM_GROUP_GET, () => {
   it('fails validation if id is not a valid GUID', async () => {
     const actual = await command.validate({ options: { id: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when webUrl is not a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'abc', id: '9e54299e-208a-4000-8546-cc4139091b26' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the webUrl is a valid url', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com/sites/project-x', id: '9e54299e-208a-4000-8546-cc4139091b26' } }, commandInfo);
+    assert.strictEqual(actual, true);
   });
 
   it('passes validation when id specified', async () => {


### PR DESCRIPTION
Extends `spo term group get` command with support for getting a tenant term group as well as a sitecollection term group on site-level. Closes #4835