### PR TITLE
Adds output value 'none' to disable any output. Closes #4804

### DIFF
--- a/docs/docs/_clisettings.mdx
+++ b/docs/docs/_clisettings.mdx
@@ -10,7 +10,7 @@ Setting name|Definition|Default value
 `disableTelemetry`|Disables sending of telemetry data|`false`
 `errorOutput`|Defines if errors should be written to `stdout` or `stderr`|`stderr`
 `helpMode`|Defines what part of command's help to display. Allowed values are `options`, `examples`, `remarks`, `response`, `full`|`full`
-`output`|Defines the default output when issuing a command|`json`
+`output`|Defines the default output when issuing a command. Allowed values are `json`, `text`, `csv`, `md`, `none`|`json`
 `printErrorsAsPlainText`|When output mode is set to `json`, print error messages as plain-text rather than JSON|`true`
 `prompt`|Prompts for missing values in required options and enables interactive selection when multiple values are available for a command that requires a specific value to be retrieved.|`false`
 `showHelpOnFailure`|Automatically display help when executing a command failed|`true`

--- a/docs/docs/cmd/_global.mdx
+++ b/docs/docs/cmd/_global.mdx
@@ -6,7 +6,7 @@
 : JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples.
 
 `-o, --output [output]`
-: Output type. `json`, `text`, `csv`, `md`. Default `json`.
+: Output type. `json`, `text`, `csv`, `md`, `none`. Default `json`.
 
 `--verbose`
 : Runs command with verbose logging.

--- a/docs/docs/user-guide/cli-output-mode.mdx
+++ b/docs/docs/user-guide/cli-output-mode.mdx
@@ -9,7 +9,7 @@ CLI for Microsoft 365 commands can present their output either as plain-text, JS
 
 ## Choose the command output mode
 
-All commands in CLI for Microsoft 365 can present their output as plain-text, JSON, CSV or Markdown. By default, all commands use the JSON output mode, but by setting the `--output`, or `-o` for short, option to `text`, you can change the output mode for that command to text. By setting the output option to `csv`, you can change the output mode for that command to CSV. By setting the output option to `md`, you can change the output mode for that command to Markdown.
+All commands in CLI for Microsoft 365 can present their output as plain-text, JSON, CSV or Markdown. By default, all commands use the JSON output mode, but by setting the `--output`, or `-o` for short, option to `text`, you can change the output mode for that command to text. By setting the output option to `csv`, you can change the output mode for that command to CSV. By setting the output option to `md`, you can change the output mode for that command to Markdown. By setting the output option to `none`, no output is returned at all, not even errors.
 
 ## JSON output mode
 
@@ -658,3 +658,13 @@ $apps | ? Deployed -eq $false | % { m365 spo app deploy -i $_.ID }
 ```
 
 Because PowerShell offers native support for working with JSON strings and objects, the same script written in PowerShell is simpler than the one in Bash. At the end of the day it's up to you to choose if you want to use the CLI for Microsoft 365 in Bash, PowerShell or some other shell. Both Bash and PowerShell are available on multiple platforms, and if you have a team using different platforms, writing scripts using CLI for Microsoft 365 in Bash or PowerShell will let everyone in your team use them.
+
+## Hiding all output
+
+When setting the value of the output option to `none`, no output is returned at all. This includes command output, errors, validation errors and help documentation. This can be useful when running the CLI for Microsoft 365 in an environment where console output is problematic. 
+
+An example of this is when running the CLI on an Azure Function. The Azure Functions PowerShell runtime throws exceptions when the CLI for Microsoft 365 tries to render the spinner when running commands. The spinner must in this case be hidden by running the following with output `none`:
+
+```sh
+m365 cli config set --key showSpinner --value false --output none
+```

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -65,7 +65,7 @@ export default abstract class Command {
   protected telemetryProperties: any = {};
 
   protected get allowedOutputs(): string[] {
-    return ['csv', 'json', 'md', 'text'];
+    return ['csv', 'json', 'md', 'text', 'none'];
   }
 
   public options: CommandOption[] = [];

--- a/src/autocomplete.spec.ts
+++ b/src/autocomplete.spec.ts
@@ -119,9 +119,9 @@ describe('autocomplete', () => {
     assert(writeFileSyncStub.calledWith(path.join(__dirname, `..${path.sep}commands.json`), JSON.stringify({
       cli: {
         mock: {
-          "-o": ["csv", "json", "md", "text"],
+          "-o": ["csv", "json", "md", "text", "none"],
           "--query": {},
-          "--output": ["csv", "json", "md", "text"],
+          "--output": ["csv", "json", "md", "text", "none"],
           "--verbose": {},
           "--debug": {},
           "--help": {},
@@ -157,7 +157,7 @@ describe('autocomplete', () => {
 
     assert.strictEqual(clink, [
       'local parser = clink.arg.new_parser',
-      'local m365_parser = parser({"cli"..parser({"mock"..parser({},"--debug", "--help", "--output"..parser({"csv","json","md","text"}), "--query", "--verbose", "-h", "-o"..parser({"csv","json","md","text"}))})})',
+      'local m365_parser = parser({"cli"..parser({"mock"..parser({},"--debug", "--help", "--output"..parser({"csv","json","md","none","text"}), "--query", "--verbose", "-h", "-o"..parser({"csv","json","md","none","text"}))})})',
       '',
       'clink.arg.register_parser("m365", m365_parser)',
       'clink.arg.register_parser("microsoft365", m365_parser)'
@@ -170,7 +170,7 @@ describe('autocomplete', () => {
 
     assert.strictEqual(clink, [
       'local parser = clink.arg.new_parser',
-      'local m365_parser = parser({"cli"..parser({"mock2"..parser({},"--debug", "--help", "--longOption", "--output"..parser({"csv","json","md","text"}), "--query", "--verbose", "-h", "-l", "-o"..parser({"csv","json","md","text"}))})})',
+      'local m365_parser = parser({"cli"..parser({"mock2"..parser({},"--debug", "--help", "--longOption", "--output"..parser({"csv","json","md","none","text"}), "--query", "--verbose", "-h", "-l", "-o"..parser({"csv","json","md","none","text"}))})})',
       '',
       'clink.arg.register_parser("m365", m365_parser)',
       'clink.arg.register_parser("microsoft365", m365_parser)'
@@ -183,7 +183,7 @@ describe('autocomplete', () => {
 
     assert.strictEqual(clink, [
       'local parser = clink.arg.new_parser',
-      'local m365_parser = parser({"cli"..parser({"mock2"..parser({},"--debug", "--help", "--longOption", "--output"..parser({"csv","json","md","text"}), "--query", "--verbose", "-h", "-l", "-o"..parser({"csv","json","md","text"}))})})',
+      'local m365_parser = parser({"cli"..parser({"mock2"..parser({},"--debug", "--help", "--longOption", "--output"..parser({"csv","json","md","none","text"}), "--query", "--verbose", "-h", "-l", "-o"..parser({"csv","json","md","none","text"}))})})',
       '',
       'clink.arg.register_parser("m365", m365_parser)',
       'clink.arg.register_parser("microsoft365", m365_parser)'
@@ -196,7 +196,7 @@ describe('autocomplete', () => {
 
     assert.strictEqual(clink, [
       'local parser = clink.arg.new_parser',
-      'local m365_parser = parser({"cli"..parser({"mock2"..parser({},"--debug", "--help", "--longOption", "--output"..parser({"csv","json","md","text"}), "--query", "--verbose", "-h", "-l", "-o"..parser({"csv","json","md","text"}))})})',
+      'local m365_parser = parser({"cli"..parser({"mock2"..parser({},"--debug", "--help", "--longOption", "--output"..parser({"csv","json","md","none","text"}), "--query", "--verbose", "-h", "-l", "-o"..parser({"csv","json","md","none","text"}))})})',
       '',
       'clink.arg.register_parser("m365", m365_parser)',
       'clink.arg.register_parser("microsoft365", m365_parser)'
@@ -209,7 +209,7 @@ describe('autocomplete', () => {
 
     assert.strictEqual(clink, [
       'local parser = clink.arg.new_parser',
-      'local m365_parser = parser({"cli"..parser({"alias"..parser({},"--debug", "--help", "--output"..parser({"csv","json","md","text"}), "--query", "--verbose", "-h", "-o"..parser({"csv","json","md","text"})),"mock"..parser({},"--debug", "--help", "--output"..parser({"csv","json","md","text"}), "--query", "--verbose", "-h", "-o"..parser({"csv","json","md","text"}))})})',
+      'local m365_parser = parser({"cli"..parser({"alias"..parser({},"--debug", "--help", "--output"..parser({"csv","json","md","none","text"}), "--query", "--verbose", "-h", "-o"..parser({"csv","json","md","none","text"})),"mock"..parser({},"--debug", "--help", "--output"..parser({"csv","json","md","none","text"}), "--query", "--verbose", "-h", "-o"..parser({"csv","json","md","none","text"}))})})',
       '',
       'clink.arg.register_parser("m365", m365_parser)',
       'clink.arg.register_parser("microsoft365", m365_parser)'

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -2232,4 +2232,44 @@ describe('Cli', () => {
     const spyShouldTrimOutput = Cli.shouldTrimOutput('json');
     assert.strictEqual(spyShouldTrimOutput, false);
   });
+
+  it('does not show help when output is set to none', (done) => {
+    cli
+      .execute(rootFolder, ['cli', 'completion', 'clink', 'update', '-h', 'examples', '--output', 'none'])
+      .then(_ => {
+        try {
+          assert.strictEqual(log.length === 0, true);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      }, e => done(e));
+  });
+
+  it(`shows no output on succesful run with output set to none`, (done) => {
+    cli
+      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'true', '--booleanParameterY', 'false', '--output', 'none'])
+      .then(_ => {
+        try {
+          assert.strictEqual(cliLogStub.notCalled, true);
+          assert.strictEqual(cliErrorStub.notCalled, true);
+          done();
+        }
+        catch (e) {
+          done(e);
+        }
+      }, e => done(e));
+  });
+
+  it(`shows no output when a validation error occurs in and output is set to none`, (done) => {
+    cli
+      .execute(rootFolder, ['cli', 'mock', 'boolean', 'rewrite', '--booleanParameterX', 'folse', '--output', 'none'])
+      .then(_ => {
+        assert(cliErrorStub.notCalled);
+        assert(cliLogStub.notCalled);
+        done();
+      }, _ => done('Promise fulfilled with error, no error expected'));
+  });
+
 });

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -58,7 +58,7 @@ class CliConfigSetCommand extends AnonymousCommand {
           return `${args.options.key} is not a valid setting. Allowed values: ${CliConfigSetCommand.optionNames.join(', ')}`;
         }
 
-        const allowedOutputs = ['text', 'json', 'csv', 'md'];
+        const allowedOutputs = ['text', 'json', 'csv', 'md', 'none'];
         if (args.options.key === settingsNames.output &&
           allowedOutputs.indexOf(args.options.value) === -1) {
           return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${allowedOutputs.join(', ')}`;


### PR DESCRIPTION
Closes #4804

Adds output value 'none' to disable any output.
Added extra allowed value to `cli config set --key output`
Updates to documentation
