### PR TITLE
Include md output: yammer commands. Closes #4300

### DIFF
--- a/docs/docs/cmd/yammer/group/group-list.md
+++ b/docs/docs/cmd/yammer/group/group-list.md
@@ -113,3 +113,45 @@ m365 yammer group list --userId 5611239081 --limit 10
     id,name,email,privacy,external,moderated
     31158067201,wombathub,,public,false,false
     ```
+
+=== "Markdown"
+
+    ```md
+    # yammer group list --limit "1"
+
+    Date: 2023-05-16
+
+    ## leadership (123412865024)
+
+    Property | Value
+    ---------|-------
+    type | group
+    id | 123412865024
+    email | leadership+contoso.onmicrosoft.com@yammer.com
+    full\_name | Leadership
+    network\_id | 98327945216
+    name | leadership
+    description | Share what's on your mind and get important announcements from Patti and the rest of the Leadership Team.
+    privacy | public
+    url | https://www.yammer.com/api/v1/groups/123412865024
+    web\_url | https://www.yammer.com/contoso.onmicrosoft.com/#/threads/inGroup?type=in\_group&feedId=123412865024
+    mugshot\_url | https://mugshot0.assets-yammer.com/mugshot/images/5jjCjcSTJsdzFn0Ps50Vz0tqNdWdgnWs?P1=1684267104&P2=104&P3=1&P4=igdO9ZCQbSd5YS7tzwuIFj9CmMPsPWWpAjsk0xGDGrciD-3XKKsHbYx-e6H22yZ6OqLc3zt\_5ZOWefd8l537cWNUOPzeDg2lz\_fNxx1bowFMIdz6mRCHcCwygEwtKI0HxX5eHd4cdJBg54c4R6VN1\_Oex7Ug9Are6hVux4DsLg7eoNMMYvvcjXUp2zcT7o6bXYcZM2WBf\_r1IC24Sb-PLaSfAtKJZsswBBTkmz\_B7O5PZFcY4TQJvd5XzwEL17aqWm1hV1MCUSEd3Ms7Clc7KwxA0Hhv1rWYF064siAHEDiVlKZrE1yN7j-gCt0K1\_xUHWc54TrUIjFxnrwMDGZvzw&size=48x48
+    mugshot\_redirect\_url | https://www.yammer.com/mugshot/images/redirect/48x48/5jjCjcSTJsdzFn0Ps50Vz0tqNdWdgnWs
+    mugshot\_url\_template | https://mugshot0.assets-yammer.com/mugshot/images/5jjCjcSTJsdzFn0Ps50Vz0tqNdWdgnWs?P1=1684267104&P2=104&P3=1&P4=igdO9ZCQbSd5YS7tzwuIFj9CmMPsPWWpAjsk0xGDGrciD-3XKKsHbYx-e6H22yZ6OqLc3zt\_5ZOWefd8l537cWNUOPzeDg2lz\_fNxx1bowFMIdz6mRCHcCwygEwtKI0HxX5eHd4cdJBg54c4R6VN1\_Oex7Ug9Are6hVux4DsLg7eoNMMYvvcjXUp2zcT7o6bXYcZM2WBf\_r1IC24Sb-PLaSfAtKJZsswBBTkmz\_B7O5PZFcY4TQJvd5XzwEL17aqWm1hV1MCUSEd3Ms7Clc7KwxA0Hhv1rWYF064siAHEDiVlKZrE1yN7j-gCt0K1\_xUHWc54TrUIjFxnrwMDGZvzw&size={width}x{height}
+    mugshot\_redirect\_url\_template | https://www.yammer.com/mugshot/images/redirect/{width}x{height}/5jjCjcSTJsdzFn0Ps50Vz0tqNdWdgnWs
+    mugshot\_id | 5jjCjcSTJsdzFn0Ps50Vz0tqNdWdgnWs
+    show\_in\_directory | true
+    created\_at | 2022/12/12 12:51:11 +0000
+    aad\_guests | 0
+    color | #0e4f7a
+    external | false
+    moderated | false
+    header\_image\_url | https://mugshot0.assets-yammer.com/mugshot/images/group-header-megaphone.png?P1=1684266783&P2=104&P3=1&P4=FObDxfvTV7O201-7u4v-u4Y25mAZNrpD9QhUqSXbUyC8UaqvGJH7mT5yPtx0Qls\_QUkM3606i0F2GnkQHOwC1tVW8Vse0yNZHWDTyqA\_wSRX\_fn6cP47uoC4wvSsGAmWeb6epr-hJpDW\_qn-1CHQF7cen2Ti9Ap-XncmOiu2Tfd2DTuGyuHKivI6cxGGbIQ5ERU1NgiVEXqKClOMb9qPUBu4dqPc1gfaFDaA1umUslwTG3DRfAIVviECiG1eHI5cjkTX5qifscUXCmEOQU5lLih9J409qVUOPa0vs1clNspm6XtkVaAfC8FB2gaBmEqbVtFBVbAwyoUJhu2KM0Vp7w
+    category | unclassified
+    default\_thread\_starter\_type | normal
+    restricted\_posting | false
+    company\_group | false
+    creator\_type | user
+    creator\_id | 1842176974848
+    state | active
+    ```

--- a/docs/docs/cmd/yammer/message/message-add.md
+++ b/docs/docs/cmd/yammer/message/message-add.md
@@ -124,3 +124,35 @@ m365 yammer message add --body "Hello everyone!" --groupId 12312312312 --network
     id
     2000337749565441
     ```
+
+=== "Markdown"
+
+    ```md
+    # yammer message add --body "Hello everyone!" --groupId "123412865024"
+
+    Date: 2023-05-16
+
+    ## 2269815632207872
+
+    Property | Value
+    ---------|-------
+    id | 2269815632207872
+    sender\_id | 1842170699776
+    created\_at | 2023/05/16 18:42:34 +0000
+    published\_at | 2023/05/16 18:42:34 +0000
+    network\_id | 98327945216
+    message\_type | update
+    sender\_type | user
+    url | https://www.yammer.com/api/v1/messages/2269815632207872
+    web\_url | https://www.yammer.com/contoso.onmicrosoft.com/messages/2269815632207872
+    group\_id | 123412865024
+    thread\_id | 2269815632207872
+    client\_type | O365 Api Auth
+    client\_url | https://api.yammer.com
+    system\_message | false
+    direct\_message | false
+    privacy | public
+    supplemental\_reply | false
+    content\_excerpt | Hello everyone!
+    group\_created\_id | 123412865024
+    ```

--- a/docs/docs/cmd/yammer/message/message-get.md
+++ b/docs/docs/cmd/yammer/message/message-get.md
@@ -97,3 +97,35 @@ m365 yammer message get --id 1239871123 --output json
     id,sender_id,replied_to_id,thread_id,group_id,created_at,direct_message,system_message,privacy,message_type,content_excerpt
     2000337749565441,36425097217,,2000337749565441,31158067201,2022/11/11 21:00:20 +0000,,,public,update,Hello everyone!
     ```
+
+=== "Markdown"
+
+    ```md
+    # yammer message get --id "2269815632207872"
+
+    Date: 2023-05-16
+
+    ## 2269815632207872
+
+    Property | Value
+    ---------|-------
+    id | 2269815632207872
+    sender\_id | 1842170699776
+    created\_at | 2023/05/16 18:42:34 +0000
+    published\_at | 2023/05/16 18:42:34 +0000
+    network\_id | 98327945216
+    message\_type | update
+    sender\_type | user
+    url | https://www.yammer.com/api/v1/messages/2269815632207872
+    web\_url | https://www.yammer.com/contoso.onmicrosoft.com/messages/2269815632207872
+    group\_id | 123412865024
+    thread\_id | 2269815632207872
+    client\_type | O365 Api Auth
+    client\_url | https://api.yammer.com
+    system\_message | false
+    direct\_message | false
+    language | no
+    privacy | public
+    supplemental\_reply | false
+    content\_excerpt | Hello everyone!
+    ```

--- a/docs/docs/cmd/yammer/message/message-list.md
+++ b/docs/docs/cmd/yammer/message/message-list.md
@@ -148,3 +148,37 @@ m365 yammer message list --feedType Sent --limit 20
     id,replied_to_id,thread_id,group_id,shortBody
     2000337749565441,,2000337749565441,31158067201,Hello everyone!
     ```
+
+=== "Markdown"
+
+    ```md
+    # yammer message list --limit "1" --feedType "All"
+
+    Date: 2023-05-16
+
+    ## 2269815632207872
+
+    Property | Value
+    ---------|-------
+    id | 2269815632207872
+    sender\_id | 1842170699776
+    created\_at | 2023/05/16 18:42:34 +0000
+    published\_at | 2023/05/16 18:42:34 +0000
+    network\_id | 98327945216
+    message\_type | update
+    sender\_type | user
+    url | https://www.yammer.com/api/v1/messages/2269815632207872
+    web\_url | https://www.yammer.com/contoso.onmicrosoft.com/messages/2269815632207872
+    group\_id | 123412865024
+    thread\_id | 2269815632207872
+    client\_type | O365 Api Auth
+    client\_url | https://api.yammer.com
+    system\_message | false
+    direct\_message | false
+    language | no
+    privacy | public
+    supplemental\_reply | false
+    content\_excerpt | Hello everyone!
+    group\_created\_id | 123412865024
+    shortBody | Hello everyone!
+    ```

--- a/docs/docs/cmd/yammer/network/network-list.md
+++ b/docs/docs/cmd/yammer/network/network-list.md
@@ -129,3 +129,73 @@ m365 yammer network list --includeSuspended
     id,name,email,community,permalink,web_url
     5897756673,Contoso,,,contoso.onmicrosoft.com,https://www.yammer.com/contoso.onmicrosoft.com
     ```
+
+=== "Markdown"
+
+    ```md
+    # yammer network list
+
+    Date: 2023-05-16
+
+    ## Contoso (98327945216)
+
+    Property | Value
+    ---------|-------
+    type | network
+    id | 98327945216
+    email | contoso.onmicrosoft.com@yammer.com
+    name | Contoso
+    community | false
+    permalink | contoso.onmicrosoft.com
+    web\_url | https://www.yammer.com/contoso.onmicrosoft.com
+    show\_upgrade\_banner | false
+    header\_background\_color | #396B9A
+    header\_text\_color | #FFFFFF
+    navigation\_background\_color | #38699F
+    navigation\_text\_color | #FFFFFF
+    paid | true
+    moderated | false
+    is\_freemium | false
+    is\_org\_chart\_enabled | false
+    is\_group\_enabled | true
+    is\_chat\_enabled | true
+    is\_translation\_enabled | false
+    created\_at | 2022/12/08 07:38:34 +0000
+    is\_storyline\_enabled | true
+    is\_storyline\_preview\_enabled | false
+    is\_storyline\_per\_user\_control\_enabled | false
+    is\_stories\_enabled | true
+    is\_stories\_preview\_enabled | false
+    is\_premium\_preview\_enabled | false
+    is\_leadership\_corner\_enabled | true
+    external\_messaging\_state | inbound\_only
+    state | enabled
+    enforce\_office\_authentication | true
+    office\_authentication\_committed | true
+    is\_gif\_shortcut\_enabled | true
+    is\_link\_preview\_enabled | true
+    attachments\_in\_private\_messages | false
+    secret\_groups | false
+    force\_connected\_groups | true
+    force\_spo\_files | true
+    connected\_all\_company | true
+    m365\_native\_mode | true
+    force\_optin\_modern\_client | true
+    admin\_modern\_client\_flexible\_optin | false
+    aad\_guests\_enabled | true
+    all\_company\_group\_creation\_state | 3
+    is\_network\_questions\_enabled | true
+    is\_network\_questions\_only\_mode\_enabled | false
+    unseen\_message\_count | -1
+    preferred\_unseen\_message\_count | -1
+    private\_unseen\_thread\_count | 0
+    inbox\_unseen\_thread\_count | 0
+    private\_unread\_thread\_count | 0
+    unseen\_notification\_count | 2
+    has\_fake\_email | false
+    is\_primary | true
+    allow\_attachments | true
+    attachment\_types\_allowed | ALL
+    privacy\_link | https://go.microsoft.com/fwlink/p/?linkid=857875
+    user\_state | active
+    ```

--- a/docs/docs/cmd/yammer/report/report-activitycounts.md
+++ b/docs/docs/cmd/yammer/report/report-activitycounts.md
@@ -68,3 +68,10 @@ m365 yammer report activitycounts --period D7 --output json > "activitycounts.js
     Report Refresh Date,Liked,Posted,Read,Report Date,Report Period
     2022-11-09,12,6,435,2022-11-09,90
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,Liked,Posted,Read,Report Date,Report Period
+    2022-11-09,12,6,435,2022-11-09,90
+    ```

--- a/docs/docs/cmd/yammer/report/report-activityusercounts.md
+++ b/docs/docs/cmd/yammer/report/report-activityusercounts.md
@@ -68,3 +68,10 @@ m365 yammer report activityusercounts --period D7 --output json > "activityuserc
     Report Refresh Date,Liked,Posted,Read,Report Date,Report Period
     2022-11-09,9,5,64,2022-11-09,7
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,Liked,Posted,Read,Report Date,Report Period
+    2022-11-09,9,5,64,2022-11-09,7
+    ```

--- a/docs/docs/cmd/yammer/report/report-activityuserdetail.md
+++ b/docs/docs/cmd/yammer/report/report-activityuserdetail.md
@@ -86,3 +86,10 @@ m365 yammer report activityuserdetail --period D7 --output json > "activityuserd
     Report Refresh Date,User Principal Name,Display Name,User State,State Change Date,Last Activity Date,Posted Count,Read Count,Liked Count,Assigned Products,Report Period
     2022-11-09,77E5979DD60BA6EAA53E814DBEEEFA5F,4291DA7C39EE3263E97336B42734A667,,,,0,0,0,MICROSOFT 365 E5 DEVELOPER (WITHOUT WINDOWS AND AUDIO CONFERENCING),7
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,User Principal Name,Display Name,User State,State Change Date,Last Activity Date,Posted Count,Read Count,Liked Count,Assigned Products,Report Period
+    2022-11-09,77E5979DD60BA6EAA53E814DBEEEFA5F,4291DA7C39EE3263E97336B42734A667,,,,0,0,0,MICROSOFT 365 E5 DEVELOPER (WITHOUT WINDOWS AND AUDIO CONFERENCING),7
+    ```

--- a/docs/docs/cmd/yammer/report/report-deviceusagedistributionusercounts.md
+++ b/docs/docs/cmd/yammer/report/report-deviceusagedistributionusercounts.md
@@ -70,3 +70,10 @@ m365 yammer report deviceusagedistributionusercounts --period D7 --output json >
     Report Refresh Date,Web,Windows Phone,Android Phone,iPhone,iPad,Other,Report Period
     2022-11-09,77,5,1,7,6,108,7
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,Web,Windows Phone,Android Phone,iPhone,iPad,Other,Report Period
+    2022-11-09,77,5,1,7,6,108,7
+    ```

--- a/docs/docs/cmd/yammer/report/report-deviceusageusercounts.md
+++ b/docs/docs/cmd/yammer/report/report-deviceusageusercounts.md
@@ -71,3 +71,10 @@ m365 yammer report deviceusageusercounts --period D7 --output json > "deviceusag
     Report Refresh Date,Web,Windows Phone,Android Phone,iPhone,iPad,Other,Report Date,Report Period
     2022-11-09,4,5,6,3,3,60,2022-11-09,7
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,Web,Windows Phone,Android Phone,iPhone,iPad,Other,Report Date,Report Period
+    2022-11-09,4,5,6,3,3,60,2022-11-09,7
+    ```

--- a/docs/docs/cmd/yammer/report/report-deviceusageuserdetail.md
+++ b/docs/docs/cmd/yammer/report/report-deviceusageuserdetail.md
@@ -88,3 +88,10 @@ m365 yammer report deviceusageuserdetail --period D7 --output json > "deviceusag
     Report Refresh Date,User Principal Name,Display Name,User State,State Change Date,Last Activity Date,Used Web,Used Windows Phone,Used Android Phone,Used iPhone,Used iPad,Used Others,Report Period
     2022-11-09,77E5979DD60BA6EAA53E814DBEEEFA5F,4291DA7C39EE3263E97336B42734A667,,,,No,No,No,No,No,No,7
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,User Principal Name,Display Name,User State,State Change Date,Last Activity Date,Used Web,Used Windows Phone,Used Android Phone,Used iPhone,Used iPad,Used Others,Report Period
+    2022-11-09,77E5979DD60BA6EAA53E814DBEEEFA5F,4291DA7C39EE3263E97336B42734A667,,,,No,No,No,No,No,No,7
+    ```

--- a/docs/docs/cmd/yammer/report/report-groupsactivitycounts.md
+++ b/docs/docs/cmd/yammer/report/report-groupsactivitycounts.md
@@ -68,3 +68,10 @@ m365 yammer report groupsactivitycounts --period D7 --output json > "groupsactiv
     Report Refresh Date,Liked,Posted,Read,Report Date,Report Period
     2022-11-10,5,6,7,2022-11-10,7
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,Liked,Posted,Read,Report Date,Report Period
+    2022-11-10,5,6,7,2022-11-10,7
+    ```

--- a/docs/docs/cmd/yammer/report/report-groupsactivitydetail.md
+++ b/docs/docs/cmd/yammer/report/report-groupsactivitydetail.md
@@ -87,3 +87,10 @@ m365 yammer report groupsactivitydetail --period D7 --output json > "groupsactiv
     Report Refresh Date,Group Display Name,Is Deleted,Owner Principal Name,Last Activity Date,Group Type,Office 365 Connected,Member Count,Posted Count,Read Count,Liked Count,Report Period
     2022-11-10,7D3654B07E126BBD0D18174368FC243F,False,,,public,No,3,,,,7
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,Group Display Name,Is Deleted,Owner Principal Name,Last Activity Date,Group Type,Office 365 Connected,Member Count,Posted Count,Read Count,Liked Count,Report Period
+    2022-11-10,7D3654B07E126BBD0D18174368FC243F,False,,,public,No,3,,,,7
+    ```

--- a/docs/docs/cmd/yammer/report/report-groupsactivitygroupcounts.md
+++ b/docs/docs/cmd/yammer/report/report-groupsactivitygroupcounts.md
@@ -67,3 +67,10 @@ m365 yammer report groupsactivitygroupcounts --period D7 --output json > "groups
     Report Refresh Date,Total,Active,Report Date,Report Period
     2022-11-10,1,0,2022-11-10,7
     ```
+
+=== "Markdown"
+
+    ```md
+    Report Refresh Date,Total,Active,Report Date,Report Period
+    2022-11-10,1,0,2022-11-10,7
+    ```

--- a/docs/docs/cmd/yammer/user/user-get.md
+++ b/docs/docs/cmd/yammer/user/user-get.md
@@ -149,3 +149,58 @@ m365 yammer user get --email john.smith@contoso.com --output json
     id,full_name,email,job_title,state,url
     172006440961,admvalo,johndoe@contoso.onmicrosoft.com,,active,https://www.yammer.com/api/v1/users/172006440961
     ```
+
+=== "Markdown"
+
+    ```md
+    # yammer user get --email "johndoe@contoso.onmicrosoft.com"
+
+    Date: 2023-05-16
+
+    ## john (172006440961)
+
+    Property | Value
+    ---------|-------
+    type | user
+    id | 172006440961
+    network\_id | 98327945216
+    state | active
+    job\_title |
+    location |
+    summary |
+    full\_name | john doe
+    activated\_at | 2022/12/12 12:48:58 +0000
+    auto\_activated | false
+    show\_ask\_for\_photo | false
+    first\_name | john
+    last\_name | doe
+    network\_name | Contoso
+    url | https://www.yammer.com/api/v1/users/172006440961
+    web\_url | https://www.yammer.com/contoso.onmicrosoft.com/users/172006440961
+    name | john
+    mugshot\_url | https://mugshot0.assets-yammer.com/mugshot/images/j3vWbMtXbkp952gqLQlDqKj8s3Fw42Xc\_5306d18a-4133-48a7-b568-a47af1bab178?P1=1684269373&P2=104&P3=1&P4=fnQKCoHkdFGwue-NUtuMDHzqeFOZF0\_4qq0S0-H58C-98YH7QMJ51UBeJTbQduTeM5\_68DNW3eS-BsuYL1dS1fogpRYtLuZBhbYm4hW0D7ZeSbbEGPLnbEDSb6yjAN6ATTCHp2erTw5apasxyO3UcnTTJKBrIp56KfW0nxoFIrIYsqscpHXDHAhAqQ3eD8qfGyShNL1ZMlQBeTjm4qNMlI7qLM4lomhrKIHwjJsmczchlCBRX26HxNx6hWt4apWZi41dxAvJxYVht36kShq0W4WCAqwUEFbyPPJBdeFHB7nGkdYq6x3ab9W-\_CcptsxiOp1tP1jxZbE5x79STjUKaA&size=48x48
+    mugshot\_redirect\_url | https://www.yammer.com/mugshot/images/redirect/48x48/j3vWbMtXbkp952gqLQlDqKj8s3Fw42Xc\_5306d18a-4133-48a7-b568-a47af1bab178
+    mugshot\_url\_template | https://mugshot0.assets-yammer.com/mugshot/images/j3vWbMtXbkp952gqLQlDqKj8s3Fw42Xc\_5306d18a-4133-48a7-b568-a47af1bab178?P1=1684269373&P2=104&P3=1&P4=fnQKCoHkdFGwue-NUtuMDHzqeFOZF0\_4qq0S0-H58C-98YH7QMJ51UBeJTbQduTeM5\_68DNW3eS-BsuYL1dS1fogpRYtLuZBhbYm4hW0D7ZeSbbEGPLnbEDSb6yjAN6ATTCHp2erTw5apasxyO3UcnTTJKBrIp56KfW0nxoFIrIYsqscpHXDHAhAqQ3eD8qfGyShNL1ZMlQBeTjm4qNMlI7qLM4lomhrKIHwjJsmczchlCBRX26HxNx6hWt4apWZi41dxAvJxYVht36kShq0W4WCAqwUEFbyPPJBdeFHB7nGkdYq6x3ab9W-\_CcptsxiOp1tP1jxZbE5x79STjUKaA&size={width}x{height}
+    mugshot\_redirect\_url\_template | https://www.yammer.com/mugshot/images/redirect/{width}x{height}/j3vWbMtXbkp952gqLQlDqKj8s3Fw42Xc\_5306d18a-4133-48a7-b568-a47af1bab178
+    birth\_date |
+    birth\_date\_complete |
+    timezone | Pacific Time (US & Canada)
+    admin | true
+    verified\_admin | true
+    m365\_yammer\_admin | false
+    supervisor\_admin | false
+    o365\_tenant\_admin | true
+    answers\_admin | false
+    corporate\_communicator | false
+    can\_broadcast | true
+    email | johndoe@contoso.onmicrosoft.com
+    guest | false
+    aad\_guest | false
+    can\_view\_delegations | false
+    can\_create\_new\_network | true
+    can\_browse\_external\_networks | true
+    reaction\_accent\_color | none
+    significant\_other |
+    kids\_names |
+    show\_invite\_lightbox | false
+    ```

--- a/docs/docs/cmd/yammer/user/user-list.md
+++ b/docs/docs/cmd/yammer/user/user-list.md
@@ -154,3 +154,58 @@ m365 user list --groupId 5785177 --limit 10
     id,full_name,email
     36425097217,John Doe,johndoe@contoso.onmicrosoft.com
     ```
+
+=== "Markdown"
+
+    ```md
+    # yammer user list --limit "1"
+
+    Date: 2023-05-16
+
+    ## john (172006440961)
+
+    Property | Value
+    ---------|-------
+    type | user
+    id | 172006440961
+    network\_id | 98327945216
+    state | active
+    job\_title | Retail Manager
+    location | 18/2111
+    summary |
+    full\_name | john doe
+    activated\_at | 2022/12/12 12:49:34 +0000
+    auto\_activated | false
+    show\_ask\_for\_photo | false
+    first\_name | john
+    last\_name | doe
+    network\_name | Contoso
+    url | https://www.yammer.com/api/v1/users/172006440961
+    web\_url | https://www.yammer.com/contoso.onmicrosoft.com/users/172006440961
+    name | john
+    mugshot\_url | https://mugshot0.assets-yammer.com/mugshot/images/jm2p4dHNWgVr1Q1C5jbGvcmWqVM5W9Zj?P1=1684269325&P2=104&P3=1&P4=I\_DbxkwAcCq1cmFgxWINlSF3VQH9EqvZBvoYtO\_XqC4T0mboYO6i381CGmffkQvNAbhjlAn1u9uFg-9mnK0alNJI3DzstJNRSEvFEi-iu0TPnWM7obmcD6tLr5xPNnkhn0jVIcVCF\_l0MyMUGAL2tcSHRy\_j0IvfrP3i4jkColZbiYmng\_4QseJC5y1G9fFn7mpPt2LN7-Qew\_ybxWJXEh6ABLAoCm9\_PmV7TuUt4M\_s-pKDZkQA6\_CDgRLdcHzV2MgZVX0MhkYLnsonoqFiQfns9qmeMPrKAUawQKuupxEI9QHG\_4\_T\_Ncp5OfYXGQXmZt3L5OhAlk2SpoYhdBYtQ&size=48x48
+    mugshot\_redirect\_url | https://www.yammer.com/mugshot/images/redirect/48x48/jm2p4dHNWgVr1Q1C5jbGvcmWqVM5W9Zj
+    mugshot\_url\_template | https://mugshot0.assets-yammer.com/mugshot/images/jm2p4dHNWgVr1Q1C5jbGvcmWqVM5W9Zj?P1=1684269325&P2=104&P3=1&P4=I\_DbxkwAcCq1cmFgxWINlSF3VQH9EqvZBvoYtO\_XqC4T0mboYO6i381CGmffkQvNAbhjlAn1u9uFg-9mnK0alNJI3DzstJNRSEvFEi-iu0TPnWM7obmcD6tLr5xPNnkhn0jVIcVCF\_l0MyMUGAL2tcSHRy\_j0IvfrP3i4jkColZbiYmng\_4QseJC5y1G9fFn7mpPt2LN7-Qew\_ybxWJXEh6ABLAoCm9\_PmV7TuUt4M\_s-pKDZkQA6\_CDgRLdcHzV2MgZVX0MhkYLnsonoqFiQfns9qmeMPrKAUawQKuupxEI9QHG\_4\_T\_Ncp5OfYXGQXmZt3L5OhAlk2SpoYhdBYtQ&size={width}x{height}
+    mugshot\_redirect\_url\_template | https://www.yammer.com/mugshot/images/redirect/{width}x{height}/jm2p4dHNWgVr1Q1C5jbGvcmWqVM5W9Zj
+    birth\_date |
+    birth\_date\_complete |
+    timezone | Pacific Time (US & Canada)
+    admin | false
+    verified\_admin | false
+    m365\_yammer\_admin | false
+    supervisor\_admin | false
+    o365\_tenant\_admin | false
+    answers\_admin | false
+    corporate\_communicator | false
+    can\_broadcast | false
+    email | johndoe@contoso.onmicrosoft.com
+    guest | false
+    aad\_guest | false
+    can\_view\_delegations | false
+    can\_create\_new\_network | true
+    can\_browse\_external\_networks | true
+    reaction\_accent\_color | none
+    significant\_other |
+    kids\_names |
+    show\_invite\_lightbox | false
+    ```

--- a/docs/docs/cmd/yammer/yammer-search.md
+++ b/docs/docs/cmd/yammer/yammer-search.md
@@ -131,9 +131,10 @@ m365 yammer search --queryText "community" --output json --limit 50
 === "Text"
 
     ```text
-    id                description      type     web_url
-    ----------------  ---------------  -------  ----------------------------------------------------------------------------
-    2000337648877569  Hello everyone!  message  https://www.yammer.com/contoso.onmicrosoft.com/messages/2000337648877569
+    description: It was great to meet so many of you at last week's sales conference! I came away...
+    id         : 2044787632865280
+    type       : message
+    web_url    : https://www.yammer.com/m365x47213793.onmicrosoft.com/messages/2044787632865280
     ```
 
 === "CSV"
@@ -141,4 +142,15 @@ m365 yammer search --queryText "community" --output json --limit 50
     ```csv
     id,description,type,web_url
     2000337648877569,Hello everyone!,message,https://www.yammer.com/contoso.onmicrosoft.com/messages/2000337648877569
+    ```
+
+=== "Markdown"
+
+    ```md
+    # yammer search --queryText "contoso.onmicrosoft.com" --show "users" --limit "1"
+
+    Date: 2023-05-16
+
+    Property | Value
+    ---------|-------
     ```


### PR DESCRIPTION
Closes #4300

The text response format for the `m365 yammer search` in the document was incorrect. Additionally, the `csv` and `md` responses are empty. I have corrected the `text` output format and added the `md` response as it is currently shown, but it may need to be investigated as a separate issue as to why the `csv`, and `md` responses for this command are empty.