### PR TITLE
Centralize core command logic in mocha hooks. Closes #4901

### DIFF
--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -212,7 +212,7 @@ class MockCommandWithRawOutput extends AnonymousCommand {
       await logger.logToStderr('Debug output');
     }
 
-    await logger.logRaw('Raw output');
+    await logger.logRaw!('Raw output');
   }
 }
 

--- a/src/cli/Logger.ts
+++ b/src/cli/Logger.ts
@@ -6,7 +6,7 @@ export interface Logger {
   /**
    * Logs message without formatting to stdout
    */
-  logRaw: (message: any) => Promise<void>;
+  logRaw?: (message: any) => Promise<void>;
   /**
    * Logs message without formatting to stderr
    */

--- a/src/m365/spo/commands/cdn/cdn-origin-add.spec.ts
+++ b/src/m365/spo/commands/cdn/cdn-origin-add.spec.ts
@@ -3,38 +3,20 @@ import sinon from 'sinon';
 import auth from '../../../../Auth.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import config from '../../../../config.js';
 import request from '../../../../request.js';
-import { telemetry } from '../../../../telemetry.js';
-import { pid } from '../../../../utils/pid.js';
-import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
-import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import command from './cdn-origin-add.js';
+import { centralizedAfterEachHook, centralizedAfterHook, centralizedBeforeEachHook, centralizedBeforeHook, log, logger } from '../../../../utils/tests.js';
 
 describe(commands.CDN_ORIGIN_ADD, () => {
-  let log: string[];
-  let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(telemetry, 'trackEvent').returns();
-    sinon.stub(pid, 'getProcessName').returns('');
-    sinon.stub(session, 'getId').returns('');
-    sinon.stub(spo, 'getRequestDigest').resolves(
-      {
-        FormDigestValue: 'abc',
-        FormDigestTimeoutSeconds: 1800,
-        FormDigestExpiresAt: new Date(),
-        WebFullUrl: 'https://contoso.sharepoint.com'
-      }
-    );
-    auth.service.connected = true;
+    centralizedBeforeHook(true);
     auth.service.spoUrl = 'https://contoso.sharepoint.com';
     auth.service.tenantId = 'abc';
     sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -62,26 +44,16 @@ describe(commands.CDN_ORIGIN_ADD, () => {
   });
 
   beforeEach(() => {
-    log = [];
-    logger = {
-      log: async (msg: string) => {
-        log.push(msg);
-      },
-      logRaw: async (msg: string) => {
-        log.push(msg);
-      },
-      logToStderr: async (msg: string) => {
-        log.push(msg);
-      }
-    };
+    centralizedBeforeEachHook();
     requests = [];
   });
 
+  afterEach(() => {
+    centralizedAfterEachHook();
+  });
+
   after(() => {
-    sinon.restore();
-    auth.service.connected = false;
-    auth.service.spoUrl = undefined;
-    auth.service.tenantId = undefined;
+    centralizedAfterHook();
   });
 
   it('has correct name', () => {

--- a/src/m365/spo/commands/cdn/cdn-origin-add.spec.ts
+++ b/src/m365/spo/commands/cdn/cdn-origin-add.spec.ts
@@ -9,16 +9,25 @@ import request from '../../../../request.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './cdn-origin-add.js';
-import { centralizedAfterEachHook, centralizedAfterHook, centralizedBeforeEachHook, centralizedBeforeHook, log, logger } from '../../../../utils/tests.js';
+import { includeDefaultAfterHookSetup, includeDefaultBeforeEachHookSetup, includeDefaultAfterEachHookSetup, includeDefaultBeforeHookSetup, logger } from '../../../../utils/tests.js';
+import { spo } from '../../../../utils/spo.js';
 
 describe(commands.CDN_ORIGIN_ADD, () => {
   let commandInfo: CommandInfo;
   let requests: any[];
 
   before(() => {
-    centralizedBeforeHook(true);
+    includeDefaultBeforeHookSetup();
     auth.service.spoUrl = 'https://contoso.sharepoint.com';
     auth.service.tenantId = 'abc';
+    sinon.stub(spo, 'getRequestDigest').resolves(
+      {
+        FormDigestValue: 'abc',
+        FormDigestTimeoutSeconds: 1800,
+        FormDigestExpiresAt: new Date(),
+        WebFullUrl: 'https://contoso.sharepoint.com'
+      }
+    );
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
@@ -44,16 +53,16 @@ describe(commands.CDN_ORIGIN_ADD, () => {
   });
 
   beforeEach(() => {
-    centralizedBeforeEachHook();
+    includeDefaultBeforeEachHookSetup();
     requests = [];
   });
 
   afterEach(() => {
-    centralizedAfterEachHook();
+    includeDefaultAfterEachHookSetup();
   });
 
   after(() => {
-    centralizedAfterHook();
+    includeDefaultAfterHookSetup();
   });
 
   it('has correct name', () => {

--- a/src/m365/spo/commands/cdn/cdn-origin-remove.spec.ts
+++ b/src/m365/spo/commands/cdn/cdn-origin-remove.spec.ts
@@ -3,37 +3,21 @@ import sinon from 'sinon';
 import auth from '../../../../Auth.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import config from '../../../../config.js';
 import request from '../../../../request.js';
-import { telemetry } from '../../../../telemetry.js';
-import { pid } from '../../../../utils/pid.js';
-import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
-import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import command from './cdn-origin-remove.js';
+import { centralizedAfterEachHook, centralizedBeforeEachHook, centralizedBeforeHook, logger, promptOptions } from '../../../../utils/tests.js';
 
 describe(commands.CDN_ORIGIN_REMOVE, () => {
-  let log: string[];
-  let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(telemetry, 'trackEvent').returns();
-    sinon.stub(pid, 'getProcessName').returns('');
-    sinon.stub(session, 'getId').returns('');
-    sinon.stub(spo, 'getRequestDigest').resolves({
-      FormDigestValue: 'abc',
-      FormDigestTimeoutSeconds: 1800,
-      FormDigestExpiresAt: new Date(),
-      WebFullUrl: 'https://contoso.sharepoint.com'
-    });
-    auth.service.connected = true;
+    centralizedBeforeHook(true);
+
     auth.service.spoUrl = 'https://contoso.sharepoint.com';
     auth.service.tenantId = 'abc';
     sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -55,28 +39,13 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
   });
 
   beforeEach(() => {
-    log = [];
-    logger = {
-      log: async (msg: string) => {
-        log.push(msg);
-      },
-      logRaw: async (msg: string) => {
-        log.push(msg);
-      },
-      logToStderr: async (msg: string) => {
-        log.push(msg);
-      }
-    };
+    centralizedBeforeEachHook(true);
+
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
-    });
-    promptOptions = undefined;
   });
 
   afterEach(() => {
-    sinonUtil.restore(Cli.prompt);
+    centralizedAfterEachHook();
   });
 
   after(() => {

--- a/src/m365/spo/commands/cdn/cdn-origin-remove.spec.ts
+++ b/src/m365/spo/commands/cdn/cdn-origin-remove.spec.ts
@@ -76,7 +76,7 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
   });
 
   it('removes existing CDN origin from the public CDN when Public type specified without prompting with confirmation argument', async () => {
-    await command.action(testSetup.logger, { options: { origin: '*/cdn', confirm: true, type: 'Public' } });
+    await command.action(testSetup.logger, { options: { origin: '*/cdn', force: true, type: 'Public' } });
     let deleteRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
@@ -90,7 +90,7 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
   });
 
   it('removes existing CDN origin from the private CDN when Private type specified without prompting with confirmation argument', async () => {
-    await assert.rejects(command.action(testSetup.logger, { options: { origin: '*/cdn', confirm: true, type: 'Private' } }));
+    await assert.rejects(command.action(testSetup.logger, { options: { origin: '*/cdn', force: true, type: 'Private' } }));
     let deleteRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
@@ -104,7 +104,7 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
   });
 
   it('removes existing CDN origin from the private CDN when Private type specified without prompting with confirmation argument (debug)', async () => {
-    await assert.rejects(command.action(testSetup.logger, { options: { debug: true, origin: '*/cdn', confirm: true, type: 'Private' } }));
+    await assert.rejects(command.action(testSetup.logger, { options: { debug: true, origin: '*/cdn', force: true, type: 'Private' } }));
     let deleteRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
@@ -118,7 +118,7 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
   });
 
   it('removes existing CDN origin from the public CDN when no type specified without prompting with confirmation argument', async () => {
-    await command.action(testSetup.logger, { options: { origin: '*/cdn', confirm: true } });
+    await command.action(testSetup.logger, { options: { origin: '*/cdn', force: true } });
     let deleteRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf('/_vti_bin/client.svc/ProcessQuery') > -1 &&
@@ -187,14 +187,14 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(testSetup.logger, { options: { debug: true, origin: '*/cdn', confirm: true } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(testSetup.logger, { options: { debug: true, origin: '*/cdn', force: true } } as any), new CommandError('An error has occurred'));
   });
 
   it('correctly handles a random API error', async () => {
     sinonUtil.restore(request.post);
     sinon.stub(request, 'post').rejects(new Error('An error has occurred'));
 
-    await assert.rejects(command.action(testSetup.logger, { options: { origin: '*/cdn', confirm: true } } as any),
+    await assert.rejects(command.action(testSetup.logger, { options: { origin: '*/cdn', force: true } } as any),
       new CommandError('An error has occurred'));
   });
 

--- a/src/m365/spo/commands/sitescript/sitescript-remove.spec.ts
+++ b/src/m365/spo/commands/sitescript/sitescript-remove.spec.ts
@@ -3,52 +3,32 @@ import sinon from 'sinon';
 import auth from '../../../../Auth.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
-import { telemetry } from '../../../../telemetry.js';
-import { pid } from '../../../../utils/pid.js';
-import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import command from './sitescript-remove.js';
+import { centralizedAfterHook, centralizedBeforeEachHook, centralizedAfterEachHook, centralizedBeforeHook, logger } from '../../../../utils/tests.js';
 
 describe(commands.SITESCRIPT_REMOVE, () => {
-  let log: string[];
-  let logger: Logger;
   let commandInfo: CommandInfo;
   let promptOptions: any;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(telemetry, 'trackEvent').returns();
-    sinon.stub(pid, 'getProcessName').returns('');
-    sinon.stub(session, 'getId').returns('');
+    centralizedBeforeHook();
     sinon.stub(spo, 'getRequestDigest').resolves({
       FormDigestValue: 'ABC',
       FormDigestTimeoutSeconds: 1800,
       FormDigestExpiresAt: new Date(),
       WebFullUrl: 'https://contoso.sharepoint.com'
     });
-    auth.service.connected = true;
     auth.service.spoUrl = 'https://contoso.sharepoint.com';
     commandInfo = Cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
-    log = [];
-    logger = {
-      log: async (msg: string) => {
-        log.push(msg);
-      },
-      logRaw: async (msg: string) => {
-        log.push(msg);
-      },
-      logToStderr: async (msg: string) => {
-        log.push(msg);
-      }
-    };
+    centralizedBeforeEachHook();
     promptOptions = undefined;
     sinon.stub(Cli, 'prompt').callsFake(async (options) => {
       promptOptions = options;
@@ -57,6 +37,7 @@ describe(commands.SITESCRIPT_REMOVE, () => {
   });
 
   afterEach(() => {
+    centralizedAfterEachHook();
     sinonUtil.restore([
       request.post,
       Cli.prompt
@@ -64,9 +45,7 @@ describe(commands.SITESCRIPT_REMOVE, () => {
   });
 
   after(() => {
-    sinon.restore();
-    auth.service.connected = false;
-    auth.service.spoUrl = undefined;
+    centralizedAfterHook();
   });
 
   it('has correct name', () => {

--- a/src/m365/spo/commands/sitescript/sitescript-remove.spec.ts
+++ b/src/m365/spo/commands/sitescript/sitescript-remove.spec.ts
@@ -9,14 +9,14 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import command from './sitescript-remove.js';
-import { centralizedAfterHook, centralizedBeforeEachHook, centralizedAfterEachHook, centralizedBeforeHook, logger } from '../../../../utils/tests.js';
+import { includeDefaultAfterHookSetup, includeDefaultBeforeEachHookSetup, includeDefaultAfterEachHookSetup, includeDefaultBeforeHookSetup, logger } from '../../../../utils/tests.js';
 
 describe(commands.SITESCRIPT_REMOVE, () => {
   let commandInfo: CommandInfo;
   let promptOptions: any;
 
   before(() => {
-    centralizedBeforeHook();
+    includeDefaultBeforeHookSetup();
     sinon.stub(spo, 'getRequestDigest').resolves({
       FormDigestValue: 'ABC',
       FormDigestTimeoutSeconds: 1800,
@@ -28,7 +28,7 @@ describe(commands.SITESCRIPT_REMOVE, () => {
   });
 
   beforeEach(() => {
-    centralizedBeforeEachHook();
+    includeDefaultBeforeEachHookSetup();
     promptOptions = undefined;
     sinon.stub(Cli, 'prompt').callsFake(async (options) => {
       promptOptions = options;
@@ -37,7 +37,7 @@ describe(commands.SITESCRIPT_REMOVE, () => {
   });
 
   afterEach(() => {
-    centralizedAfterEachHook();
+    includeDefaultAfterEachHookSetup();
     sinonUtil.restore([
       request.post,
       Cli.prompt
@@ -45,7 +45,7 @@ describe(commands.SITESCRIPT_REMOVE, () => {
   });
 
   after(() => {
-    centralizedAfterHook();
+    includeDefaultAfterHookSetup();
   });
 
   it('has correct name', () => {

--- a/src/m365/spo/commands/sitescript/sitescript-remove.spec.ts
+++ b/src/m365/spo/commands/sitescript/sitescript-remove.spec.ts
@@ -71,7 +71,7 @@ describe(commands.SITESCRIPT_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(testSetup.logger, { options: { confirm: true, id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b' } });
+    await command.action(testSetup.logger, { options: { force: true, id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b' } });
   });
 
   it('prompts before removing the specified site script when confirm option not passed', async () => {
@@ -95,9 +95,8 @@ describe(commands.SITESCRIPT_REMOVE, () => {
     const postStub = sinon.stub(request, 'post').resolves();
 
     sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+
     await command.action(testSetup.logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6' } });
     assert(postStub.called);
   });
@@ -105,7 +104,7 @@ describe(commands.SITESCRIPT_REMOVE, () => {
   it('correctly handles error when site script not found', async () => {
     sinon.stub(request, 'post').rejects({ error: { 'odata.error': { message: { value: 'File Not Found.' } } } });
 
-    await assert.rejects(command.action(testSetup.logger, { options: { confirm: true, id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b' } } as any), new CommandError('File Not Found.'));
+    await assert.rejects(command.action(testSetup.logger, { options: { force: true, id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b' } } as any), new CommandError('File Not Found.'));
   });
 
   it('supports specifying id', () => {

--- a/src/m365/spo/commands/sitescript/sitescript-set.spec.ts
+++ b/src/m365/spo/commands/sitescript/sitescript-set.spec.ts
@@ -3,65 +3,42 @@ import sinon from 'sinon';
 import auth from '../../../../Auth.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
-import { telemetry } from '../../../../telemetry.js';
-import { pid } from '../../../../utils/pid.js';
-import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import command from './sitescript-set.js';
+import { centralizedAfterHook, centralizedBeforeEachHook, centralizedAfterEachHook, centralizedBeforeHook, logger, loggerLogSpy } from '../../../../utils/tests.js';
 
 describe(commands.SITESCRIPT_SET, () => {
-  let log: string[];
-  let logger: Logger;
-  let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(telemetry, 'trackEvent').returns();
-    sinon.stub(pid, 'getProcessName').returns('');
-    sinon.stub(session, 'getId').returns('');
+    centralizedBeforeHook();
     sinon.stub(spo, 'getRequestDigest').resolves({
       FormDigestValue: 'ABC',
       FormDigestTimeoutSeconds: 1800,
       FormDigestExpiresAt: new Date(),
       WebFullUrl: 'https://contoso.sharepoint.com'
     });
-    auth.service.connected = true;
     auth.service.spoUrl = 'https://contoso.sharepoint.com';
     commandInfo = Cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
-    log = [];
-    logger = {
-      log: async (msg: string) => {
-        log.push(msg);
-      },
-      logRaw: async (msg: string) => {
-        log.push(msg);
-      },
-      logToStderr: async (msg: string) => {
-        log.push(msg);
-      }
-    };
-    loggerLogSpy = sinon.spy(logger, 'log');
+    centralizedBeforeEachHook();
   });
 
   afterEach(() => {
+    centralizedAfterEachHook();
     sinonUtil.restore([
       request.post
     ]);
   });
 
   after(() => {
-    sinon.restore();
-    auth.service.connected = false;
-    auth.service.spoUrl = undefined;
+    centralizedAfterHook();
   });
 
   it('has correct name', () => {

--- a/src/m365/spo/commands/sitescript/sitescript-set.spec.ts
+++ b/src/m365/spo/commands/sitescript/sitescript-set.spec.ts
@@ -9,13 +9,14 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import command from './sitescript-set.js';
-import { includeDefaultAfterHookSetup, includeDefaultBeforeEachHookSetup, includeDefaultAfterEachHookSetup, includeDefaultBeforeHookSetup, logger, loggerLogSpy } from '../../../../utils/tests.js';
+import { CentralizedTestSetup, initializeTestSetup } from '../../../../utils/tests.js';
 
 describe(commands.SITESCRIPT_SET, () => {
   let commandInfo: CommandInfo;
+  let testSetup: CentralizedTestSetup;
 
   before(() => {
-    includeDefaultBeforeHookSetup();
+    testSetup = initializeTestSetup();
     sinon.stub(spo, 'getRequestDigest').resolves({
       FormDigestValue: 'ABC',
       FormDigestTimeoutSeconds: 1800,
@@ -27,18 +28,18 @@ describe(commands.SITESCRIPT_SET, () => {
   });
 
   beforeEach(() => {
-    includeDefaultBeforeEachHookSetup();
+    testSetup.runBeforeEachHookDefaults();
   });
 
   afterEach(() => {
-    includeDefaultAfterEachHookSetup();
+    testSetup.runAfterEachHookDefaults();
     sinonUtil.restore([
       request.post
     ]);
   });
 
   after(() => {
-    includeDefaultAfterHookSetup();
+    testSetup.runAfterHookDefaults();
   });
 
   it('has correct name', () => {
@@ -70,8 +71,8 @@ describe(commands.SITESCRIPT_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', title: 'Contoso' } });
-    assert(loggerLogSpy.calledWith({
+    await command.action(testSetup.logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', title: 'Contoso' } });
+    assert(testSetup.loggerLogSpy.calledWith({
       "Content": JSON.stringify({}),
       "Description": "My contoso script",
       "Id": "0f27a016-d277-4bb4-b3c3-b5b040c9559b",
@@ -101,8 +102,8 @@ describe(commands.SITESCRIPT_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', title: 'Contoso' } });
-    assert(loggerLogSpy.calledWith({
+    await command.action(testSetup.logger, { options: { debug: true, id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', title: 'Contoso' } });
+    assert(testSetup.loggerLogSpy.calledWith({
       "Content": JSON.stringify({}),
       "Description": "My contoso script",
       "Id": "0f27a016-d277-4bb4-b3c3-b5b040c9559b",
@@ -132,8 +133,8 @@ describe(commands.SITESCRIPT_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', description: 'My contoso script' } });
-    assert(loggerLogSpy.calledWith({
+    await command.action(testSetup.logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', description: 'My contoso script' } });
+    assert(testSetup.loggerLogSpy.calledWith({
       "Content": JSON.stringify({}),
       "Description": "My contoso script",
       "Id": "0f27a016-d277-4bb4-b3c3-b5b040c9559b",
@@ -163,8 +164,8 @@ describe(commands.SITESCRIPT_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', version: '1' } });
-    assert(loggerLogSpy.calledWith({
+    await command.action(testSetup.logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', version: '1' } });
+    assert(testSetup.loggerLogSpy.calledWith({
       "Content": JSON.stringify({}),
       "Description": "My contoso script",
       "Id": "0f27a016-d277-4bb4-b3c3-b5b040c9559b",
@@ -194,8 +195,8 @@ describe(commands.SITESCRIPT_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', content: JSON.stringify({}) } });
-    assert(loggerLogSpy.calledWith({
+    await command.action(testSetup.logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', content: JSON.stringify({}) } });
+    assert(testSetup.loggerLogSpy.calledWith({
       "Content": JSON.stringify({}),
       "Description": "My contoso script",
       "Id": "0f27a016-d277-4bb4-b3c3-b5b040c9559b",
@@ -228,8 +229,8 @@ describe(commands.SITESCRIPT_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', title: 'Contoso', description: 'My contoso script', version: '1', content: JSON.stringify({}) } });
-    assert(loggerLogSpy.calledWith({
+    await command.action(testSetup.logger, { options: { id: '0f27a016-d277-4bb4-b3c3-b5b040c9559b', title: 'Contoso', description: 'My contoso script', version: '1', content: JSON.stringify({}) } });
+    assert(testSetup.loggerLogSpy.calledWith({
       "Content": JSON.stringify({}),
       "Description": "My contoso script",
       "Id": "0f27a016-d277-4bb4-b3c3-b5b040c9559b",
@@ -241,7 +242,7 @@ describe(commands.SITESCRIPT_SET, () => {
   it('correctly handles OData error when creating site script', async () => {
     sinon.stub(request, 'post').rejects({ error: { 'odata.error': { message: { value: 'An error has occurred' } } } });
 
-    await assert.rejects(command.action(logger, { options: { id: '449c0c6d-5380-4df2-b84b-622e0ac8ec24', title: 'Contoso' } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(testSetup.logger, { options: { id: '449c0c6d-5380-4df2-b84b-622e0ac8ec24', title: 'Contoso' } } as any), new CommandError('An error has occurred'));
   });
 
   it('supports specifying id', () => {

--- a/src/m365/spo/commands/sitescript/sitescript-set.spec.ts
+++ b/src/m365/spo/commands/sitescript/sitescript-set.spec.ts
@@ -9,13 +9,13 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import command from './sitescript-set.js';
-import { centralizedAfterHook, centralizedBeforeEachHook, centralizedAfterEachHook, centralizedBeforeHook, logger, loggerLogSpy } from '../../../../utils/tests.js';
+import { includeDefaultAfterHookSetup, includeDefaultBeforeEachHookSetup, includeDefaultAfterEachHookSetup, includeDefaultBeforeHookSetup, logger, loggerLogSpy } from '../../../../utils/tests.js';
 
 describe(commands.SITESCRIPT_SET, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    centralizedBeforeHook();
+    includeDefaultBeforeHookSetup();
     sinon.stub(spo, 'getRequestDigest').resolves({
       FormDigestValue: 'ABC',
       FormDigestTimeoutSeconds: 1800,
@@ -27,18 +27,18 @@ describe(commands.SITESCRIPT_SET, () => {
   });
 
   beforeEach(() => {
-    centralizedBeforeEachHook();
+    includeDefaultBeforeEachHookSetup();
   });
 
   afterEach(() => {
-    centralizedAfterEachHook();
+    includeDefaultAfterEachHookSetup();
     sinonUtil.restore([
       request.post
     ]);
   });
 
   after(() => {
-    centralizedAfterHook();
+    includeDefaultAfterHookSetup();
   });
 
   it('has correct name', () => {

--- a/src/m365/spo/commands/spo-get.spec.ts
+++ b/src/m365/spo/commands/spo-get.spec.ts
@@ -1,55 +1,31 @@
 import assert from 'assert';
-import sinon from 'sinon';
 import auth from '../../../Auth.js';
 import { CommandError } from '../../../Command.js';
 import { Cli } from '../../../cli/Cli.js';
 import { CommandInfo } from '../../../cli/CommandInfo.js';
-import { Logger } from '../../../cli/Logger.js';
-import { telemetry } from '../../../telemetry.js';
-import { pid } from '../../../utils/pid.js';
-import { session } from '../../../utils/session.js';
+import { centralizedAfterHook, centralizedBeforeEachHook, centralizedAfterEachHook, centralizedBeforeHook, logger, loggerLogSpy } from '../../../utils/tests.js';
 import commands from '../commands.js';
 import command from './spo-get.js';
 
 describe(commands.GET, () => {
-  let log: string[];
-  let logger: Logger;
-  let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(auth, 'storeConnectionInfo').resolves();
-    sinon.stub(telemetry, 'trackEvent').returns();
-    sinon.stub(pid, 'getProcessName').returns('');
-    sinon.stub(session, 'getId').returns('');
-    auth.service.connected = true;
+    centralizedBeforeHook();
     commandInfo = Cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
-    log = [];
-    logger = {
-      log: async (msg: string) => {
-        log.push(msg);
-      },
-      logRaw: async (msg: string) => {
-        log.push(msg);
-      },
-      logToStderr: async (msg: string) => {
-        log.push(msg);
-      }
-    };
-    loggerLogSpy = sinon.spy(logger, 'log');
+    centralizedBeforeEachHook();
   });
 
   afterEach(() => {
+    centralizedAfterEachHook();
     auth.service.spoUrl = undefined;
   });
 
   after(() => {
-    sinon.restore();
-    auth.service.connected = false;
+    centralizedAfterHook();
   });
 
   it('has correct name', () => {
@@ -61,8 +37,6 @@ describe(commands.GET, () => {
   });
 
   it('gets SPO URL when no URL was get previously', async () => {
-    auth.service.spoUrl = undefined;
-
     await command.action(logger, {
       options: {
         output: 'json',
@@ -128,4 +102,6 @@ describe(commands.GET, () => {
     const actual = await command.validate({ options: {} }, commandInfo);
     assert.strictEqual(actual, true);
   });
+
 });
+

--- a/src/m365/spo/commands/spo-get.spec.ts
+++ b/src/m365/spo/commands/spo-get.spec.ts
@@ -3,7 +3,7 @@ import auth from '../../../Auth.js';
 import { CommandError } from '../../../Command.js';
 import { Cli } from '../../../cli/Cli.js';
 import { CommandInfo } from '../../../cli/CommandInfo.js';
-import { centralizedAfterHook, centralizedBeforeEachHook, centralizedAfterEachHook, centralizedBeforeHook, logger, loggerLogSpy } from '../../../utils/tests.js';
+import { includeDefaultAfterHookSetup, includeDefaultBeforeEachHookSetup, includeDefaultAfterEachHookSetup, includeDefaultBeforeHookSetup, logger, loggerLogSpy } from '../../../utils/tests.js';
 import commands from '../commands.js';
 import command from './spo-get.js';
 
@@ -11,21 +11,21 @@ describe(commands.GET, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    centralizedBeforeHook();
+    includeDefaultBeforeHookSetup();
     commandInfo = Cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
-    centralizedBeforeEachHook();
+    includeDefaultBeforeEachHookSetup();
   });
 
   afterEach(() => {
-    centralizedAfterEachHook();
+    includeDefaultAfterEachHookSetup();
     auth.service.spoUrl = undefined;
   });
 
   after(() => {
-    centralizedAfterHook();
+    includeDefaultAfterHookSetup();
   });
 
   it('has correct name', () => {

--- a/src/m365/spo/commands/spo-set.spec.ts
+++ b/src/m365/spo/commands/spo-set.spec.ts
@@ -7,27 +7,27 @@ import { CommandError } from '../../../Command.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
 import command from './spo-set.js';
-import { centralizedAfterEachHook, centralizedAfterHook, centralizedBeforeEachHook, centralizedBeforeHook, logger } from '../../../utils/tests.js';
+import { includeDefaultAfterHookSetup, includeDefaultBeforeEachHookSetup, includeDefaultAfterEachHookSetup, includeDefaultBeforeHookSetup, logger } from '../../../utils/tests.js';
 
 describe(commands.SET, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    centralizedBeforeHook();
+    includeDefaultBeforeHookSetup();
     commandInfo = Cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
-    centralizedBeforeEachHook();
+    includeDefaultBeforeEachHookSetup();
   });
 
   afterEach(() => {
-    centralizedAfterEachHook();
+    includeDefaultAfterEachHookSetup();
     auth.service.spoUrl = undefined;
   });
 
   after(() => {
-    centralizedAfterHook();
+    includeDefaultAfterHookSetup();
   });
 
   it('has correct name', () => {

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -6,19 +6,17 @@ import sinon = require('sinon');
 import { Logger } from '../cli/Logger';
 import { Cli } from '../cli/Cli';
 import { sinonUtil } from './sinonUtil';
-import { spo } from './spo';
 
 let cli: Cli;
 export let log: string[] = [];
 export let loggerLogSpy: sinon.SinonSpy;
 export let loggerLogToStderrSpy: sinon.SinonSpy;
-export let promptOptions: any;
 export const logger: Logger = {
   log: (msg: string) => log.push(msg),
   logToStderr: (msg: string) => log.push(msg)
 };
 
-export function centralizedBeforeHook(includeRequestDigest: boolean = false): void {
+export function includeDefaultBeforeHookSetup(): void {
   cli = Cli.getInstance();
   sinon.stub(auth, 'restoreAuth').resolves();
   sinon.stub(auth, 'storeConnectionInfo').resolves();
@@ -28,43 +26,19 @@ export function centralizedBeforeHook(includeRequestDigest: boolean = false): vo
   loggerLogSpy = sinon.spy(logger, 'log');
   loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
   auth.service.connected = true;
-
-  if (includeRequestDigest) {
-    sinon.stub(spo, 'getRequestDigest').resolves({
-      FormDigestValue: 'ABC',
-      FormDigestTimeoutSeconds: 1800,
-      FormDigestExpiresAt: new Date(),
-      WebFullUrl: 'https://contoso.sharepoint.com'
-    });
-    sinon.stub(spo, 'ensureFormDigest').resolves({
-      FormDigestValue: 'ABC',
-      FormDigestTimeoutSeconds: 1800,
-      FormDigestExpiresAt: new Date(),
-      WebFullUrl: 'https://contoso.sharepoint.com'
-    });
-  }
 }
 
-export function centralizedBeforeEachHook(includePrompt: boolean = false): void {
+export function includeDefaultBeforeEachHookSetup(): void {
   log = [];
   sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(((settingName, defaultValue) => defaultValue));
   auth.service.connected = true;
-
-  if (includePrompt) {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
-    });
-    promptOptions = undefined;
-  }
 }
 
-export function centralizedAfterEachHook(): void {
+export function includeDefaultAfterEachHookSetup(): void {
   sinonUtil.restore([cli.getSettingWithDefaultValue]);
 }
 
-export function centralizedAfterHook(): void {
+export function includeDefaultAfterHookSetup(): void {
   sinon.restore();
   auth.service.connected = false;
   auth.service.spoUrl = undefined;

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -1,0 +1,73 @@
+import { telemetry } from '../telemetry';
+import { pid } from './pid';
+import { session } from './session';
+import auth from '../Auth';
+import sinon = require('sinon');
+import { Logger } from '../cli/Logger';
+import { Cli } from '../cli/Cli';
+import { sinonUtil } from './sinonUtil';
+import { spo } from './spo';
+
+let cli: Cli;
+export let log: string[] = [];
+export let loggerLogSpy: sinon.SinonSpy;
+export let loggerLogToStderrSpy: sinon.SinonSpy;
+export let promptOptions: any;
+export const logger: Logger = {
+  log: (msg: string) => log.push(msg),
+  logToStderr: (msg: string) => log.push(msg)
+};
+
+export function centralizedBeforeHook(includeRequestDigest: boolean = false): void {
+  cli = Cli.getInstance();
+  sinon.stub(auth, 'restoreAuth').resolves();
+  sinon.stub(auth, 'storeConnectionInfo').resolves();
+  sinon.stub(telemetry, 'trackEvent').returns();
+  sinon.stub(pid, 'getProcessName').returns('');
+  sinon.stub(session, 'getId').returns('');
+  loggerLogSpy = sinon.spy(logger, 'log');
+  loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
+  auth.service.connected = true;
+
+  if (includeRequestDigest) {
+    sinon.stub(spo, 'getRequestDigest').resolves({
+      FormDigestValue: 'ABC',
+      FormDigestTimeoutSeconds: 1800,
+      FormDigestExpiresAt: new Date(),
+      WebFullUrl: 'https://contoso.sharepoint.com'
+    });
+    sinon.stub(spo, 'ensureFormDigest').resolves({
+      FormDigestValue: 'ABC',
+      FormDigestTimeoutSeconds: 1800,
+      FormDigestExpiresAt: new Date(),
+      WebFullUrl: 'https://contoso.sharepoint.com'
+    });
+  }
+}
+
+export function centralizedBeforeEachHook(includePrompt: boolean = false): void {
+  log = [];
+  sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(((settingName, defaultValue) => defaultValue));
+  auth.service.connected = true;
+
+  if (includePrompt) {
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
+      promptOptions = options;
+      return { continue: false };
+    });
+    promptOptions = undefined;
+  }
+}
+
+export function centralizedAfterEachHook(): void {
+  sinonUtil.restore([cli.getSettingWithDefaultValue]);
+}
+
+export function centralizedAfterHook(): void {
+  sinon.restore();
+  auth.service.connected = false;
+  auth.service.spoUrl = undefined;
+  auth.service.tenantId = undefined;
+  auth.service.accessTokens = {};
+}

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -1,11 +1,11 @@
-import { telemetry } from '../telemetry';
-import { pid } from './pid';
-import { session } from './session';
-import auth from '../Auth';
-import sinon = require('sinon');
-import { Logger } from '../cli/Logger';
-import { Cli } from '../cli/Cli';
-import { sinonUtil } from './sinonUtil';
+import { telemetry } from '../telemetry.js';
+import { pid } from './pid.js';
+import { session } from './session.js';
+import auth from '../Auth.js';
+import sinon from 'sinon';
+import { Logger } from '../cli/Logger.js';
+import { Cli } from '../cli/Cli.js';
+import { sinonUtil } from './sinonUtil.js';
 
 export interface CentralizedTestSetup {
   log: () => string[];
@@ -20,8 +20,8 @@ export interface CentralizedTestSetup {
 export function initializeTestSetup(): CentralizedTestSetup {
   const cli = Cli.getInstance();
   const logger: Logger = {
-    log: (msg: string) => log.push(msg),
-    logToStderr: (msg: string) => log.push(msg)
+    log: async (msg: string) => { await Promise.resolve(); log.push(msg); },
+    logToStderr: async (msg: string) => { await Promise.resolve(); log.push(msg); }
   };
   let log: string[] = [];
   const loggerLogSpy: sinon.SinonSpy = sinon.spy(logger, 'log');


### PR DESCRIPTION
Closes #4901

A way to centralize some code.

> I had a test coverage issue with the `logRaw` function of the Logger interface. I checked and we're only using it once. I made the `logRaw` function optional to work around the issue.

