### PR TITLE
Documentation update - spo contenttype set

### DIFF
--- a/docs/docs/cmd/spo/contenttype/contenttype-set.md
+++ b/docs/docs/cmd/spo/contenttype/contenttype-set.md
@@ -1,6 +1,6 @@
 # spo contenttype set
 
-Update an existing content type
+Updates an existing content type
 
 ## Usage
 
@@ -16,7 +16,7 @@ m365 spo contenttype set [options]
 `-i, --id [id]`
 : ID of the content type to update. Specify `id` or `name` but not both, one is required.
 
-`-n, name [name]`
+`-n, --name [name]`
 : Name of the content type to update. Specify the `id` or the `name` but not both, one is required.
 
 `--listTitle [listTitle]`


### PR DESCRIPTION
Updated documentation of below command(s):
- `spo contenttype set`

Corrected cmdlet documentation to fix the issue with "name" option/parameter. It should be `--name` and not `name` only.