### PR TITLE
Enhances `spo folder copy` documentation

### DIFF
--- a/docs/docs/cmd/spo/folder/folder-copy.md
+++ b/docs/docs/cmd/spo/folder/folder-copy.md
@@ -45,7 +45,7 @@ m365 spo folder copy --webUrl https://contoso.sharepoint.com/sites/test1 --sourc
 Copies folder to a document library in another site collection. Allow for schema mismatch
 
 ```sh
-m365 spo folder cope --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/MyFolder --targetUrl /sites/test2/Shared%20Documents/ --allowSchemaMismatch
+m365 spo folder copy --webUrl https://contoso.sharepoint.com/sites/test1 --sourceUrl /Shared%20Documents/MyFolder --targetUrl /sites/test2/Shared%20Documents/ --allowSchemaMismatch
 ```
 
 ## More information


### PR DESCRIPTION
Noticed a little typo in the documentation of `spo folder copy`. In the third example it has to be `spo folder copy` instead of `spo folder cope`