### PR TITLE
Export Microsoft Teams messages for the given user or team

### DIFF
--- a/docs/docs/cmd/teams/message/message-export.mdx
+++ b/docs/docs/cmd/teams/message/message-export.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams message export
 
-Export Microsoft Teams chat messages for a given user or a team.
+Exports Microsoft Teams chat messages for a given user or a team.
 
 ## Usage
 
@@ -15,25 +15,25 @@ m365 teams message export [options]
 ## Options
 
 ```md definition-list
-`--userId [userId]`
+`-u, --userId [userId]`
 : The ID of the user whose messages are to be exported. Specify either `userId`, `userName` or `teamId`
 
-`--userName [userName]`
+`-n, --userName [userName]`
 : The UPN of the user whose messages are to be exported. Specify either `userId`, `userName` or `teamId`.
 
-`--teamId [teamId]`
+`-i, --teamId [teamId]`
 : The ID of the team of which the messages are to be exported. Specify either `userId`, `userName` or `teamId`.
 
-`--fromDateTime [fromDateTime]`
-: The start time range to query. This should be defined as a valid ISO 8601 string. `2021-12-16T18:28:48.6964197Z`
+`-f, --fromDateTime [fromDateTime]`
+: The start of the time range to query. This should be defined as a valid ISO 8601 string. `2021-12-16T18:28:48.6964197Z`
 
-`--toDateTime [toDateTime]`
-: The end time range to query. This should be defined as a valid ISO 8601 string. `2021-12-16T18:28:48.6964197Z`
+`-t --toDateTime [toDateTime]`
+: The end of the time range to query. This should be defined as a valid ISO 8601 string. `2021-12-16T18:28:48.6964197Z`
 
-`--withAttachments`
+`-a, --withAttachments`
 : When specified, the command will also download all chat attachments. Use `folderPath` as well to set the rootfolder.
 
-`--folderPath [folderPath]`
+`-p, --folderPath [folderPath]`
 : The folder path to save downloaded attachments to when using `withAttachments`. A specific folder will be created to store the attachments for every message.
 ```
 

--- a/docs/docs/cmd/teams/message/message-export.mdx
+++ b/docs/docs/cmd/teams/message/message-export.mdx
@@ -1,0 +1,170 @@
+import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# teams message export
+
+Export Microsoft Teams chat messages for a given user or a team.
+
+## Usage
+
+```sh
+m365 teams message export [options]
+```
+
+## Options
+
+```md definition-list
+`--userId [userId]`
+: The ID of the user whose messages are to be exported. Specify either `userId`, `userName` or `teamId`
+
+`--userName [userName]`
+: The UPN of the user whose messages are to be exported. Specify either `userId`, `userName` or `teamId`.
+
+`--teamId [teamId]`
+: The ID of the team of which the messages are to be exported. Specify either `userId`, `userName` or `teamId`.
+
+`--fromDateTime [fromDateTime]`
+: The start time range to query. This should be defined as a valid ISO 8601 string. `2021-12-16T18:28:48.6964197Z`
+
+`--toDateTime [toDateTime]`
+: The end time range to query. This should be defined as a valid ISO 8601 string. `2021-12-16T18:28:48.6964197Z`
+
+`--withAttachments`
+: When specified, the command will also download all chat attachments. Use `folderPath` as well to set the rootfolder.
+
+`--folderPath [folderPath]`
+: The folder path to save downloaded attachments to when using `withAttachments`. A specific folder will be created to store the attachments for every message.
+```
+
+<Global />
+
+## Remarks
+
+Microsoft Teams APIs in Microsoft Graph that access sensitive data are considered protected APIs. Export APIs require that you have additional validation, beyond permissions and consent, before you can use them. To access the protected APIs, please refer to the following url: [Enable metered APIs and services in Microsoft Graph](https://learn.microsoft.com/en-us/graph/metered-api-setup?tabs=azurecloudshell)
+
+## Examples
+
+Export all messages for a specific Microsoft Teams team with the attachments being saved in the folder 'C:\Temp'.
+
+```sh
+m365 teams message export --teamId 80fc64e4-f5e1-4dc1-b34c-3198375bd9b2 --withAttachments --folderPath C:\Temp
+```
+
+Export all messages for a specific user retrieved by id.
+
+```sh
+m365 teams message export --userId 5f5d7b71-1161-44d8-bcc1-3da710eb4171
+```
+
+Export all messages for a specific user retrieved by UPN between a set of dates.
+
+```sh
+m365 teams message export --userName john@contoso.com --fromDateTime 2023-04-01T00:00:00Z --toDateTime 2023-04-30T23:59:59Z
+```
+
+## Response
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ``` json
+  [
+    {
+      "id":"1683611790633",
+      "replyToId":null,
+      "etag":"1683612581046",
+      "messageType":"message",
+      "createdDateTime":"2023-05-09T05:56:30.633Z",
+      "lastModifiedDateTime":"2023-05-09T06:09:41.046Z",
+      "lastEditedDateTime":"2023-05-09T06:09:40.914Z",
+      "deletedDateTime":null,
+      "subject":null,
+      "summary":null,
+      "chatId":null,
+      "importance":"normal",
+      "locale":"en-us",
+      "webUrl":"https://teams.microsoft.com/l/message/19%3A0ade024bcdec4f4fbb03dfa0e5afc3ee%40thread.tacv2/1683611790633?groupId=80fc64e4-f5e1-4dc1-b34c-3198375bd9b2&tenantId=e1dd4023-a656-480a-8a0e-c1b1eec51e1d&createdTime=1683611790633&parentMessageId=1683611790633",
+      "policyViolation":null,
+      "eventDetail":null,
+      "from":{
+        "application":null,
+        "device":null,
+        "user":{
+          "id":"fe36f75e-c103-410b-a18a-2bf6df06ac3a",
+          "displayName":"John Doe",
+          "userIdentityType":"aadUser",
+          "tenantId":"e1dd4023-a656-480a-8a0e-c1b1eec51e1d"
+        }
+      },
+      "body":{
+        "contentType":"text",
+        "content":"CLI For Microsoft 365 Rocks! <attachment id=\\'161D73CB-20D7-47FC-95CA-2E60A5A44D8D\\'></attachment>"
+      },
+      "channelIdentity":{
+        "teamId":"80fc64e4-f5e1-4dc1-b34c-3198375bd9b2",
+        "channelId":"19:0ade024bcdec4f4fbb03dfa0e5afc3ee@thread.tacv2"
+      },
+      "attachments":[
+        {
+          "id":"161D73CB-20D7-47FC-95CA-2E60A5A44D8D",
+          "contentType":"reference",
+          "contentUrl":"https://contoso-my.sharepoint.com/personal/john_contoso_onmicrosoft_com/Documents/File1.pdf",
+          "content":null,
+          "name":"File1.pdf",
+          "thumbnailUrl":null,
+          "teamsAppId":null
+        }
+      ],
+      "mentions":[
+        
+      ],
+      "reactions":[
+        
+      ]
+    }
+  ]
+  ```
+
+  </TabItem>
+  <TabItem value="Text">
+
+  ``` text
+  id             replyToId  etag           messageType  createdDateTime           lastModifiedDateTime      lastEditedDateTime        deletedDateTime  subject  summary  chatId  importance  locale  webUrl                                                                                                                                                                                                                                                       policyViolation  eventDetail  from             body             channelIdentity  attachments                      mentions  reactions
+  -------------  ---------  -------------  -----------  ------------------------  ------------------------  ------------------------  ---------------  -------  -------  ------  ----------  ------  -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ---------------  -----------  ---------------  ---------------  ---------------  -------------------------------  --------  ---------
+  1683611790633  null       1683612581046  message      2023-05-09T05:56:30.633Z  2023-05-09T06:09:41.046Z  2023-05-09T06:09:40.914Z  null             null     null     null    normal      en-us   https://teams.microsoft.com/l/message/19%3A0ade024bcdec4f4fbb03dfa0e5afc3ee%40thread.tacv2/1683611790633?groupId=80fc64e4-f5e1-4dc1-b34c-3198375bd9b2&tenantId=e1dd4023-a656-480a-8a0e-c1b1eec51e1d&createdTime=1683611790633&parentMessageId=1683611790633  null             null         [object Object]  [object Object]  [object Object]  [object Object],[object Object]
+  ```
+
+  </TabItem>
+  <TabItem value="CSV">
+
+  ```csv
+  id,etag,messageType,createdDateTime,lastModifiedDateTime,lastEditedDateTime,importance,locale,webUrl
+  1683611790633,1683612581046,message,2023-05-09T05:56:30.633Z,2023-05-09T06:09:41.046Z,2023-05-09T06:09:40.914Z,normal,en-us,https://teams.microsoft.com/l/message/19%3A0ade024bcdec4f4fbb03dfa0e5afc3ee%40thread.tacv2/1683611790633?groupId=80fc64e4-f5e1-4dc1-b34c-3198375bd9b2&tenantId=e1dd4023-a656-480a-8a0e-c1b1eec51e1d&createdTime=1683611790633&parentMessageId=1683611790633
+  ```
+
+  </TabItem>
+  <TabItem value="Markdown">
+
+  ```md
+  # teams message export --teamId "80fc64e4-f5e1-4dc1-b34c-3198375bd9b2"
+
+  Date: 21/05/2023
+
+  ## 1683611790633
+
+  Property | Value
+  ---------|-------
+  id | 1683611790633
+  etag | 1683612581046
+  messageType | message
+  createdDateTime | 2023-05-09T05:56:30.633Z
+  lastModifiedDateTime | 2023-05-09T06:09:41.046Z
+  lastEditedDateTime | 2023-05-09T06:09:40.914Z
+  importance | normal
+  locale | en-us
+  webUrl | https://teams.microsoft.com/l/message/19%3A0ade024bcdec4f4fbb03dfa0e5afc3ee%40thread.tacv2/1683611790633?groupId=80fc64e4-f5e1-4dc1-b34c-3198375bd9b2&tenantId=e1dd4023-a656-480a-8a0e-c1b1eec51e1d&createdTime=1683611790633&parentMessageId=1683611790633
+  ```
+  
+  </TabItem>
+</Tabs>

--- a/docs/src/config/sidebars.js
+++ b/docs/src/config/sidebars.js
@@ -3699,6 +3699,11 @@ const sidebars = {
           message: [
             {
               type: 'doc',
+              label: 'message export',
+              id: 'cmd/teams/message/message-export'
+            },
+            {
+              type: 'doc',
               label: 'message get',
               id: 'cmd/teams/message/message-get'
             },

--- a/src/m365/teams/commands.ts
+++ b/src/m365/teams/commands.ts
@@ -33,6 +33,7 @@ export default {
   MEETING_TRANSCRIPT_LIST: `${prefix} meeting transcript list`,
   MEMBERSETTINGS_LIST: `${prefix} membersettings list`,
   MEMBERSETTINGS_SET: `${prefix} membersettings set`,
+  MESSAGE_EXPORT: `${prefix} message export`,
   MESSAGE_GET: `${prefix} message get`,
   MESSAGE_LIST: `${prefix} message list`,
   MESSAGE_REPLY_LIST: `${prefix} message reply list`,

--- a/src/m365/teams/commands/message/message-export.spec.ts
+++ b/src/m365/teams/commands/message/message-export.spec.ts
@@ -1,0 +1,124 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { telemetry } from '../../../../telemetry';
+import auth from '../../../../Auth';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { pid } from '../../../../utils/pid';
+import { session } from '../../../../utils/session';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+import * as fs from 'fs';
+const command: Command = require('./message-export');
+
+describe(commands.MESSAGE_EXPORT, () => {
+  const userId = '11f43044-095e-456a-b339-7e1901b0c3ae';
+  const teamId = '75619fc7-5dce-412b-82ee-f76988d3efaa';
+  const fromDateTime = '2023-04-01T00:00:00Z';
+  const toDateTime = '2023-04-30T23:59:59Z';
+  const folderPath = 'C:\\Temp';
+
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    sinon.stub(session, 'getId').callsFake(() => '');
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get
+    ]);
+  });
+
+  after(() => {
+    sinonUtil.restore([
+      auth.restoreAuth,
+      telemetry.trackEvent,
+      pid.getProcessName,
+      session.getId
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.MESSAGE_EXPORT);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if userId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { folderPath: folderPath, userId: 'invalid', withAttachments: false } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if userName is not a valid userPrincipalName', async () => {
+    const actual = await command.validate({ options: { folderPath: folderPath, userName: 'invalid', withAttachments: false } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if teamId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { folderPath: folderPath, teamId: 'invalid', withAttachments: false } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if fromDateTime is not a valid ISO DateTime', async () => {
+    const actual = await command.validate({ options: { folderPath: folderPath, userId: userId, fromDateTime: 'invalid', withAttachments: false } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if toDateTime is not a valid ISO DateTime', async () => {
+    const actual = await command.validate({ options: { folderPath: folderPath, userId: userId, toDateTime: 'invalid', withAttachments: false } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if folderPath does not exist', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => false);
+    const actual = await command.validate({ options: { folderPath: folderPath, userId: userId, withAttachments: false } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+    sinonUtil.restore(fs.existsSync);
+  });
+
+  it('passes validation if folderPath exists and userId is a valid GUID', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => true);
+    const actual = await command.validate({ options: { folderPath: folderPath, userId: userId, withAttachments: false } }, commandInfo);
+    assert.strictEqual(actual, true);
+    sinonUtil.restore(fs.existsSync);
+  });
+
+  it('passes validation if folderPath exists, teamId is a valid GUID and both dates are valid ISO dates', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => true);
+    const actual = await command.validate({ options: { folderPath: folderPath, teamId: teamId, fromDateTime: fromDateTime, toDateTime: toDateTime, withAttachments: false } }, commandInfo);
+    assert.strictEqual(actual, true);
+    sinonUtil.restore(fs.existsSync);
+  });
+
+});

--- a/src/m365/teams/commands/message/message-export.spec.ts
+++ b/src/m365/teams/commands/message/message-export.spec.ts
@@ -164,6 +164,7 @@ describe(commands.MESSAGE_EXPORT, () => {
 
     await command.action(logger, { options: { userName: userPrincipalName, fromDateTime: fromDateTime, toDateTime: toDateTime, withAttachments: true, folderPath: folderPath } });
     assert(getStub.notCalled);
+    assert(loggerLogSpy.calledWith(userMessageResponseWithoutAttachments));
   });
 
   it('handles error when request to retrieve data fails', async () => {

--- a/src/m365/teams/commands/message/message-export.spec.ts
+++ b/src/m365/teams/commands/message/message-export.spec.ts
@@ -202,7 +202,7 @@ describe(commands.MESSAGE_EXPORT, () => {
       writeStream.emit('error', 'ENOENT: no such file or directory');
     }, 5);
 
-    await assert.rejects(command.action(logger, { options: { teamId: teamId, withAttachments: true, folderPath: folderPath, verbose: true } }), new CommandError('Error: ENOENT: no such file or directory'));
+    await assert.rejects(command.action(logger, { options: { teamId: teamId, withAttachments: true, folderPath: folderPath, verbose: true } }), new CommandError('ENOENT: no such file or directory'));
   });
 
   it('fails validation if userId is not a valid GUID', async () => {

--- a/src/m365/teams/commands/message/message-export.spec.ts
+++ b/src/m365/teams/commands/message/message-export.spec.ts
@@ -12,6 +12,8 @@ import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
 import * as fs from 'fs';
 import { odata } from '../../../../utils/odata';
+import request from '../../../../request';
+import { PassThrough } from 'stream';
 const command: Command = require('./message-export');
 
 describe(commands.MESSAGE_EXPORT, () => {
@@ -22,7 +24,7 @@ describe(commands.MESSAGE_EXPORT, () => {
   const toDateTime = '2023-04-30T23:59:59Z';
   const folderPath = 'C:\\Temp';
 
-  const teamMessageResponse = [{ 'id': '1683611790633', 'replyToId': null, 'etag': '1683612581046', 'messageType': 'message', 'createdDateTime': '2023-05-09T05:56:30.633Z', 'lastModifiedDateTime': '2023-05-09T06:09:41.046Z', 'lastEditedDateTime': '2023-05-09T06:09:40.914Z', 'deletedDateTime': null, 'subject': null, 'summary': null, 'chatId': null, 'importance': 'normal', 'locale': 'en-us', 'webUrl': 'https://teams.microsoft.com/l/message/19%3A0ade024bcdec4f4fbb03dfa0e5afc3ee%40thread.tacv2/1683611790633?groupId=80fc64e4-f5e1-4dc1-b34c-3198375bd9b2&tenantId=e1dd4023-a656-480a-8a0e-c1b1eec51e1d&createdTime=1683611790633&parentMessageId=1683611790633', 'policyViolation': null, 'eventDetail': null, 'from': { 'application': null, 'device': null, 'user': { 'id': 'fe36f75e-c103-410b-a18a-2bf6df06ac3a', 'displayName': 'John Doe', 'userIdentityType': 'aadUser', 'tenantId': 'e1dd4023-a656-480a-8a0e-c1b1eec51e1d' } }, 'body': { 'contentType': 'text', 'content': 'Hello! <attachment id=\'0e7fbdea-21ec-4525-aa30-c94e4e24c90b\'></attachment><attachment id=\'161D73CB-20D7-47FC-95CA-2E60A5A44D8D\'></attachment>' }, 'channelIdentity': { 'teamId': '80fc64e4-f5e1-4dc1-b34c-3198375bd9b2', 'channelId': '19:0ade024bcdec4f4fbb03dfa0e5afc3ee@thread.tacv2' }, 'attachments': [{ 'id': '0e7fbdea-21ec-4525-aa30-c94e4e24c90b', 'contentType': 'reference', 'contentUrl': 'https://contoso.sharepoint.com/sites/HR/Shared Documents/General/Registrations.xml', 'content': null, 'name': 'Registrations.xml', 'thumbnailUrl': null, 'teamsAppId': null }, { 'id': '161D73CB-20D7-47FC-95CA-2E60A5A44D8D', 'contentType': 'reference', 'contentUrl': 'https://contoso-my.sharepoint.com/personal/john_contoso_onmicrosoft_com/Documents/File1.pdf', 'content': null, 'name': 'File1.pdf', 'thumbnailUrl': null, 'teamsAppId': null }], 'mentions': [], 'reactions': [] }];
+  const teamMessageResponse = [{ 'id': '1683611790633', 'replyToId': null, 'etag': '1683612581046', 'messageType': 'message', 'createdDateTime': '2023-05-09T05:56:30.633Z', 'lastModifiedDateTime': '2023-05-09T06:09:41.046Z', 'lastEditedDateTime': '2023-05-09T06:09:40.914Z', 'deletedDateTime': null, 'subject': null, 'summary': null, 'chatId': null, 'importance': 'normal', 'locale': 'en-us', 'webUrl': 'https://teams.microsoft.com/l/message/19%3A0ade024bcdec4f4fbb03dfa0e5afc3ee%40thread.tacv2/1683611790633?groupId=80fc64e4-f5e1-4dc1-b34c-3198375bd9b2&tenantId=e1dd4023-a656-480a-8a0e-c1b1eec51e1d&createdTime=1683611790633&parentMessageId=1683611790633', 'policyViolation': null, 'eventDetail': null, 'from': { 'application': null, 'device': null, 'user': { 'id': 'fe36f75e-c103-410b-a18a-2bf6df06ac3a', 'displayName': 'John Doe', 'userIdentityType': 'aadUser', 'tenantId': 'e1dd4023-a656-480a-8a0e-c1b1eec51e1d' } }, 'body': { 'contentType': 'text', 'content': 'Hello! <attachment id=\'0e7fbdea-21ec-4525-aa30-c94e4e24c90b\'></attachment><attachment id=\'161D73CB-20D7-47FC-95CA-2E60A5A44D8D\'></attachment>' }, 'channelIdentity': { 'teamId': '80fc64e4-f5e1-4dc1-b34c-3198375bd9b2', 'channelId': '19:0ade024bcdec4f4fbb03dfa0e5afc3ee@thread.tacv2' }, 'attachments': [{ 'id': '161D73CB-20D7-47FC-95CA-2E60A5A44D8D', 'contentType': 'reference', 'contentUrl': 'https://contoso-my.sharepoint.com/personal/john_contoso_onmicrosoft_com/Documents/File1.pdf', 'content': null, 'name': 'File1.pdf', 'thumbnailUrl': null, 'teamsAppId': null }], 'mentions': [], 'reactions': [] }];
   const userMessageResponse = [{ 'id': '1668781541156', 'replyToId': null, 'etag': '1668781541156', 'messageType': 'message', 'createdDateTime': '2022-11-18T14:25:41.156Z', 'lastModifiedDateTime': '2022-11-18T14:25:41.156Z', 'lastEditedDateTime': null, 'deletedDateTime': null, 'subject': null, 'summary': null, 'chatId': '19:meeting_YmQwYbNzZgUtNmYxMC00YzFjLWE1MDctY2QwNmVkMGU4N2Ex@thread.v2', 'importance': 'normal', 'locale': 'en-us', 'webUrl': null, 'channelIdentity': null, 'policyViolation': null, 'eventDetail': null, 'from': { 'application': null, 'device': null, 'user': { 'id': 'fe36f75e-c103-410b-a18a-2bf6df06ac3a', 'displayName': 'John Doe', 'userIdentityType': 'aadUser', 'tenantId': 'e1dd4023-a656-480a-8a0e-c1b1eec51e1d' } }, 'body': { 'contentType': 'text', 'content': 'CLI For Microsoft 365 Rocks!' }, 'attachments': [], 'mentions': [], 'reactions': [] }];
 
   let log: string[];
@@ -57,17 +59,16 @@ describe(commands.MESSAGE_EXPORT, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      odata.getAllItems
+      odata.getAllItems,
+      request.get,
+      fs.createWriteStream,
+      fs.existsSync,
+      fs.mkdirSync
     ]);
   });
 
   after(() => {
-    sinonUtil.restore([
-      auth.restoreAuth,
-      telemetry.trackEvent,
-      pid.getProcessName,
-      session.getId
-    ]);
+    sinon.restore();
     auth.service.connected = false;
   });
 
@@ -88,6 +89,40 @@ describe(commands.MESSAGE_EXPORT, () => {
     });
 
     await command.action(logger, { options: { teamId: teamId } });
+    assert(loggerLogSpy.calledWith(teamMessageResponse));
+  });
+
+  it('retrieves messages for a specific team with attachments', async () => {
+    const mockResponse = `CLI For Microsoft 365 Rocks!`;
+    const responseStream = new PassThrough();
+    responseStream.write(mockResponse);
+    responseStream.end(); //Mark that we pushed all the data.
+
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/teams/${teamId}/channels/getAllMessages`) {
+        return teamMessageResponse;
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso-my.sharepoint.com/personal/john_contoso_onmicrosoft_com/_api/web/getFileByServerRelativePath(decodedUrl='/personal/john_contoso_onmicrosoft_com/Documents/File1.pdf')/$value`) {
+        return { data: responseStream };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(fs, 'existsSync').returns(false);
+    sinon.stub(fs, 'mkdirSync').returns(`${folderPath}\\${teamMessageResponse[0].id}`);
+
+    const writeStream = new PassThrough();
+    sinon.stub(fs, 'createWriteStream').returns(writeStream as any);
+    setTimeout(() => {
+      writeStream.emit('close');
+    }, 5);
+
+    await command.action(logger, { options: { teamId: teamId, withAttachments: true, folderPath: folderPath, verbose: true } });
     assert(loggerLogSpy.calledWith(teamMessageResponse));
   });
 
@@ -135,6 +170,39 @@ describe(commands.MESSAGE_EXPORT, () => {
     });
 
     await assert.rejects(command.action(logger, { options: { userName: userPrincipalName } }), new CommandError('Evaluation mode capacity has been exceeded. Use a valid billing model. Visit https://docs.microsoft.com/en-us/graph/teams-licenses for more details.'));
+  });
+
+  it('handles error when attachment cannot be saved properly', async () => {
+    const mockResponse = `CLI For Microsoft 365 Rocks!`;
+    const responseStream = new PassThrough();
+    responseStream.write(mockResponse);
+    responseStream.end(); //Mark that we pushed all the data.
+
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/teams/${teamId}/channels/getAllMessages`) {
+        return teamMessageResponse;
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso-my.sharepoint.com/personal/john_contoso_onmicrosoft_com/_api/web/getFileByServerRelativePath(decodedUrl='/personal/john_contoso_onmicrosoft_com/Documents/File1.pdf')/$value`) {
+        return { data: responseStream };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(fs, 'existsSync').returns(false);
+    sinon.stub(fs, 'mkdirSync').returns(`${folderPath}\\${teamMessageResponse[0].id}`);
+
+    const writeStream = new PassThrough();
+    sinon.stub(fs, 'createWriteStream').returns(writeStream as any);
+    setTimeout(() => {
+      writeStream.emit('error', 'ENOENT: no such file or directory');
+    }, 5);
+
+    await assert.rejects(command.action(logger, { options: { teamId: teamId, withAttachments: true, folderPath: folderPath, verbose: true } }), new CommandError('Error: ENOENT: no such file or directory'));
   });
 
   it('fails validation if userId is not a valid GUID', async () => {

--- a/src/m365/teams/commands/message/message-export.spec.ts
+++ b/src/m365/teams/commands/message/message-export.spec.ts
@@ -6,20 +6,24 @@ import { Cli } from '../../../../cli/Cli';
 import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
-import request from '../../../../request';
 import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
 import * as fs from 'fs';
+import { odata } from '../../../../utils/odata';
 const command: Command = require('./message-export');
 
 describe(commands.MESSAGE_EXPORT, () => {
   const userId = '11f43044-095e-456a-b339-7e1901b0c3ae';
+  const userPrincipalName = 'john@contoso.com';
   const teamId = '75619fc7-5dce-412b-82ee-f76988d3efaa';
   const fromDateTime = '2023-04-01T00:00:00Z';
   const toDateTime = '2023-04-30T23:59:59Z';
   const folderPath = 'C:\\Temp';
+
+  const teamMessageResponse = [{ 'id': '1683611790633', 'replyToId': null, 'etag': '1683612581046', 'messageType': 'message', 'createdDateTime': '2023-05-09T05:56:30.633Z', 'lastModifiedDateTime': '2023-05-09T06:09:41.046Z', 'lastEditedDateTime': '2023-05-09T06:09:40.914Z', 'deletedDateTime': null, 'subject': null, 'summary': null, 'chatId': null, 'importance': 'normal', 'locale': 'en-us', 'webUrl': 'https://teams.microsoft.com/l/message/19%3A0ade024bcdec4f4fbb03dfa0e5afc3ee%40thread.tacv2/1683611790633?groupId=80fc64e4-f5e1-4dc1-b34c-3198375bd9b2&tenantId=e1dd4023-a656-480a-8a0e-c1b1eec51e1d&createdTime=1683611790633&parentMessageId=1683611790633', 'policyViolation': null, 'eventDetail': null, 'from': { 'application': null, 'device': null, 'user': { 'id': 'fe36f75e-c103-410b-a18a-2bf6df06ac3a', 'displayName': 'John Doe', 'userIdentityType': 'aadUser', 'tenantId': 'e1dd4023-a656-480a-8a0e-c1b1eec51e1d' } }, 'body': { 'contentType': 'text', 'content': 'Hello! <attachment id=\'0e7fbdea-21ec-4525-aa30-c94e4e24c90b\'></attachment><attachment id=\'161D73CB-20D7-47FC-95CA-2E60A5A44D8D\'></attachment>' }, 'channelIdentity': { 'teamId': '80fc64e4-f5e1-4dc1-b34c-3198375bd9b2', 'channelId': '19:0ade024bcdec4f4fbb03dfa0e5afc3ee@thread.tacv2' }, 'attachments': [{ 'id': '0e7fbdea-21ec-4525-aa30-c94e4e24c90b', 'contentType': 'reference', 'contentUrl': 'https://contoso.sharepoint.com/sites/HR/Shared Documents/General/Registrations.xml', 'content': null, 'name': 'Registrations.xml', 'thumbnailUrl': null, 'teamsAppId': null }, { 'id': '161D73CB-20D7-47FC-95CA-2E60A5A44D8D', 'contentType': 'reference', 'contentUrl': 'https://contoso-my.sharepoint.com/personal/john_contoso_onmicrosoft_com/Documents/File1.pdf', 'content': null, 'name': 'File1.pdf', 'thumbnailUrl': null, 'teamsAppId': null }], 'mentions': [], 'reactions': [] }];
+  const userMessageResponse = [{ 'id': '1668781541156', 'replyToId': null, 'etag': '1668781541156', 'messageType': 'message', 'createdDateTime': '2022-11-18T14:25:41.156Z', 'lastModifiedDateTime': '2022-11-18T14:25:41.156Z', 'lastEditedDateTime': null, 'deletedDateTime': null, 'subject': null, 'summary': null, 'chatId': '19:meeting_YmQwYbNzZgUtNmYxMC00YzFjLWE1MDctY2QwNmVkMGU4N2Ex@thread.v2', 'importance': 'normal', 'locale': 'en-us', 'webUrl': null, 'channelIdentity': null, 'policyViolation': null, 'eventDetail': null, 'from': { 'application': null, 'device': null, 'user': { 'id': 'fe36f75e-c103-410b-a18a-2bf6df06ac3a', 'displayName': 'John Doe', 'userIdentityType': 'aadUser', 'tenantId': 'e1dd4023-a656-480a-8a0e-c1b1eec51e1d' } }, 'body': { 'contentType': 'text', 'content': 'CLI For Microsoft 365 Rocks!' }, 'attachments': [], 'mentions': [], 'reactions': [] }];
 
   let log: string[];
   let logger: Logger;
@@ -53,7 +57,7 @@ describe(commands.MESSAGE_EXPORT, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get
+      odata.getAllItems
     ]);
   });
 
@@ -73,6 +77,64 @@ describe(commands.MESSAGE_EXPORT, () => {
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
+  });
+
+  it('retrieves messages for a specific team without downloading attachments', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/teams/${teamId}/channels/getAllMessages`) {
+        return teamMessageResponse;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { teamId: teamId } });
+    assert(loggerLogSpy.calledWith(teamMessageResponse));
+  });
+
+  it('retrieves messages for a specific user by id without downloading attachments', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/users/${userId}/chats/getAllMessages`) {
+        return userMessageResponse;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { userId: userId } });
+    assert(loggerLogSpy.calledWith(userMessageResponse));
+  });
+
+  it('retrieves messages for a specific user by user name without downloading attachments and filtering on dates', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/users/${userPrincipalName}/chats/getAllMessages?$filter=createdDateTime ge ${fromDateTime} and createdDateTime lt ${toDateTime}`) {
+        return userMessageResponse;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { userName: userPrincipalName, fromDateTime: fromDateTime, toDateTime: toDateTime } });
+    assert(loggerLogSpy.calledWith(userMessageResponse));
+  });
+
+  it('handles error when request to retrieve data fails', async () => {
+    const errorMessage = {
+      'error': {
+        'code': 'PaymentRequired',
+        'message': 'Evaluation mode capacity has been exceeded. Use a valid billing model. Visit https://docs.microsoft.com/en-us/graph/teams-licenses for more details.',
+        'innerError': {
+          'date': '2023-05-21T20:06:07',
+          'request-id': '2e9937c1-307c-46f3-a656-76deb2d8d77f',
+          'client-request-id': '2e9937c1-307c-46f3-a656-76deb2d8d77f'
+        }
+      }
+    };
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/users/${userPrincipalName}/chats/getAllMessages`) {
+        throw errorMessage;
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { userName: userPrincipalName } }), new CommandError('Evaluation mode capacity has been exceeded. Use a valid billing model. Visit https://docs.microsoft.com/en-us/graph/teams-licenses for more details.'));
   });
 
   it('fails validation if userId is not a valid GUID', async () => {
@@ -121,4 +183,8 @@ describe(commands.MESSAGE_EXPORT, () => {
     sinonUtil.restore(fs.existsSync);
   });
 
+  it('passes validation if userName is a valid userPrincipalName', async () => {
+    const actual = await command.validate({ options: { userName: userPrincipalName } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
 });

--- a/src/m365/teams/commands/message/message-export.ts
+++ b/src/m365/teams/commands/message/message-export.ts
@@ -24,7 +24,6 @@ interface Options extends GlobalOptions {
 }
 
 class TeamsMessageExportCommand extends GraphCommand {
-  private readonly allowedLicenseModels: string[] = ['A', 'B'];
 
   public get name(): string {
     return commands.MESSAGE_EXPORT;
@@ -60,10 +59,6 @@ class TeamsMessageExportCommand extends GraphCommand {
         option: '--toDateTime [toDateTime]'
       },
       {
-        option: '--licenseModel [licenseModel]',
-        autocomplete: this.allowedLicenseModels
-      },
-      {
         option: '--withAttachments'
       },
       {
@@ -80,7 +75,7 @@ class TeamsMessageExportCommand extends GraphCommand {
         }
 
         if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
-          return `${args.options.userId} is not a valid userPrincipalName`;
+          return `${args.options.userName} is not a valid userPrincipalName`;
         }
 
         if (args.options.teamId && !validation.isValidGuid(args.options.teamId)) {
@@ -93,10 +88,6 @@ class TeamsMessageExportCommand extends GraphCommand {
 
         if (args.options.toDateTime && !validation.isValidISODateTime(args.options.toDateTime)) {
           return `${args.options.toDateTime} is not a valid ISO DateTime`;
-        }
-
-        if (args.options.licenseModel && !this.allowedLicenseModels.some(value => value === args.options.licenseModel)) {
-          return `${args.options.licenseModel} is not a valid license model. Allowed values are ${this.allowedLicenseModels.join(',')}`;
         }
 
         if (!fs.existsSync(args.options.folderPath)) {
@@ -153,6 +144,7 @@ class TeamsMessageExportCommand extends GraphCommand {
             for await (const attachment of message.attachments) {
               const _url = url.parse(attachment['contentUrl']);
               let siteUrl = _url.protocol + '//' + _url.host!;
+
               if (_url.path!.split('/')[1] === 'sites' || _url.path!.split('/')[1] === 'teams' || _url.path!.split('/')[1] === 'personal') {
                 siteUrl += '/' + _url.path!.split('/')[1] + '/' + _url.path!.split('/')[2];
               }
@@ -164,6 +156,7 @@ class TeamsMessageExportCommand extends GraphCommand {
               };
               const file = await request.get<any>(requestOptions);
               const filePath = `${args.options.folderPath}\\${_url.path!.split('/').pop()}`;
+
               // Not possible to use async/await for this promise
               await new Promise<void>(() => {
                 const writer = fs.createWriteStream(filePath);
@@ -183,6 +176,7 @@ class TeamsMessageExportCommand extends GraphCommand {
           }
         }
       }
+      logger.log(res);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);

--- a/src/m365/teams/commands/message/message-export.ts
+++ b/src/m365/teams/commands/message/message-export.ts
@@ -1,0 +1,139 @@
+import { Logger } from '../../../../cli/Logger';
+import GlobalOptions from '../../../../GlobalOptions';
+import request, { CliRequestOptions } from '../../../../request';
+import { validation } from '../../../../utils/validation';
+import GraphCommand from "../../../base/GraphCommand";
+import commands from '../../commands';
+import * as fs from 'fs';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  userId?: string;
+  userName?: string;
+  teamId?: string;
+  fromDateTime?: string;
+  toDateTime?: string;
+  licenseModel?: string;
+  withAttachments?: boolean;
+  folderPath: string;
+}
+
+class TeamsMessageExportCommand extends GraphCommand {
+  private readonly allowedLicenseModels: string[] = ['A', 'B'];
+
+  public get name(): string {
+    return commands.MESSAGE_EXPORT;
+  }
+
+  public get description(): string {
+    return 'Export Microsoft Teams chat messages for a given user, or a team.';
+  }
+
+  constructor() {
+    super();
+
+    this.#initOptions();
+    this.#initValidators();
+    this.#initOptionSets();
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '--userId [userId]'
+      },
+      {
+        option: '--userName [userName]'
+      },
+      {
+        option: '--teamId [teamId]'
+      },
+      {
+        option: '--fromDateTime [fromDateTime]'
+      },
+      {
+        option: '--toDateTime [toDateTime]'
+      },
+      {
+        option: '--licenseModel [licenseModel]',
+        autocomplete: this.allowedLicenseModels
+      },
+      {
+        option: '--withAttachments'
+      },
+      {
+        option: '--folderPath <folderPath>'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
+          return `${args.options.userId} is not a valid GUID`;
+        }
+
+        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
+          return `${args.options.userId} is not a valid userPrincipalName`;
+        }
+
+        if (args.options.teamId && !validation.isValidGuid(args.options.teamId)) {
+          return `${args.options.teamId} is not a valid GUID`;
+        }
+
+        if (args.options.fromDateTime && !validation.isValidISODateTime(args.options.fromDateTime)) {
+          return `${args.options.fromDateTime} is not a valid ISO DateTime`;
+        }
+
+        if (args.options.toDateTime && !validation.isValidISODateTime(args.options.toDateTime)) {
+          return `${args.options.toDateTime} is not a valid ISO DateTime`;
+        }
+
+        if (args.options.licenseModel && !this.allowedLicenseModels.some(value => value === args.options.licenseModel)) {
+          return `${args.options.licenseModel} is not a valid license model. Allowed values are ${this.allowedLicenseModels.join(',')}`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['userId', 'userName', 'teamId'] });
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (!fs.existsSync(args.options.folderPath)) {
+      throw `Path ${args.options.folderPath} does not exist.`;
+    }
+
+    const requestOptions: CliRequestOptions = {
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    if (args.options.userId || args.options.userName) {
+      requestOptions.url = `${this.resource}/v1.0/users/${args.options.userId || args.options.userName}/chats`;
+    }
+    else {
+      requestOptions.url = `${this.resource}/v1.0/teams/${args.options.teamId}/channels`;
+    }
+    requestOptions.url += '/getAllMessages';
+
+    try {
+      const res: any = await request.get(requestOptions);
+      logger.log(res);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+}
+
+module.exports = new TeamsMessageExportCommand();


### PR DESCRIPTION
Closes #2073 

The process of requesting an evaluation license has recently been changed so that yo no longer have to fill in the MS Form. I also removed the option `--licenseModel` as this is not being used when calling the endpoint.

Also, I did not add the shorts for `--withAttachments` and `--folderPath` as I didn't think that it would make that much sense. I could add them if needed obviously.