### PR TITLE
Bug-fix: Add Group creation wait to `teams team add` command 

### DIFF
--- a/src/m365/teams/commands/team/team-add.spec.ts
+++ b/src/m365/teams/commands/team/team-add.spec.ts
@@ -40,6 +40,7 @@ describe(commands.TEAM_ADD, () => {
     };
     loggerLogSpy = sinon.spy(logger, 'log');
     (command as any).items = [];
+    (command as any).pollingInterval = 0;
   });
 
   afterEach(() => {

--- a/src/m365/teams/commands/team/team-add.ts
+++ b/src/m365/teams/commands/team/team-add.ts
@@ -1,29 +1,11 @@
+import { Group, TeamsAsyncOperation } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
 import { aadGroup } from '../../../../utils/aadGroup';
 import GraphCommand from '../../../base/GraphCommand';
 import commands from '../../commands';
-
-enum TeamsAsyncOperationStatus {
-  Invalid = "invalid",
-  NotStarted = "notStarted",
-  InProgress = "inProgress",
-  Succeeded = "succeeded",
-  Failed = "failed"
-}
-
-interface TeamsAsyncOperation {
-  id: string;
-  operationType: string;
-  createdDateTime: Date;
-  status: TeamsAsyncOperationStatus;
-  lastActionDateTime: Date;
-  attemptsCount: number;
-  targetResourceId: string;
-  targetResourceLocation: string;
-  error?: any;
-}
+import { setTimeout } from "timers/promises";
 
 interface CommandArgs {
   options: Options;
@@ -52,7 +34,7 @@ class TeamsTeamAddCommand extends GraphCommand {
 
     this.#initTelemetry();
     this.#initOptions();
-    this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initTelemetry(): void {
@@ -83,20 +65,19 @@ class TeamsTeamAddCommand extends GraphCommand {
     );
   }
 
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!args.options.template) {
-          if (!args.options.name) {
-            return `Required parameter name missing`;
-          }
-
-          if (!args.options.description) {
-            return `Required parameter description missing`;
-          }
+  #initOptionSets(): void {
+    this.optionSets.push(
+      {
+        options: ['name'],
+        runsWhen: (args) => {
+          return !args.options.template;
         }
-
-        return true;
+      },
+      {
+        options: ['description'],
+        runsWhen: (args) => {
+          return !args.options.template;
+        }
       }
     );
   }
@@ -124,6 +105,10 @@ class TeamsTeamAddCommand extends GraphCommand {
       }
     }
     else {
+      if (this.verbose) {
+        logger.logToStderr(`Creating team with name ${args.options.name} and description ${args.options.description}`);
+      }
+
       requestBody = {
         'template@odata.bind': `https://graph.microsoft.com/v1.0/teamsTemplates('standard')`,
         displayName: args.options.name,
@@ -150,53 +135,57 @@ class TeamsTeamAddCommand extends GraphCommand {
         responseType: 'json'
       };
 
-      const teamsAsyncOperation: TeamsAsyncOperation = await new Promise(async (resolve, reject) => {
-        const teamsAsyncOperation: TeamsAsyncOperation = await request.get<TeamsAsyncOperation>(requestOptions);
-        if (!args.options.wait) {
-          resolve(teamsAsyncOperation);
-        }
-        else {
-          setTimeout(() => {
-            this.waitUntilFinished(requestOptions, resolve, reject, logger);
-          }, this.pollingInterval);
-        }
-      });
-
-      let output;
+      const teamsAsyncOperation: TeamsAsyncOperation = await request.get<TeamsAsyncOperation>(requestOptions);
 
       if (!args.options.wait) {
-        output = teamsAsyncOperation;
+        logger.log(teamsAsyncOperation);
       }
       else {
-        output = await aadGroup.getGroupById(teamsAsyncOperation.targetResourceId);
+        await this.waitUntilTeamFinishedProvisioning(teamsAsyncOperation, requestOptions, logger);
+        const aadGroup = await this.getAadGroup(teamsAsyncOperation.targetResourceId!, logger);
+        logger.log(aadGroup);
       }
-
-      logger.log(output);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
   }
 
-  private waitUntilFinished(requestOptions: any, resolve: (teamsAsyncOperation: TeamsAsyncOperation) => void, reject: (error: any) => void, logger: Logger): void {
-    request
-      .get<TeamsAsyncOperation>(requestOptions)
-      .then((teamsAsyncOperation: TeamsAsyncOperation): void => {
-        if (teamsAsyncOperation.status === TeamsAsyncOperationStatus.Succeeded) {
-          if (this.verbose) {
-            process.stdout.write('\n');
-          }
-          resolve(teamsAsyncOperation);
-          return;
-        }
-        if (teamsAsyncOperation.error) {
-          reject(teamsAsyncOperation.error);
-          return;
-        }
-        setTimeout(() => {
-          this.waitUntilFinished(requestOptions, resolve, reject, logger);
-        }, this.pollingInterval);
-      }).catch(err => reject(err));
+  private async waitUntilTeamFinishedProvisioning(teamsAsyncOperation: TeamsAsyncOperation, requestOptions: CliRequestOptions, logger: Logger): Promise<void> {
+    if (teamsAsyncOperation.status === 'succeeded') {
+      if (this.verbose) {
+        logger.logToStderr('Team provisioned succesfully. Returning...');
+      }
+      return;
+    }
+    else if (teamsAsyncOperation.error) {
+      throw teamsAsyncOperation.error;
+    }
+    else {
+      if (this.verbose) {
+        logger.logToStderr(`Team still provisioning. Retrying in ${this.pollingInterval / 1000} seconds...`);
+      }
+      await setTimeout(this.pollingInterval);
+      teamsAsyncOperation = await request.get<TeamsAsyncOperation>(requestOptions);
+      await this.waitUntilTeamFinishedProvisioning(teamsAsyncOperation, requestOptions, logger);
+    }
+  }
+
+  private async getAadGroup(id: string, logger: Logger): Promise<Group> {
+    let group: Group;
+
+    try {
+      group = await aadGroup.getGroupById(id);
+    }
+    catch {
+      if (this.verbose) {
+        logger.logToStderr(`Error occured on retrieving the aad group. Retrying in ${this.pollingInterval / 1000} seconds.`);
+      }
+      await setTimeout(this.pollingInterval);
+      return await this.getAadGroup(id, logger);
+    }
+
+    return group!;
   }
 }
 


### PR DESCRIPTION
I've also refactored the code a bit to align it more with our more recent standards. Following changes have been applied:
- optionsets instead of validators
- make use of async awaits instead of promise then
- replaced in line interface by ms-graph types
- added some verbose logging

Closes #2021 