### PR TITLE
Bug-fix: Unable to rename list content type

### DIFF
--- a/src/m365/spo/commands/contenttype/contenttype-set.spec.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-set.spec.ts
@@ -13,6 +13,7 @@ import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
+import { urlUtil } from '../../../../utils/urlUtil';
 const command: Command = require('./contenttype-set');
 
 describe(commands.CONTENTTYPE_SET, () => {
@@ -118,13 +119,28 @@ describe(commands.CONTENTTYPE_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if listId is specified together with updateChildren', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, id: id, listId: listId, updateChildren: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if listTitle is specified together with updateChildren', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, id: id, listTitle: listTitle, updateChildren: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if listUrl is specified together with updateChildren', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, id: id, listUrl: listUrl, updateChildren: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('passes validation when webUrl, id and listId are specified', async () => {
     const actual = await command.validate({ options: { webUrl: webUrl, id: id, listId: listId } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation when webUrl, name are specified', async () => {
-    const actual = await command.validate({ options: { webUrl: webUrl, name: name } }, commandInfo);
+  it('passes validation when webUrl, name are specified together with updateChildren', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, name: name, updateChildren: true } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
@@ -134,30 +150,30 @@ describe(commands.CONTENTTYPE_SET, () => {
   });
 
   it('correctly updates content type with id', async () => {
-    sinon.stub(request, 'get').callsFake(opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === `${webUrl}/_api/site?$select=Id`) {
-        return Promise.resolve({ Id: siteId });
+        return { Id: siteId };
       }
       else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
-        return Promise.resolve({ Id: webId });
+        return { Id: webId };
       }
 
-      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+      throw `Invalid GET-request ${JSON.stringify(opts)}`;
     });
-    sinon.stub(request, 'post').callsFake(opts => {
+    sinon.stub(request, 'post').callsFake(async opts => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
-        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
-        return Promise.resolve(`[
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty><Method Name="Update" Id="13" ObjectPathId="9"><Parameters><Parameter Type="Boolean">false</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return `[
           {
             "SchemaVersion": "15.0.0.0",
             "LibraryVersion": "16.0.7911.1206",
             "ErrorInfo": null,
             "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
           }
-        ]`);
+        ]`;
       }
 
-      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+      throw `Invalid POST-request ${JSON.stringify(opts)}`;
     });
 
     await command.action(logger, { options: { webUrl: webUrl, id: id, Name: newName } } as any);
@@ -165,23 +181,23 @@ describe(commands.CONTENTTYPE_SET, () => {
   });
 
   it('correctly updates content type with name', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `${webUrl}/_api/site?$select=Id`) {
-        return Promise.resolve({ Id: siteId });
+        return { Id: siteId };
       }
       else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
-        return Promise.resolve({ Id: webId });
+        return { Id: webId };
       }
       else if (opts.url === `${webUrl}/_api/Web/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
-        return Promise.resolve(contentTypesResponse);
+        return contentTypesResponse;
       }
 
-      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+      throw `Invalid GET-request ${JSON.stringify(opts)}`;
     });
-    sinon.stub(request, 'post').callsFake(opts => {
+    sinon.stub(request, 'post').callsFake(async opts => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
-        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
-        return Promise.resolve(`[
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty><Method Name="Update" Id="13" ObjectPathId="9"><Parameters><Parameter Type="Boolean">false</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return (`[
           {
             "SchemaVersion": "15.0.0.0",
             "LibraryVersion": "16.0.7911.1206",
@@ -191,75 +207,41 @@ describe(commands.CONTENTTYPE_SET, () => {
         ]`);
       }
 
-      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+      throw `Invalid POST-request ${JSON.stringify(opts)}`;
     });
 
     await command.action(logger, { options: { webUrl: webUrl, name: name, Name: newName } } as any);
     assert(loggerLogSpy.notCalled);
   });
 
-  it('correctly updates content type with name (Debug)', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `${webUrl}/_api/site?$select=Id`) {
-        return Promise.resolve({ Id: siteId });
-      }
-      else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
-        return Promise.resolve({ Id: webId });
-      }
-      else if (opts.url === `${webUrl}/_api/Web/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
-        return Promise.resolve(contentTypesResponse);
-      }
-
-      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
-    });
-    sinon.stub(request, 'post').callsFake(opts => {
-      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
-        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
-        return Promise.resolve(`[
-          {
-            "SchemaVersion": "15.0.0.0",
-            "LibraryVersion": "16.0.7911.1206",
-            "ErrorInfo": null,
-            "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
-          }
-        ]`);
-      }
-
-      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
-    });
-
-    await command.action(logger, { options: { webUrl: webUrl, name: name, Name: newName, debug: true } } as any);
-    assert(loggerLogSpy.notCalled);
-  });
-
   it('correctly updates content type with name and listId', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `${webUrl}/_api/site?$select=Id`) {
-        return Promise.resolve({ Id: siteId });
+        return { Id: siteId };
       }
       else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
-        return Promise.resolve({ Id: webId });
+        return { Id: webId };
       }
       else if (opts.url === `${webUrl}/_api/Web/Lists/GetById('${formatting.encodeQueryParameter(listId)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
-        return Promise.resolve(contentTypesResponse);
+        return contentTypesResponse;
       }
 
-      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+      throw `Invalid GET-request ${JSON.stringify(opts)}`;
     });
-    sinon.stub(request, 'post').callsFake(opts => {
+    sinon.stub(request, 'post').callsFake(async opts => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
-        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
-        return Promise.resolve(`[
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty><Method Name="Update" Id="13" ObjectPathId="9"><Parameters><Parameter Type="Boolean">false</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:list:${listId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return `[
           {
             "SchemaVersion": "15.0.0.0",
             "LibraryVersion": "16.0.7911.1206",
             "ErrorInfo": null,
             "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
           }
-        ]`);
+        ]`;
       }
 
-      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+      throw `Invalid POST-request ${JSON.stringify(opts)}`;
     });
 
     await command.action(logger, { options: { webUrl: webUrl, name: name, listId: listId, Name: newName } } as any);
@@ -267,33 +249,36 @@ describe(commands.CONTENTTYPE_SET, () => {
   });
 
   it('correctly updates content type with name and listTitle', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `${webUrl}/_api/site?$select=Id`) {
-        return Promise.resolve({ Id: siteId });
+        return { Id: siteId };
       }
       else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
-        return Promise.resolve({ Id: webId });
+        return { Id: webId };
       }
       else if (opts.url === `${webUrl}/_api/Web/Lists/GetByTitle('${formatting.encodeQueryParameter(listTitle)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
-        return Promise.resolve(contentTypesResponse);
+        return contentTypesResponse;
+      }
+      else if (opts.url === `${webUrl}/_api/web/lists/getByTitle('${formatting.encodeQueryParameter(listTitle)}')?$select=Id`) {
+        return { Id: listId };
       }
 
-      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+      throw `Invalid GET-request ${JSON.stringify(opts)}`;
     });
-    sinon.stub(request, 'post').callsFake(opts => {
+    sinon.stub(request, 'post').callsFake(async opts => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
-        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
-        return Promise.resolve(`[
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty><Method Name="Update" Id="13" ObjectPathId="9"><Parameters><Parameter Type="Boolean">false</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:list:${listId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return `[
           {
             "SchemaVersion": "15.0.0.0",
             "LibraryVersion": "16.0.7911.1206",
             "ErrorInfo": null,
             "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
           }
-        ]`);
+        ]`;
       }
 
-      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+      throw `Invalid POST-request ${JSON.stringify(opts)}`;
     });
 
     await command.action(logger, { options: { webUrl: webUrl, name: name, listTitle: listTitle, Name: newName } } as any);
@@ -301,64 +286,68 @@ describe(commands.CONTENTTYPE_SET, () => {
   });
 
   it('correctly updates content type with name and listUrl', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    const listServerRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, listUrl);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `${webUrl}/_api/site?$select=Id`) {
-        return Promise.resolve({ Id: siteId });
+        return { Id: siteId };
       }
       else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
-        return Promise.resolve({ Id: webId });
+        return { Id: webId };
       }
       else if (opts.url === `${webUrl}/_api/Web/GetList('${formatting.encodeQueryParameter(listUrl)}')/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
-        return Promise.resolve(contentTypesResponse);
+        return contentTypesResponse;
+      }
+      else if (opts.url === `${webUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')?$select=Id`) {
+        return { Id: listId };
       }
 
-      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+      throw `Invalid GET-request ${JSON.stringify(opts)}`;
     });
-    sinon.stub(request, 'post').callsFake(opts => {
+    sinon.stub(request, 'post').callsFake(async opts => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
-        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
-        return Promise.resolve(`[
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty><Method Name="Update" Id="13" ObjectPathId="9"><Parameters><Parameter Type="Boolean">false</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:list:${listId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return `[
           {
             "SchemaVersion": "15.0.0.0",
             "LibraryVersion": "16.0.7911.1206",
             "ErrorInfo": null,
             "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
           }
-        ]`);
+        ]`;
       }
 
-      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+      throw `Invalid POST-request ${JSON.stringify(opts)}`;
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, name: name, listUrl: listUrl, Name: newName } } as any);
+    await command.action(logger, { options: { verbose: true, webUrl: webUrl, name: name, listUrl: listUrl, Name: newName } } as any);
     assert(loggerLogSpy.notCalled);
   });
 
   it('correctly updates content type with id and pushing changes to children', async () => {
-    sinon.stub(request, 'get').callsFake(opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === `${webUrl}/_api/site?$select=Id`) {
-        return Promise.resolve({ Id: siteId });
+        return { Id: siteId };
       }
       else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
-        return Promise.resolve({ Id: webId });
+        return { Id: webId };
       }
 
-      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+      throw `Invalid GET-request ${JSON.stringify(opts)}`;
     });
-    sinon.stub(request, 'post').callsFake(opts => {
+    sinon.stub(request, 'post').callsFake(async opts => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
         && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty><Method Name="Update" Id="13" ObjectPathId="9"><Parameters><Parameter Type="Boolean">true</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
-        return Promise.resolve(`[
+        return `[
           {
             "SchemaVersion": "15.0.0.0",
             "LibraryVersion": "16.0.7911.1206",
             "ErrorInfo": null,
             "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
           }
-        ]`);
+        ]`;
       }
 
-      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+      throw `Invalid POST-request ${JSON.stringify(opts)}`;
     });
 
     await command.action(logger, { options: { webUrl: webUrl, id: id, Name: newName, updateChildren: true } } as any);
@@ -366,12 +355,12 @@ describe(commands.CONTENTTYPE_SET, () => {
   });
 
   it('fails to update content type with name and listUrl when content type does not exist', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `${webUrl}/_api/Web/ContentTypes?$filter=Name eq '${name}'&$select=Id`) {
-        return Promise.resolve({ value: [] });
+        return { value: [] };
       }
 
-      return Promise.reject('Invalid request url: ' + opts.url);
+      throw 'Invalid request url: ' + opts.url;
     });
     const patchStub = sinon.stub(request, 'patch').callsFake(() => Promise.resolve());
 
@@ -380,21 +369,20 @@ describe(commands.CONTENTTYPE_SET, () => {
   });
 
   it('correctly handles random API error', async () => {
-    sinon.stub(request, 'get').callsFake(opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === `${webUrl}/_api/site?$select=Id`) {
-        return Promise.resolve({ Id: siteId });
+        return { Id: siteId };
       }
       else if (opts.url === `${webUrl}/_api/web?$select=Id`) {
-        return Promise.resolve({ Id: webId });
+        return { Id: webId };
       }
 
-      return Promise.reject(`Invalid GET-request ${JSON.stringify(opts)}`);
+      throw `Invalid GET-request ${JSON.stringify(opts)}`;
     });
-    sinon.stub(request, 'post').callsFake(opts => {
+    sinon.stub(request, 'post').callsFake(async opts => {
       if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`
-        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
-        //&& opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="CLI for Microsoft 365 v6.0.0" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${id}" /></ObjectPaths></Request>`) {
-        return Promise.resolve(`[
+        && opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="12" ObjectPathId="9" Name="Name"><Parameter Type="String">${newName}</Parameter></SetProperty><Method Name="Update" Id="13" ObjectPathId="9"><Parameters><Parameter Type="Boolean">false</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="9" Name="fc4179a0-e0d7-5000-c38b-bc3506fbab6f|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:web:${webId}:contenttype:${formatting.escapeXml(id)}" /></ObjectPaths></Request>`) {
+        return `[
           {
             "SchemaVersion": "15.0.0.0",
             "LibraryVersion": "16.0.7911.1206",
@@ -403,10 +391,10 @@ describe(commands.CONTENTTYPE_SET, () => {
             },
             "TraceCorrelationId": "e5547d9e-705d-0000-22fb-8faca5696ed8"
           }
-        ]`);
+        ]`;
       }
 
-      return Promise.reject(`Invalid POST-request ${JSON.stringify(opts)}`);
+      throw `Invalid POST-request ${JSON.stringify(opts)}`;
     });
 
     await assert.rejects(command.action(logger, { options: { webUrl: webUrl, id: id, Name: newName } } as any), new CommandError('Unknown Error'));


### PR DESCRIPTION
Closes #4885 

Noticed that for the `post` call to the csom endpoint, there was never a `list:{listId}` being passed, so it makes sense 😄 
Resolved this so that the command now also will work on list content types.