### PR TITLE
Enhances `spo term group add` with `--webUrl`

### DIFF
--- a/docs/docs/cmd/spo/term/term-group-add.mdx
+++ b/docs/docs/cmd/spo/term/term-group-add.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # spo term group add
 
@@ -21,15 +23,22 @@ m365 spo term group add [options]
 
 `-d, --description [description]`
 : Description of the term group to add
+
+`-u, --webUrl [webUrl]`
+: If specified, allows you to add a term group to the tenant term store as a term store administrator without the SharePoint administrator role.
 ```
 
 <Global />
 
 ## Remarks
 
-:::info
+:::caution    
 
-To use this command you have to have permissions to access the tenant admin site.
+To use this command without the `--webUrl` option you must have permissions to access the tenant admin site.
+
+When using the `--webUrl` option you can connect to the term store with limited permissions, and do not need the SharePoint Adminstrator role. It allows you to add a term group to the tenant term store if you are listed as a term store administrator.
+
+This command does not create a sitecollection specific term store/group when using the `--webUrl` option.
 
 :::
 
@@ -47,8 +56,58 @@ Add a new taxonomy term group with the specified name and id
 m365 spo term group add --name PnPTermSets --id 0e8f395e-ff58-4d45-9ff7-e331ab728beb
 ```
 
-Add a new taxonomy term group with the specified name and description
+Add a new taxonomy term group with the specified name and description with limited permissions
 
 ```sh
-m365 spo term group add --name PnPTermSets --description 'Term sets for PnP'
+m365 spo term group add --name PnPTermSets --description 'Term sets for PnP' --webUrl 'https://contoso.sharepoint.com'
 ```
+
+## Response
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ```json
+  {
+    "Name": "PnPTermSets",
+    "Id": "cafe662c-c3fa-4c83-bcb0-50b701b37164",
+    "Description": "Term sets for PnP"
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="Text">
+
+  ```text
+  Description: Term sets for PnP
+  Id         : cafe662c-c3fa-4c83-bcb0-50b701b37164
+  Name       : PnPTermSets
+  ```
+
+  </TabItem>
+  <TabItem value="CSV">
+
+  ```csv
+  Name,Id,Description
+  PnPTermSets,cafe662c-c3fa-4c83-bcb0-50b701b37164,Term sets for PnP
+  ```
+
+  </TabItem>
+  <TabItem value="Markdown">
+
+  ```md
+  # spo term group add --name "PnPTermSets" --description 'Term sets for PnP'
+  
+  Date: 24/05/2023
+  
+  ## PnPTermSets (cafe662c-c3fa-4c83-bcb0-50b701b37164)
+  
+  | Property    | Value                                |
+  | ----------- | ------------------------------------ |
+  | Name        | PnPTermSets                          |
+  | Id          | cafe662c-c3fa-4c83-bcb0-50b701b37164 |
+  | Description | Term sets for PnP                    |
+  ```
+
+  </TabItem>
+</Tabs>

--- a/src/m365/spo/commands/term/term-group-add.spec.ts
+++ b/src/m365/spo/commands/term/term-group-add.spec.ts
@@ -281,6 +281,59 @@ describe(commands.TERM_GROUP_ADD, () => {
     }));
   });
 
+  it('adds term group by id with description when webUrl is specified', async () => {
+    const webUrl = 'https://contoso.sharepoint.com';
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_vti_bin/client.svc/ProcessQuery`) {
+        if (opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectIdentityQuery Id="5" ObjectPathId="3" /><ObjectPath Id="7" ObjectPathId="6" /><ObjectIdentityQuery Id="8" ObjectPathId="6" /><Query Id="9" ObjectPathId="6"><Query SelectAllProperties="true"><Properties /></Query></Query></Actions><ObjectPaths><StaticMethod Id="3" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="6" ParentId="3" Name="GetDefaultSiteCollectionTermStore" /></ObjectPaths></Request>`) {
+          return JSON.stringify([
+            {
+              "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8112.1217", "ErrorInfo": null, "TraceCorrelationId": "d94a919e-5076-0000-29c7-0729bb255d69"
+            }, 4, {
+              "IsNull": false
+            }, 5, {
+              "_ObjectIdentity_": "d94a919e-5076-0000-29c7-0729bb255d69|fec14c62-7c3b-481b-851b-c80d7802b224:ss:"
+            }, 7, {
+              "IsNull": false
+            }, 8, {
+              "_ObjectIdentity_": "d94a919e-5076-0000-29c7-0729bb255d69|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ=="
+            }, 9, {
+              "_ObjectType_": "SP.Taxonomy.TermStore", "_ObjectIdentity_": "d94a919e-5076-0000-29c7-0729bb255d69|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ==", "DefaultLanguage": 1033, "Id": "\/Guid(707e4d61-bd1c-4bc1-a1fd-fce01591a951)\/", "IsOnline": true, "Languages": [
+                1033
+              ], "Name": "Taxonomy_tDB2pT87w98nSRfEZAp8tQ==", "WorkingLanguage": 1033
+            }
+          ]);
+        }
+
+        if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="14" ObjectPathId="13" /><ObjectIdentityQuery Id="15" ObjectPathId="13" /><Query Id="16" ObjectPathId="13"><Query SelectAllProperties="false"><Properties><Property Name="Name" ScalarProperty="true" /><Property Name="Id" ScalarProperty="true" /><Property Name="Description" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><Method Id="13" ParentId="6" Name="CreateGroup"><Parameters><Parameter Type="String">PnPTermSets</Parameter><Parameter Type="Guid">{6cb612c7-2e96-47b9-b7c7-41ddc87379a8}</Parameter></Parameters></Method><Identity Id="6" Name="d94a919e-5076-0000-29c7-0729bb255d69|fec14c62-7c3b-481b-851b-c80d7802b224:st:YU1+cBy9wUuh\u002ffzgFZGpUQ==" /></ObjectPaths></Request>`) > -1) {
+          return JSON.stringify([
+            {
+              "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8112.1217", "ErrorInfo": null, "TraceCorrelationId": "d94a919e-0083-0000-29c7-00c65c41f487"
+            }, 14, {
+              "IsNull": false
+            }, 15, {
+              "_ObjectIdentity_": "d94a919e-0083-0000-29c7-00c65c41f487|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUccStmyWLrlHt8dB3chzeac="
+            }, 16, {
+              "_ObjectType_": "SP.Taxonomy.TermGroup", "_ObjectIdentity_": "d94a919e-0083-0000-29c7-00c65c41f487|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUccStmyWLrlHt8dB3chzeac=", "Name": "PnPTermSets", "Id": "\/Guid(6cb612c7-2e96-47b9-b7c7-41ddc87379a8)\/", "Description": ""
+            }
+          ]);
+        }
+
+        if (opts.data.indexOf(`<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="51" ObjectPathId="45" Name="Description"><Parameter Type="String">Term sets for PnP</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="45" Name="d94a919e-0083-0000-29c7-00c65c41f487|fec14c62-7c3b-481b-851b-c80d7802b224:gr:YU1+cBy9wUuh\u002ffzgFZGpUccStmyWLrlHt8dB3chzeac=" /></ObjectPaths></Request>`) > -1) {
+          return JSON.stringify([
+            {
+              "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8112.1217", "ErrorInfo": null, "TraceCorrelationId": "164b919e-40fa-0000-2cdb-e0b737b04e48"
+            }
+          ]);
+        }
+      }
+
+      throw 'Invalid request';
+    });
+    await command.action(logger, { options: { name: 'PnPTermSets', id: '6cb612c7-2e96-47b9-b7c7-41ddc87379a8', description: 'Term sets for PnP', webUrl: webUrl } } as any);
+    assert(loggerLogSpy.calledWith({ "Name": "PnPTermSets", "Id": "6cb612c7-2e96-47b9-b7c7-41ddc87379a8", "Description": "Term sets for PnP" }));
+  });
+
   it('correctly handles error when retrieving the term store', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf('/_vti_bin/client.svc/ProcessQuery') > -1) {
@@ -544,13 +597,18 @@ describe(commands.TERM_GROUP_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if webUrl is not a valid webUrl', async () => {
+    const actual = await command.validate({ options: { name: 'PnPTermSets', webUrl: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('passes validation when id and name specified', async () => {
     const actual = await command.validate({ options: { name: 'PnPTermSets', id: '9e54299e-208a-4000-8546-cc4139091b26' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation when name specified', async () => {
-    const actual = await command.validate({ options: { name: 'People' } }, commandInfo);
+  it('passes validation when name and webUrl are specified', async () => {
+    const actual = await command.validate({ options: { name: 'People', webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 });


### PR DESCRIPTION
Closes #4838 

@martinlingstuyl this made the enhancement a lot easier (and really small), but seems to work lovely. 

I've tried this with a user authenticated using `--authType deviceCode` that did only have term store administrator permissions, and without the `--webUrl` this command indeed failed. Including the `--webUrl` works just fine. The user does still need to have access to the site that we are passing in `--webUrl` obviously, otherwise it will throw an unauthorized exception. Read permissions seems to be enough