### PR TITLE
Adds command `spo file checkout undo`

### DIFF
--- a/docs/docs/cmd/spo/file/file-checkout-undo.mdx
+++ b/docs/docs/cmd/spo/file/file-checkout-undo.mdx
@@ -1,0 +1,47 @@
+import Global from '/docs/cmd/_global.mdx';
+
+# spo file checkout undo
+
+Discards a checked out file
+
+## Usage
+
+```sh
+m365 spo file checkout undo [options]
+```
+
+## Options
+
+```md definition-list
+`-u, --webUrl <webUrl>`
+: The URL of the site where the file is located.
+
+`-f, --fileUrl [fileUrl]`
+: The server- or site-relative URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both.
+
+`-i, --fileId [fileId]`
+: The UniqueId (GUID) of the file to retrieve. Specify either `fileUrl` or `fileId` but not both.
+
+`--confirm`
+: Don't prompt for confirmation.
+```
+
+<Global />
+
+## Examples
+
+Discards a checked-out file with a specific ID.
+
+```sh
+m365 spo file checkout undo --webUrl https://contoso.sharepoint.com/sites/project-x --fileId 'b2307a39-e878-458b-bc90-03bc578531d6'
+```
+
+Discards a checked-out file with a specific URL without prompting for confirmation.
+
+```sh
+m365 spo file checkout undo --webUrl https://contoso.sharepoint.com/sites/project-x --fileUrl'/sites/project-x/documents/Test1.docx' --confirm
+```
+
+## Response
+
+The command won't return a response on success.

--- a/docs/docs/cmd/spo/file/file-checkout-undo.mdx
+++ b/docs/docs/cmd/spo/file/file-checkout-undo.mdx
@@ -28,6 +28,14 @@ m365 spo file checkout undo [options]
 
 <Global />
 
+## Remarks
+
+:::info
+
+When using this command, make sure to only use decoded URLs or the command will not work.
+
+:::
+
 ## Examples
 
 Discards a checked-out file with a specific ID.
@@ -39,7 +47,7 @@ m365 spo file checkout undo --webUrl https://contoso.sharepoint.com/sites/projec
 Discards a checked-out file with a specific URL without prompting for confirmation.
 
 ```sh
-m365 spo file checkout undo --webUrl https://contoso.sharepoint.com/sites/project-x --fileUrl'/sites/project-x/documents/Test1.docx' --confirm
+m365 spo file checkout undo --webUrl https://contoso.sharepoint.com/sites/project-x --fileUrl '/sites/project-x/documents/Test1.docx' --confirm
 ```
 
 ## Response

--- a/docs/src/config/sidebars.js
+++ b/docs/src/config/sidebars.js
@@ -2076,6 +2076,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              label: 'file checkout undo',
+              id: 'cmd/spo/file/file-checkout-undo'
+            },
+            {
+              type: 'doc',
               label: 'file copy',
               id: 'cmd/spo/file/file-copy'
             },

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -59,6 +59,7 @@ export default {
   FILE_ADD: `${prefix} file add`,
   FILE_CHECKIN: `${prefix} file checkin`,
   FILE_CHECKOUT: `${prefix} file checkout`,
+  FILE_CHECKOUT_UNDO: `${prefix} file checkout undo`,
   FILE_COPY: `${prefix} file copy`,
   FILE_GET: `${prefix} file get`,
   FILE_LIST: `${prefix} file list`,

--- a/src/m365/spo/commands/file/file-checkout-undo.spec.ts
+++ b/src/m365/spo/commands/file/file-checkout-undo.spec.ts
@@ -1,0 +1,165 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { telemetry } from '../../../../telemetry';
+import auth from '../../../../Auth';
+import { Cli } from '../../../../cli/Cli';
+import { CommandInfo } from '../../../../cli/CommandInfo';
+import { Logger } from '../../../../cli/Logger';
+import Command, { CommandError } from '../../../../Command';
+import request from '../../../../request';
+import { pid } from '../../../../utils/pid';
+import { session } from '../../../../utils/session';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+import commands from '../../commands';
+import { formatting } from '../../../../utils/formatting';
+import { urlUtil } from '../../../../utils/urlUtil';
+const command: Command = require('./file-checkout-undo');
+
+describe(commands.FILE_CHECKOUT_UNDO, () => {
+  const webUrl = 'https://contoso.sharepoint.com/sites/projects';
+  const fileId = 'f09c4efe-b8c0-4e89-a166-03418661b89b';
+  const fileUrl = '/sites/projects/shared documents/test.docx';
+
+  let cli: Cli;
+  let log: any[];
+  let logger: Logger;
+  let commandInfo: CommandInfo;
+  let promptOptions: any;
+
+  before(() => {
+    cli = Cli.getInstance();
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
+    auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
+      promptOptions = options;
+      return { continue: false };
+    });
+    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(((_, defaultValue) => defaultValue));
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.post,
+      Cli.prompt,
+      cli.getSettingWithDefaultValue
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.FILE_CHECKOUT_UNDO);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('undos checkout for file retrieved by fileId when prompt confirmed', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/getFileById('${fileId}')/undocheckout`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: true }
+    ));
+    await command.action(logger, { options: { webUrl: webUrl, fileId: fileId, verbose: true } });
+    assert(postStub.called);
+  });
+
+  it('undos checkout for file retrieved by fileUrl', async () => {
+    const serverRelativePath = urlUtil.getServerRelativePath(webUrl, fileUrl);
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/getFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/undocheckout`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+    await command.action(logger, { options: { webUrl: webUrl, fileUrl: fileUrl, confirm: true, verbose: true } });
+    assert(postStub.called);
+  });
+
+  it('handles error when file is not checked out', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/getFileById('${fileId}')/undocheckout`) {
+        throw {
+          error: {
+            'odata.error': {
+              code: '-2147024738, Microsoft.SharePoint.SPFileCheckOutException',
+              message: {
+                lang: 'en-US',
+                value: 'The file "Shared Documents/4.docx" is not checked out.'
+              }
+            }
+          }
+        };
+      }
+
+      throw 'Invalid request';
+    });
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, fileId: fileId, confirm: true, verbose: true } }), new CommandError('The file "Shared Documents/4.docx" is not checked out.'));
+  });
+
+  it('prompts before undoing checkout when confirmation argument not passed', async () => {
+    await command.action(logger, { options: { webUrl: webUrl, fileId: fileId } });
+    let promptIssued = false;
+
+    if (promptOptions && promptOptions.type === 'confirm') {
+      promptIssued = true;
+    }
+
+    assert(promptIssued);
+  });
+
+  it('aborts undoing checkout when prompt not confirmed', async () => {
+    const postStub = sinon.stub(request, 'post');
+    sinonUtil.restore(Cli.prompt);
+    sinon.stub(Cli, 'prompt').callsFake(async () => (
+      { continue: false }
+    ));
+    await command.action(logger, { options: { webUrl: webUrl, id: fileId } });
+    assert(postStub.notCalled);
+  });
+
+  it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({ options: { webUrl: 'invalid', fileId: fileId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the fileId option is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, fileId: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the webUrl option is a valid SharePoint site URL and fileId is a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: webUrl, fileId: fileId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+});

--- a/src/m365/spo/commands/file/file-checkout-undo.ts
+++ b/src/m365/spo/commands/file/file-checkout-undo.ts
@@ -1,0 +1,138 @@
+import { Cli } from '../../../../cli/Cli';
+import { Logger } from '../../../../cli/Logger';
+import GlobalOptions from '../../../../GlobalOptions';
+import request, { CliRequestOptions } from '../../../../request';
+import { formatting } from '../../../../utils/formatting';
+import { urlUtil } from '../../../../utils/urlUtil';
+import { validation } from '../../../../utils/validation';
+import SpoCommand from '../../../base/SpoCommand';
+import commands from '../../commands';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  fileUrl?: string;
+  fileId?: string;
+  confirm?: boolean;
+}
+
+class SpoFileCheckoutUndoCommand extends SpoCommand {
+  public get name(): string {
+    return commands.FILE_CHECKOUT_UNDO;
+  }
+
+  public get description(): string {
+    return 'Discards a checked out file';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initOptionSets();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        fileId: typeof args.options.fileId !== 'undefined',
+        fileUrl: typeof args.options.fileUrl !== 'undefined',
+        confirm: !!args.options.confirm
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '-f, --fileUrl [fileUrl]'
+      },
+      {
+        option: '-i, --fileId [fileId]'
+      },
+      {
+        option: '--confirm'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        const isValidSharePointUrl: boolean | string = validation.isValidSharePointUrl(args.options.webUrl);
+        if (isValidSharePointUrl !== true) {
+          return isValidSharePointUrl;
+        }
+
+        if (args.options.fileId && !validation.isValidGuid(args.options.fileId)) {
+          return `${args.options.fileId} is not a valid GUID`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['fileId', 'fileUrl'] });
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+
+    const undoCheckout = async (): Promise<void> => {
+      let requestUrl: string = `${args.options.webUrl}/_api/web/`;
+
+      if (args.options.fileId) {
+        requestUrl += `getFileById('${args.options.fileId}')`;
+      }
+
+      if (args.options.fileUrl) {
+        const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl);
+        requestUrl += `getFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')`;
+      }
+
+      requestUrl += '/undocheckout';
+
+      const requestOptions: CliRequestOptions = {
+        url: requestUrl,
+        headers: {
+          'accept': 'application/json;odata=nometadata'
+        },
+        responseType: 'json'
+      };
+
+      try {
+        await request.post(requestOptions);
+      }
+      catch (err: any) {
+        this.handleRejectedODataJsonPromise(err);
+      }
+    };
+
+    if (args.options.confirm) {
+      await undoCheckout();
+    }
+    else {
+      const result = await Cli.prompt<{ continue: boolean }>({
+        type: 'confirm',
+        name: 'continue',
+        default: false,
+        message: `Are you sure you want to undo the checkout for file ${args.options.fileId || args.options.fileUrl} ?`
+      });
+
+      if (result.continue) {
+        await undoCheckout();
+      }
+    }
+  }
+}
+
+module.exports = new SpoFileCheckoutUndoCommand();

--- a/src/m365/spo/commands/file/file-checkout-undo.ts
+++ b/src/m365/spo/commands/file/file-checkout-undo.ts
@@ -86,30 +86,32 @@ class SpoFileCheckoutUndoCommand extends SpoCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-
     const undoCheckout = async (): Promise<void> => {
-      let requestUrl: string = `${args.options.webUrl}/_api/web/`;
-
-      if (args.options.fileId) {
-        requestUrl += `getFileById('${args.options.fileId}')`;
-      }
-
-      if (args.options.fileUrl) {
-        const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl);
-        requestUrl += `getFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')`;
-      }
-
-      requestUrl += '/undocheckout';
-
-      const requestOptions: CliRequestOptions = {
-        url: requestUrl,
-        headers: {
-          'accept': 'application/json;odata=nometadata'
-        },
-        responseType: 'json'
-      };
-
       try {
+        if (this.verbose) {
+          logger.logToStderr(`Undoing checkout for file ${args.options.fileId || args.options.fileUrl} on web ${args.options.webUrl}`);
+        }
+
+        let requestUrl: string = `${args.options.webUrl}/_api/web/`;
+
+        if (args.options.fileId) {
+          requestUrl += `getFileById('${args.options.fileId}')`;
+        }
+        else if (args.options.fileUrl) {
+          const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl);
+          requestUrl += `getFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')`;
+        }
+
+        requestUrl += '/undocheckout';
+
+        const requestOptions: CliRequestOptions = {
+          url: requestUrl,
+          headers: {
+            'accept': 'application/json;odata=nometadata'
+          },
+          responseType: 'json'
+        };
+
         await request.post(requestOptions);
       }
       catch (err: any) {


### PR DESCRIPTION
Closes #4926 

@milanholemans I know that we discussed that we would first to the single verb commands, and then the multiple verb commands, but I think that this one has to be underneath the `file checkout` one, as this is directly related. If you would like to have this changed, feel free to tell me.
![image](https://github.com/pnp/cli-microsoft365/assets/9193870/3b23a12a-dcdd-45cb-a385-aca8610a89f8)

