### PR TITLE
Add extra resources for 'util accesstoken get'. Closes #4669

### DIFF
--- a/docs/docs/cmd/util/accesstoken/accesstoken-get.mdx
+++ b/docs/docs/cmd/util/accesstoken/accesstoken-get.mdx
@@ -26,15 +26,13 @@ m365 util accesstoken get [options]
 
 ## Remarks
 
-The `util accesstoken get` command returns an access token for the specified resource. If an access token has been previously retrieved and is still valid, the command will return the cached token. If you want to ensure that the returned access token is valid for as long as possible, you can force the command to retrieve a new access token by using the `--new` option.
-
-If the URL of your SharePoint tenant has been previously retrieved, you can use `sharepoint` as the resource to retrieve access token for SharePoint. To verify if the URL of your SharePoint tenant has been previously retrieved, use the [`spo get`](../../spo/spo-get.mdx) command. To explicitly set the URL of your SharePoint tenant use the [`spo set`](../../spo/spo-set.mdx) command.
-
 :::tip
 
 You can use `sharepoint` as the resource to retrieve access token for SharePoint and `graph` to retrieve access token for Microsoft Graph.
 
 :::
+
+The `util accesstoken get` command returns an access token for the specified resource. If an access token has been previously retrieved and is still valid, the command will return the cached token. If you want to ensure that the returned access token is valid for as long as possible, you can force the command to retrieve a new access token by using the `--new` option.
 
 ## Examples
 

--- a/docs/docs/cmd/util/accesstoken/accesstoken-get.mdx
+++ b/docs/docs/cmd/util/accesstoken/accesstoken-get.mdx
@@ -30,7 +30,11 @@ The `util accesstoken get` command returns an access token for the specified res
 
 If the URL of your SharePoint tenant has been previously retrieved, you can use `sharepoint` as the resource to retrieve access token for SharePoint. To verify if the URL of your SharePoint tenant has been previously retrieved, use the [`spo get`](../../spo/spo-get.mdx) command. To explicitly set the URL of your SharePoint tenant use the [`spo set`](../../spo/spo-set.mdx) command.
 
-You can use `graph` as the resource to retrieve access token for Microsoft Graph.
+:::tip
+
+You can use `sharepoint` as the resource to retrieve access token for SharePoint and `graph` to retrieve access token for Microsoft Graph.
+
+:::
 
 ## Examples
 

--- a/docs/docs/cmd/util/accesstoken/accesstoken-get.mdx
+++ b/docs/docs/cmd/util/accesstoken/accesstoken-get.mdx
@@ -30,6 +30,8 @@ The `util accesstoken get` command returns an access token for the specified res
 
 If the URL of your SharePoint tenant has been previously retrieved, you can use `sharepoint` as the resource to retrieve access token for SharePoint. To verify if the URL of your SharePoint tenant has been previously retrieved, use the [`spo get`](../../spo/spo-get.mdx) command. To explicitly set the URL of your SharePoint tenant use the [`spo set`](../../spo/spo-set.mdx) command.
 
+You can use `graph` as the resource to retrieve access token for Microsoft Graph.
+
 ## Examples
 
 Get access token for the Microsoft Graph
@@ -42,6 +44,12 @@ Get access token for SharePoint Online using the shorthand identifier
 
 ```sh
 m365 util accesstoken get --resource sharepoint
+```
+
+Get access token for Microsoft Graph using the shorthand identifier
+
+```sh
+m365 util accesstoken get --resource graph
 ```
 
 Get a new access token for SharePoint Online

--- a/src/m365/util/commands/accesstoken/accesstoken-get.spec.ts
+++ b/src/m365/util/commands/accesstoken/accesstoken-get.spec.ts
@@ -100,4 +100,16 @@ describe(commands.ACCESSTOKEN_GET, () => {
 
     await assert.rejects(command.action(logger, { options: { resource: 'sharepoint' } } as any), new CommandError(`SharePoint URL undefined. Use the 'm365 spo set --url https://contoso.sharepoint.com' command to set the URL`));
   });
+
+  it('retrieves access token for graph.microsoft.com when graph specified as the resource', async () => {
+    const d: Date = new Date();
+    d.setMinutes(d.getMinutes() + 1);
+    auth.service.accessTokens['https://graph.microsoft.com'] = {
+      expiresOn: d.toString(),
+      accessToken: 'ABC'
+    };
+
+    await command.action(logger, { options: { resource: 'graph' } });
+    assert(loggerLogSpy.calledWith('ABC'));
+  });
 });

--- a/src/m365/util/commands/accesstoken/accesstoken-get.ts
+++ b/src/m365/util/commands/accesstoken/accesstoken-get.ts
@@ -60,10 +60,14 @@ class UtilAccessTokenGetCommand extends Command {
       }
     }
 
-    try { 
+    if (resource.toLowerCase() === 'graph') {
+      resource = auth.defaultResource;
+    }
+
+    try {
       const accessToken: string = await auth.ensureAccessToken(resource, logger, this.debug, args.options.new);
-      logger.log(accessToken);      
-    } 
+      logger.log(accessToken);
+    }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }

--- a/src/m365/util/commands/accesstoken/accesstoken-get.ts
+++ b/src/m365/util/commands/accesstoken/accesstoken-get.ts
@@ -1,4 +1,4 @@
-import auth from '../../../../Auth';
+import auth, { Auth } from '../../../../Auth';
 import { Logger } from '../../../../cli/Logger';
 import Command from '../../../../Command';
 import GlobalOptions from '../../../../GlobalOptions';
@@ -51,20 +51,19 @@ class UtilAccessTokenGetCommand extends Command {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     let resource: string = args.options.resource;
 
-    if (resource.toLowerCase() === 'sharepoint') {
-      if (auth.service.spoUrl) {
-        resource = auth.service.spoUrl;
-      }
-      else {
-        throw `SharePoint URL undefined. Use the 'm365 spo set --url https://contoso.sharepoint.com' command to set the URL`;
-      }
-    }
-
-    if (resource.toLowerCase() === 'graph') {
-      resource = auth.defaultResource;
-    }
-
     try {
+      if (resource.toLowerCase() === 'sharepoint') {
+        if (auth.service.spoUrl) {
+          resource = auth.service.spoUrl;
+        }
+        else {
+          throw `SharePoint URL undefined. Use the 'm365 spo set --url https://contoso.sharepoint.com' command to set the URL`;
+        }
+      }
+      else if (resource.toLowerCase() === 'graph') {
+        resource = Auth.getEndpointForResource('https://graph.microsoft.com', auth.service.cloudType);
+      }
+
       const accessToken: string = await auth.ensureAccessToken(resource, logger, this.debug, args.options.new);
       logger.log(accessToken);
     }


### PR DESCRIPTION
### Add extra resources for 'util accesstoken get'. Closes #4669
- Extends 'util accesstoken get' command with extra resource shorthand identifier `graph`. Closes #4669

Closes #4669