### PR TITLE
Refactor codebase to async/await - `m365 pp aibuildermodel` until `m365 pp chatbot`, Closes #4990

### DIFF
--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.spec.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.spec.ts
@@ -70,10 +70,10 @@ describe(commands.AIBUILDERMODEL_GET, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.spec.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.spec.ts
@@ -107,7 +107,7 @@ describe(commands.AIBUILDERMODEL_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.AIBUILDERMODEL_GET), true);
+    assert.strictEqual(command.name, commands.AIBUILDERMODEL_GET);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-list.spec.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-list.spec.ts
@@ -66,10 +66,10 @@ describe(commands.AIBUILDERMODEL_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-remove.spec.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-remove.spec.ts
@@ -112,7 +112,7 @@ describe(commands.AIBUILDERMODEL_REMOVE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.AIBUILDERMODEL_REMOVE), true);
+    assert.strictEqual(command.name, commands.AIBUILDERMODEL_REMOVE);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-remove.spec.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-remove.spec.ts
@@ -68,10 +68,10 @@ describe(commands.AIBUILDERMODEL_REMOVE, () => {
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/card/card-clone.spec.ts
+++ b/src/m365/pp/commands/card/card-clone.spec.ts
@@ -31,10 +31,10 @@ describe(commands.CARD_CLONE, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/card/card-clone.spec.ts
+++ b/src/m365/pp/commands/card/card-clone.spec.ts
@@ -71,7 +71,7 @@ describe(commands.CARD_CLONE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.CARD_CLONE), true);
+    assert.strictEqual(command.name, commands.CARD_CLONE);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/card/card-get.spec.ts
+++ b/src/m365/pp/commands/card/card-get.spec.ts
@@ -116,7 +116,7 @@ describe(commands.CARD_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.CARD_GET), true);
+    assert.strictEqual(command.name, commands.CARD_GET);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/card/card-get.spec.ts
+++ b/src/m365/pp/commands/card/card-get.spec.ts
@@ -79,10 +79,10 @@ describe(commands.CARD_GET, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/card/card-list.spec.ts
+++ b/src/m365/pp/commands/card/card-list.spec.ts
@@ -110,7 +110,7 @@ describe(commands.CARD_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.CARD_LIST), true);
+    assert.strictEqual(command.name, commands.CARD_LIST);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/card/card-list.spec.ts
+++ b/src/m365/pp/commands/card/card-list.spec.ts
@@ -75,10 +75,10 @@ describe(commands.CARD_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/card/card-remove.spec.ts
+++ b/src/m365/pp/commands/card/card-remove.spec.ts
@@ -74,7 +74,7 @@ describe(commands.CARD_REMOVE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.CARD_REMOVE), true);
+    assert.strictEqual(command.name, commands.CARD_REMOVE);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/card/card-remove.spec.ts
+++ b/src/m365/pp/commands/card/card-remove.spec.ts
@@ -30,10 +30,10 @@ describe(commands.CARD_REMOVE, () => {
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/chatbot/chatbot-get.spec.ts
+++ b/src/m365/pp/commands/chatbot/chatbot-get.spec.ts
@@ -81,10 +81,10 @@ describe(commands.CHATBOT_GET, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/chatbot/chatbot-list.spec.ts
+++ b/src/m365/pp/commands/chatbot/chatbot-list.spec.ts
@@ -127,7 +127,7 @@ describe(commands.CHATBOT_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.CHATBOT_LIST), true);
+    assert.strictEqual(command.name, commands.CHATBOT_LIST);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/chatbot/chatbot-list.spec.ts
+++ b/src/m365/pp/commands/chatbot/chatbot-list.spec.ts
@@ -91,10 +91,10 @@ describe(commands.CHATBOT_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/chatbot/chatbot-remove.spec.ts
+++ b/src/m365/pp/commands/chatbot/chatbot-remove.spec.ts
@@ -30,10 +30,10 @@ describe(commands.CHATBOT_REMOVE, () => {
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });


### PR DESCRIPTION
Refactoring of the commands from `m365 pp aibuildermodel` until `m365 pp chatbot`
- `m365 pp aibuildermodel get`
- `m365 pp aibuildermodel list`
- `m365 pp aibuildermodel remove`
- `m365 pp card clone`
- `m365 pp card get`
- `m365 pp card list`
- `m365 pp card remove`
- `m365 pp chatbot get`
- `m365 pp chatbot list`
- `m365 pp chatbot remove`

Closes #4990