### PR TITLE
Refactor codebase to async/await - `m365 pp dataverse` until `m365 pp managementapp`, Closes #4992

### DIFF
--- a/src/m365/pp/commands/dataverse/dataverse-table-get.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-get.spec.ts
@@ -121,7 +121,7 @@ describe(commands.DATAVERSE_TABLE_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.DATAVERSE_TABLE_GET), true);
+    assert.strictEqual(command.name, commands.DATAVERSE_TABLE_GET);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/dataverse/dataverse-table-get.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-get.spec.ts
@@ -85,10 +85,10 @@ describe(commands.DATAVERSE_TABLE_GET, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/dataverse/dataverse-table-list.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-list.spec.ts
@@ -150,10 +150,10 @@ describe(commands.DATAVERSE_TABLE_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -198,23 +198,23 @@ describe(commands.DATAVERSE_TABLE_LIST, () => {
 
   it('retrieves data from dataverse', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url === `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/4be50206-9576-4237-8b17-38d8aadfaa36?api-version=2020-10-01&$select=properties.linkedEnvironmentMetadata.instanceApiUrl`)) {
+      if (opts.url === `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/4be50206-9576-4237-8b17-38d8aadfaa36?api-version=2020-10-01&$select=properties.linkedEnvironmentMetadata.instanceApiUrl`) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve(envResponse);
+          return envResponse;
         }
       }
 
-      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.0/EntityDefinitions?$select=MetadataId,IsCustomEntity,IsManaged,SchemaName,IconVectorName,LogicalName,EntitySetName,IsActivity,DataProviderId,IsRenameable,IsCustomizable,CanCreateForms,CanCreateViews,CanCreateCharts,CanCreateAttributes,CanChangeTrackingBeEnabled,CanModifyAdditionalSettings,CanChangeHierarchicalRelationship,CanEnableSyncToExternalSearchIndex&$filter=(IsIntersect eq false and IsLogicalEntity eq false and%0APrimaryNameAttribute ne null and PrimaryNameAttribute ne %27%27 and ObjectTypeCode gt 0 and%0AObjectTypeCode ne 4712 and ObjectTypeCode ne 4724 and ObjectTypeCode ne 9933 and ObjectTypeCode ne 9934 and%0AObjectTypeCode ne 9935 and ObjectTypeCode ne 9947 and ObjectTypeCode ne 9945 and ObjectTypeCode ne 9944 and%0AObjectTypeCode ne 9942 and ObjectTypeCode ne 9951 and ObjectTypeCode ne 2016 and ObjectTypeCode ne 9949 and%0AObjectTypeCode ne 9866 and ObjectTypeCode ne 9867 and ObjectTypeCode ne 9868) and (IsCustomizable/Value eq true or IsCustomEntity eq true or IsManaged eq false or IsMappable/Value eq true or IsRenameable/Value eq true)&api-version=9.1`)) {
+      if (opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.0/EntityDefinitions?$select=MetadataId,IsCustomEntity,IsManaged,SchemaName,IconVectorName,LogicalName,EntitySetName,IsActivity,DataProviderId,IsRenameable,IsCustomizable,CanCreateForms,CanCreateViews,CanCreateCharts,CanCreateAttributes,CanChangeTrackingBeEnabled,CanModifyAdditionalSettings,CanChangeHierarchicalRelationship,CanEnableSyncToExternalSearchIndex&$filter=(IsIntersect eq false and IsLogicalEntity eq false and%0APrimaryNameAttribute ne null and PrimaryNameAttribute ne %27%27 and ObjectTypeCode gt 0 and%0AObjectTypeCode ne 4712 and ObjectTypeCode ne 4724 and ObjectTypeCode ne 9933 and ObjectTypeCode ne 9934 and%0AObjectTypeCode ne 9935 and ObjectTypeCode ne 9947 and ObjectTypeCode ne 9945 and ObjectTypeCode ne 9944 and%0AObjectTypeCode ne 9942 and ObjectTypeCode ne 9951 and ObjectTypeCode ne 2016 and ObjectTypeCode ne 9949 and%0AObjectTypeCode ne 9866 and ObjectTypeCode ne 9867 and ObjectTypeCode ne 9868) and (IsCustomizable/Value eq true or IsCustomEntity eq true or IsManaged eq false or IsMappable/Value eq true or IsRenameable/Value eq true)&api-version=9.1`) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve(dataverseResponse);
+          return dataverseResponse;
         }
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { debug: true, environment: '4be50206-9576-4237-8b17-38d8aadfaa36' } });
@@ -223,23 +223,23 @@ describe(commands.DATAVERSE_TABLE_LIST, () => {
 
   it('retrieves data from dataverse as admin', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url === `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/4be50206-9576-4237-8b17-38d8aadfaa36?api-version=2020-10-01&$select=properties.linkedEnvironmentMetadata.instanceApiUrl`)) {
+      if (opts.url === `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/4be50206-9576-4237-8b17-38d8aadfaa36?api-version=2020-10-01&$select=properties.linkedEnvironmentMetadata.instanceApiUrl`) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve(envResponse);
+          return envResponse;
         }
       }
 
-      if ((opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.0/EntityDefinitions?$select=MetadataId,IsCustomEntity,IsManaged,SchemaName,IconVectorName,LogicalName,EntitySetName,IsActivity,DataProviderId,IsRenameable,IsCustomizable,CanCreateForms,CanCreateViews,CanCreateCharts,CanCreateAttributes,CanChangeTrackingBeEnabled,CanModifyAdditionalSettings,CanChangeHierarchicalRelationship,CanEnableSyncToExternalSearchIndex&$filter=(IsIntersect eq false and IsLogicalEntity eq false and%0APrimaryNameAttribute ne null and PrimaryNameAttribute ne %27%27 and ObjectTypeCode gt 0 and%0AObjectTypeCode ne 4712 and ObjectTypeCode ne 4724 and ObjectTypeCode ne 9933 and ObjectTypeCode ne 9934 and%0AObjectTypeCode ne 9935 and ObjectTypeCode ne 9947 and ObjectTypeCode ne 9945 and ObjectTypeCode ne 9944 and%0AObjectTypeCode ne 9942 and ObjectTypeCode ne 9951 and ObjectTypeCode ne 2016 and ObjectTypeCode ne 9949 and%0AObjectTypeCode ne 9866 and ObjectTypeCode ne 9867 and ObjectTypeCode ne 9868) and (IsCustomizable/Value eq true or IsCustomEntity eq true or IsManaged eq false or IsMappable/Value eq true or IsRenameable/Value eq true)&api-version=9.1`)) {
+      if (opts.url === `https://contoso-dev.api.crm4.dynamics.com/api/data/v9.0/EntityDefinitions?$select=MetadataId,IsCustomEntity,IsManaged,SchemaName,IconVectorName,LogicalName,EntitySetName,IsActivity,DataProviderId,IsRenameable,IsCustomizable,CanCreateForms,CanCreateViews,CanCreateCharts,CanCreateAttributes,CanChangeTrackingBeEnabled,CanModifyAdditionalSettings,CanChangeHierarchicalRelationship,CanEnableSyncToExternalSearchIndex&$filter=(IsIntersect eq false and IsLogicalEntity eq false and%0APrimaryNameAttribute ne null and PrimaryNameAttribute ne %27%27 and ObjectTypeCode gt 0 and%0AObjectTypeCode ne 4712 and ObjectTypeCode ne 4724 and ObjectTypeCode ne 9933 and ObjectTypeCode ne 9934 and%0AObjectTypeCode ne 9935 and ObjectTypeCode ne 9947 and ObjectTypeCode ne 9945 and ObjectTypeCode ne 9944 and%0AObjectTypeCode ne 9942 and ObjectTypeCode ne 9951 and ObjectTypeCode ne 2016 and ObjectTypeCode ne 9949 and%0AObjectTypeCode ne 9866 and ObjectTypeCode ne 9867 and ObjectTypeCode ne 9868) and (IsCustomizable/Value eq true or IsCustomEntity eq true or IsManaged eq false or IsMappable/Value eq true or IsRenameable/Value eq true)&api-version=9.1`) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve(dataverseResponse);
+          return dataverseResponse;
         }
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { debug: true, environment: '4be50206-9576-4237-8b17-38d8aadfaa36', asAdmin: true } });
@@ -248,15 +248,15 @@ describe(commands.DATAVERSE_TABLE_LIST, () => {
 
   it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url === `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/4be50206-9576-4237-8b17-38d8aadfaa36?api-version=2020-10-01&$select=properties.linkedEnvironmentMetadata.instanceApiUrl`)) {
+      if (opts.url === `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/4be50206-9576-4237-8b17-38d8aadfaa36?api-version=2020-10-01&$select=properties.linkedEnvironmentMetadata.instanceApiUrl`) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve(envResponse);
+          return envResponse;
         }
       }
 
-      return Promise.reject({
+      throw {
         error: {
           'odata.error': {
             code: '-1, InvalidOperationException',
@@ -265,7 +265,7 @@ describe(commands.DATAVERSE_TABLE_LIST, () => {
             }
           }
         }
-      });
+      };
     });
 
     try {

--- a/src/m365/pp/commands/dataverse/dataverse-table-list.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-list.spec.ts
@@ -185,7 +185,7 @@ describe(commands.DATAVERSE_TABLE_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.DATAVERSE_TABLE_LIST), true);
+    assert.strictEqual(command.name, commands.DATAVERSE_TABLE_LIST);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/dataverse/dataverse-table-remove.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-remove.spec.ts
@@ -68,7 +68,7 @@ describe(commands.DATAVERSE_TABLE_REMOVE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.DATAVERSE_TABLE_REMOVE), true);
+    assert.strictEqual(command.name, commands.DATAVERSE_TABLE_REMOVE);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/dataverse/dataverse-table-remove.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-remove.spec.ts
@@ -26,10 +26,10 @@ describe(commands.DATAVERSE_TABLE_REMOVE, () => {
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/dataverse/dataverse-table-row-list.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-row-list.spec.ts
@@ -56,10 +56,10 @@ describe(commands.DATAVERSE_TABLE_ROW_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/dataverse/dataverse-table-row-remove.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-row-remove.spec.ts
@@ -33,10 +33,10 @@ describe(commands.DATAVERSE_TABLE_ROW_REMOVE, () => {
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/environment/environment-get.spec.ts
+++ b/src/m365/pp/commands/environment/environment-get.spec.ts
@@ -67,7 +67,7 @@ describe(commands.ENVIRONMENT_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.ENVIRONMENT_GET), true);
+    assert.strictEqual(command.name, commands.ENVIRONMENT_GET);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/environment/environment-get.spec.ts
+++ b/src/m365/pp/commands/environment/environment-get.spec.ts
@@ -30,10 +30,10 @@ describe(commands.ENVIRONMENT_GET, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/environment/environment-list.spec.ts
+++ b/src/m365/pp/commands/environment/environment-list.spec.ts
@@ -52,7 +52,7 @@ describe(commands.ENVIRONMENT_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.ENVIRONMENT_LIST), true);
+    assert.strictEqual(command.name, commands.ENVIRONMENT_LIST);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/environment/environment-list.spec.ts
+++ b/src/m365/pp/commands/environment/environment-list.spec.ts
@@ -17,10 +17,10 @@ describe(commands.ENVIRONMENT_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -212,11 +212,11 @@ describe(commands.ENVIRONMENT_LIST, () => {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve(env);
+          return env;
         }
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { debug: true } });
@@ -372,11 +372,11 @@ describe(commands.ENVIRONMENT_LIST, () => {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve(env);
+          return env;
         }
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: {} });
@@ -532,29 +532,29 @@ describe(commands.ENVIRONMENT_LIST, () => {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve(env);
+          return env;
         }
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { asAdmin: true } });
     assert(loggerLogSpy.calledWith(env.value));
   });
   it('correctly handles no environments', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/providers/Microsoft.BusinessAppPlatform/environments?api-version=2020-10-01`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
-          return Promise.resolve({
+          return {
             value: []
-          });
+          };
         }
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: {} });
@@ -563,7 +563,7 @@ describe(commands.ENVIRONMENT_LIST, () => {
 
   it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').callsFake(() => {
-      return Promise.reject({
+      throw {
         error: {
           'odata.error': {
             code: '-1, InvalidOperationException',
@@ -572,7 +572,7 @@ describe(commands.ENVIRONMENT_LIST, () => {
             }
           }
         }
-      });
+      };
     });
 
     await assert.rejects(command.action(logger, { options: {} } as any),

--- a/src/m365/pp/commands/gateway/gateway-get.spec.ts
+++ b/src/m365/pp/commands/gateway/gateway-get.spec.ts
@@ -31,10 +31,10 @@ describe(commands.GATEWAY_GET, () => {
   };
 
   before(() => {
-    sinon.stub(auth, "restoreAuth").callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, "trackEvent").callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -100,7 +100,7 @@ describe(commands.GATEWAY_GET, () => {
 
   it("correctly handles error", async () => {
     sinon.stub(request, "get").callsFake(() => {
-      return Promise.reject("An error has occurred");
+      throw "An error has occurred";
     });
 
     await assert.rejects(
@@ -120,9 +120,9 @@ describe(commands.GATEWAY_GET, () => {
         "https://api.powerbi.com" +
         `/v1.0/myorg/gateways/${formatting.encodeQueryParameter(gateway.id)}`
       ) {
-        return Promise.resolve(gateway);
+        return gateway;
       }
-      return Promise.reject("Invalid request");
+      throw "Invalid request";
     });
 
     await command.action(logger, {

--- a/src/m365/pp/commands/gateway/gateway-get.spec.ts
+++ b/src/m365/pp/commands/gateway/gateway-get.spec.ts
@@ -65,7 +65,7 @@ describe(commands.GATEWAY_GET, () => {
   });
 
   it("has correct name", () => {
-    assert.strictEqual(command.name.startsWith(commands.GATEWAY_GET), true);
+    assert.strictEqual(command.name, commands.GATEWAY_GET);
   });
 
   it("has a description", () => {

--- a/src/m365/pp/commands/gateway/gateway-list.spec.ts
+++ b/src/m365/pp/commands/gateway/gateway-list.spec.ts
@@ -17,10 +17,10 @@ describe(commands.GATEWAY_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -85,11 +85,11 @@ describe(commands.GATEWAY_LIST, () => {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json;odata.metadata=none') === 0) {
-          return Promise.resolve(gateways);
+          return gateways;
         }
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { debug: true } });
@@ -98,7 +98,7 @@ describe(commands.GATEWAY_LIST, () => {
 
   it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').callsFake(() => {
-      return Promise.reject({
+      throw {
         error: {
           'odata.error': {
             code: '-1, InvalidOperationException',
@@ -107,7 +107,7 @@ describe(commands.GATEWAY_LIST, () => {
             }
           }
         }
-      });
+      };
     });
 
     await assert.rejects(command.action(logger, { options: {} } as any),

--- a/src/m365/pp/commands/gateway/gateway-list.spec.ts
+++ b/src/m365/pp/commands/gateway/gateway-list.spec.ts
@@ -52,7 +52,7 @@ describe(commands.GATEWAY_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.GATEWAY_LIST), true);
+    assert.strictEqual(command.name, commands.GATEWAY_LIST);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/managementapp/managementapp-add.spec.ts
+++ b/src/m365/pp/commands/managementapp/managementapp-add.spec.ts
@@ -122,7 +122,7 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('handles error when retrieving information about app through appId failed', async () => {
-    sinon.stub(request, 'get').callsFake(_ => { throw 'An error has occurred'; });
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
 
     await assert.rejects(command.action(logger, {
       options: {

--- a/src/m365/pp/commands/managementapp/managementapp-add.spec.ts
+++ b/src/m365/pp/commands/managementapp/managementapp-add.spec.ts
@@ -61,7 +61,7 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.MANAGEMENTAPP_ADD), true);
+    assert.strictEqual(command.name, commands.MANAGEMENTAPP_ADD);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/managementapp/managementapp-add.spec.ts
+++ b/src/m365/pp/commands/managementapp/managementapp-add.spec.ts
@@ -22,10 +22,10 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
 
   before(() => {
     cli = Cli.getInstance();
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -69,12 +69,12 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('handles error when the app specified with the objectId not found', async () => {
-    sinon.stub(request, 'get').callsFake(opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=id eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=appId`) {
-        return Promise.resolve({ value: [] });
+        return { value: [] };
       }
 
-      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+      throw `Invalid request ${JSON.stringify(opts)}`;
     });
 
     await assert.rejects(command.action(logger, {
@@ -85,12 +85,12 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('handles error when the app with the specified the name not found', async () => {
-    sinon.stub(request, 'get').callsFake(opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=displayName eq 'My%20app'&$select=appId`) {
-        return Promise.resolve({ value: [] });
+        return { value: [] };
       }
 
-      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+      throw `Invalid request ${JSON.stringify(opts)}`;
     });
 
     await assert.rejects(command.action(logger, {
@@ -101,17 +101,17 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('handles error when multiple apps with the specified name found', async () => {
-    sinon.stub(request, 'get').callsFake(opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=displayName eq 'My%20app'&$select=appId`) {
-        return Promise.resolve({
+        return {
           value: [
             { appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f' },
             { appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67g' }
           ]
-        });
+        };
       }
 
-      return Promise.reject(`Invalid request ${JSON.stringify(opts)}`);
+      throw `Invalid request ${JSON.stringify(opts)}`;
     });
 
     await assert.rejects(command.action(logger, {
@@ -122,7 +122,7 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('handles error when retrieving information about app through appId failed', async () => {
-    sinon.stub(request, 'get').callsFake(_ => Promise.reject('An error has occurred'));
+    sinon.stub(request, 'get').callsFake(_ => { throw 'An error has occurred'; });
 
     await assert.rejects(command.action(logger, {
       options: {
@@ -132,7 +132,7 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('handles error when retrieving information about app through name failed', async () => {
-    sinon.stub(request, 'get').callsFake(_ => Promise.reject('An error has occurred'));
+    sinon.stub(request, 'get').callsFake(_ => { throw 'An error has occurred'; });
 
     await assert.rejects(command.action(logger, {
       options: {
@@ -187,14 +187,14 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('successfully registers app as managementapp when passing appId', async () => {
-    sinon.stub(request, 'put').callsFake((opts) => {
+    sinon.stub(request, 'put').callsFake(async (opts) => {
       if ((opts.url as string).indexOf('providers/Microsoft.BusinessAppPlatform/adminApplications/9b1b1e42-794b-4c71-93ac-5ed92488b67f?api-version=2020-06-01') > -1) {
-        return Promise.resolve({
+        return {
           "applicationId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f"
-        });
+        };
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, {
@@ -207,9 +207,9 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
   });
 
   it('successfully registers app as managementapp when passing name ', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=displayName eq 'My%20Test%20App'&$select=appId`) {
-        return Promise.resolve({
+        return {
           value: [
             {
               "id": "340a4aa3-1af6-43ac-87d8-189819003952",
@@ -219,20 +219,20 @@ describe(commands.MANAGEMENTAPP_ADD, () => {
               "description": null
             }
           ]
-        });
+        };
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
-    sinon.stub(request, 'put').callsFake((opts) => {
+    sinon.stub(request, 'put').callsFake(async (opts) => {
       if ((opts.url as string).indexOf('providers/Microsoft.BusinessAppPlatform/adminApplications/9b1b1e42-794b-4c71-93ac-5ed92488b67f?api-version=2020-06-01') > -1) {
-        return Promise.resolve({
+        return {
           "applicationId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f"
-        });
+        };
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, {

--- a/src/m365/pp/commands/managementapp/managementapp-list.spec.ts
+++ b/src/m365/pp/commands/managementapp/managementapp-list.spec.ts
@@ -16,10 +16,10 @@ describe(commands.MANAGEMENTAPP_LIST, () => {
   let logger: Logger;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -59,13 +59,13 @@ describe(commands.MANAGEMENTAPP_LIST, () => {
   });
 
   it('successfully retrieves management application', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/adminApplications?api-version=2020-06-01") {
-        return Promise.resolve({
+        return {
           "value": [{ "applicationId": "31359c7f-bd7e-475c-86db-fdb8c937548e" }]
-        });
+        };
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, {
@@ -80,13 +80,13 @@ describe(commands.MANAGEMENTAPP_LIST, () => {
   });
 
   it('successfully retrieves multiple management applications', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/adminApplications?api-version=2020-06-01") {
-        return Promise.resolve({
+        return {
           "value": [{ "applicationId": "31359c7f-bd7e-475c-86db-fdb8c937548e" }, { "applicationId": "31359c7f-bd7e-475c-86db-fdb8c937548f" }]
-        });
+        };
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, {
@@ -101,13 +101,13 @@ describe(commands.MANAGEMENTAPP_LIST, () => {
   });
 
   it('successfully handles no result found', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/adminApplications?api-version=2020-06-01") {
-        return Promise.resolve({
+        return {
           "value": [{}]
-        });
+        };
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, {
@@ -122,7 +122,7 @@ describe(commands.MANAGEMENTAPP_LIST, () => {
 
   it('handles error correctly', async () => {
     sinon.stub(request, 'get').callsFake(() => {
-      return Promise.reject('An error has occurred');
+      throw 'An error has occurred';
     });
 
     await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('An error has occurred'));

--- a/src/m365/pp/commands/managementapp/managementapp-list.spec.ts
+++ b/src/m365/pp/commands/managementapp/managementapp-list.spec.ts
@@ -51,7 +51,7 @@ describe(commands.MANAGEMENTAPP_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.MANAGEMENTAPP_LIST), true);
+    assert.strictEqual(command.name, commands.MANAGEMENTAPP_LIST);
   });
 
   it('has a description', () => {


### PR DESCRIPTION
Refactoring of the commands from `m365 pp dataverse` until `m365 pp managementapp`
- `m365 pp dataverse table get`
- `m365 pp dataverse table list`
- `m365 pp dataverse table remove`
- `m365 pp dataverse table row list`
- `m365 pp dataverse table row remove`
- `m365 pp environment get`
- `m365 pp environment list`
- `m365 pp gateway get`
- `m365 pp gateway list`
- `m365 pp managementapp add`
- `m365 pp managementapp list`

Closes #4992