### PR TITLE
Refactor codebase to async/await - `m365 pp solution` until `m365 pp tenant`, Closes #4994

### DIFF
--- a/src/m365/pp/commands/solution/solution-get.spec.ts
+++ b/src/m365/pp/commands/solution/solution-get.spec.ts
@@ -85,7 +85,7 @@ describe(commands.SOLUTION_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.SOLUTION_GET), true);
+    assert.strictEqual(command.name, commands.SOLUTION_GET);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/solution/solution-get.spec.ts
+++ b/src/m365/pp/commands/solution/solution-get.spec.ts
@@ -48,10 +48,10 @@ describe(commands.SOLUTION_GET, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/solution/solution-list.spec.ts
+++ b/src/m365/pp/commands/solution/solution-list.spec.ts
@@ -78,10 +78,10 @@ describe(commands.SOLUTION_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/solution/solution-list.spec.ts
+++ b/src/m365/pp/commands/solution/solution-list.spec.ts
@@ -113,7 +113,7 @@ describe(commands.SOLUTION_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.SOLUTION_LIST), true);
+    assert.strictEqual(command.name, commands.SOLUTION_LIST);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/solution/solution-publish.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publish.spec.ts
@@ -44,10 +44,10 @@ describe(commands.SOLUTION_PUBLISH, () => {
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/solution/solution-publish.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publish.spec.ts
@@ -84,7 +84,7 @@ describe(commands.SOLUTION_PUBLISH, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.SOLUTION_PUBLISH), true);
+    assert.strictEqual(command.name, commands.SOLUTION_PUBLISH);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/solution/solution-publisher-add.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-add.spec.ts
@@ -29,10 +29,10 @@ describe(commands.SOLUTION_PUBLISHER_ADD, () => {
   let logger: Logger;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/solution/solution-publisher-get.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-get.spec.ts
@@ -39,10 +39,10 @@ describe(commands.SOLUTION_PUBLISHER_GET, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/solution/solution-publisher-get.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-get.spec.ts
@@ -76,7 +76,7 @@ describe(commands.SOLUTION_PUBLISHER_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.SOLUTION_PUBLISHER_GET), true);
+    assert.strictEqual(command.name, commands.SOLUTION_PUBLISHER_GET);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/solution/solution-publisher-list.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-list.spec.ts
@@ -44,10 +44,10 @@ describe(commands.SOLUTION_PUBLISHER_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/solution/solution-publisher-list.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-list.spec.ts
@@ -80,7 +80,7 @@ describe(commands.SOLUTION_PUBLISHER_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.SOLUTION_PUBLISHER_LIST), true);
+    assert.strictEqual(command.name, commands.SOLUTION_PUBLISHER_LIST);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/solution/solution-publisher-remove.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-remove.spec.ts
@@ -30,10 +30,10 @@ describe(commands.SOLUTION_PUBLISHER_REMOVE, () => {
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/solution/solution-publisher-remove.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-remove.spec.ts
@@ -75,7 +75,7 @@ describe(commands.SOLUTION_PUBLISHER_REMOVE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.SOLUTION_PUBLISHER_REMOVE), true);
+    assert.strictEqual(command.name, commands.SOLUTION_PUBLISHER_REMOVE);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/solution/solution-remove.spec.ts
+++ b/src/m365/pp/commands/solution/solution-remove.spec.ts
@@ -74,7 +74,7 @@ describe(commands.SOLUTION_REMOVE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.SOLUTION_REMOVE), true);
+    assert.strictEqual(command.name, commands.SOLUTION_REMOVE);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/solution/solution-remove.spec.ts
+++ b/src/m365/pp/commands/solution/solution-remove.spec.ts
@@ -30,10 +30,10 @@ describe(commands.SOLUTION_REMOVE, () => {
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
@@ -53,10 +53,10 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 

--- a/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-list.spec.ts
@@ -88,7 +88,7 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.TENANT_SETTINGS_LIST), true);
+    assert.strictEqual(command.name, commands.TENANT_SETTINGS_LIST);
   });
 
   it('has a description', () => {

--- a/src/m365/pp/commands/tenant/tenant-settings-set.spec.ts
+++ b/src/m365/pp/commands/tenant/tenant-settings-set.spec.ts
@@ -72,10 +72,10 @@ describe(commands.TENANT_SETTINGS_SET, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });


### PR DESCRIPTION
Refactoring of the commands from `m365 pp dataverse` until `m365 pp managementapp`
- `m365 pp solution get`
- `m365 pp solution list`
- `m365 pp solution publish`
- `m365 pp solution publisher add`
- `m365 pp solution publisher get`
- `m365 pp solution publisher list`
- `m365 pp solution publisher remove`
- `m365 pp solution remove`
- `m365 pp tenant settings list`
- `m365 pp tenant settings set`

Closes #4994