### PR TITLE
Refactor codebase to async/await - `m365 purview retentionlabel` until `m365 purview threatassessment`, Closes #4998

### DIFF
--- a/src/m365/purview/commands/retentionlabel/retentionlabel-add.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-add.spec.ts
@@ -89,10 +89,10 @@ describe(commands.RETENTIONLABEL_ADD, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     auth.service.accessTokens[(command as any).resource] = {
       accessToken: 'abc',
@@ -134,7 +134,7 @@ describe(commands.RETENTIONLABEL_ADD, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.RETENTIONLABEL_ADD), true);
+    assert.strictEqual(command.name, commands.RETENTIONLABEL_ADD);
   });
 
   it('has a description', () => {
@@ -344,7 +344,7 @@ describe(commands.RETENTIONLABEL_ADD, () => {
   });
 
   it('correctly handles random API error', async () => {
-    sinon.stub(request, 'post').callsFake(() => Promise.reject('An error has occurred'));
+    sinon.stub(request, 'post').callsFake(() => { throw 'An error has occurred'; });
 
     await assert.rejects(command.action(logger, {
       options: {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-get.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-get.spec.ts
@@ -54,10 +54,10 @@ describe(commands.RETENTIONLABEL_GET, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     auth.service.accessTokens[(command as any).resource] = {
       accessToken: 'abc',

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-list.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-list.spec.ts
@@ -60,10 +60,10 @@ describe(commands.RETENTIONLABEL_LIST, () => {
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     auth.service.accessTokens[(command as any).resource] = {
       accessToken: 'abc',

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-remove.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-remove.spec.ts
@@ -23,10 +23,10 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     auth.service.accessTokens[(command as any).resource] = {
       accessToken: 'abc',
@@ -71,7 +71,7 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.RETENTIONLABEL_REMOVE), true);
+    assert.strictEqual(command.name, commands.RETENTIONLABEL_REMOVE);
   });
 
   it('has a description', () => {
@@ -123,12 +123,12 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
   });
 
   it('Correctly deletes retention label by id', async () => {
-    sinon.stub(request, 'delete').callsFake((opts) => {
+    sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/beta/security/labels/retentionLabels/${validId}`) {
-        return Promise.resolve();
+        return;
       }
 
-      return Promise.reject('Invalid Request');
+      throw 'Invalid Request';
     });
 
     sinonUtil.restore(Cli.prompt);
@@ -144,12 +144,12 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
   });
 
   it('Correctly deletes retention label by id when prompt confirmed', async () => {
-    sinon.stub(request, 'delete').callsFake((opts) => {
+    sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/beta/security/labels/retentionLabels/${validId}`) {
-        return Promise.resolve();
+        return;
       }
 
-      return Promise.reject('Invalid Request');
+      throw 'Invalid Request';
     });
 
     await command.action(logger, {
@@ -161,7 +161,7 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
   });
 
   it('correctly handles random API error', async () => {
-    sinon.stub(request, 'delete').callsFake(() => Promise.reject('An error has occurred'));
+    sinon.stub(request, 'delete').callsFake(() => { throw 'An error has occurred'; });
 
     await assert.rejects(command.action(logger, {
       options: {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
@@ -70,25 +70,8 @@ class PurviewRetentionLabelRemoveCommand extends GraphCommand {
       this.handleError('This command does not support application permissions.');
     }
 
-    const removeRetentionLabel: () => Promise<void> = async (): Promise<void> => {
-      try {
-        const requestOptions: CliRequestOptions = {
-          url: `${this.resource}/beta/security/labels/retentionLabels/${args.options.id}`,
-          headers: {
-            accept: 'application/json;odata.metadata=none'
-          },
-          responseType: 'json'
-        };
-
-        await request.delete(requestOptions);
-      }
-      catch (err: any) {
-        this.handleRejectedODataJsonPromise(err);
-      }
-    };
-
     if (args.options.confirm) {
-      await removeRetentionLabel();
+      await this.removeRetentionLabel(args);
     }
     else {
       const result = await Cli.prompt<{ continue: boolean }>({
@@ -99,8 +82,25 @@ class PurviewRetentionLabelRemoveCommand extends GraphCommand {
       });
 
       if (result.continue) {
-        await removeRetentionLabel();
+        await this.removeRetentionLabel(args);
       }
+    }
+  }
+
+  private async removeRetentionLabel(args: CommandArgs): Promise<void> {
+    try {
+      const requestOptions: CliRequestOptions = {
+        url: `${this.resource}/beta/security/labels/retentionLabels/${args.options.id}`,
+        headers: {
+          accept: 'application/json;odata.metadata=none'
+        },
+        responseType: 'json'
+      };
+
+      await request.delete(requestOptions);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
     }
   }
 }

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-set.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-set.spec.ts
@@ -23,10 +23,10 @@ describe(commands.RETENTIONLABEL_SET, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     auth.service.accessTokens[(command as any).resource] = {
       accessToken: 'abc',
@@ -66,7 +66,7 @@ describe(commands.RETENTIONLABEL_SET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.RETENTIONLABEL_SET), true);
+    assert.strictEqual(command.name, commands.RETENTIONLABEL_SET);
   });
 
   it('has a description', () => {

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.spec.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.spec.ts
@@ -40,10 +40,10 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     auth.service.accessTokens[(command as any).resource] = {
       accessToken: 'abc',

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.spec.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.spec.ts
@@ -44,10 +44,10 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     auth.service.accessTokens[(command as any).resource] = {
       accessToken: 'abc',

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.spec.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.spec.ts
@@ -32,10 +32,10 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     auth.service.accessTokens[(command as any).resource] = {
       accessToken: 'abc',

--- a/src/m365/purview/commands/threatassessment/threatassessment-get.spec.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-get.spec.ts
@@ -52,10 +52,10 @@ describe(commands.THREATASSESSMENT_GET, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });


### PR DESCRIPTION
Refactor codebase to async/await - `m365 purview auditlog` until `m365 purview retentioneventtype`
- `m365 purview retentionlabel add`
- `m365 purview retentionlabel get`
- `m365 purview retentionlabel list`
- `m365 purview retentionlabel remove`
- `m365 purview retentionlabel set`
- `m365 purview sensitivitylabel get`
- `m365 purview sensitivitylabel list`
- `m365 purview sensitivitylabel policysettings list`
- `m365 purview threatassessment get`

Closes #4998