### PR TITLE
Refactor codebase to async/await - `m365 search` until `m365 project-externalize`/rules/DynamicRule.ts, Closes #5010

### DIFF
--- a/src/m365/search/commands/externalconnection/externalconnection-add.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-add.spec.ts
@@ -41,10 +41,10 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   };
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -77,7 +77,7 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.EXTERNALCONNECTION_ADD), true);
+    assert.strictEqual(command.name, commands.EXTERNALCONNECTION_ADD);
   });
 
   it('has a description', () => {
@@ -87,9 +87,9 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   it('adds an external connection', async () => {
     const postStub = sinon.stub(request, 'post').callsFake((opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
-        return Promise.resolve(externalConnectionAddResponse);
+        return externalConnectionAddResponse;
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
     const options: any = {
       id: 'TestConnectionForCLI',
@@ -103,9 +103,9 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   it('adds an external connection with authorized app id', async () => {
     const postStub = sinon.stub(request, 'post').callsFake((opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
-        return Promise.resolve(externalConnectionAddResponse);
+        return externalConnectionAddResponse;
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
     const options: any = {
       id: 'TestConnectionForCLI',
@@ -120,9 +120,9 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   it('adds an external connection with authorised app IDs', async () => {
     const postStub = sinon.stub(request, 'post').callsFake((opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
-        return Promise.resolve(externalConnectionAddResponseWithAppIDs);
+        return externalConnectionAddResponseWithAppIDs;
       }
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
     const options: any = {
       id: 'TestConnectionForCLI',
@@ -136,7 +136,7 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
 
   it('correctly handles error', async () => {
     sinon.stub(request, 'post').callsFake(() => {
-      return Promise.reject({
+      throw {
         "error": {
           "code": "Error",
           "message": "An error has occurred",
@@ -145,7 +145,7 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
             "date": "2018-04-24T18:56:48"
           }
         }
-      });
+      };
     });
 
     await assert.rejects(command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' } } as any),

--- a/src/m365/search/commands/externalconnection/externalconnection-add.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-add.spec.ts
@@ -11,6 +11,7 @@ import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
+import { ExternalConnectors } from '@microsoft/microsoft-graph-types';
 const command: Command = require('./externalconnection-add');
 
 describe(commands.EXTERNALCONNECTION_ADD, () => {
@@ -18,7 +19,7 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
 
-  const externalConnectionAddResponse: any = {
+  const externalConnectionAddResponse: ExternalConnectors.ExternalConnection = {
     configuration: {
       authorizedAppIds: []
     },
@@ -27,7 +28,7 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
     name: 'Test Connection for CLI'
   };
 
-  const externalConnectionAddResponseWithAppIDs: any = {
+  const externalConnectionAddResponseWithAppIDs: ExternalConnectors.ExternalConnection = {
     configuration: {
       'authorizedAppIds': [
         '00000000-0000-0000-0000-000000000000',
@@ -85,7 +86,7 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   });
 
   it('adds an external connection', async () => {
-    const postStub = sinon.stub(request, 'post').callsFake((opts: any) => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
         return externalConnectionAddResponse;
       }
@@ -101,7 +102,7 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   });
 
   it('adds an external connection with authorized app id', async () => {
-    const postStub = sinon.stub(request, 'post').callsFake((opts: any) => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
         return externalConnectionAddResponse;
       }
@@ -118,7 +119,7 @@ describe(commands.EXTERNALCONNECTION_ADD, () => {
   });
 
   it('adds an external connection with authorised app IDs', async () => {
-    const postStub = sinon.stub(request, 'post').callsFake((opts: any) => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
         return externalConnectionAddResponseWithAppIDs;
       }

--- a/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-get.spec.ts
@@ -9,6 +9,7 @@ import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
+import { ExternalConnectors } from '@microsoft/microsoft-graph-types';
 const command: Command = require('./externalconnection-get');
 
 describe(commands.EXTERNALCONNECTION_GET, () => {
@@ -16,16 +17,13 @@ describe(commands.EXTERNALCONNECTION_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
 
-  const externalConnection: any =
+  const externalConnection: ExternalConnectors.ExternalConnection =
   {
     "id": "contosohr",
     "name": "Contoso HR",
     "description": "Connection to index Contoso HR system",
     "state": "draft",
     "configuration": {
-      "authorizedApps": [
-        "de8bc8b5-d9f9-48b1-a8ad-b748da725064"
-      ],
       "authorizedAppIds": [
         "de8bc8b5-d9f9-48b1-a8ad-b748da725064"
       ]
@@ -88,7 +86,7 @@ describe(commands.EXTERNALCONNECTION_GET, () => {
   });
 
   it('should get external connection information for the Microsoft Search by id (debug)', async () => {
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections/contosohr`) {
         return externalConnection;
       }

--- a/src/m365/search/commands/externalconnection/externalconnection-list.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-list.spec.ts
@@ -9,6 +9,7 @@ import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
+import { ExternalConnectors } from '@microsoft/microsoft-graph-types';
 const command: Command = require('./externalconnection-list');
 
 describe(commands.EXTERNALCONNECTION_LIST, () => {
@@ -16,7 +17,7 @@ describe(commands.EXTERNALCONNECTION_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
 
-  const externalConnections: any = {
+  const externalConnections: { value: ExternalConnectors.ExternalConnection[] } = {
     value: [
       {
         "id": "contosohr",
@@ -24,9 +25,6 @@ describe(commands.EXTERNALCONNECTION_LIST, () => {
         "description": "Connection to index Contoso HR system",
         "state": "draft",
         "configuration": {
-          "authorizedApps": [
-            "de8bc8b5-d9f9-48b1-a8ad-b748da725064"
-          ],
           "authorizedAppIds": [
             "de8bc8b5-d9f9-48b1-a8ad-b748da725064"
           ]
@@ -94,7 +92,7 @@ describe(commands.EXTERNALCONNECTION_LIST, () => {
   });
 
   it('retrieves list of external connections defined in the Microsoft Search', async () => {
-    sinon.stub(request, 'get').callsFake((opts: any) => {
+    sinon.stub(request, 'get').callsFake(async (opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
         return externalConnections;
       }

--- a/src/m365/search/commands/externalconnection/externalconnection-list.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-list.spec.ts
@@ -36,10 +36,10 @@ describe(commands.EXTERNALCONNECTION_LIST, () => {
   };
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -71,7 +71,7 @@ describe(commands.EXTERNALCONNECTION_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.EXTERNALCONNECTION_LIST), true);
+    assert.strictEqual(command.name, commands.EXTERNALCONNECTION_LIST);
   });
 
   it('has a description', () => {
@@ -84,7 +84,7 @@ describe(commands.EXTERNALCONNECTION_LIST, () => {
 
   it('correctly handles error', async () => {
     sinon.stub(request, 'get').callsFake(() => {
-      return Promise.reject('An error has occurred');
+      throw 'An error has occurred';
     });
 
     await assert.rejects(command.action(logger, {
@@ -96,10 +96,10 @@ describe(commands.EXTERNALCONNECTION_LIST, () => {
   it('retrieves list of external connections defined in the Microsoft Search', async () => {
     sinon.stub(request, 'get').callsFake((opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections`) {
-        return Promise.resolve(externalConnections);
+        return externalConnections;
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { debug: true } } as any);

--- a/src/m365/search/commands/externalconnection/externalconnection-remove.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-remove.spec.ts
@@ -18,10 +18,10 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
   let promptOptions: any;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -60,7 +60,7 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.EXTERNALCONNECTION_REMOVE), true);
+    assert.strictEqual(command.name, commands.EXTERNALCONNECTION_REMOVE);
   });
 
   it('has a description', () => {
@@ -106,13 +106,13 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
   it('removes the specified external connection when prompt confirmed (debug)', async () => {
     let externalConnectionRemoveCallIssued = false;
 
-    sinon.stub(request, 'delete').callsFake((opts) => {
+    sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections/contosohr`) {
         externalConnectionRemoveCallIssued = true;
-        return Promise.resolve();
+        return;
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     sinonUtil.restore(Cli.prompt);
@@ -126,32 +126,32 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
   });
 
   it('removes the specified external connection without prompting when confirm specified', async () => {
-    sinon.stub(request, 'delete').callsFake((opts) => {
+    sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections/contosohr`) {
-        return Promise.resolve();
+        return;
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { id: "contosohr", confirm: true } });
   });
 
   it('removes external connection with specified ID', async () => {
-    sinon.stub(request, 'delete').callsFake((opts: any) => {
+    sinon.stub(request, 'delete').callsFake(async (opts: any) => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/external/connections/contosohr') {
-        return Promise.resolve();
+        return;
       }
-      return Promise.reject();
+      throw '';
     });
 
     await command.action(logger, { options: { id: "contosohr", confirm: true } });
   });
 
   it('removes external connection with specified name', async () => {
-    sinon.stub(request, 'get').callsFake((opts: any) => {
+    sinon.stub(request, 'get').callsFake(async (opts: any) => {
       if ((opts.url as string).indexOf(`/v1.0/external/connections?$filter=name eq `) > -1) {
-        return Promise.resolve({
+        return {
           value: [
             {
               "id": "contosohr",
@@ -159,16 +159,16 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
               "description": "Connection to index Contoso HR system"
             }
           ]
-        });
+        };
       }
-      return Promise.reject();
+      throw '';
     });
 
-    sinon.stub(request, 'delete').callsFake((opts: any) => {
+    sinon.stub(request, 'delete').callsFake(async (opts: any) => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/external/connections/contosohr') {
-        return Promise.resolve();
+        return;
       }
-      return Promise.reject();
+      throw '';
     });
 
     await command.action(logger, { options: { name: "Contoso HR", confirm: true } });
@@ -176,12 +176,12 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
 
   it('fails to get external connection by name when it does not exists', async () => {
     sinonUtil.restore(request.get);
-    sinon.stub(request, 'get').callsFake((opts: any) => {
+    sinon.stub(request, 'get').callsFake(async (opts: any) => {
       if ((opts.url as string).indexOf(`/v1.0/external/connections?$filter=`) > -1) {
-        return Promise.resolve({ value: [] });
+        return { value: [] };
       }
 
-      return Promise.reject('The specified connection does not exist in Microsoft Search');
+      throw 'The specified connection does not exist in Microsoft Search';
     });
 
     await assert.rejects(command.action(logger, {
@@ -194,9 +194,9 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
 
   it('fails when multiple external connections with same name exists', async () => {
     sinonUtil.restore(request.get);
-    sinon.stub(request, 'get').callsFake((opts) => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/v1.0/external/connections?$filter=`) > -1) {
-        return Promise.resolve({
+        return {
           value: [
             {
               "id": "fabrikamhr"
@@ -205,10 +205,10 @@ describe(commands.EXTERNALCONNECTION_REMOVE, () => {
               "id": "contosohr"
             }
           ]
-        });
+        };
       }
 
-      return Promise.reject("Invalid request");
+      throw "Invalid request";
     });
 
     await assert.rejects(command.action(logger, {

--- a/src/m365/search/commands/externalconnection/externalconnection-schema-add.spec.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-schema-add.spec.ts
@@ -22,10 +22,10 @@ describe(commands.EXTERNALCONNECTION_SCHEMA_ADD, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/skype/commands/report/report-activitycounts.spec.ts
+++ b/src/m365/skype/commands/report/report-activitycounts.spec.ts
@@ -16,10 +16,10 @@ describe(commands.REPORT_ACTIVITYCOUNTS, () => {
   let logger: Logger;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -51,7 +51,7 @@ describe(commands.REPORT_ACTIVITYCOUNTS, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.REPORT_ACTIVITYCOUNTS), true);
+    assert.strictEqual(command.name, commands.REPORT_ACTIVITYCOUNTS);
   });
 
   it('has a description', () => {
@@ -59,14 +59,12 @@ describe(commands.REPORT_ACTIVITYCOUNTS, () => {
   });
 
   it('gets the report for the last week', async () => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getSkypeForBusinessActivityCounts(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,Report Date,Report Period,Peer-to-peer,Organized,Participated`
-        );
+        return `Report Refresh Date,Report Date,Report Period,Peer-to-peer,Organized,Participated`;
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { period: 'D7' } });

--- a/src/m365/skype/commands/report/report-activityusercounts.spec.ts
+++ b/src/m365/skype/commands/report/report-activityusercounts.spec.ts
@@ -16,10 +16,10 @@ describe(commands.REPORT_ACTIVITYUSERCOUNTS, () => {
   let logger: Logger;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -51,7 +51,7 @@ describe(commands.REPORT_ACTIVITYUSERCOUNTS, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.REPORT_ACTIVITYUSERCOUNTS), true);
+    assert.strictEqual(command.name, commands.REPORT_ACTIVITYUSERCOUNTS);
   });
 
   it('has a description', () => {
@@ -59,14 +59,12 @@ describe(commands.REPORT_ACTIVITYUSERCOUNTS, () => {
   });
 
   it('gets the report for the last week', async () => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getSkypeForBusinessActivityUserCounts(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,Report Date,Report Period,Peer-to-peer,Organized,Participated`
-        );
+        return `Report Refresh Date,Report Date,Report Period,Peer-to-peer,Organized,Participated`;
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { period: 'D7' } });

--- a/src/m365/skype/commands/report/report-activityuserdetail.spec.ts
+++ b/src/m365/skype/commands/report/report-activityuserdetail.spec.ts
@@ -16,10 +16,10 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
   let logger: Logger;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
   });
 
@@ -51,7 +51,7 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.REPORT_ACTIVITYUSERDETAIL), true);
+    assert.strictEqual(command.name, commands.REPORT_ACTIVITYUSERDETAIL);
   });
 
   it('has a description', () => {
@@ -59,14 +59,12 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
   });
 
   it('gets the report for the last week', async () => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getSkypeForBusinessActivityUserDetail(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,User Principal Name,Is Deleted,Deleted Date,Last Activity Date,Total Peer-to-peer Session Count,Total Organized Conference Count,Total Participated Conference Count,Peer-to-peer Last Activity Date,Organized Conference Last Activity Date,Participated Conference Last Activity Date,Peer-to-peer IM Count,Peer-to-peer Audio Count,Peer-to-peer Audio Minutes,Peer-to-peer Video Count,Peer-to-peer Video Minutes,Peer-to-peer App Sharing Count,Peer-to-peer File Transfer Count,Organized Conference IM Count,Organized Conference Audio/Video Count,Organized Conference Audio/Video Minutes,Organized Conference App Sharing Count,Organized Conference Web Count,Organized Conference Dial-in/out 3rd Party Count,Organized Conference Dial-in/out Microsoft Count,Organized Conference Dial-in Microsoft Minutes,Organized Conference Dial-out Microsoft Minutes,Paricipated Conference IM Count,Participated Conference Audio/Video Count,Participated Conference Audio/Video Minutes,Participated Conference App Sharing Count,Participated Conference Web Count,Participated Conference Dial-in/out 3rd Party Count,Assigned Products,Report Period`
-        );
+        return `Report Refresh Date,User Principal Name,Is Deleted,Deleted Date,Last Activity Date,Total Peer-to-peer Session Count,Total Organized Conference Count,Total Participated Conference Count,Peer-to-peer Last Activity Date,Organized Conference Last Activity Date,Participated Conference Last Activity Date,Peer-to-peer IM Count,Peer-to-peer Audio Count,Peer-to-peer Audio Minutes,Peer-to-peer Video Count,Peer-to-peer Video Minutes,Peer-to-peer App Sharing Count,Peer-to-peer File Transfer Count,Organized Conference IM Count,Organized Conference Audio/Video Count,Organized Conference Audio/Video Minutes,Organized Conference App Sharing Count,Organized Conference Web Count,Organized Conference Dial-in/out 3rd Party Count,Organized Conference Dial-in/out Microsoft Count,Organized Conference Dial-in Microsoft Minutes,Organized Conference Dial-out Microsoft Minutes,Paricipated Conference IM Count,Participated Conference Audio/Video Count,Participated Conference Audio/Video Minutes,Participated Conference App Sharing Count,Participated Conference Web Count,Participated Conference Dial-in/out 3rd Party Count,Assigned Products,Report Period`;
       }
 
-      return Promise.reject('Invalid request');
+      throw 'Invalid request';
     });
 
     await command.action(logger, { options: { period: 'D7' } });

--- a/src/m365/spfx/commands/package/package-generate.spec.ts
+++ b/src/m365/spfx/commands/package/package-generate.spec.ts
@@ -28,9 +28,9 @@ describe(commands.PACKAGE_GENERATE, () => {
   let commandInfo: CommandInfo;
 
   before(() => {
-    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     (command as any).archive = admZipMock;
     commandInfo = Cli.getCommandInfo(command);
     Cli.getInstance().config;
@@ -86,7 +86,7 @@ describe(commands.PACKAGE_GENERATE, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.PACKAGE_GENERATE), true);
+    assert.strictEqual(command.name, commands.PACKAGE_GENERATE);
   });
 
   it('has a description', () => {

--- a/src/m365/spfx/commands/project/project-externalize/rules/DynamicRule.spec.ts
+++ b/src/m365/spfx/commands/project/project-externalize/rules/DynamicRule.spec.ts
@@ -60,8 +60,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path, options);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
-    sinon.stub(request, 'post').callsFake(() => Promise.reject());
+    sinon.stub(request, 'head').resolves();
+    sinon.stub(request, 'post').rejects();
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 1);
   });
@@ -87,8 +87,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path, options);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
-    sinon.stub(request, 'post').callsFake(() => Promise.reject());
+    sinon.stub(request, 'head').resolves();
+    sinon.stub(request, 'post').rejects();
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 0);
   });
@@ -111,7 +111,7 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
+    sinon.stub(request, 'head').resolves();
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 0);
   });
@@ -137,8 +137,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.reject());
-    sinon.stub(request, 'post').callsFake(() => Promise.resolve({ scriptType: 'UMD' }));
+    sinon.stub(request, 'head').rejects();
+    sinon.stub(request, 'post').callsFake(async () => { return { scriptType: 'UMD' }; });
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 0);
   });
@@ -163,8 +163,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path, options);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
-    sinon.stub(request, 'post').callsFake(() => Promise.resolve({ scriptType: 'CommonJs' }));
+    sinon.stub(request, 'head').resolves();
+    sinon.stub(request, 'post').callsFake(async () => { return { scriptType: 'CommonJs' }; });
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 0);
   });
@@ -189,8 +189,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
-    sinon.stub(request, 'post').callsFake(() => Promise.resolve({ scriptType: 'UMD' }));
+    sinon.stub(request, 'head').resolves();
+    sinon.stub(request, 'post').callsFake(async () => { return { scriptType: 'UMD' }; });
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 1);
   });
@@ -215,8 +215,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
-    sinon.stub(request, 'post').callsFake(() => Promise.resolve({ scriptType: 'UMD', exports: ['pnpjs'] }));
+    sinon.stub(request, 'head').resolves();
+    sinon.stub(request, 'post').callsFake(async () => { return { scriptType: 'UMD', exports: ['pnpjs'] }; });
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 1);
     assert.strictEqual(findings.entries[0].globalName, 'pnpjs');
@@ -250,8 +250,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path, options);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
-    sinon.stub(request, 'post').callsFake(() => Promise.resolve({ scriptType: 'UMD' }));
+    sinon.stub(request, 'head').resolves();
+    sinon.stub(request, 'post').callsFake(async () => { return { scriptType: 'UMD' }; });
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 1);
   });
@@ -297,8 +297,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
-    sinon.stub(request, 'post').callsFake(() => Promise.resolve({ scriptType: 'ES2015' }));
+    sinon.stub(request, 'head').resolves();
+    sinon.stub(request, 'post').callsFake(async () => { return { scriptType: 'ES2015' }; });
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 1);
   });
@@ -323,8 +323,8 @@ describe('DynamicRule', () => {
         return originalReadFileSync(path);
       }
     });
-    sinon.stub(request, 'head').callsFake(() => Promise.resolve());
-    sinon.stub(request, 'post').callsFake(() => Promise.resolve({ scriptType: 'AMD' }));
+    sinon.stub(request, 'head').resolves();
+    sinon.stub(request, 'post').callsFake(async () => { return { scriptType: 'AMD' }; });
     const findings = await rule.visit(project);
     assert.strictEqual(findings.entries.length, 1);
   });

--- a/src/m365/spfx/commands/project/project-externalize/rules/DynamicRule.ts
+++ b/src/m365/spfx/commands/project/project-externalize/rules/DynamicRule.ts
@@ -18,8 +18,7 @@ export class DynamicRule extends BasicDependencyRule {
   private fileVariationSuffixes = ['.min', '.bundle', '-min', '.bundle.min'];
 
   public async visit(project: Project): Promise<VisitationResult> {
-    if (!project.packageJson ||
-      !project.packageJson.dependencies) {
+    if (!project.packageJson || !project.packageJson.dependencies) {
       return { entries: [], suggestions: [] };
     }
 
@@ -27,16 +26,16 @@ export class DynamicRule extends BasicDependencyRule {
       .filter(x => this.restrictedNamespaces.map(y => x.indexOf(y) === -1).reduce((y, z) => y && z))
       .filter(x => this.restrictedModules.indexOf(x) === -1);
 
-    return Promise
-      .all(validPackageNames.map((x) => this.getExternalEntryForPackage(x, project)))
-      .then((res: (ExternalizeEntry | undefined)[]) => {
-        return {
-          entries: res
-            .filter(x => x !== undefined)
-            .map(x => x as ExternalizeEntry),
-          suggestions: []
-        };
-      });
+    const res: (ExternalizeEntry | undefined)[] = await Promise.all(
+      validPackageNames.map((x) => this.getExternalEntryForPackage(x, project))
+    );
+
+    const entries = res.filter(x => x !== undefined) as ExternalizeEntry[];
+
+    return {
+      entries,
+      suggestions: []
+    };
   }
 
   private async getExternalEntryForPackage(packageName: string, project: Project): Promise<ExternalizeEntry | undefined> {

--- a/src/m365/spfx/commands/project/project-externalize/rules/DynamicRule.ts
+++ b/src/m365/spfx/commands/project/project-externalize/rules/DynamicRule.ts
@@ -27,18 +27,16 @@ export class DynamicRule extends BasicDependencyRule {
       .filter(x => this.restrictedNamespaces.map(y => x.indexOf(y) === -1).reduce((y, z) => y && z))
       .filter(x => this.restrictedModules.indexOf(x) === -1);
 
-    const results = [];
-    for (const packageName of validPackageNames) {
-      const entry = await this.getExternalEntryForPackage(packageName, project);
-      results.push(entry);
-    }
-
-    const entries = results.filter((x) => x !== undefined).map((x) => x as ExternalizeEntry);
-
-    return {
-      entries: entries,
-      suggestions: []
-    };
+    return Promise
+      .all(validPackageNames.map((x) => this.getExternalEntryForPackage(x, project)))
+      .then((res: (ExternalizeEntry | undefined)[]) => {
+        return {
+          entries: res
+            .filter(x => x !== undefined)
+            .map(x => x as ExternalizeEntry),
+          suggestions: []
+        };
+      });
   }
 
   private async getExternalEntryForPackage(packageName: string, project: Project): Promise<ExternalizeEntry | undefined> {

--- a/src/m365/spfx/commands/project/project-externalize/rules/DynamicRule.ts
+++ b/src/m365/spfx/commands/project/project-externalize/rules/DynamicRule.ts
@@ -17,50 +17,57 @@ export class DynamicRule extends BasicDependencyRule {
   private restrictedNamespaces = ['@types/', '@microsoft/'];
   private fileVariationSuffixes = ['.min', '.bundle', '-min', '.bundle.min'];
 
-  public visit(project: Project): Promise<VisitationResult> {
+  public async visit(project: Project): Promise<VisitationResult> {
     if (!project.packageJson ||
       !project.packageJson.dependencies) {
-      return Promise.resolve({ entries: [], suggestions: [] });
+      return { entries: [], suggestions: [] };
     }
 
     const validPackageNames: string[] = Object.getOwnPropertyNames(project.packageJson.dependencies)
       .filter(x => this.restrictedNamespaces.map(y => x.indexOf(y) === -1).reduce((y, z) => y && z))
       .filter(x => this.restrictedModules.indexOf(x) === -1);
 
-    return Promise
-      .all(validPackageNames.map((x) => this.getExternalEntryForPackage(x, project)))
-      .then((res: (ExternalizeEntry | undefined)[]) => {
-        return {
-          entries: res
-            .filter(x => x !== undefined)
-            .map(x => x as ExternalizeEntry),
-          suggestions: []
-        };
-      });
+    const results = [];
+    for (const packageName of validPackageNames) {
+      const entry = await this.getExternalEntryForPackage(packageName, project);
+      results.push(entry);
+    }
+
+    const entries = results.filter((x) => x !== undefined).map((x) => x as ExternalizeEntry);
+
+    return {
+      entries: entries,
+      suggestions: []
+    };
   }
 
-  private getExternalEntryForPackage(packageName: string, project: Project): Promise<ExternalizeEntry | undefined> {
+  private async getExternalEntryForPackage(packageName: string, project: Project): Promise<ExternalizeEntry | undefined> {
     const version: string | undefined = project.packageJson!.dependencies![packageName];
     const filesPaths: string[] = this.getFilePath(packageName).map(x => this.cleanFilePath(x));
 
     if (!version || filesPaths.length === 0) {
-      return Promise.resolve(undefined);
+      return undefined;
     }
 
     const filesPathsVariations = filesPaths
       .map(x => this.fileVariationSuffixes.map(y => x.indexOf(y) === -1 ? x.replace('.js', `${y}.js`) : x))
       .reduce((x, y) => [...x, ...y]);
     const pathsAndVariations = [...filesPaths, ...filesPathsVariations];
-    return Promise.all(pathsAndVariations.map(x => this.getExternalEntryForFilePath(x, packageName, version)))
-      .then((externalizeEntryCandidates) => {
-        const dExternalizeEntryCandidates = externalizeEntryCandidates.filter(x => x !== undefined) as ExternalizeEntry[];
-        const minifiedModule = dExternalizeEntryCandidates.find(x => !x.globalName && this.pathContainsMinifySuffix(x.path));
-        const minifiedNonModule = dExternalizeEntryCandidates.find(x => x.globalName && this.pathContainsMinifySuffix(x.path));
-        const nonMinifiedModule = dExternalizeEntryCandidates.find(x => x.globalName && !this.pathContainsMinifySuffix(x.path));
-        const nonMinifiedNonModule = dExternalizeEntryCandidates.find(x => !x.globalName && !this.pathContainsMinifySuffix(x.path));
-        const externalizeEntriesPrioritized = [minifiedModule, minifiedNonModule, nonMinifiedModule, nonMinifiedNonModule].filter(x => x !== undefined);
-        return externalizeEntriesPrioritized.length > 0 ? externalizeEntriesPrioritized[0] : undefined;
-      });
+
+    const externalizeEntryCandidates = [];
+    for (const pathAndVariation of pathsAndVariations) {
+      const entry = await this.getExternalEntryForFilePath(pathAndVariation, packageName, version);
+      externalizeEntryCandidates.push(entry);
+    }
+
+    const dExternalizeEntryCandidates = externalizeEntryCandidates.filter((x) => x !== undefined) as ExternalizeEntry[];
+    const minifiedModule = dExternalizeEntryCandidates.find((x) => !x.globalName && this.pathContainsMinifySuffix(x.path));
+    const minifiedNonModule = dExternalizeEntryCandidates.find((x) => x.globalName && this.pathContainsMinifySuffix(x.path));
+    const nonMinifiedModule = dExternalizeEntryCandidates.find((x) => x.globalName && !this.pathContainsMinifySuffix(x.path));
+    const nonMinifiedNonModule = dExternalizeEntryCandidates.find((x) => !x.globalName && !this.pathContainsMinifySuffix(x.path));
+    const externalizeEntriesPrioritized = [minifiedModule, minifiedNonModule, nonMinifiedModule, nonMinifiedNonModule].filter((x) => x !== undefined);
+
+    return externalizeEntriesPrioritized.length > 0 ? externalizeEntriesPrioritized[0] : undefined;
   }
 
   private pathContainsMinifySuffix(path: string): boolean {
@@ -69,19 +76,19 @@ export class DynamicRule extends BasicDependencyRule {
       .filter(y => y > -1).length > 0;
   }
 
-  private getExternalEntryForFilePath(filePath: string, packageName: string, version: string): Promise<ExternalizeEntry | undefined> {
+  private async getExternalEntryForFilePath(filePath: string, packageName: string, version: string): Promise<ExternalizeEntry | undefined> {
     const url: string = this.getFileUrl(packageName, version, filePath);
 
     return this
       .testUrl(url)
       .then((testResult) => {
         if (!testResult) {
-          return Promise.resolve(undefined);
+          return undefined;
         }
 
         return this.getModuleType(url).then((moduleInfo) => {
           if (moduleInfo.scriptType === 'CommonJs') {
-            return Promise.resolve(undefined); //browsers don't support those module types without an additional library
+            return undefined; //browsers don't support those module types without an additional library
           }
           else if (moduleInfo.scriptType === 'ES2015' || moduleInfo.scriptType === 'AMD') {
             return {


### PR DESCRIPTION
Refactor codebase to async/await - `m365 search` until `m365 spfx project externalize`/rule/DynamicRule

- `m365 search externalconnection add`
- `m365 search externalconnection get`
- `m365 search externalconnection list`
- `m365 search externalconnection remove`
- `m365 search externalconnection schema add`
- `m365 skype report activitycounts`
- `m365 skype report activityusercounts`
- `m365 skype report activityuserdetail`
- `m365 spfx package generate`
- `m365 spfx project externalize`/DynamicRule

Closes #5010