### PR TITLE
Adds m365? alias to Dockerfile. Closes #4966

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,12 @@ RUN bash -c 'echo "export PATH=$PATH:/home/cli-microsoft365/.npm-global/bin:/hom
   && bash -c 'echo "export CLIMICROSOFT365_ENV=\"docker\"" >> ~/.bash_profile' \
   && bash -c 'npm i -g @pnp/cli-microsoft365@${CLI_VERSION} --production --quiet --no-progress' \ 
   && bash -c 'echo "source /etc/profile.d/bash_completion.sh" >> ~/.bash_profile' \
+  && bash -c 'echo "alias \"m365?\"=\"m365_chili\"" >> ~/.bash_profile' \
   && bash -c 'echo ". .bashrc" >> ~/.bash_profile' \
   && bash -c 'npm cache clean --force' \
   && bash -c 'm365 cli completion sh setup' \
-  && pwsh -c 'm365 cli completion pwsh setup --profile $profile'
+  && pwsh -c 'm365 cli completion pwsh setup --profile $profile' \
+  && pwsh -c 'Add-Content -Path $PROFILE -Value "`r`Set-Alias -Name m365? -Value m365_chili"'
 
 RUN pip install setuptools==58
 RUN pip install jmespath-terminal

--- a/docs/docs/user-guide/chili.mdx
+++ b/docs/docs/user-guide/chili.mdx
@@ -31,6 +31,12 @@ We believe that 🌶️ chili should be available at your fingertips and super s
   </TabItem>
 </Tabs>
 
+:::tip
+
+If you use our [Docker image](./run-cli-in-docker-container.mdx), you don't need to setup the alias manually. We setup the `m365?` alias for you in both bash and PowerShell.
+
+:::
+
 :::info
 
 If you don't set up an alias, you can still use 🌶️ chili by running `m365_chili` instead of `m365?`.


### PR DESCRIPTION
Closes #4966 

Merging this pull request will:

- Add `m365?` alias to bash profile in Docker image
- Add `m365?` alias to PowerShell profile in Docker image
- Adds remark to docs that the `m365?` alias is pre-configured in Docker image

<img width="460" alt="image" src="https://github.com/pnp/cli-microsoft365/assets/11563347/2ee3b07b-2448-43ce-9a99-76cd119c1b80">
