### PR TITLE
Fixes last updated date in docs

### DIFF
--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -119,6 +119,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags. Default: 1
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
The issue occurs because only the last commit is checked out at the GitHub workflow to deploy the docs. Locally, it seems to be working fine.
Only updated the `release_next` workflow because this is the only workflow that deploys the docs. I think it's not really needed to check out the entire git history just to validate whether the docs build.

Closes #5057