### PR TITLE
Fixes creating list with list title consisting only of numeric characters. Closes #5059

### DIFF
--- a/src/m365/spo/commands/list/list-add.ts
+++ b/src/m365/spo/commands/list/list-add.ts
@@ -568,6 +568,7 @@ class SpoListAddCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push(
+      'title',
       'baseTemplate',
       'webUrl',
       'templateFeatureId',


### PR DESCRIPTION
Closes #5059