### PR TITLE
Extends 'purview retentionevent' and 'purview retentioneventtype' commands with support for using GA endpoint. Closes #5025

### DIFF
--- a/src/m365/purview/commands/retentionevent/retentionevent-add.spec.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-add.spec.ts
@@ -153,7 +153,7 @@ describe(commands.RETENTIONEVENT_ADD, () => {
 
   it('adds retention event with minimal required parameters and assetIds', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents`) {
         return EventResponse;
       }
 
@@ -166,7 +166,7 @@ describe(commands.RETENTIONEVENT_ADD, () => {
 
   it('adds retention event with minimal required parameters and keywords', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents`) {
         return EventResponse;
       }
 
@@ -179,7 +179,7 @@ describe(commands.RETENTIONEVENT_ADD, () => {
 
   it('adds retention event with all parameters', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents`) {
         return EventResponse;
       }
 
@@ -192,7 +192,7 @@ describe(commands.RETENTIONEVENT_ADD, () => {
 
   it('adds retention event with minimal required parameters and assetIds based on event type name', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents`) {
         return EventResponse;
       }
 
@@ -200,7 +200,7 @@ describe(commands.RETENTIONEVENT_ADD, () => {
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes`) {
         return eventTypeResponse;
       }
 
@@ -213,7 +213,7 @@ describe(commands.RETENTIONEVENT_ADD, () => {
 
   it('throws error when no event type found', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes`) {
         return ({ "value": [] });
       }
 

--- a/src/m365/purview/commands/retentionevent/retentionevent-add.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-add.ts
@@ -117,7 +117,7 @@ class PurviewRetentionEventAddCommand extends GraphCommand {
     const eventTypeId = await this.getEventTypeId(logger, args);
 
     const data = {
-      'retentionEventType@odata.bind': `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes/${eventTypeId}`,
+      'retentionEventType@odata.bind': `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes/${eventTypeId}`,
       displayName: args.options.displayName,
       description: args.options.description,
       eventQueries: eventQueries,
@@ -126,7 +126,7 @@ class PurviewRetentionEventAddCommand extends GraphCommand {
 
     try {
       const requestOptions: CliRequestOptions = {
-        url: `${this.resource}/beta/security/triggers/retentionEvents`,
+        url: `${this.resource}/v1.0/security/triggers/retentionEvents`,
         headers: {
           accept: 'application/json;odata.metadata=none'
         },
@@ -151,7 +151,7 @@ class PurviewRetentionEventAddCommand extends GraphCommand {
       logger.logToStderr(`Retrieving the event type id for event type ${args.options.eventTypeName}`);
     }
 
-    const items: any = await odata.getAllItems(`${this.resource}/beta/security/triggerTypes/retentionEventTypes`);
+    const items: any = await odata.getAllItems(`${this.resource}/v1.0/security/triggerTypes/retentionEventTypes`);
 
     const eventTypes = items.filter((x: any) => x.displayName === args.options.eventTypeName);
 

--- a/src/m365/purview/commands/retentionevent/retentionevent-get.spec.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-get.spec.ts
@@ -126,7 +126,7 @@ describe(commands.RETENTIONEVENT_GET, () => {
 
   it('retrieves retention event by specified id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents/${retentionEventId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents/${retentionEventId}`) {
         return retentionEventGetResponse;
       }
 
@@ -140,7 +140,7 @@ describe(commands.RETENTIONEVENT_GET, () => {
   it('handles error when retention event by specified id is not found', async () => {
     const errorMessage = `Error: The operation couldn't be performed because object '${retentionEventId}' couldn't be found on 'FfoConfigurationSession'.`;
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents/${retentionEventId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents/${retentionEventId}`) {
         throw errorMessage;
       }
 

--- a/src/m365/purview/commands/retentionevent/retentionevent-get.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-get.ts
@@ -56,7 +56,7 @@ class PurviewRetentionEventGetCommand extends GraphCommand {
 
     try {
       const requestOptions: CliRequestOptions = {
-        url: `${this.resource}/beta/security/triggers/retentionEvents/${args.options.id}`,
+        url: `${this.resource}/v1.0/security/triggers/retentionEvents/${args.options.id}`,
         headers: {
           accept: 'application/json;odata.metadata=none'
         },

--- a/src/m365/purview/commands/retentionevent/retentionevent-list.spec.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-list.spec.ts
@@ -42,7 +42,7 @@ describe(commands.RETENTIONEVENTTYPE_GET, () => {
   ];
 
   const mockResponse = {
-    "@odata.context": "https://graph.microsoft.com/beta/$metadata#security/triggers/retentionEvents",
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#security/triggers/retentionEvents",
     "@odata.count": 2,
     "value": mockResponseArray
   };
@@ -107,7 +107,7 @@ describe(commands.RETENTIONEVENTTYPE_GET, () => {
 
   it('retrieves retention events', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents`) {
         return mockResponse;
       }
 
@@ -120,7 +120,7 @@ describe(commands.RETENTIONEVENTTYPE_GET, () => {
 
   it('handles error when retrieving retention events', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents`) {
         throw { error: { error: { message: 'An error has occurred' } } };
       }
 

--- a/src/m365/purview/commands/retentionevent/retentionevent-list.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-list.ts
@@ -22,7 +22,7 @@ class PurviewRetentionEventListCommand extends GraphCommand {
         logger.logToStderr('Retrieving Purview retention events');
       }
 
-      const items = await odata.getAllItems(`${this.resource}/beta/security/triggers/retentionEvents`);
+      const items = await odata.getAllItems(`${this.resource}/v1.0/security/triggers/retentionEvents`);
       logger.log(items);
     }
     catch (err: any) {

--- a/src/m365/purview/commands/retentionevent/retentionevent-remove.spec.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-remove.spec.ts
@@ -121,7 +121,7 @@ describe(commands.RETENTIONEVENT_REMOVE, () => {
 
   it('Correctly deletes retention event by id', async () => {
     sinon.stub(request, 'delete').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents/${validId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents/${validId}`) {
         return Promise.resolve();
       }
 
@@ -142,7 +142,7 @@ describe(commands.RETENTIONEVENT_REMOVE, () => {
 
   it('Correctly deletes retention event by id when prompt confirmed', async () => {
     sinon.stub(request, 'delete').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggers/retentionEvents/${validId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggers/retentionEvents/${validId}`) {
         return Promise.resolve();
       }
 

--- a/src/m365/purview/commands/retentionevent/retentionevent-remove.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-remove.ts
@@ -68,7 +68,7 @@ class PurviewRetentionEventRemoveCommand extends GraphCommand {
     const removeRetentionEvent: () => Promise<void> = async (): Promise<void> => {
       try {
         const requestOptions: AxiosRequestConfig = {
-          url: `${this.resource}/beta/security/triggers/retentionEvents/${args.options.id}`,
+          url: `${this.resource}/v1.0/security/triggers/retentionEvents/${args.options.id}`,
           headers: {
             accept: 'application/json;odata.metadata=none'
           },

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-add.spec.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-add.spec.ts
@@ -92,7 +92,7 @@ describe(commands.RETENTIONEVENTTYPE_ADD, () => {
 
   it('adds retention event type', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes`) {
         return requestResponse;
       }
 

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-add.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-add.ts
@@ -55,7 +55,7 @@ class PurviewRetentionEventTypeAddCommand extends GraphCommand {
     };
 
     const requestOptions: CliRequestOptions = {
-      url: `${this.resource}/beta/security/triggerTypes/retentionEventTypes`,
+      url: `${this.resource}/v1.0/security/triggerTypes/retentionEventTypes`,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-get.spec.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-get.spec.ts
@@ -102,7 +102,7 @@ describe(commands.RETENTIONEVENTTYPE_GET, () => {
 
   it('retrieves retention event type by specified id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes/${retentionEventTypeId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes/${retentionEventTypeId}`) {
         return retentionEventTypeGetResponse;
       }
 
@@ -116,7 +116,7 @@ describe(commands.RETENTIONEVENTTYPE_GET, () => {
   it('handles error when retention event type by specified id is not found', async () => {
     const errorMessage = `Error: The operation couldn't be performed because object '${retentionEventTypeId}' couldn't be found on 'FfoConfigurationSession'.`;
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes/${retentionEventTypeId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes/${retentionEventTypeId}`) {
         throw errorMessage;
       }
 

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-get.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-get.ts
@@ -56,7 +56,7 @@ class PurviewRetentionEventTypeGetCommand extends GraphCommand {
       }
 
       const requestOptions: CliRequestOptions = {
-        url: `${this.resource}/beta/security/triggerTypes/retentionEventTypes/${args.options.id}`,
+        url: `${this.resource}/v1.0/security/triggerTypes/retentionEventTypes/${args.options.id}`,
         headers: {
           accept: 'application/json;odata.metadata=none'
         },

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-list.spec.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-list.spec.ts
@@ -37,7 +37,7 @@ describe(commands.RETENTIONEVENTTYPE_LIST, () => {
   ];
 
   const mockResponse = {
-    "@odata.context": "https://graph.microsoft.com/beta/$metadata#security/triggerTypes/retentionEventTypes",
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#security/triggerTypes/retentionEventTypes",
     "@odata.count": 1,
     "value": mockResponseArray
   };
@@ -102,7 +102,7 @@ describe(commands.RETENTIONEVENTTYPE_LIST, () => {
 
   it('retrieves retention event types', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes`) {
         return mockResponse;
       }
 
@@ -115,7 +115,7 @@ describe(commands.RETENTIONEVENTTYPE_LIST, () => {
 
   it('handles error when retrieving event types', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes`) {
         throw { error: { error: { message: 'An error has occurred' } } };
       }
 

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-list.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-list.ts
@@ -18,7 +18,7 @@ class PurviewRetentionEventTypeListCommand extends GraphCommand {
 
   public async commandAction(logger: Logger): Promise<void> {
     try {
-      const items = await odata.getAllItems(`${this.resource}/beta/security/triggerTypes/retentionEventTypes`);
+      const items = await odata.getAllItems(`${this.resource}/v1.0/security/triggerTypes/retentionEventTypes`);
       logger.log(items);
     }
     catch (err: any) {

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.spec.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.spec.ts
@@ -105,7 +105,7 @@ describe(commands.RETENTIONEVENTTYPE_REMOVE, () => {
 
   it('correctly deletes retention event type by id', async () => {
     sinon.stub(request, 'delete').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes/${validId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes/${validId}`) {
         return;
       }
 
@@ -122,7 +122,7 @@ describe(commands.RETENTIONEVENTTYPE_REMOVE, () => {
 
   it('correctly deletes retention event type by id when prompt confirmed', async () => {
     sinon.stub(request, 'delete').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes/${validId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes/${validId}`) {
         return;
       }
 

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.ts
@@ -67,7 +67,7 @@ class PurviewRetentionEventTypeRemoveCommand extends GraphCommand {
     const removeRetentionEventType: () => Promise<void> = async (): Promise<void> => {
       try {
         const requestOptions: CliRequestOptions = {
-          url: `${this.resource}/beta/security/triggerTypes/retentionEventTypes/${args.options.id}`,
+          url: `${this.resource}/v1.0/security/triggerTypes/retentionEventTypes/${args.options.id}`,
           headers: {
             accept: 'application/json;odata.metadata=none'
           },

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-set.spec.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-set.spec.ts
@@ -90,7 +90,7 @@ describe(commands.RETENTIONEVENTTYPE_SET, () => {
     };
 
     const patchStub = sinon.stub(request, 'patch').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/security/triggerTypes/retentionEventTypes/${validId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventTypes/${validId}`) {
         return;
       }
 

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-set.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-set.ts
@@ -77,7 +77,7 @@ class PurviewRetentionEventTypeSetCommand extends GraphCommand {
       };
 
       const requestOptions: CliRequestOptions = {
-        url: `${this.resource}/beta/security/triggerTypes/retentionEventTypes/${args.options.id}`,
+        url: `${this.resource}/v1.0/security/triggerTypes/retentionEventTypes/${args.options.id}`,
         headers: {
           accept: 'application/json'
         },


### PR DESCRIPTION
Extends `purview retentionevent` and `purview retentioneventtype` commands with support for using GA endpoint. Closes #5025