### PR TITLE
Added socialBarOnSitePagesDisabled option to spo site set cmdlet. Closes #5072

### DIFF
--- a/docs/docs/cmd/spo/site/site-set.mdx
+++ b/docs/docs/cmd/spo/site/site-set.mdx
@@ -28,6 +28,9 @@ m365 spo site set [options]
 `--disableFlows [disableFlows]`
 : Set to `true` to disable using Microsoft Flow in this site collection
 
+`--socialBarOnSitePagesDisabled [socialBarOnSitePagesDisabled]`
+: Set to `true` to disable Social Bar for the site collection
+
 `--isPublic [isPublic]`
 : Set to `true` to make the group linked to the site public or to `false` to make it private
 
@@ -119,6 +122,12 @@ Disable using Microsoft Flow on the site collection
 
 ```sh
 m365 spo site set --url https://contoso.sharepoint.com/sites/sales --disableFlows true
+```
+
+Disable Social Bar for the site collection
+
+```sh
+m365 spo site set --url https://contoso.sharepoint.com/sites/sales --socialBarOnSitePagesDisabled true
 ```
 
 Update the visibility of the Microsoft 365 group behind the specified groupified site collection to public

--- a/src/m365/spo/commands/site/site-set.spec.ts
+++ b/src/m365/spo/commands/site/site-set.spec.ts
@@ -304,6 +304,16 @@ describe(commands.SITE_SET, () => {
     assert.strictEqual(actual, true);
   });
 
+  it('passes validation if url and socialBarOnSitePagesDisabled true specified', async () => {
+    const actual = await command.validate({ options: { url: 'https://contoso.sharepoint.com', socialBarOnSitePagesDisabled: true } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if url and socialBarOnSitePagesDisabled false specified', async () => {
+    const actual = await command.validate({ options: { url: 'https://contoso.sharepoint.com', socialBarOnSitePagesDisabled: false } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
   it('passes validation if url, id, classification and disableFlows specified', async () => {
     const actual = await command.validate({ options: { id: '255a50b2-527f-4413-8485-57f4c17a24d1', url: 'https://contoso.sharepoint.com', classification: 'HBI', disableFlows: true } }, commandInfo);
     assert.strictEqual(actual, true);
@@ -1824,6 +1834,90 @@ describe(commands.SITE_SET, () => {
     assert(loggerLogSpy.notCalled);
   });
 
+  it('sets socialBarOnSitePagesDisabled to true for the specified site', async () => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === 'https://contoso.sharepoint.com/sites/Sales/_api/site?$select=GroupId,Id') {
+        return Promise.resolve({
+          Id: '255a50b2-527f-4413-8485-57f4c17a24d1',
+          GroupId: '00000000-0000-0000-0000-000000000000'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery` &&
+        opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="27" ObjectPathId="5" Name="SocialBarOnSitePagesDisabled"><Parameter Type="Boolean">true</Parameter></SetProperty><ObjectPath Id="14" ObjectPathId="13" /><ObjectIdentityQuery Id="15" ObjectPathId="5" /><Query Id="16" ObjectPathId="13"><Query SelectAllProperties="false"><Properties><Property Name="IsComplete" ScalarProperty="true" /><Property Name="PollingInterval" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><Identity Id="5" Name="53d8499e-d0d2-5000-cb83-9ade5be42ca4|908bed80-a04a-4433-b4a0-883d9847d110:67753f63-bc14-4012-869e-f808a43fe023&#xA;SiteProperties&#xA;https%3A%2F%2Fcontoso.sharepoint.com%2Fsites%2FSales" /><Method Id="13" ParentId="5" Name="Update" /></ObjectPaths></Request>`) {
+        return Promise.resolve(JSON.stringify([
+          {
+            "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.7317.1205", "ErrorInfo": null, "TraceCorrelationId": "f10a459e-409f-4000-c5b4-09fb5e795218"
+          }
+        ]));
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, { options: { socialBarOnSitePagesDisabled: true, id: '255a50b2-527f-4413-8485-57f4c17a24d1', url: 'https://contoso.sharepoint.com/sites/Sales' } });
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('sets socialBarOnSitePagesDisabled to true for the specified groupified site', async () => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === 'https://contoso.sharepoint.com/sites/Sales/_api/site?$select=GroupId,Id') {
+        return Promise.resolve({
+          Id: '255a50b2-527f-4413-8485-57f4c17a24d1',
+          GroupId: 'e10a459e-60c8-4000-8240-a68d6a12d39e'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery` &&
+        opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="27" ObjectPathId="5" Name="SocialBarOnSitePagesDisabled"><Parameter Type="Boolean">true</Parameter></SetProperty><ObjectPath Id="14" ObjectPathId="13" /><ObjectIdentityQuery Id="15" ObjectPathId="5" /><Query Id="16" ObjectPathId="13"><Query SelectAllProperties="false"><Properties><Property Name="IsComplete" ScalarProperty="true" /><Property Name="PollingInterval" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><Identity Id="5" Name="53d8499e-d0d2-5000-cb83-9ade5be42ca4|908bed80-a04a-4433-b4a0-883d9847d110:67753f63-bc14-4012-869e-f808a43fe023&#xA;SiteProperties&#xA;https%3A%2F%2Fcontoso.sharepoint.com%2Fsites%2FSales" /><Method Id="13" ParentId="5" Name="Update" /></ObjectPaths></Request>`) {
+        return Promise.resolve(JSON.stringify([
+          {
+            "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.7317.1205", "ErrorInfo": null, "TraceCorrelationId": "f10a459e-409f-4000-c5b4-09fb5e795218"
+          }
+        ]));
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, { options: { socialBarOnSitePagesDisabled: true, id: '255a50b2-527f-4413-8485-57f4c17a24d1', url: 'https://contoso.sharepoint.com/sites/Sales' } });
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('sets socialBarOnSitePagesDisabled to false for the specified site', async () => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === 'https://contoso.sharepoint.com/sites/Sales/_api/site?$select=GroupId,Id') {
+        return Promise.resolve({
+          Id: '255a50b2-527f-4413-8485-57f4c17a24d1',
+          GroupId: '00000000-0000-0000-0000-000000000000'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery` &&
+        opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="27" ObjectPathId="5" Name="SocialBarOnSitePagesDisabled"><Parameter Type="Boolean">false</Parameter></SetProperty><ObjectPath Id="14" ObjectPathId="13" /><ObjectIdentityQuery Id="15" ObjectPathId="5" /><Query Id="16" ObjectPathId="13"><Query SelectAllProperties="false"><Properties><Property Name="IsComplete" ScalarProperty="true" /><Property Name="PollingInterval" ScalarProperty="true" /></Properties></Query></Query></Actions><ObjectPaths><Identity Id="5" Name="53d8499e-d0d2-5000-cb83-9ade5be42ca4|908bed80-a04a-4433-b4a0-883d9847d110:67753f63-bc14-4012-869e-f808a43fe023&#xA;SiteProperties&#xA;https%3A%2F%2Fcontoso.sharepoint.com%2Fsites%2FSales" /><Method Id="13" ParentId="5" Name="Update" /></ObjectPaths></Request>`) {
+        return Promise.resolve(JSON.stringify([
+          {
+            "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.7317.1205", "ErrorInfo": null, "TraceCorrelationId": "f10a459e-409f-4000-c5b4-09fb5e795218"
+          }
+        ]));
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, { options: { socialBarOnSitePagesDisabled: false, id: '255a50b2-527f-4413-8485-57f4c17a24d1', url: 'https://contoso.sharepoint.com/sites/Sales' } });
+    assert(loggerLogSpy.notCalled);
+  });
+
   it('sets shareByEmailEnabled to true for the specified site', async () => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === 'https://contoso.sharepoint.com/sites/Sales/_api/site?$select=GroupId,Id') {
@@ -2419,6 +2513,17 @@ describe(commands.SITE_SET, () => {
     let containsOption = false;
     options.forEach(o => {
       if (o.option.indexOf('--disableFlows') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying socialBarOnSitePagesDisabled', () => {
+    const options = command.options;
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--socialBarOnSitePagesDisabled') > -1) {
         containsOption = true;
       }
     });

--- a/src/m365/spo/commands/site/site-set.ts
+++ b/src/m365/spo/commands/site/site-set.ts
@@ -25,6 +25,7 @@ interface CommandArgs {
 export interface Options extends GlobalOptions {
   classification?: string;
   disableFlows?: boolean;
+  socialBarOnSitePagesDisabled?: boolean;
   isPublic?: boolean;
   owners?: string;
   shareByEmailEnabled?: boolean;
@@ -73,6 +74,7 @@ class SpoSiteSetCommand extends SpoCommand {
       Object.assign(this.telemetryProperties, {
         classification: typeof args.options.classification === 'string',
         disableFlows: args.options.disableFlows,
+        socialBarOnSitePagesDisabled: args.options.socialBarOnSitePagesDisabled,
         isPublic: args.options.isPublic,
         owners: typeof args.options.owners !== 'undefined',
         shareByEmailEnabled: args.options.shareByEmailEnabled,
@@ -106,6 +108,10 @@ class SpoSiteSetCommand extends SpoCommand {
       },
       {
         option: '--disableFlows [disableFlows]',
+        autocomplete: ['true', 'false']
+      },
+      {
+        option: '--socialBarOnSitePagesDisabled [socialBarOnSitePagesDisabled]',
         autocomplete: ['true', 'false']
       },
       {
@@ -175,6 +181,7 @@ class SpoSiteSetCommand extends SpoCommand {
 
         if (typeof args.options.classification === 'undefined' &&
           typeof args.options.disableFlows === 'undefined' &&
+          typeof args.options.socialBarOnSitePagesDisabled === 'undefined' &&
           typeof args.options.title === 'undefined' &&
           typeof args.options.description === 'undefined' &&
           typeof args.options.isPublic === 'undefined' &&
@@ -252,7 +259,7 @@ class SpoSiteSetCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push('classification');
-    this.types.boolean.push('isPublic', 'disableFlows', 'shareByEmailEnabled', 'allowSelfServiceUpgrade', 'noScriptSite');
+    this.types.boolean.push('isPublic', 'disableFlows', 'socialBarOnSitePagesDisabled', 'shareByEmailEnabled', 'allowSelfServiceUpgrade', 'noScriptSite');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -568,7 +575,7 @@ class SpoSiteSetCommand extends SpoCommand {
 
   private updateSiteProperties(logger: Logger, args: CommandArgs): Promise<string> {
     const isGroupConnectedSite = this.isGroupConnectedSite();
-    const sharedProperties: string[] = ['classification', 'disableFlows', 'shareByEmailEnabled', 'sharingCapability', 'noScriptSite'];
+    const sharedProperties: string[] = ['classification', 'disableFlows', 'socialBarOnSitePagesDisabled', 'shareByEmailEnabled', 'sharingCapability', 'noScriptSite'];
     const siteProperties: string[] = ['title', 'resourceQuota', 'resourceQuotaWarningLevel', 'storageQuota', 'storageQuotaWarningLevel', 'allowSelfServiceUpgrade'];
     let properties: string[] = sharedProperties;
 
@@ -627,6 +634,9 @@ class SpoSiteSetCommand extends SpoCommand {
         }
         if (typeof args.options.disableFlows !== 'undefined') {
           payload.push(`<SetProperty Id="${propertyId++}" ObjectPathId="5" Name="DisableFlows"><Parameter Type="Boolean">${args.options.disableFlows}</Parameter></SetProperty>`);
+        }
+        if (typeof args.options.socialBarOnSitePagesDisabled !== 'undefined') {
+          payload.push(`<SetProperty Id="${propertyId++}" ObjectPathId="5" Name="SocialBarOnSitePagesDisabled"><Parameter Type="Boolean">${args.options.socialBarOnSitePagesDisabled}</Parameter></SetProperty>`);
         }
         if (typeof args.options.shareByEmailEnabled !== 'undefined') {
           payload.push(`<SetProperty Id="${propertyId++}" ObjectPathId="5" Name="ShareByEmailEnabled"><Parameter Type="Boolean">${args.options.shareByEmailEnabled}</Parameter></SetProperty>`);


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##

Closes #5072 

## What is in this Pull Request ? ##

Added `--socialBarOnSitePagesDisabled` parameter to `spo site set` cmdlet which allows enabling/disabling social bar on site pages for individual SharePoint sites.