### PR TITLE
Removal of double forward slash in documentation

### DIFF
--- a/docs/docs/cmd/spo/file/file-retentionlabel-ensure.mdx
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-ensure.mdx
@@ -33,7 +33,7 @@ m365 spo file retentionlabel ensure [options]
 
 ## Remarks
 
-You can also use [spo listitem retentionlabel remove](./../../../cmd/spo//listitem/listitem-retentionlabel-remove.mdx) for removing the retention label from a listitem.
+You can also use [spo listitem retentionlabel remove](./../../../cmd/spo/listitem/listitem-retentionlabel-remove.mdx) for removing the retention label from a listitem.
 
 The `--assetId` option has to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created.
 

--- a/docs/docs/cmd/spo/folder/folder-retentionlabel-ensure.mdx
+++ b/docs/docs/cmd/spo/folder/folder-retentionlabel-ensure.mdx
@@ -30,7 +30,7 @@ m365 spo folder retentionlabel ensure [options]
 
 ## Remarks
 
-You can also use [spo listitem retentionlabel remove](./../../../cmd/spo//listitem/listitem-retentionlabel-remove.mdx) for removing the retention label from a listitem.
+You can also use [spo listitem retentionlabel remove](./../../../cmd/spo/listitem/listitem-retentionlabel-remove.mdx) for removing the retention label from a listitem.
 
 ## Examples
 


### PR DESCRIPTION
A bit of nitpicking here, but noticed that there are 2 docs with a double forward slash