### PR TITLE
Refactores Interactive mode config key. Related #5053

### DIFF
--- a/docs/docs/_clisettings.mdx
+++ b/docs/docs/_clisettings.mdx
@@ -10,9 +10,8 @@ Setting name|Definition|Default value
 `disableTelemetry`|Disables sending of telemetry data|`false`
 `errorOutput`|Defines if errors should be written to `stdout` or `stderr`|`stderr`
 `helpMode`|Defines what part of command's help to display. Allowed values are `options`, `examples`, `remarks`, `response`, `full`|`full`
-`interactive`|Enables interactive selection when multiple values are available for a command that requires a specific value to be retrieved.|`false`
 `output`|Defines the default output when issuing a command|`json`
 `printErrorsAsPlainText`|When output mode is set to `json`, print error messages as plain-text rather than JSON|`true`
-`prompt`|Prompts for missing values in required options|`false`
+`prompt`|Prompts for missing values in required options and enables interactive selection when multiple values are available for a command that requires a specific value to be retrieved.|`false`
 `showHelpOnFailure`|Automatically display help when executing a command failed|`true`
 `showSpinner`|Display spinner when executing commands|`true`

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -955,8 +955,8 @@ export class Cli {
   }
 
   public static async handleMultipleResultsFound(promptMessage: string, errorMessage: string, values: { [key: string]: object }): Promise<object | CommandError> {
-    const interactive: boolean = Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.interactive, false);
-    if (!interactive) {
+    const prompt: boolean = Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.prompt, false);
+    if (!prompt) {
       throw errorMessage;
     }
 

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -90,7 +90,6 @@ class CliConfigSetCommand extends AnonymousCommand {
       case settingsNames.csvQuoted:
       case settingsNames.csvQuotedEmpty:
       case settingsNames.disableTelemetry:
-      case settingsNames.interactive:
       case settingsNames.printErrorsAsPlainText:
       case settingsNames.prompt:
       case settingsNames.showHelpOnFailure:

--- a/src/m365/commands/setupPresets.ts
+++ b/src/m365/commands/setupPresets.ts
@@ -1,7 +1,6 @@
 export const interactivePreset = {
   autoOpenLinksInBrowser: true,
   copyDeviceCodeToClipboard: true,
-  interactive: true,
   output: 'text',
   printErrorsAsPlainText: true,
   prompt: true,
@@ -11,7 +10,6 @@ export const interactivePreset = {
 export const scriptingPreset = {
   autoOpenLinksInBrowser: false,
   copyDeviceCodeToClipboard: false,
-  interactive: false,
   output: 'json',
   printErrorsAsPlainText: false,
   prompt: false,

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -9,7 +9,6 @@ const settingsNames = {
   disableTelemetry: 'disableTelemetry',
   errorOutput: 'errorOutput',
   helpMode: 'helpMode',
-  interactive: 'interactive',
   output: 'output',
   printErrorsAsPlainText: 'printErrorsAsPlainText',
   prompt: 'prompt',


### PR DESCRIPTION
## 🎯 Aim

The aim is to refactor the CLI logi to use `prompt` config for our new interactie mode 

## 📷 Result

![image](https://github.com/pnp/cli-microsoft365/assets/58668583/2eabdb0f-ab7a-428b-ad52-6e3534e5eb1e)


## 🔗 Related issue

Related #5053