### PR TITLE
Extends 'spo tenant applicationcustomizer set' command with support to update the clientSideComponentId. Closes #5063

### DIFF
--- a/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-set.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-set.mdx
@@ -14,13 +14,13 @@ m365 spo tenant applicationcustomizer set [options]
 
 ```md definition-list
 `-t, --title [title]`
-: The title of the Application Customizer to update. Specify either `title`, `id`, or `clientSideComponentId`.
+: The title of the Application Customizer to update. Specify either `title`, `id` or `clientSideComponentId`.
 
 `-i, --id [id]`
-: The id of the Application Customizer to update. Specify either `title`, `id`, or `clientSideComponentId`.
+: The id of the Application Customizer to update. Specify either `title`, `id` or `clientSideComponentId`.
 
 `-c, --clientSideComponentId  [clientSideComponentId]`
-: The Client Side Component Id (GUID) of the Application Customizer to update. Specify either `title`, `id`, or `clientSideComponentId`.
+: The Client Side Component Id (GUID) of the Application Customizer to update. Specify either `title`, `id` or `clientSideComponentId`.
 
 `--newTitle [newTitle]`
 : The updated title of the Application Customizer.

--- a/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-set.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-set.mdx
@@ -14,16 +14,19 @@ m365 spo tenant applicationcustomizer set [options]
 
 ```md definition-list
 `-t, --title [title]`
-: The title of the Application Customizer to update. Specify either `title`, `id` or `clientSideComponentId`.
+: The title of the Application Customizer to update. Specify either `title`, `id`, or `clientSideComponentId`.
 
 `-i, --id [id]`
-: The id of the Application Customizer to update. Specify either `title`, `id` or `clientSideComponentId`.
+: The id of the Application Customizer to update. Specify either `title`, `id`, or `clientSideComponentId`.
 
 `-c, --clientSideComponentId  [clientSideComponentId]`
-: The Client Side Component Id (GUID) of the Application Customizer to update. Specify either `title`, `id` or `clientSideComponentId`.
+: The Client Side Component Id (GUID) of the Application Customizer to update. Specify either `title`, `id`, or `clientSideComponentId`.
 
 `--newTitle [newTitle]`
 : The updated title of the Application Customizer.
+
+`--newClientSideComponentId [newClientSideComponentId]`
+: The new Client Side Component Id (GUID) of the Application Customizer.
 
 `-p, --clientSideComponentProperties [clientSideComponentProperties]`
 : The Client Side Component properties of the Application Customizer.
@@ -55,7 +58,13 @@ When using the `--clientSideComponentProperties` option it's possible to enter a
 Updates the title of an Application Customizer that is deployed as a tenant-wide extension by its id
 
 ```sh
-m365 spo tenant applicationcustomizer set --id 3 --newTitle  "Some customizer" 
+m365 spo tenant applicationcustomizer set --id 3 --newTitle "Some customizer" 
+```
+
+Updates the Client Side Component Id of an Application Customizer that is deployed as a tenant-wide extension by its id
+
+```sh
+m365 spo tenant applicationcustomizer set --id 3 --newClientSideComponentId "b44a5182-9877-4029-baec-0181c70dacbc" 
 ```
 
 Updates the properties of an Application Customizer that is deployed as a tenant-wide extension by its id
@@ -67,13 +76,13 @@ m365 spo tenant applicationcustomizer set --id 3 --clientSideComponentProperties
 Updates the title of an Application Customizer that is deployed as a tenant-wide extension by its title
 
 ```sh
-m365 spo tenant applicationcustomizer set --title "Some customizer" --newTitle  "Updated customizer" 
+m365 spo tenant applicationcustomizer set --title "Some customizer" --newTitle "Updated customizer" 
 ```
 
 Updates the title of an Application Customizer that is deployed as a tenant-wide extension by its clientSideComponentId
 
 ```sh
-m365 spo tenant applicationcustomizer set --clientSideComponentId "7f8fd1f2-9d26-4a4a-a607-bf4622d7ec11" --newTitle  "Some customizer" 
+m365 spo tenant applicationcustomizer set --clientSideComponentId "7f8fd1f2-9d26-4a4a-a607-bf4622d7ec11" --newTitle "Some customizer" 
 ```
 
 ## Response

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.spec.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import auth from '../../../../Auth';
-import appInsights from '../../../../appInsights';
 import { Cli } from '../../../../cli/Cli';
 import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.spec.ts
@@ -123,7 +123,6 @@ describe(commands.TENANT_APPLICATIONCUSTOMIZER_SET, () => {
   before(() => {
     cli = Cli.getInstance();
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
     sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
     sinon.stub(session, 'getId').callsFake(() => '');
@@ -335,7 +334,7 @@ describe(commands.TENANT_APPLICATIONCUSTOMIZER_SET, () => {
     }), new CommandError(errorMessage));
   });
 
-  it('Updates title of an application customizer by title', async () => {
+  it('updates title of an application customizer by title', async () => {
     defaultGetCallStub("Title eq 'Some customizer'");
     const executeCallsStub: sinon.SinonStub = defaultPostCallsStub();
     await command.action(logger, {
@@ -411,7 +410,7 @@ describe(commands.TENANT_APPLICATIONCUSTOMIZER_SET, () => {
       new CommandError('No component found with the specified clientSideComponentId found in the component manifest list. Make sure that the application is added to the application catalog'));
   });
 
-  it('throws an error when the manifest of a specific client side component is not of type application customizer', async () => {
+  it('throws an error when client side component to update is not of type application customizer', async () => {
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
       if (command === spoListItemListCommand) {
         if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.ts
@@ -25,6 +25,7 @@ interface Options extends GlobalOptions {
   title?: string;
   clientSideComponentId?: string;
   newTitle?: string;
+  newClientSideComponentId?: string;
   clientSideComponentProperties?: string;
   webTemplate?: string;
 }
@@ -54,6 +55,7 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
         id: typeof args.options.id !== 'undefined',
         clientSideComponentId: typeof args.options.clientSideComponentId !== 'undefined',
         newTitle: typeof args.options.newTitle !== 'undefined',
+        newClientSideComponentId: typeof args.options.newClientSideComponentId !== 'undefined',
         clientSideComponentProperties: typeof args.options.clientSideComponentProperties !== 'undefined',
         webTemplate: typeof args.options.webTemplate !== 'undefined'
       });
@@ -75,6 +77,9 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
         option: '--newTitle [newTitle]'
       },
       {
+        option: '--newClientSideComponentId [newClientSideComponentId]'
+      },
+      {
         option: '-p, --clientSideComponentProperties [clientSideComponentProperties]'
       },
       {
@@ -94,7 +99,11 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
           return `${args.options.clientSideComponentId} is not a valid GUID`;
         }
 
-        if (!args.options.newTitle && !args.options.clientSideComponentProperties && !args.options.webTemplate) {
+        if (args.options.newClientSideComponentId && !validation.isValidGuid(args.options.newClientSideComponentId)) {
+          return `${args.options.newClientSideComponentId} is not a valid GUID`;
+        }
+
+        if (!args.options.newTitle && !args.options.newClientSideComponentId && !args.options.clientSideComponentProperties && !args.options.webTemplate) {
           return `Please specify an option to be updated`;
         }
 
@@ -146,7 +155,7 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
   }
 
   private async updateTenantWideExtension(appCatalogUrl: string, options: Options, listServerRelativeUrl: string, itemId: number, logger: Logger): Promise<void> {
-    const { title, id, clientSideComponentId, newTitle, clientSideComponentProperties, webTemplate } = options;
+    const { title, id, clientSideComponentId, newTitle, newClientSideComponentId, clientSideComponentProperties, webTemplate } = options;
 
     if (this.verbose) {
       logger.logToStderr(`Updating tenant-wide application customizer: "${title || id || clientSideComponentId}"...`);
@@ -158,6 +167,13 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
       formValues.push({
         FieldName: 'Title',
         FieldValue: newTitle
+      });
+    }
+
+    if (newClientSideComponentId !== undefined) {
+      formValues.push({
+        FieldName: 'TenantWideExtensionComponentId',
+        FieldValue: newClientSideComponentId
       });
     }
 

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.ts
@@ -193,11 +193,13 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
     };
 
     const output = await Cli.executeCommandWithOutput(spoListItemListCommand as Command, { options: { ...commandOptions, _: [] } });
+
     if (this.verbose) {
       logger.logToStderr(output.stderr);
     }
 
     const outputParsed = JSON.parse(output.stdout);
+
     if (outputParsed.length === 0) {
       throw 'No component found with the specified clientSideComponentId found in the component manifest list. Make sure that the application is added to the application catalog';
     }

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.ts
@@ -8,8 +8,13 @@ import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
 import * as os from 'os';
+import Command from '../../../../Command';
 import { ListItemInstance } from '../listitem/ListItemInstance';
+import { Cli } from '../../../../cli/Cli';
+import { Options as spoListItemListCommandOptions } from '../listitem/listitem-list';
+import * as spoListItemListCommand from '../listitem/listitem-list';
 import request, { CliRequestOptions } from '../../../../request';
+import { Solution } from './Solution';
 
 interface CommandArgs {
   options: Options;
@@ -124,6 +129,24 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
         throw 'No app catalog URL found';
       }
 
+      if (args.options.newClientSideComponentId !== undefined) {
+        const componentManifest = await this.getComponentManifest(appCatalogUrl, args.options.newClientSideComponentId, logger);
+        const clientComponentManifest = JSON.parse(componentManifest.ClientComponentManifest);
+
+        if (clientComponentManifest.extensionType !== "ApplicationCustomizer") {
+          throw `The extension type of this component is not of type 'ApplicationCustomizer' but of type '${clientComponentManifest.extensionType}'`;
+        }
+
+        const solution = await this.getSolutionFromAppCatalog(appCatalogUrl, componentManifest.SolutionId, logger);
+
+        if (!solution.ContainsTenantWideExtension) {
+          throw `The solution does not contain an extension that can be deployed to all sites. Make sure that you've entered the correct component Id.`;
+        }
+        else if (!solution.SkipFeatureDeployment) {
+          throw 'The solution has not been deployed to all sites. Make sure to deploy this solution to all sites.';
+        }
+      }
+
       const listServerRelativeUrl: string = urlUtil.getServerRelativePath(appCatalogUrl, '/lists/TenantWideExtensions');
       const listItemId: number = await this.getListItemId(appCatalogUrl, args.options, listServerRelativeUrl, logger);
       await this.updateTenantWideExtension(appCatalogUrl, args.options, listServerRelativeUrl, listItemId, logger);
@@ -152,6 +175,62 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
     }
 
     return listItemInstances[0].Id;
+  }
+
+  private async getComponentManifest(appCatalogUrl: string, clientSideComponentId: string, logger: Logger): Promise<any> {
+    if (this.verbose) {
+      logger.logToStderr('Retrieving component manifest item from the ComponentManifests list on the app catalog site so that we get the solution id');
+    }
+
+    const camlQuery = `<View><ViewFields><FieldRef Name='ClientComponentId'></FieldRef><FieldRef Name='SolutionId'></FieldRef><FieldRef Name='ClientComponentManifest'></FieldRef></ViewFields><Query><Where><Eq><FieldRef Name='ClientComponentId' /><Value Type='Guid'>${clientSideComponentId}</Value></Eq></Where></Query></View>`;
+    const commandOptions: spoListItemListCommandOptions = {
+      webUrl: appCatalogUrl,
+      listUrl: `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`,
+      camlQuery: camlQuery,
+      verbose: this.verbose,
+      debug: this.debug,
+      output: 'json'
+    };
+
+    const output = await Cli.executeCommandWithOutput(spoListItemListCommand as Command, { options: { ...commandOptions, _: [] } });
+    if (this.verbose) {
+      logger.logToStderr(output.stderr);
+    }
+
+    const outputParsed = JSON.parse(output.stdout);
+    if (outputParsed.length === 0) {
+      throw 'No component found with the specified clientSideComponentId found in the component manifest list. Make sure that the application is added to the application catalog';
+    }
+
+    return outputParsed[0];
+  }
+
+  private async getSolutionFromAppCatalog(appCatalogUrl: string, solutionId: string, logger: Logger): Promise<Solution> {
+    if (this.verbose) {
+      logger.logToStderr(`Retrieving solution with id ${solutionId} from the application catalog`);
+    }
+
+    const camlQuery = `<View><ViewFields><FieldRef Name='SkipFeatureDeployment'></FieldRef><FieldRef Name='ContainsTenantWideExtension'></FieldRef></ViewFields><Query><Where><Eq><FieldRef Name='AppProductID' /><Value Type='Guid'>${solutionId}</Value></Eq></Where></Query></View>`;
+    const commandOptions: spoListItemListCommandOptions = {
+      webUrl: appCatalogUrl,
+      listUrl: `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`,
+      camlQuery: camlQuery,
+      verbose: this.verbose,
+      debug: this.debug,
+      output: 'json'
+    };
+
+    const output = await Cli.executeCommandWithOutput(spoListItemListCommand as Command, { options: { ...commandOptions, _: [] } });
+    if (this.verbose) {
+      logger.logToStderr(output.stderr);
+    }
+
+    const outputParsed = JSON.parse(output.stdout);
+    if (outputParsed.length === 0) {
+      throw `No component found with the solution id ${solutionId}. Make sure that the solution is available in the app catalog`;
+    }
+
+    return outputParsed[0];
   }
 
   private async updateTenantWideExtension(appCatalogUrl: string, options: Options, listServerRelativeUrl: string, itemId: number, logger: Logger): Promise<void> {


### PR DESCRIPTION
Extends `spo tenant applicationcustomizer set` command with support to update the `clientSideComponentId` of an application customizer that's deployed tenant-wide. Closes #5063