### PR TITLE
Refactores prompts for options sets

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -246,7 +246,7 @@ export default abstract class Command {
     const resultOptionValue = await (inquirer as Inquirer)
       .prompt({
         name: 'missingRequiredOptionValue',
-        message: `Value for '${missingRequiredOptionName}':`
+        message: `${missingRequiredOptionName}:`
       });
 
     args.options[missingRequiredOptionName] = resultOptionValue.missingRequiredOptionValue;

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -869,7 +869,7 @@ describe('Cli', () => {
     await cli.execute(rootFolder, ['cli', 'mock', 'optionsets']);
     assert.strictEqual(promptStub.firstCall.args[0].choices[0], firstOptionValue);
     assert.strictEqual(promptStub.firstCall.args[0].choices[1], secondOptionValue);
-    assert.strictEqual(promptStub.lastCall.args[0].message, `Value for '${firstOptionValue}':`);
+    assert.strictEqual(promptStub.lastCall.args[0].message, `${firstOptionValue}:`);
     assert(promptStub.calledTwice);
   });
 


### PR DESCRIPTION
### Refactores prompts for options sets

Agreed internally on the behavior that prompting for the required option set value should behave the same as prompting for a required option


https://github.com/pnp/cli-microsoft365/assets/58668583/5a5c93bb-8113-4fc1-a93c-61ec3ccf2ce6

