### PR TITLE
Fixes 'spo list retentionlabel get' and 'spo list retentionlabel ensure' commands. Closes #4177

### DIFF
--- a/docs/docs/cmd/spo/list/list-retentionlabel-ensure.mdx
+++ b/docs/docs/cmd/spo/list/list-retentionlabel-ensure.mdx
@@ -10,12 +10,6 @@ Sets a default retention label on the specified list or library.
 m365 spo list retentionlabel ensure [options]
 ```
 
-## Alias
-
-```sh
-m365 spo list label set [options]
-```
-
 ## Options
 
 ```md definition-list

--- a/docs/docs/cmd/spo/list/list-retentionlabel-get.mdx
+++ b/docs/docs/cmd/spo/list/list-retentionlabel-get.mdx
@@ -12,12 +12,6 @@ Gets the default retention label set on the specified list or library.
 m365 spo list retentionlabel get [options]
 ```
 
-## Alias
-
-```sh
-m365 spo list label get [options]
-```
-
 ## Options
 
 ```md definition-list

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -45,8 +45,6 @@ describe('Lazy loading commands', () => {
       'consent',
       'flow connector export',
       'flow connector list',
-      'spo list label get',
-      'spo list label set',
       'spo page template remove',
       'spo sp grant add',
       'spo sp grant list',

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -131,8 +131,6 @@ export default {
   LIST_CONTENTTYPE_REMOVE: `${prefix} list contenttype remove`,
   LIST_CONTENTTYPE_DEFAULT_SET: `${prefix} list contenttype default set`,
   LIST_GET: `${prefix} list get`,
-  LIST_LABEL_GET: `${prefix} list label get`,
-  LIST_LABEL_SET: `${prefix} list label set`,
   LIST_LIST: `${prefix} list list`,
   LIST_REMOVE: `${prefix} list remove`,
   LIST_RETENTIONLABEL_ENSURE: `${prefix} list retentionlabel ensure`,

--- a/src/m365/spo/commands/list/list-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-ensure.spec.ts
@@ -62,11 +62,6 @@ describe(commands.LIST_RETENTIONLABEL_ENSURE, () => {
     assert.strictEqual(command.name, commands.LIST_RETENTIONLABEL_ENSURE);
   });
 
-  it('defines correct alias', () => {
-    const alias = command.alias();
-    assert.strictEqual((alias && alias.indexOf(commands.LIST_LABEL_SET) !== -1), true);
-  });
-
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
   });

--- a/src/m365/spo/commands/list/list-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-ensure.ts
@@ -29,10 +29,6 @@ class SpoListRetentionLabelEnsureCommand extends SpoCommand {
     return commands.LIST_RETENTIONLABEL_ENSURE;
   }
 
-  public alias(): string[] | undefined {
-    return [commands.LIST_LABEL_SET];
-  }
-
   public get description(): string {
     return 'Sets a default retention label on the specified list or library.';
   }
@@ -110,8 +106,6 @@ class SpoListRetentionLabelEnsureCommand extends SpoCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    this.showDeprecationWarning(logger, commands.LIST_LABEL_SET, commands.LIST_RETENTIONLABEL_ENSURE);
-
     if (args.options.label) {
       args.options.name = args.options.label;
 

--- a/src/m365/spo/commands/list/list-retentionlabel-get.spec.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-get.spec.ts
@@ -60,11 +60,6 @@ describe(commands.LIST_RETENTIONLABEL_GET, () => {
     assert.strictEqual(command.name, commands.LIST_RETENTIONLABEL_GET);
   });
 
-  it('defines correct alias', () => {
-    const alias = command.alias();
-    assert.strictEqual((alias && alias.indexOf(commands.LIST_LABEL_GET) !== -1), true);
-  });
-
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
   });

--- a/src/m365/spo/commands/list/list-retentionlabel-get.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-get.ts
@@ -24,10 +24,6 @@ class SpoListRetentionLabelGetCommand extends SpoCommand {
     return commands.LIST_RETENTIONLABEL_GET;
   }
 
-  public alias(): string[] | undefined {
-    return [commands.LIST_LABEL_GET];
-  }
-
   public get description(): string {
     return 'Gets the default retention label set on the specified list or library.';
   }
@@ -92,8 +88,6 @@ class SpoListRetentionLabelGetCommand extends SpoCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    this.showDeprecationWarning(logger, commands.LIST_LABEL_GET, commands.LIST_RETENTIONLABEL_GET);
-
     try {
       if (this.verbose) {
         logger.logToStderr(`Getting label set on the list ${args.options.listId || args.options.listTitle || args.options.listUrl} in site at ${args.options.webUrl}...`);


### PR DESCRIPTION
Fixes `spo list retentionlabel get` and `spo list retentionlabel ensure` commands by removing `spo list label get` and `spo list label get` aliases respectively. Closes #4177