### PR TITLE
Extends 'spo tenant commandset set' command. Closes #4961

### DIFF
--- a/docs/docs/cmd/spo/tenant/tenant-commandset-set.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-commandset-set.mdx
@@ -13,19 +13,25 @@ m365 spo tenant commandset set [options]
 ## Options
 
 ```md definition-list
-`-i, --id <id>`
-: The id of the ListView Command Set
+`-t, --title [title]`
+: The title of the ListView Command Set to update. Specify either `title`, `id` or `clientSideComponentId`.
 
-`-t, --newTitle [newTitle]`
-: The updated title of the ListView Command Set
+`-i, --id [id]`
+: The id of the ListView Command Set to update. Specify either `title`, `id` or `clientSideComponentId`.
+
+`-c, --clientSideComponentId  [clientSideComponentId]`
+: The Client Side Component Id (GUID) of the ListView Command Set to update. Specify either `title`, `id` or `clientSideComponentId`.
+
+`--newTitle [newTitle]`
+: The updated title of the ListView Command Set.
 
 `-l, --listType [listType]`
 : The list or library type to register the ListView Command Set on. Allowed values `List` or `Library`.
 
-`-c, --clientSideComponentId  [clientSideComponentId]`
-: The Client Side Component Id (GUID) of the ListView Command Set.
+`--newClientSideComponentId  [newClientSideComponentId]`
+: The updated Client Side Component Id (GUID) of the ListView Command Set.
 
-`-p, --clientSideComponentProperties  [clientSideComponentProperties]`
+`-p, --clientSideComponentProperties [clientSideComponentProperties]`
 : The Client Side Component properties of the ListView Command Set.
 
 `-w, --webTemplate [webTemplate]`
@@ -47,16 +53,22 @@ When using the `--clientSideComponentProperties` option it's possible to enter a
 
 ## Examples
 
-Updates the title of a ListView Command Set that's deployed tenant wide.
+Updates the title of a ListView Command Set that's deployed tenant wide by its id.
 
 ```sh
-m365 spo tenant commandset set --id 4  --newTitle "Some customizer"
+m365 spo tenant commandset set --id 4 --newTitle "Some customizer"
 ```
 
-Updates the properties of a ListView Command Set.
+Updates the properties of a ListView Command Set that's deployed tenant wide by its title.
 
 ```sh
-m365 spo tenant commandset  set --id 3  --clientSideComponentProperties '{ "someProperty": "Some value" }'
+m365 spo tenant commandset set --title "Some Command Set" --clientSideComponentProperties '{ "someProperty": "Some value" }'
+```
+
+Updates the Client Side Component Id (GUID) of a ListView Command Set that's deployed tenant wide by its clientSideComponentId.
+
+```sh
+m365 spo tenant commandset set --clientSideComponentId "07ee7d3d-923e-49be-b050-86f53edb45fb" --newClientSideComponentId "b44a5182-9877-4029-baec-0181c70dacbc"
 ```
 
 ## Response

--- a/src/m365/spo/commands/tenant/tenant-commandset-set.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-set.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import appInsights from '../../../../appInsights';
+import { telemetry } from '../../../../telemetry';
 import auth from '../../../../Auth';
 import { Cli } from '../../../../cli/Cli';
 import { CommandInfo } from '../../../../cli/CommandInfo';
@@ -9,18 +9,30 @@ import Command, { CommandError } from '../../../../Command';
 import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
+import { spo } from '../../../../utils/spo';
 import commands from '../../commands';
+import * as spoListItemListCommand from '../listitem/listitem-list';
+import { urlUtil } from '../../../../utils/urlUtil';
 import request from '../../../../request';
+import * as os from 'os';
 const command: Command = require('./tenant-commandset-set');
 
 describe(commands.TENANT_COMMANDSET_SET, () => {
+  const title = 'Some Command Set';
   const id = 1;
   const clientSideComponentId = '9748c81b-d72e-4048-886a-e98649543743';
+  const newTitle = 'New Command Set';
+  const newClientSideComponentId = '7096cded-b83d-4eab-96f0-df477ed8c0bc';
   const clientSideComponentProperties = '{ "someProperty": "Some value" }';
-  const title = 'Some Command Set';
   const webTemplate = 'GROUP#0';
   const spoUrl = 'https://contoso.sharepoint.com';
   const appCatalogUrl = `https://contoso.sharepoint.com/sites/apps`;
+  const solutionId = 'ac555cb1-e5ac-409e-86dc-61e6651b1e66';
+  const clientComponentManifest = "{\"id\":\"8645b5d7-51e1-40af-8a62-d64af8a8487e\",\"alias\":\"HelloWorldCommandSet\",\"componentType\":\"Extension\",\"extensionType\":\"ListViewCommandSet\",\"version\":\"0.0.1\",\"manifestVersion\":2,\"items\":{\"COMMAND_1\":{\"title\":{\"default\":\"Command One\"},\"iconImageUrl\":\"icons/request.png\",\"type\":\"command\"},\"COMMAND_2\":{\"title\":{\"default\":\"Command Two\"},\"iconImageUrl\":\"icons/cancel.png\",\"type\":\"command\"}},\"loaderConfig\":{\"internalModuleBaseUrls\":[\"HTTPS://SPCLIENTSIDEASSETLIBRARY/\"],\"entryModuleId\":\"hello-world-command-set\",\"scriptResources\":{\"hello-world-command-set\":{\"type\":\"path\",\"path\":\"hello-world-command-set_087bd3f44cb1a4a2316f.js\"},\"@microsoft/sp-dialog\":{\"type\":\"component\",\"id\":\"c0c518b8-701b-4f6f-956d-5782772bb731\",\"version\":\"1.17.3\"},\"@microsoft/sp-listview-extensibility\":{\"type\":\"component\",\"id\":\"d37b65ee-c7d8-4570-bc74-2b294ff3b380\",\"version\":\"1.17.3\"},\"@microsoft/sp-core-library\":{\"type\":\"component\",\"id\":\"7263c7d0-1d6a-45ec-8d85-d4d1d234171b\",\"version\":\"1.17.3\"}}},\"mpnId\":\"Undefined-1.17.3\",\"clientComponentDeveloper\":\"\"}";
+  const solution = { "FileSystemObjectType": 0, "Id": 67, "ServerRedirectedEmbedUri": null, "ServerRedirectedEmbedUrl": "", "ClientComponentId": clientSideComponentId, "SolutionId": solutionId, "ClientComponentManifest": clientComponentManifest, "Created": "2023-07-09T20:23:37", "Modified": "2023-07-09T20:23:37" };
+  const solutionResponse = [solution];
+  const application = { "FileSystemObjectType": 0, "Id": 61, "ServerRedirectedEmbedUri": null, "ServerRedirectedEmbedUrl": "", "SkipFeatureDeployment": true, "ContainsTenantWideExtension": true, "Modified": '2023-07-09T20:23:36', "CheckoutUserId": null, "EditorId": 9 };
+  const applicationResponse = [application];
   const commandSetResponse = {
     "FileSystemObjectType": 0,
     "Id": id,
@@ -37,24 +49,39 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
     "GUID": "6e6f2429-cdec-4b90-89da-139d2665919e",
     "ComplianceAssetId": null,
     "TenantWideExtensionComponentId": clientSideComponentId,
-    "TenantWideExtensionComponentProperties": "{\"testMessage\":\"Test message\"}",
+    "TenantWideExtensionComponentProperties": "{\"sampleTextOne\":\"One item is selected in the list.\", \"sampleTextTwo\":\"This command is always visible.\"}",
     "TenantWideExtensionWebTemplate": null,
     "TenantWideExtensionListTemplate": 101,
-    "TenantWideExtensionLocation": "ClientSideExtension.ListViewCommandSet.ContextMenu",
+    "TenantWideExtensionLocation": "ClientSideExtension.ListViewCommandSet.CommandBar",
     "TenantWideExtensionSequence": 0,
     "TenantWideExtensionHostProperties": null,
     "TenantWideExtensionDisabled": false
   };
+  const multipleResponses = {
+    value:
+      [
+        { Title: title, Id: 3, TenantWideExtensionComponentId: clientSideComponentId },
+        { Title: title, Id: 4, TenantWideExtensionComponentId: clientSideComponentId }
+      ]
+  };
 
+  let cli: Cli;
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
 
   before(() => {
+    cli = Cli.getInstance();
     sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(appInsights, 'trackEvent').returns();
+    sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(spo, 'getRequestDigest').resolves({
+      FormDigestValue: 'ABC',
+      FormDigestTimeoutSeconds: 1800,
+      FormDigestExpiresAt: new Date(),
+      WebFullUrl: 'https://contoso.sharepoint.com'
+    });
     auth.service.connected = true;
     auth.service.spoUrl = spoUrl;
     commandInfo = Cli.getCommandInfo(command);
@@ -73,18 +100,23 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
         log.push(msg);
       }
     };
+    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(((settingName, defaultValue) => defaultValue));
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.post
+      request.post,
+      cli.getSettingWithDefaultValue,
+      Cli.executeCommand,
+      Cli.executeCommandWithOutput
     ]);
   });
 
   after(() => {
     sinon.restore();
     auth.service.connected = false;
+    auth.service.spoUrl = undefined;
   });
 
   it('has correct name', () => {
@@ -95,14 +127,31 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('updates a tenant-wide ListView Command Set for lists', async () => {
+  it('updates a tenant-wide listview command set for lists by id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/SP_TenantSettings_Current`) {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
         return { CorporateCatalogUrl: appCatalogUrl };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Id eq '1'`) {
+        return { value: [commandSetResponse] };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
         return commandSetResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify(applicationResponse) };
+        }
       }
 
       throw 'Invalid request';
@@ -124,7 +173,7 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
               ErrorCode: 0,
               ErrorMessage: null,
               FieldName: "TenantWideExtensionComponentId",
-              FieldValue: clientSideComponentId,
+              FieldValue: newClientSideComponentId,
               HasException: false,
               ItemId: 4
             },
@@ -132,7 +181,7 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
               ErrorCode: 0,
               ErrorMessage: null,
               FieldName: "TenantWideExtensionComponentId",
-              FieldValue: clientSideComponentId,
+              FieldValue: newClientSideComponentId,
               HasException: false,
               ItemId: 4
             },
@@ -175,16 +224,20 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
       throw 'Invalid request';
     });
 
-    await assert.doesNotReject(command.action(logger, { options: { id: id, newTitle: title, clientSideComponentId: clientSideComponentId, listType: 'List', location: 'Both', webTemplate: webTemplate, clientSideComponentProperties: clientSideComponentProperties, verbose: true } }));
+    await assert.doesNotReject(command.action(logger, { options: { id: id, newTitle: title, newClientSideComponentId: newClientSideComponentId, listType: 'List', location: 'Both', webTemplate: webTemplate, clientSideComponentProperties: clientSideComponentProperties, verbose: true } }));
   });
 
-  it('updates a tenant-wide ListView Command Set for lists with location ContextMenu and listType SitePages', async () => {
+  it('updates a tenant-wide listview command set for lists with location ContextMenu and listType SitePages by id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/SP_TenantSettings_Current`) {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
         return { CorporateCatalogUrl: appCatalogUrl };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Id eq '1'`) {
+        return { value: [commandSetResponse] };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
         return commandSetResponse;
       }
 
@@ -221,13 +274,17 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
     await assert.doesNotReject(command.action(logger, { options: { id: id, location: 'ContextMenu', listType: 'SitePages' } }));
   });
 
-  it('updates a tenant-wide ListView Command Set for lists with location CommandBar and listType Library ', async () => {
+  it('updates a tenant-wide listview command set for lists with location CommandBar and listType Library by id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/SP_TenantSettings_Current`) {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
         return { CorporateCatalogUrl: appCatalogUrl };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Id eq '1'`) {
+        return { value: [commandSetResponse] };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
         return commandSetResponse;
       }
 
@@ -264,9 +321,443 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
     await assert.doesNotReject(command.action(logger, { options: { id: id, location: 'CommandBar', listType: 'Library' } }));
   });
 
-  const errorMessage = 'No app catalog URL found';
+  it('updates title of tenant-wide listview command set for lists by title', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
 
-  it('throws error when tenant app catalog doesn\'t exist', async () => {
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Title eq 'Some Command Set'`) {
+        return {
+          value: [
+            commandSetResponse
+          ]
+        };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+        return commandSetResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify(applicationResponse) };
+        }
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)/ValidateUpdateListItem()`) {
+        return {
+          value: [
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionComponentId",
+              FieldValue: newClientSideComponentId,
+              HasException: false,
+              ItemId: 4
+            },
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionLocation",
+              FieldValue: "ClientSideExtension.ListViewCommandSet.CommandBar",
+              HasException: false,
+              ItemId: 4
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.doesNotReject(command.action(logger, { options: { title: title, newClientSideComponentId: newClientSideComponentId, verbose: true } }));
+  });
+
+  it('updates title of tenant-wide listview command set for lists by ClientSideComponentId', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and TenantWideExtensionComponentId eq '9748c81b-d72e-4048-886a-e98649543743'`) {
+        return {
+          value: [
+            commandSetResponse
+          ]
+        };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+        return commandSetResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify(applicationResponse) };
+        }
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)/ValidateUpdateListItem()`) {
+        return {
+          value: [
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionComponentId",
+              FieldValue: newClientSideComponentId,
+              HasException: false,
+              ItemId: 4
+            },
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionLocation",
+              FieldValue: "ClientSideExtension.ListViewCommandSet.CommandBar",
+              HasException: false,
+              ItemId: 4
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.doesNotReject(command.action(logger, { options: { clientSideComponentId: clientSideComponentId, newClientSideComponentId: newClientSideComponentId, verbose: true } }));
+  });
+
+  it('throws an error when specific client side component is not found in manifest list', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify([]) };
+        }
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Id eq '1'`) {
+        return { value: [commandSetResponse] };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+        return commandSetResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)/ValidateUpdateListItem()`) {
+        return {
+          value: [
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionComponentId",
+              FieldValue: newClientSideComponentId,
+              HasException: false,
+              ItemId: 4
+            },
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionLocation",
+              FieldValue: "ClientSideExtension.ListViewCommandSet",
+              HasException: false,
+              ItemId: 4
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { id: id, newClientSideComponentId: newClientSideComponentId, verbose: true } }),
+      new CommandError('No component found with the specified clientSideComponentId found in the component manifest list. Make sure that the application is added to the application catalog'));
+  });
+
+  it('throws an error when client side component to update is not of type listview commandset', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          const faultyClientComponentManifest = "{\"id\":\"6b2a54c5-3317-49eb-8621-1bbb76263629\",\"alias\":\"HelloWorldApplicationCustomizer\",\"componentType\":\"Extension\",\"extensionType\":\"FormCustomizer\",\"version\":\"0.0.1\",\"manifestVersion\":2,\"loaderConfig\":{\"internalModuleBaseUrls\":[\"HTTPS://SPCLIENTSIDEASSETLIBRARY/\"],\"entryModuleId\":\"hello-world-application-customizer\",\"scriptResources\":{\"hello-world-application-customizer\":{\"type\":\"path\",\"path\":\"hello-world-application-customizer_b47769f9eca3d3b6c4d5.js\"},\"HelloWorldApplicationCustomizerStrings\":{\"type\":\"path\",\"path\":\"HelloWorldApplicationCustomizerStrings_en-us_72ca11838ac9bae2790a8692c260e1ac.js\"},\"@microsoft/sp-application-base\":{\"type\":\"component\",\"id\":\"4df9bb86-ab0a-4aab-ab5f-48bf167048fb\",\"version\":\"1.15.2\"},\"@microsoft/sp-core-library\":{\"type\":\"component\",\"id\":\"7263c7d0-1d6a-45ec-8d85-d4d1d234171b\",\"version\":\"1.15.2\"}}},\"mpnId\":\"Undefined-1.15.2\",\"clientComponentDeveloper\":\"\"}";
+          const solutionDuplicate = { ...solution };
+          solutionDuplicate.ClientComponentManifest = faultyClientComponentManifest;
+          return { 'stdout': JSON.stringify([solutionDuplicate]) };
+        }
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Id eq '1'`) {
+        return { value: [commandSetResponse] };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+        return commandSetResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)/ValidateUpdateListItem()`) {
+        return {
+          value: [
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionComponentId",
+              FieldValue: newClientSideComponentId,
+              HasException: false,
+              ItemId: 4
+            },
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionLocation",
+              FieldValue: "ClientSideExtension.ListViewCommandSet",
+              HasException: false,
+              ItemId: 4
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { id: id, newClientSideComponentId: newClientSideComponentId, verbose: true } }),
+      new CommandError(`The extension type of this component is not of type 'ListViewCommandSet' but of type 'FormCustomizer'`));
+  });
+
+  it('throws an error when solution is not found in app catalog', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          return { 'stdout': JSON.stringify([]) };
+        }
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Id eq '1'`) {
+        return { value: [commandSetResponse] };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+        return commandSetResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)/ValidateUpdateListItem()`) {
+        return {
+          value: [
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionComponentId",
+              FieldValue: newClientSideComponentId,
+              HasException: false,
+              ItemId: 4
+            },
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionLocation",
+              FieldValue: "ClientSideExtension.ListViewCommandSet",
+              HasException: false,
+              ItemId: 4
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { id: id, newClientSideComponentId: newClientSideComponentId, verbose: true } }),
+      new CommandError(`No component found with the solution id ${solutionId}. Make sure that the solution is available in the app catalog`));
+  });
+
+  it('throws an error when solution does not contain extension that can be deployed tenant-wide', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          const faultyApplication = { ...application };
+          faultyApplication.ContainsTenantWideExtension = false;
+          return { 'stdout': JSON.stringify([faultyApplication]) };
+        }
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Id eq '1'`) {
+        return { value: [commandSetResponse] };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+        return commandSetResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)/ValidateUpdateListItem()`) {
+        return {
+          value: [
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionComponentId",
+              FieldValue: newClientSideComponentId,
+              HasException: false,
+              ItemId: 4
+            },
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionLocation",
+              FieldValue: "ClientSideExtension.ListViewCommandSet",
+              HasException: false,
+              ItemId: 4
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { id: id, newClientSideComponentId: newClientSideComponentId, verbose: true } }),
+      new CommandError(`The solution does not contain an extension that can be deployed to all sites. Make sure that you've entered the correct component Id.`));
+  });
+
+  it('throws an error when solution is not deployed globally', async () => {
+    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command, args): Promise<any> => {
+      if (command === spoListItemListCommand) {
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`) {
+          return { 'stdout': JSON.stringify(solutionResponse) };
+        }
+        if (args.options.listUrl === `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`) {
+          const faultyApplication = { ...application };
+          faultyApplication.SkipFeatureDeployment = false;
+          return { 'stdout': JSON.stringify([faultyApplication]) };
+        }
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Id eq '1'`) {
+        return { value: [commandSetResponse] };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
+        return commandSetResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)/ValidateUpdateListItem()`) {
+        return {
+          value: [
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionComponentId",
+              FieldValue: newClientSideComponentId,
+              HasException: false,
+              ItemId: 4
+            },
+            {
+              ErrorCode: 0,
+              ErrorMessage: null,
+              FieldName: "TenantWideExtensionLocation",
+              FieldValue: "ClientSideExtension.ListViewCommandSet",
+              HasException: false,
+              ItemId: 4
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { id: id, newClientSideComponentId: newClientSideComponentId, verbose: true } }),
+      new CommandError(`The solution has not been deployed to all sites. Make sure to deploy this solution to all sites.`));
+  });
+
+  it('handles error when tenant app catalog doesn\'t exist', async () => {
+    const errorMessage = 'No app catalog URL found';
+
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
         return { CorporateCatalogUrl: null };
@@ -283,7 +774,7 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
     }), new CommandError(errorMessage));
   });
 
-  it('throws error when retrieving a tenant app catalog fails with an exception', async () => {
+  it('handles error when retrieving a tenant app catalog fails with an exception', async () => {
     const errorMessage = 'Couldn\'t retrieve tenant app catalog URL';
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
@@ -302,39 +793,15 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
     }), new CommandError(errorMessage));
   });
 
-  it('throws error when retrieving an item which is not a listview commandset', async () => {
-    const errorMessage = 'The item is not a ListViewCommandSet';
-
+  it('handles error when no listview commandset with the specified title found', async () => {
+    const errorMessage = 'The specified listview commandset was not found';
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/SP_TenantSettings_Current`) {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
         return { CorporateCatalogUrl: appCatalogUrl };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items(1)`) {
-        return {
-          "FileSystemObjectType": 0,
-          "ID": 4,
-          "ServerRedirectedEmbedUri": null,
-          "ServerRedirectedEmbedUrl": "",
-          "ContentTypeId": "0x00693E2C487575B448BD420C12CEAE7EFE",
-          "Title": title,
-          "Modified": "2023-01-11T15:47:38Z",
-          "Created": "2023-01-11T15:47:38Z",
-          "AuthorId": 9,
-          "EditorId": 9,
-          "OData__UIVersionString": "1.0",
-          "Attachments": false,
-          "GUID": id,
-          "ComplianceAssetId": null,
-          "TenantWideExtensionComponentId": clientSideComponentId,
-          "TenantWideExtensionComponentProperties": "{\"testMessage\":\"Test message\"}",
-          "TenantWideExtensionWebTemplate": null,
-          "TenantWideExtensionListTemplate": 0,
-          "TenantWideExtensionLocation": "ClientSideExtension.ApplicationCustomizer",
-          "TenantWideExtensionSequence": 0,
-          "TenantWideExtensionHostProperties": null,
-          "TenantWideExtensionDisabled": false
-        };
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Title eq 'Some Command Set'`) {
+        return { value: [] };
       }
 
       throw 'Invalid request';
@@ -342,19 +809,79 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        id: id,
-        newTitle: title
+        title: title, newTitle: newTitle
       }
     }), new CommandError(errorMessage));
   });
 
-  it('fails validation if no option to update is specified is not a valid Guid', async () => {
-    const actual = await command.validate({ options: { id: id } }, commandInfo);
+  it('handles error when multiple listview commandsets with the specified title found', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and Title eq 'Some Command Set'`) {
+        return multipleResponses;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        title: title, newTitle: newTitle
+      }
+    }), new CommandError(`Multiple listview commandsets with title '${title}' found. Please disambiguate using IDs: ${os.EOL}${multipleResponses.value.map(item => `- ${(item as any).Id}`).join(os.EOL)}`));
+  });
+
+  it('handles error when multiple listview commandsets with the clientSideComponentId found', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${spoUrl}/_api/SP_TenantSettings_Current`) {
+        return { CorporateCatalogUrl: appCatalogUrl };
+      }
+
+      if (opts.url === `${spoUrl}/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and TenantWideExtensionComponentId eq '9748c81b-d72e-4048-886a-e98649543743'`) {
+        return multipleResponses;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        clientSideComponentId: clientSideComponentId, newTitle: newTitle
+      }
+    }), new CommandError(`Multiple listview commandsets with ClientSideComponentId '${clientSideComponentId}' found. Please disambiguate using IDs: ${os.EOL}${multipleResponses.value.map(item => `- ${(item as any).Id}`).join(os.EOL)}`));
+  });
+
+  it('fails validation if the id is not a number', async () => {
+    const actual = await command.validate({ options: { id: 'abc', newTitle: newTitle } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if clientSideComponentId is not a valid Guid', async () => {
-    const actual = await command.validate({ options: { id: id, clientSideComponentId: 'foo' } }, commandInfo);
+  it('fails validation if the clientSideComponentId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { clientSideComponentId: 'abc', newTitle: newTitle } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the newClientSideComponentId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { id: id, newClientSideComponentId: 'abc' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation when all options are specified', async () => {
+    const actual = await command.validate({
+      options: {
+        title: title,
+        id: id,
+        clientSideComponentId: clientSideComponentId
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if no option to update is specified', async () => {
+    const actual = await command.validate({ options: { id: id } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
@@ -368,8 +895,18 @@ describe(commands.TENANT_COMMANDSET_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('passes validation if clientSideComponentId is valid', async () => {
+    const actual = await command.validate({ options: { clientSideComponentId: clientSideComponentId, newTitle: newTitle } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if newClientSideComponentId is valid', async () => {
+    const actual = await command.validate({ options: { id: id, newClientSideComponentId: newClientSideComponentId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
   it('passes validation when all properties are specified', async () => {
-    const actual = await command.validate({ options: { id: id, newTitle: title, clientSideComponentId: clientSideComponentId, listType: 'List', location: 'Both', webTemplate: webTemplate, clientSideComponentProperties: clientSideComponentProperties } }, commandInfo);
+    const actual = await command.validate({ options: { id: id, newTitle: title, newClientSideComponentId: newClientSideComponentId, listType: 'List', location: 'Both', webTemplate: webTemplate, clientSideComponentProperties: clientSideComponentProperties } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 });

--- a/src/m365/spo/commands/tenant/tenant-commandset-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-set.ts
@@ -3,20 +3,30 @@ import GlobalOptions from '../../../../GlobalOptions';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
 import commands from '../../commands';
+import * as os from 'os';
 import { urlUtil } from '../../../../utils/urlUtil';
+import Command from '../../../../Command';
+import { ListItemInstance } from '../listitem/ListItemInstance';
+import { Cli } from '../../../../cli/Cli';
+import { Options as spoListItemListCommandOptions } from '../listitem/listitem-list';
+import * as spoListItemListCommand from '../listitem/listitem-list';
 import request, { CliRequestOptions } from '../../../../request';
 import { formatting } from '../../../../utils/formatting';
 import { spo } from '../../../../utils/spo';
+import { odata } from '../../../../utils/odata';
+import { Solution } from './Solution';
 
 interface CommandArgs {
   options: Options;
 }
 
 interface Options extends GlobalOptions {
-  id: string;
+  id?: string;
+  title?: string;
+  clientSideComponentId?: string;
   newTitle?: string;
   listType?: string;
-  clientSideComponentId?: string;
+  newClientSideComponentId?: string;
   clientSideComponentProperties?: string;
   webTemplate?: string;
   location?: string;
@@ -40,14 +50,18 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
+        title: typeof args.options.title !== 'undefined',
+        id: typeof args.options.id !== 'undefined',
+        clientSideComponentId: typeof args.options.clientSideComponentId !== 'undefined',
         newTitle: typeof args.options.newTitle !== 'undefined',
         listType: args.options.listType,
-        clientSideComponentId: typeof args.options.clientSideComponentId !== 'undefined',
+        newClientSideComponentId: typeof args.options.newClientSideComponentId !== 'undefined',
         clientSideComponentProperties: typeof args.options.clientSideComponentProperties !== 'undefined',
         webTemplate: typeof args.options.webTemplate !== 'undefined',
         location: args.options.location
@@ -58,17 +72,23 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-i, --id <id>'
+        option: '-i, --id [id]'
       },
       {
-        option: '-t, --newTitle [newTitle]'
+        option: '-t, --title [title]'
+      },
+      {
+        option: '-c, --clientSideComponentId [clientSideComponentId]'
+      },
+      {
+        option: '--newTitle [newTitle]'
       },
       {
         option: '-l, --listType [listType]',
         autocomplete: SpoTenantCommandSetSetCommand.listTypes
       },
       {
-        option: '-c, --clientSideComponentId [clientSideComponentId]'
+        option: '--newClientSideComponentId [newClientSideComponentId]'
       },
       {
         option: '-p, --clientSideComponentProperties [clientSideComponentProperties]'
@@ -88,15 +108,23 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
       async (args: CommandArgs) => {
         if (!args.options.newTitle &&
           !args.options.listType &&
-          !args.options.clientSideComponentId &&
+          !args.options.newClientSideComponentId &&
           !args.options.clientSideComponentProperties &&
           !args.options.webTemplate &&
           !args.options.location) {
           return 'Specify at least one property to update';
         }
 
+        if (args.options.id && isNaN(parseInt(args.options.id))) {
+          return `${args.options.id} is not a number`;
+        }
+
         if (args.options.clientSideComponentId && !validation.isValidGuid(args.options.clientSideComponentId)) {
           return `${args.options.clientSideComponentId} is not a valid GUID`;
+        }
+
+        if (args.options.newClientSideComponentId && !validation.isValidGuid(args.options.newClientSideComponentId)) {
+          return `${args.options.newClientSideComponentId} is not a valid GUID`;
         }
 
         if (args.options.listType && SpoTenantCommandSetSetCommand.listTypes.indexOf(args.options.listType) < 0) {
@@ -112,6 +140,10 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
     );
   }
 
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['title', 'id', 'clientSideComponentId'] });
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const appCatalogUrl = await spo.getTenantAppCatalogUrl(logger, this.debug);
@@ -120,36 +152,116 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
         throw 'No app catalog URL found';
       }
 
-      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(appCatalogUrl, '/lists/TenantWideExtensions');
-      const listItem = await this.getListItemById(logger, appCatalogUrl, listServerRelativeUrl, args.options.id);
+      if (args.options.newClientSideComponentId !== undefined) {
+        const componentManifest = await this.getComponentManifest(appCatalogUrl, args.options.newClientSideComponentId, logger);
+        const clientComponentManifest = JSON.parse(componentManifest.ClientComponentManifest);
 
-      if (listItem.TenantWideExtensionLocation.indexOf("ClientSideExtension.ListViewCommandSet") === -1) {
-        throw 'The item is not a ListViewCommandSet';
+        if (clientComponentManifest.extensionType !== "ListViewCommandSet") {
+          throw `The extension type of this component is not of type 'ListViewCommandSet' but of type '${clientComponentManifest.extensionType}'`;
+        }
+
+        const solution = await this.getSolutionFromAppCatalog(appCatalogUrl, componentManifest.SolutionId, logger);
+
+        if (!solution.ContainsTenantWideExtension) {
+          throw `The solution does not contain an extension that can be deployed to all sites. Make sure that you've entered the correct component Id.`;
+        }
+        else if (!solution.SkipFeatureDeployment) {
+          throw 'The solution has not been deployed to all sites. Make sure to deploy this solution to all sites.';
+        }
       }
 
-      await this.updateTenantWideExtension(appCatalogUrl, args.options, listServerRelativeUrl, logger);
+      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(appCatalogUrl, '/lists/TenantWideExtensions');
+      const listItemId: number = await this.getListItemId(appCatalogUrl, args.options, listServerRelativeUrl, logger);
+
+      await this.updateTenantWideExtension(logger, appCatalogUrl, args.options, listServerRelativeUrl, listItemId);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
   }
 
-  private async getListItemById(logger: Logger, webUrl: string, listServerRelativeUrl: string, id: string): Promise<any> {
+  private async getComponentManifest(appCatalogUrl: string, clientSideComponentId: string, logger: Logger): Promise<any> {
     if (this.verbose) {
-      logger.logToStderr(`Getting the list item by id ${id}`);
+      logger.logToStderr('Retrieving component manifest item from the ComponentManifests list on the app catalog site so that we get the solution id');
     }
-    const reqOptions: CliRequestOptions = {
-      url: `${webUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/Items(${id})`,
-      headers: {
-        'accept': 'application/json;odata=nometadata'
-      },
-      responseType: 'json'
+
+    const camlQuery = `<View><ViewFields><FieldRef Name='ClientComponentId'></FieldRef><FieldRef Name='SolutionId'></FieldRef><FieldRef Name='ClientComponentManifest'></FieldRef></ViewFields><Query><Where><Eq><FieldRef Name='ClientComponentId' /><Value Type='Guid'>${clientSideComponentId}</Value></Eq></Where></Query></View>`;
+    const commandOptions: spoListItemListCommandOptions = {
+      webUrl: appCatalogUrl,
+      listUrl: `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/Lists/ComponentManifests`,
+      camlQuery: camlQuery,
+      verbose: this.verbose,
+      debug: this.debug,
+      output: 'json'
     };
 
-    return await request.get<any>(reqOptions);
+    const output = await Cli.executeCommandWithOutput(spoListItemListCommand as Command, { options: { ...commandOptions, _: [] } });
+
+    if (this.verbose) {
+      logger.logToStderr(output.stderr);
+    }
+
+    const outputParsed = JSON.parse(output.stdout);
+
+    if (outputParsed.length === 0) {
+      throw 'No component found with the specified clientSideComponentId found in the component manifest list. Make sure that the application is added to the application catalog';
+    }
+
+    return outputParsed[0];
   }
 
-  private async updateTenantWideExtension(appCatalogUrl: string, options: Options, listServerRelativeUrl: string, logger: Logger): Promise<void> {
+  private async getSolutionFromAppCatalog(appCatalogUrl: string, solutionId: string, logger: Logger): Promise<Solution> {
+    if (this.verbose) {
+      logger.logToStderr(`Retrieving solution with id ${solutionId} from the application catalog`);
+    }
+
+    const camlQuery = `<View><ViewFields><FieldRef Name='SkipFeatureDeployment'></FieldRef><FieldRef Name='ContainsTenantWideExtension'></FieldRef></ViewFields><Query><Where><Eq><FieldRef Name='AppProductID' /><Value Type='Guid'>${solutionId}</Value></Eq></Where></Query></View>`;
+    const commandOptions: spoListItemListCommandOptions = {
+      webUrl: appCatalogUrl,
+      listUrl: `${urlUtil.getServerRelativeSiteUrl(appCatalogUrl)}/AppCatalog`,
+      camlQuery: camlQuery,
+      verbose: this.verbose,
+      debug: this.debug,
+      output: 'json'
+    };
+
+    const output = await Cli.executeCommandWithOutput(spoListItemListCommand as Command, { options: { ...commandOptions, _: [] } });
+
+    if (this.verbose) {
+      logger.logToStderr(output.stderr);
+    }
+
+    const outputParsed = JSON.parse(output.stdout);
+
+    if (outputParsed.length === 0) {
+      throw `No component found with the solution id ${solutionId}. Make sure that the solution is available in the app catalog`;
+    }
+
+    return outputParsed[0];
+  }
+
+  private async getListItemId(appCatalogUrl: string, options: Options, listServerRelativeUrl: string, logger: Logger): Promise<number> {
+    const { title, id, clientSideComponentId } = options;
+    const filter = title ? `Title eq '${title}'` : id ? `Id eq '${id}'` : `TenantWideExtensionComponentId eq '${clientSideComponentId}'`;
+
+    if (this.verbose) {
+      logger.logToStderr(`Getting tenant-wide listview commandset: "${title || id || clientSideComponentId}"...`);
+    }
+
+    const listItemInstances = await odata.getAllItems<ListItemInstance>(`${appCatalogUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/Items?$filter=startswith(TenantWideExtensionLocation, 'ClientSideExtension.ListViewCommandSet') and ${filter}`);
+
+    if (!listItemInstances || listItemInstances.length === 0) {
+      throw 'The specified listview commandset was not found';
+    }
+
+    if (listItemInstances.length > 1) {
+      throw `Multiple listview commandsets with ${title ? `title '${title}'` : `ClientSideComponentId '${clientSideComponentId}'`} found. Please disambiguate using IDs: ${os.EOL}${listItemInstances.map(item => `- ${(item as any).Id}`).join(os.EOL)}`;
+    }
+
+    return listItemInstances[0].Id;
+  }
+
+  private async updateTenantWideExtension(logger: Logger, appCatalogUrl: string, options: Options, listServerRelativeUrl: string, listItemId: number): Promise<void> {
     if (this.verbose) {
       logger.logToStderr('Updating tenant wide extension to the TenantWideExtensions list');
     }
@@ -162,10 +274,10 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
       });
     }
 
-    if (options.clientSideComponentId !== undefined) {
+    if (options.newClientSideComponentId !== undefined) {
       formValues.push({
         FieldName: 'TenantWideExtensionComponentId',
-        FieldValue: options.clientSideComponentId
+        FieldValue: options.newClientSideComponentId
       });
     }
 
@@ -199,7 +311,7 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
 
     const requestOptions: CliRequestOptions =
     {
-      url: `${appCatalogUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/Items(${options.id})/ValidateUpdateListItem()`,
+      url: `${appCatalogUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/Items(${listItemId})/ValidateUpdateListItem()`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },


### PR DESCRIPTION
Extends `spo tenant commandset set` command with support to update a tenant wide deployed command set, using it's `id`, `title` or `clientSideComponentId`. Closes #4961