### PR TITLE
Fixes 'spo tenant applicationcustomizer get' command. Closes #4872

### DIFF
--- a/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-get.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-get.mdx
@@ -19,7 +19,7 @@ m365 spo tenant applicationcustomizer get [options]
 : The title of the application customizer. Specify either `title`, `id`, or `clientSideComponentId`.
 
 `-i, --id [id]`
-: The product id of the application customizer. Specify either `title`, `id`, or `clientSideComponentId`.
+: The id of the application customizer. Specify either `title`, `id`, or `clientSideComponentId`.
 
 `-c, --clientSideComponentId  [clientSideComponentId]`
 : The Client Side Component Id (GUID) of the application customizer. Specify either `title`, `id`, or `clientSideComponentId`.
@@ -38,7 +38,7 @@ m365 spo tenant applicationcustomizer get --title "Some customizer"
 Retrieves an application customizer by id.
 
 ```sh
-m365 spo tenant applicationcustomizer get --id 14125658-a9bc-4ddf-9c75-1b5767c9a337
+m365 spo tenant applicationcustomizer get --id 3
 ```
 
 Retrieves an application customizer by clientSideComponentId.

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-get.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-get.spec.ts
@@ -15,7 +15,7 @@ const command: Command = require('./tenant-applicationcustomizer-get');
 
 describe(commands.TENANT_APPLICATIONCUSTOMIZER_GET, () => {
   const title = 'Some customizer';
-  const id = '14125658-a9bc-4ddf-9c75-1b5767c9a337';
+  const id = 4;
   const clientSideComponentId = '7096cded-b83d-4eab-96f0-df477ed7c0bc';
   const spoUrl = 'https://contoso.sharepoint.com';
   const appCatalogUrl = 'https://contoso.sharepoint.com/sites/apps';
@@ -102,7 +102,7 @@ describe(commands.TENANT_APPLICATIONCUSTOMIZER_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if the id is not a valid GUID', async () => {
+  it('fails validation if the id is not a number', async () => {
     const actual = await command.validate({ options: { id: 'abc' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
@@ -266,7 +266,7 @@ describe(commands.TENANT_APPLICATIONCUSTOMIZER_GET, () => {
         return { CorporateCatalogUrl: appCatalogUrl };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/items?$filter=TenantWideExtensionLocation eq 'ClientSideExtension.ApplicationCustomizer' and GUID eq '14125658-a9bc-4ddf-9c75-1b5767c9a337'`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetList('%2Fsites%2Fapps%2Flists%2FTenantWideExtensions')/items?$filter=TenantWideExtensionLocation eq 'ClientSideExtension.ApplicationCustomizer' and Id eq '4'`) {
         return applicationCustomizerResponse;
       }
 

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-get.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-get.ts
@@ -56,7 +56,7 @@ class SpoTenantApplicationCustomizerGetCommand extends SpoCommand {
         option: '-i, --id [id]'
       },
       {
-        option: '-c, --clientSideComponentId  [clientSideComponentId]'
+        option: '-c, --clientSideComponentId [clientSideComponentId]'
       }
     );
   }
@@ -64,8 +64,8 @@ class SpoTenantApplicationCustomizerGetCommand extends SpoCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
-          return `${args.options.id} is not a valid GUID`;
+        if (args.options.id && isNaN(parseInt(args.options.id))) {
+          return `${args.options.id} is not a number`;
         }
 
         if (args.options.clientSideComponentId && !validation.isValidGuid(args.options.clientSideComponentId)) {
@@ -94,7 +94,7 @@ class SpoTenantApplicationCustomizerGetCommand extends SpoCommand {
         filter = `Title eq '${args.options.title}'`;
       }
       else if (args.options.id) {
-        filter = `GUID eq '${args.options.id}'`;
+        filter = `Id eq '${args.options.id}'`;
       }
       else {
         filter = `TenantWideExtensionComponentId eq '${args.options.clientSideComponentId}'`;


### PR DESCRIPTION
Fixes `spo tenant applicationcustomizer get` command to map the `id` property to item id. Closes #4872