### PR TITLE
Moves collecting telemetry to a separate process

### DIFF
--- a/src/appInsights.spec.ts
+++ b/src/appInsights.spec.ts
@@ -43,10 +43,4 @@ describe('appInsights', () => {
     const i: any = await import(`./appInsights.js#${Math.random()}`);
     assert(i.default.commonProperties.env === 'docker');
   });
-
-  it(`sets shell to empty string if couldn't resolve name from pid`, async () => {
-    sinon.stub(pid, 'getProcessName').callsFake(() => undefined);
-    const i: any = await import(`./appInsights.js#${Math.random()}`);
-    assert.strictEqual(i.default.commonProperties.shell, '');
-  });
 });

--- a/src/appInsights.ts
+++ b/src/appInsights.ts
@@ -9,7 +9,6 @@ import fs from 'fs';
 import path from 'path';
 import url from 'url';
 import { app } from './utils/app.js';
-import { pid } from './utils/pid.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const config = appInsights.setup('6b908c80-d09f-4cf6-8274-e54349a0149a');
@@ -19,18 +18,15 @@ config.setInternalLogging(false, false);
 // in the telemetry
 const version: string = `${app.packageJson().version}${fs.existsSync(path.join(__dirname, `..${path.sep}src`)) ? '-dev' : ''}`;
 const env: string = process.env.CLIMICROSOFT365_ENV !== undefined ? process.env.CLIMICROSOFT365_ENV : '';
-((appInsights as any).default as typeof appInsights).defaultClient.commonProperties = {
+const appInsightsClient: appInsights.TelemetryClient = ((appInsights as any).default as typeof appInsights).defaultClient;
+appInsightsClient.commonProperties = {
   version: version,
   node: process.version,
-  shell: pid.getProcessName(process.ppid) || '',
   env: env,
   ci: Boolean(process.env.CI).toString()
 };
 
-((appInsights as any).default as typeof appInsights).defaultClient.context.tags['ai.session.id'] =
-  crypto.randomBytes(24).toString('base64');
-((appInsights as any).default as typeof appInsights).defaultClient.context.tags['ai.cloud.roleInstance'] =
-  crypto.createHash('sha256').update(((appInsights as any).default as typeof appInsights).defaultClient.context.tags['ai.cloud.roleInstance']).digest('hex');
-delete ((appInsights as any).default as typeof appInsights).defaultClient.context.tags['ai.cloud.role'];
+appInsightsClient.context.tags['ai.cloud.roleInstance'] = crypto.createHash('sha256').update(appInsightsClient.context.tags['ai.cloud.roleInstance']).digest('hex');
+appInsightsClient.context.tags['ai.cloud.role'];
 
-export default ((appInsights as any).default as typeof appInsights).defaultClient;
+export default appInsightsClient;

--- a/src/m365/base/AppCommand.spec.ts
+++ b/src/m365/base/AppCommand.spec.ts
@@ -7,6 +7,7 @@ import { Logger } from '../../cli/Logger.js';
 import Command, { CommandError } from '../../Command.js';
 import { sinonUtil } from '../../utils/sinonUtil.js';
 import AppCommand from './AppCommand.js';
+import { telemetry } from '../../telemetry.js';
 
 class MockCommand extends AppCommand {
   public get name(): string {
@@ -32,6 +33,7 @@ describe('AppCommand', () => {
 
   before(() => {
     commandInfo = Cli.getCommandInfo(new MockCommand());
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
   });
 
   beforeEach(() => {
@@ -56,6 +58,10 @@ describe('AppCommand', () => {
       fs.readFileSync,
       Cli.prompt
     ]);
+  });
+
+  after(() => {
+    sinon.restore();
   });
 
   it('defines correct resource', () => {

--- a/src/m365/cli/commands/config/config-reset.spec.ts
+++ b/src/m365/cli/commands/config/config-reset.spec.ts
@@ -49,13 +49,12 @@ describe(commands.CONFIG_RESET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it(`Resets a specific configuration option to its default value`, async () => {
+  it('resets a specific configuration option to its default value', async () => {
     const output = undefined;
     const config = Cli.getInstance().config;
 
     let actualKey: string = '', actualValue: any;
 
-    sinon.restore();
     sinon.stub(config, 'delete').callsFake(((key: string) => {
       actualKey = key;
       actualValue = undefined;
@@ -66,14 +65,12 @@ describe(commands.CONFIG_RESET, () => {
     assert.strictEqual(actualValue, undefined, 'Invalid value');
   });
 
-  it(`Resets all configuration settings to default`, async () => {
+  it('resets all configuration settings to default', async () => {
     const config = Cli.getInstance().config;
     let errorOutputKey: string = '', errorOutputValue: any
       , outputKey: string = '', outputValue: any
       , printErrorsAsPlainTextKey: string = '', printErrorsAsPlainTextValue: any
       , showHelpOnFailureKey: string = '', showHelpOnFailureValue: any;
-
-    sinon.restore();
 
     sinon.stub(config, 'clear').callsFake((() => {
       errorOutputKey = settingsNames.errorOutput;

--- a/src/m365/cli/commands/config/config-set.spec.ts
+++ b/src/m365/cli/commands/config/config-set.spec.ts
@@ -82,7 +82,6 @@ describe(commands.CONFIG_SET, () => {
     const output = "text";
     const config = Cli.getInstance().config;
     let actualKey: string = '', actualValue: any;
-    sinon.restore();
     sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
       actualKey = key;
       actualValue = value;
@@ -97,7 +96,6 @@ describe(commands.CONFIG_SET, () => {
     const output = "json";
     const config = Cli.getInstance().config;
     let actualKey: string = '', actualValue: any;
-    sinon.restore();
     sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
       actualKey = key;
       actualValue = value;
@@ -112,7 +110,6 @@ describe(commands.CONFIG_SET, () => {
     const output = "csv";
     const config = Cli.getInstance().config;
     let actualKey: string = '', actualValue: any;
-    sinon.restore();
     sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
       actualKey = key;
       actualValue = value;

--- a/src/m365/context/commands/context-init.spec.ts
+++ b/src/m365/context/commands/context-init.spec.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import fs from 'fs';
 import sinon from 'sinon';
-import appInsights from '../../../appInsights.js';
 import { Logger } from '../../../cli/Logger.js';
+import { telemetry } from '../../../telemetry.js';
 import { CommandError } from '../../../Command.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
@@ -13,7 +13,7 @@ describe(commands.INIT, () => {
   let logger: Logger;
 
   before(() => {
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
   });
 
   beforeEach(() => {

--- a/src/m365/purview/commands/retentionevent/retentionevent-remove.spec.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-remove.spec.ts
@@ -2,11 +2,11 @@ import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
 import { CommandError } from '../../../../Command.js';
-import appInsights from '../../../../appInsights.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
@@ -23,7 +23,7 @@ describe(commands.RETENTIONEVENT_REMOVE, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(appInsights, 'trackEvent').returns();
+    sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;

--- a/src/m365/spo/commands/listitem/listitem-record-lock.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-record-lock.spec.ts
@@ -1,18 +1,18 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import appInsights from '../../../../appInsights.js';
 import auth from '../../../../Auth.js';
+import { CommandError } from '../../../../Command.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
-import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
+import { settingsNames } from '../../../../settingsNames.js';
+import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './listitem-record-lock.js';
-import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.LISTITEM_RECORD_LOCK, () => {
   let cli: Cli;
@@ -41,7 +41,7 @@ describe(commands.LISTITEM_RECORD_LOCK, () => {
   before(() => {
     cli = Cli.getInstance();
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
     sinon.stub(session, 'getId').callsFake(() => '');
     auth.service.connected = true;

--- a/src/m365/spo/commands/listitem/listitem-record-unlock.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-record-unlock.spec.ts
@@ -1,12 +1,12 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import appInsights from '../../../../appInsights.js';
 import auth from '../../../../Auth.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
@@ -41,7 +41,7 @@ describe(commands.LISTITEM_RECORD_UNLOCK, () => {
   before(() => {
     cli = Cli.getInstance();
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
     sinon.stub(session, 'getId').callsFake(() => '');
     auth.service.connected = true;

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.spec.ts
@@ -1,12 +1,12 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import appInsights from '../../../../appInsights.js';
 import auth from '../../../../Auth.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
@@ -65,7 +65,7 @@ describe(commands.LISTITEM_RETENTIONLABEL_ENSURE, () => {
   before(() => {
     cli = Cli.getInstance();
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
-    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
     sinon.stub(session, 'getId').callsFake(() => '');
     auth.service.connected = true;

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-add.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-add.spec.ts
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import appInsights from '../../../../appInsights.js';
 import auth from '../../../../Auth.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { telemetry } from '../../../../telemetry.js';
 import { CommandError } from '../../../../Command.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
@@ -36,7 +36,7 @@ describe(commands.TENANT_APPLICATIONCUSTOMIZER_ADD, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(appInsights, 'trackEvent').returns();
+    sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;

--- a/src/m365/spo/commands/tenant/tenant-commandset-add.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-add.spec.ts
@@ -2,10 +2,10 @@ import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
 import { CommandError } from '../../../../Command.js';
-import appInsights from '../../../../appInsights.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
@@ -36,7 +36,7 @@ describe(commands.TENANT_COMMANDSET_ADD, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(appInsights, 'trackEvent').returns();
+    sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;

--- a/src/m365/spo/commands/web/web-retentionlabel-list.spec.ts
+++ b/src/m365/spo/commands/web/web-retentionlabel-list.spec.ts
@@ -1,12 +1,12 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import appInsights from '../../../../appInsights.js';
 import auth from '../../../../Auth.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
@@ -59,7 +59,7 @@ describe(commands.WEB_RETENTIONLABEL_LIST, () => {
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
-    sinon.stub(appInsights, 'trackEvent').returns();
+    sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;

--- a/src/telemetry.spec.ts
+++ b/src/telemetry.spec.ts
@@ -1,21 +1,47 @@
-import sinon from 'sinon';
 import assert from 'assert';
-import appInsights from './appInsights.js';
+import child_process from 'child_process';
+import sinon from 'sinon';
 import { Cli } from "./cli/Cli.js";
 import { settingsNames } from './settingsNames.js';
-import { sinonUtil } from './utils/sinonUtil.js';
 import { telemetry } from './telemetry.js';
+import { pid } from './utils/pid.js';
+import { sinonUtil } from './utils/sinonUtil.js';
+import { session } from './utils/session.js';
 
 describe('Telemetry', () => {
+  let spawnStub: sinon.SinonStub;
+  let stdin: string = '';
+
+  before(() => {
+    spawnStub = sinon.stub(child_process, 'spawn').callsFake(() => {
+      return {
+        stdin: {
+          write: (s: string) => {
+            stdin += s;
+          },
+          end: () => { }
+        },
+        unref: () => { }
+      } as any;
+    });
+    sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    sinon.stub(session, 'getId').callsFake(() => 'abc123');
+  });
+
   afterEach(() => {
     sinonUtil.restore([
       Cli.getInstance().getSettingWithDefaultValue,
-      appInsights.trackEvent,
-      appInsights.trackException
+      (telemetry as any).trackTelemetry
     ]);
+    spawnStub.resetHistory();
+    stdin = '';
   });
 
-  it(`doesn't log an event when disableTelemetry is set`, async () => {
+  after(() => {
+    sinon.restore();
+  });
+
+  it(`doesn't log an event when disableTelemetry is set`, () => {
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.disableTelemetry) {
         return true;
@@ -23,14 +49,11 @@ describe('Telemetry', () => {
 
       return defaultValue;
     });
-    const trackEventStub = sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
-
     telemetry.trackEvent('foo bar', {});
-
-    assert(trackEventStub.notCalled);
+    assert(spawnStub.notCalled);
   });
 
-  it('logs an event when disableTelemetry is not set', async () => {
+  it('logs an event when disableTelemetry is not set', () => {
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.disableTelemetry) {
         return false;
@@ -38,14 +61,11 @@ describe('Telemetry', () => {
 
       return defaultValue;
     });
-    const trackEventStub = sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
-
     telemetry.trackEvent('foo bar', {});
-
-    assert(trackEventStub.called);
+    assert(spawnStub.called);
   });
 
-  it(`doesn't log an exception when disableTelemetry is set`, async () => {
+  it(`doesn't log an exception when disableTelemetry is set`, () => {
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.disableTelemetry) {
         return true;
@@ -53,14 +73,11 @@ describe('Telemetry', () => {
 
       return defaultValue;
     });
-    const exceptionStub = sinon.stub(appInsights, 'trackException').callsFake(() => { });
-
     telemetry.trackException('Error!');
-
-    assert(exceptionStub.notCalled);
+    assert(spawnStub.notCalled);
   });
 
-  it('logs an exception when disableTelemetry is not set', async () => {
+  it('logs an exception when disableTelemetry is not set', () => {
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.disableTelemetry) {
         return false;
@@ -68,10 +85,41 @@ describe('Telemetry', () => {
 
       return defaultValue;
     });
-    const trackExceptionStub = sinon.stub(appInsights, 'trackException').callsFake(() => { });
-
     telemetry.trackException('Error!');
+    assert(spawnStub.called);
+  });
 
-    assert(trackExceptionStub.called);
+  it(`logs an empty string for shell if it couldn't resolve shell process name`, () => {
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
+      if (settingName === settingsNames.disableTelemetry) {
+        return false;
+      }
+
+      return defaultValue;
+    });
+    sinonUtil.restore(pid.getProcessName);
+    sinon.stub(pid, 'getProcessName').callsFake(() => undefined);
+
+    telemetry.trackEvent('foo bar', {});
+    assert.strictEqual(JSON.parse(stdin).shell, '');
+  });
+
+  it(`silently handles exception if an error occurs while spawning telemetry runner`, (done) => {
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
+      if (settingName === settingsNames.disableTelemetry) {
+        return false;
+      }
+
+      return defaultValue;
+    });
+    sinonUtil.restore(child_process.spawn);
+    sinon.stub(child_process, 'spawn').throws();
+    try {
+      telemetry.trackEvent('foo bar', {});
+      done();
+    }
+    catch (e) {
+      done(e);
+    }
   });
 });

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,30 +1,49 @@
-import appInsights from "./appInsights.js";
-import { Cli } from "./cli/Cli.js";
-import { settingsNames } from "./settingsNames.js";
+import child_process from 'child_process';
+import path from 'path';
+import url from 'url';
+import { Cli } from './cli/Cli.js';
+import { settingsNames } from './settingsNames.js';
+import { pid } from './utils/pid.js';
+import { session } from './utils/session.js';
 
-class Telemetry {
-  public trackEvent(commandName: string, properties: any): void {
-    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.disableTelemetry, false)) {
-      return;
-    }
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-    appInsights.trackEvent({
-      name: commandName,
-      properties
+function trackTelemetry(object: any): void {
+  try {
+    const child = child_process.spawn('node', [path.join(__dirname, 'telemetryRunner.js')], {
+      stdio: ['pipe', 'ignore', 'ignore'],
+      detached: true
     });
-    appInsights.flush();
-  }
+    child.unref();
 
-  public trackException(exception: any): void {
-    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.disableTelemetry, false)) {
-      return;
-    }
+    object.shell = pid.getProcessName(process.ppid) || '';
+    object.session = session.getId(process.ppid);
 
-    appInsights.trackException({
-      exception
-    });
-    appInsights.flush();
+    child.stdin.write(JSON.stringify(object));
+    child.stdin.end();
   }
+  catch { }
 }
 
-export const telemetry = new Telemetry();
+export const telemetry = {
+  trackEvent: (commandName: string, properties: any): void => {
+    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.disableTelemetry, false)) {
+      return;
+    }
+
+    trackTelemetry({
+      commandName,
+      properties
+    });
+  },
+
+  trackException: (exception: any): void => {
+    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.disableTelemetry, false)) {
+      return;
+    }
+
+    trackTelemetry({
+      exception
+    });
+  }
+};

--- a/src/telemetryRunner.ts
+++ b/src/telemetryRunner.ts
@@ -1,0 +1,29 @@
+import appInsights from './appInsights.js';
+import * as process from 'process';
+import * as fs from 'fs';
+
+process.stdin.setEncoding('utf8');
+
+try {
+  // read from stdin
+  const input = fs.readFileSync(0, 'utf-8');
+  const data = JSON.parse(input);
+  const { commandName, properties, exception, shell, session } = data;
+
+  appInsights.commonProperties.shell = shell;
+  appInsights.context.tags['ai.session.id'] = session;
+
+  if (exception) {
+    appInsights.trackException({
+      exception
+    });
+  }
+  else {
+    appInsights.trackEvent({
+      name: commandName,
+      properties
+    });
+  }
+  appInsights.flush();
+}
+catch { }


### PR DESCRIPTION
Moves collecting telemetry to a separate process to improve CLI's performance and make collecting telemetry events non-blocking for the execution of CLI commands.