### PR TITLE
Fixes use of special chars in 'spo file' commands

### DIFF
--- a/docs/docs/cmd/spo/file/file-add.mdx
+++ b/docs/docs/cmd/spo/file/file-add.mdx
@@ -17,7 +17,7 @@ m365 spo file add [options]
 : The URL of the site where the file should be uploaded to
 
 `-f, --folder <folder>`
-: The server- or site-relative URL to the folder where the file should be uploaded
+: The server- or site-relative decoded URL to the folder where the file should be uploaded
 
 `-p, --path <path>`
 : Local path to the file to upload

--- a/docs/docs/cmd/spo/file/file-checkin.mdx
+++ b/docs/docs/cmd/spo/file/file-checkin.mdx
@@ -17,7 +17,7 @@ m365 spo file checkin [options]
 : The URL of the site where the file is located
 
 `-f, --url [url]`
-: The server- or site-relative URL of the file to retrieve. Specify either `url` or `id` but not both
+: The server- or site-relative decoded URL of the file to retrieve. Specify either `url` or `id` but not both
 
 `-i, --id [id]`
 : The UniqueId (GUID) of the file to retrieve. Specify either `url` or `id` but not both

--- a/docs/docs/cmd/spo/file/file-checkout-undo.mdx
+++ b/docs/docs/cmd/spo/file/file-checkout-undo.mdx
@@ -17,7 +17,7 @@ m365 spo file checkout undo [options]
 : The URL of the site where the file is located.
 
 `-f, --fileUrl [fileUrl]`
-: The server- or site-relative URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both.
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file to retrieve. Specify either `fileUrl` or `fileId` but not both.
@@ -27,14 +27,6 @@ m365 spo file checkout undo [options]
 ```
 
 <Global />
-
-## Remarks
-
-:::info
-
-When specifying option `fileUrl`, make sure that the URL is decoded. If not, you will get a `File Not Found` error.
-
-:::
 
 ## Examples
 

--- a/docs/docs/cmd/spo/file/file-checkout.mdx
+++ b/docs/docs/cmd/spo/file/file-checkout.mdx
@@ -17,7 +17,7 @@ m365 spo file checkout [options]
 : The URL of the site where the file is located
 
 `-f, --url [url]`
-: The server- or site-relative URL of the file to retrieve. Specify either `url` or `id` but not both
+: The server- or site-relative decoded URL of the file to retrieve. Specify either `url` or `id` but not both
 
 `-i, --id [id]`
 : The UniqueId (GUID) of the file to retrieve. Specify either `url` or `id` but not both

--- a/docs/docs/cmd/spo/file/file-copy.mdx
+++ b/docs/docs/cmd/spo/file/file-copy.mdx
@@ -17,10 +17,10 @@ m365 spo file copy [options]
 : The URL of the site where the file is located.
 
 `-s, --sourceUrl <sourceUrl>`
-: Site-relative, server-relative or absolute URL of the file.
+: Site-relative, server-relative or absolute decoded URL of the file.
 
 `-t, --targetUrl <targetUrl>`
-: Server-relative or absolute URL of the location.
+: Server-relative or absolute decoded URL of the location.
 
 `--newName [newName]`
 : New name of the destination file.
@@ -35,12 +35,6 @@ m365 spo file copy [options]
 <Global />
 
 ## Remarks
-
-:::info
-
-The required URLs `webUrl`, `sourceUrl` and `targetUrl` cannot be encoded. When you do so, you will get a `File Not Found` error.
-
-:::
 
 When you specify a value for `nameConflictBehavior`, consider the following:
 

--- a/docs/docs/cmd/spo/file/file-get.mdx
+++ b/docs/docs/cmd/spo/file/file-get.mdx
@@ -19,7 +19,7 @@ m365 spo file get [options]
 : The URL of the site where the file is located
 
 `-u, --url [url]`
-: The server- or site-relative URL of the file to retrieve. Specify either `url` or `id` but not both
+: The server- or site-relative decoded URL of the file to retrieve. Specify either `url` or `id` but not both
 
 `-i, --id [id]`
 : The UniqueId (GUID) of the file to retrieve. Specify either `url` or `id` but not both

--- a/docs/docs/cmd/spo/file/file-list.mdx
+++ b/docs/docs/cmd/spo/file/file-list.mdx
@@ -19,10 +19,10 @@ m365 spo file list [options]
 : The URL of the site where the folder from which to retrieve files is located
 
 `-f, --folderUrl <folderUrl>`
-: The server- or site-relative URL of the parent folder from which to retrieve files
+: The server- or site-relative decoded URL of the parent folder from which to retrieve files
 
 `-f, --folder <folder>`
-: (deprecated. Use `folderUrl` instead) The server- or site-relative URL of the folder from which to retrieve files
+: (deprecated. Use `folderUrl` instead) The server- or site-relative decoded URL of the folder from which to retrieve files
 
 `--fields [fields]`
 : Comma-separated list of fields to retrieve. Will retrieve all fields if not specified.

--- a/docs/docs/cmd/spo/file/file-move.mdx
+++ b/docs/docs/cmd/spo/file/file-move.mdx
@@ -17,10 +17,10 @@ m365 spo file move [options]
 : The URL of the site where the file is located
 
 `-s, --sourceUrl <sourceUrl>`
-: The server- or site-relative URL of the file to move
+: The server- or site-relative decoded URL of the file to move
 
 `-t, --targetUrl <targetUrl>`
-: Server-relative URL where to move the file
+: Server-relative decoded URL where to move the file
 
 `--deleteIfAlreadyExists`
 : If a file already exists at the targetUrl, it will be moved to the recycle bin. If omitted, the move operation will be canceled if the file already exists at the targetUrl location

--- a/docs/docs/cmd/spo/file/file-remove.mdx
+++ b/docs/docs/cmd/spo/file/file-remove.mdx
@@ -26,7 +26,7 @@ m365 spo page template remove
 : The ID of the file to remove. Specify either `id` or `url` but not both
 
 `-u, --url [url]`
-: The server- or site-relative URL of the file to remove. Specify either `id` or `url` but not both
+: The server- or site-relative decoded URL of the file to remove. Specify either `id` or `url` but not both
 
 `--recycle`
 : Recycle the file instead of actually deleting it
@@ -39,26 +39,26 @@ m365 spo page template remove
 
 ## Examples
 
-Remove the file with ID _0cd891ef-afce-4e55-b836-fce03286cccf_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Remove file by ID
 
 ```sh
 m365 spo file remove --webUrl https://contoso.sharepoint.com/sites/project-x --id 0cd891ef-afce-4e55-b836-fce03286cccf
 ```
 
-Remove the file with site-relative URL _SharedDocuments/Test.docx_ from located in site _https://contoso.sharepoint.com/sites/project-x_
+Remove the file by site-relative URL
 
 ```sh
-m365 spo file remove --webUrl https://contoso.sharepoint.com/sites/project-x --url SharedDocuments/Test.docx
+m365 spo file remove --webUrl https://contoso.sharepoint.com/sites/project-x --url "/Shared Documents/Test.docx"
 ```
 
-Move the file with server-relative URL _/sites/project-x/SharedDocuments/Test.docx_ located in site _https://contoso.sharepoint.com/sites/project-x_ to the recycle bin
+Move the file by server-relative URL to the recycle bin
 
 ```sh
-m365 spo file remove --webUrl https://contoso.sharepoint.com/sites/project-x --url /sites/project-x/SharedDocuments/Test.docx --recycle
+m365 spo file remove --webUrl https://contoso.sharepoint.com/sites/project-x --url "/sites/project-x/SharedDocuments/Test.docx" --recycle
 ```
 
-Remove the page template with site-relative URL _SharedDocuments/Test.docx_ from located in site _https://contoso.sharepoint.com/sites/project-x_
+Remove a page template by site-relative URL
 
 ```sh
-m365 spo page template remove --webUrl https://contoso.sharepoint.com/sites/project-x --url SharedDocuments/Forms/Template.dotx
+m365 spo page template remove --webUrl https://contoso.sharepoint.com/sites/project-x --url "/Shared Documents/Forms/Template.dotx"
 ```

--- a/docs/docs/cmd/spo/file/file-rename.mdx
+++ b/docs/docs/cmd/spo/file/file-rename.mdx
@@ -17,7 +17,7 @@ m365 spo file rename [options]
 : The URL of the site where the file is located
 
 `-s, --sourceUrl <sourceUrl>`
-: The server- or site-relative URL of the file to rename
+: The server- or site-relative decoded URL of the file to rename
 
 `-t, --targetFileName <targetFileName>`
 : New file name of the file
@@ -34,13 +34,13 @@ If you try to rename a file without the `--force` flag and a file with this name
 
 ## Examples
 
-Renames a file with server-relative URL _/Shared Documents/Test1.docx_ located in site _<https://contoso.sharepoint.com/sites/project-x>_ to _Test2.docx_
+Renames a file
 
 ```sh
 m365 spo file rename --webUrl https://contoso.sharepoint.com/sites/project-x --sourceUrl '/Shared Documents/Test1.docx' --targetFileName 'Test2.docx'
 ```
 
-Renames a file with server-relative URL _/Shared Documents/Test1.docx_ located in site _<https://contoso.sharepoint.com/sites/project-x>_ to _Test2.docx_. If the file with the target file name already exists, this file will be moved to the recycle bin
+Renames a file. If the file with the target file name already exists, this file will be moved to the recycle bin.
 
 ```sh
 m365 spo file rename --webUrl https://contoso.sharepoint.com/sites/project-x --sourceUrl '/Shared Documents/Test1.docx' --targetFileName 'Test2.docx' --force

--- a/docs/docs/cmd/spo/file/file-retentionlabel-ensure.mdx
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-ensure.mdx
@@ -14,10 +14,10 @@ m365 spo file retentionlabel ensure [options]
 
 ```md definition-list
 `-u, --webUrl <webUrl>`
-: URL of the site where the retention label from a file to apply is located
+: URL of the site where the retention label from a file to apply is located.
 
 `--fileUrl [fileUrl]`
-: The site- or server-relative URL of the file that should be labelled. Specify either `fileUrl` or `fileId` but not both.
+: The site- or server-relative decoded URL of the file that should be labelled. Specify either `fileUrl` or `fileId` but not both.
 
 `i, --fileId [fileId]`
 : The UniqueId (GUID) of the file that should be labelled. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-retentionlabel-remove.mdx
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-remove.mdx
@@ -14,16 +14,16 @@ m365 spo file retentionlabel remove [options]
 
 ```md definition-list
 `-u, --webUrl <webUrl>`
-: URL of the site where the retention label from a file to remove is located
+: URL of the site where the retention label from a file to remove is located.
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative URL of the file of which the label should be removed. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file of which the label should be removed. Specify either `fileUrl` or `fileId` but not both.
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file of which the label should be removed. Specify either `fileUrl` or `fileId` but not both.
 
 `--confirm`
-: Don't prompt for confirming removing the retention label from a file
+: Don't prompt for confirming removing the retention label from a file.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/file/file-roleassignment-add.mdx
+++ b/docs/docs/cmd/spo/file/file-roleassignment-add.mdx
@@ -17,7 +17,7 @@ m365 spo file roleassignment add [options]
 : URL of the site where the file is located.
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both.
 
 `i, --fileId [fileId]`
 : The UniqueId (GUID) of the file to retrieve. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-roleassignment-remove.mdx
+++ b/docs/docs/cmd/spo/file/file-roleassignment-remove.mdx
@@ -17,7 +17,7 @@ m365 spo file roleassignment remove [options]
 : URL of the site where the file is located.
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative URL of the file. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-roleinheritance-break.mdx
+++ b/docs/docs/cmd/spo/file/file-roleinheritance-break.mdx
@@ -17,7 +17,7 @@ m365 spo file roleinheritance break [options]
 : URL of the site where the file is located
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative URL of the file. Specify either `fileUrl` or `fileId` but not both
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both
 
 `i, --fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both

--- a/docs/docs/cmd/spo/file/file-roleinheritance-reset.mdx
+++ b/docs/docs/cmd/spo/file/file-roleinheritance-reset.mdx
@@ -17,7 +17,7 @@ m365 spo file roleinheritance reset [options]
 : URL of the site where the file is located
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both
+: The server- or site-relative decoded URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both
 
 `i, --fileId [fileId]`
 : The UniqueId (GUID) of the file to retrieve. Specify either `fileUrl` or `fileId` but not both

--- a/docs/docs/cmd/spo/file/file-sharinginfo-get.mdx
+++ b/docs/docs/cmd/spo/file/file-sharinginfo-get.mdx
@@ -17,7 +17,7 @@ m365 spo file sharinginfo get [options]
 : The URL of the site where the file is located
 
 `-f, --fileUrl [fileUrl]`
-: The server- or site-relative URL of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both
+: The server- or site-relative decoded URL of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file for which to build the report. Specify either `fileUrl` or `fileId` but not both

--- a/docs/docs/cmd/spo/file/file-sharinglink-add.mdx
+++ b/docs/docs/cmd/spo/file/file-sharinglink-add.mdx
@@ -19,7 +19,7 @@ m365 spo file sharinglink add [options]
 : The URL of the site where the file is located.
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative (decoded) URL of the file. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `--fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-sharinglink-clear.mdx
+++ b/docs/docs/cmd/spo/file/file-sharinglink-clear.mdx
@@ -17,7 +17,7 @@ m365 spo file sharinglink clear [options]
 : The URL of the site where the file is located.
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative (decoded) URL of the file. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `--fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-sharinglink-get.mdx
+++ b/docs/docs/cmd/spo/file/file-sharinglink-get.mdx
@@ -19,7 +19,7 @@ m365 spo file sharinglink get [options]
 : The URL of the site where the file is located.
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative (decoded) URL of the file. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `--fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-sharinglink-list.mdx
+++ b/docs/docs/cmd/spo/file/file-sharinglink-list.mdx
@@ -19,7 +19,7 @@ m365 spo file sharinglink list [options]
 : The URL of the site where the file is located.
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative (decoded) URL of the file. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `--fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-sharinglink-remove.mdx
+++ b/docs/docs/cmd/spo/file/file-sharinglink-remove.mdx
@@ -17,7 +17,7 @@ m365 spo file sharinglink remove [options]
 : The URL of the site where the file is located.
 
 `--fileUrl [fileUrl]`
-: The server- or site-relative (decoded) URL of the file. Specify either `fileUrl` or `fileId` but not both.
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `--fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-sharinglink-set.mdx
+++ b/docs/docs/cmd/spo/file/file-sharinglink-set.mdx
@@ -19,7 +19,7 @@ m365 spo file sharinglink set [options]
 :	The URL of the site where the file is located.
 
 `--fileUrl [fileUrl]`
-:	The server- or site-relative (decoded) URL of the file. Specify either `fileUrl` or `fileId` but not both.
+:	The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both.
 
 `--fileId [fileId]`
 :	The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both.

--- a/docs/docs/cmd/spo/file/file-version-clear.mdx
+++ b/docs/docs/cmd/spo/file/file-version-clear.mdx
@@ -17,7 +17,7 @@ m365 spo file version clear [options]
 : The URL of the site where the file is located
 
 `-u, --fileUrl [fileUrl]`
-: The server- or site-relative URL of the file. Specify either `fileUrl` or `fileId` but not both
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both

--- a/docs/docs/cmd/spo/file/file-version-get.mdx
+++ b/docs/docs/cmd/spo/file/file-version-get.mdx
@@ -22,7 +22,7 @@ m365 spo file version get [options]
 : Label of version which will be retrieved
 
 `-u, --fileUrl [fileUrl]`
-: The server- or site-relative URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both
+: The server- or site-relative decoded URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file to retrieve. Specify either `fileUrl` or `fileId` but not both

--- a/docs/docs/cmd/spo/file/file-version-list.mdx
+++ b/docs/docs/cmd/spo/file/file-version-list.mdx
@@ -19,7 +19,7 @@ m365 spo file version list [options]
 : The URL of the site where the file is located
 
 `-u, --fileUrl [fileUrl]`
-: The server- or site-relative URL of the file. Specify either `fileUrl` or `fileId` but not both
+: The server- or site-relative decoded URL of the file. Specify either `fileUrl` or `fileId` but not both
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file. Specify either `fileUrl` or `fileId` but not both

--- a/docs/docs/cmd/spo/file/file-version-remove.mdx
+++ b/docs/docs/cmd/spo/file/file-version-remove.mdx
@@ -20,7 +20,7 @@ m365 spo file version remove [options]
 : Label of version which will be removed
 
 `-u, --fileUrl [fileUrl]`
-: The server- or site-relative URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both
+: The server- or site-relative decoded URL of the file to retrieve. Specify either `fileUrl` or `fileId` but not both
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file to retrieve. Specify either `fileUrl` or `fileId` but not both

--- a/docs/docs/cmd/spo/file/file-version-restore.mdx
+++ b/docs/docs/cmd/spo/file/file-version-restore.mdx
@@ -20,7 +20,7 @@ m365 spo file version restore [options]
 : Label of version which will be restored
 
 `-u, --fileUrl [fileUrl]`
-: The server- or site-relative URL of the file whose version will be restored. Specify either `fileUrl` or `fileId` but not both
+: The server- or site-relative decoded URL of the file whose version will be restored. Specify either `fileUrl` or `fileId` but not both
 
 `-i, --fileId [fileId]`
 : The UniqueId (GUID) of the file whose version will be restored. Specify either `fileUrl` or `fileId` but not both

--- a/src/m365/spo/commands/file/file-add.spec.ts
+++ b/src/m365/spo/commands/file/file-add.spec.ts
@@ -34,7 +34,7 @@ describe(commands.FILE_ADD, () => {
     validateUpdateListItemRespPass: any = null
   ) => {
     return sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativeUrl(') > -1) {
+      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativePath(DecodedUrl=') > -1) {
         if ((opts.url as string).indexOf('/CheckOut') > -1) {
 
           if (checkoutResp) {
@@ -139,7 +139,7 @@ describe(commands.FILE_ADD, () => {
   ) => {
     return sinon.stub(request, 'get').callsFake(async (opts) => {
 
-      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativeUrl(') > -1) {
+      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativePath(DecodedUrl=') > -1) {
         if ((opts.url as string).indexOf('ParentList') > -1) {
 
           if (parentListResp) {
@@ -564,7 +564,7 @@ describe(commands.FILE_ADD, () => {
         verbose: true
       }
     });
-    assert.notStrictEqual(postRequests.lastCall.args[0].url.indexOf(`/GetFolderByServerRelativeUrl('%2Fsites%2Fproject-x%2FShared%2520Documents%2Ft1')/Files/Add`), -1);
+    assert.notStrictEqual(postRequests.lastCall.args[0].url.indexOf(`/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%2520Documents%2Ft1')/Files/Add`), -1);
   });
 
   it('should perform chunk upload on files over 250 MB (debug)', async () => {
@@ -593,7 +593,7 @@ describe(commands.FILE_ADD, () => {
     stubFs();
     stubGetResponses();
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativeUrl(') > -1) {
+      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativePath(DecodedUrl=') > -1) {
         if ((opts.url as string).indexOf('/StartUpload') !== -1) {
 
           return { "d": { "StartUpload": "0" } };
@@ -689,7 +689,7 @@ describe(commands.FILE_ADD, () => {
     stubFs();
     stubGetResponses();
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativeUrl(') > -1) {
+      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativePath(DecodedUrl=') > -1) {
         if ((opts.url as string).indexOf('/CheckOut') > -1) {
           return { "odata.null": true };
         }

--- a/src/m365/spo/commands/file/file-add.ts
+++ b/src/m365/spo/commands/file/file-add.ts
@@ -181,7 +181,7 @@ class SpoFileAddCommand extends SpoCommand {
     try {
       try {
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderPath)}')`,
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderPath)}')`,
           headers: {
             'accept': 'application/json;odata=nometadata'
           }
@@ -220,7 +220,7 @@ class SpoFileAddCommand extends SpoCommand {
         // initiate chunked upload session
         const uploadId: string = v4();
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderPath)}')/Files/GetByPathOrAddStub(DecodedUrl='${formatting.encodeQueryParameter(fileName)}')/StartUpload(uploadId=guid'${uploadId}')`,
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderPath)}')/Files/GetByPathOrAddStub(DecodedUrl='${formatting.encodeQueryParameter(fileName)}')/StartUpload(uploadId=guid'${uploadId}')`,
           headers: {
             'accept': 'application/json;odata=nometadata'
           }
@@ -252,7 +252,7 @@ class SpoFileAddCommand extends SpoCommand {
           }
 
           const requestOptions: CliRequestOptions = {
-            url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/cancelupload(uploadId=guid'${uploadId}')`,
+            url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/cancelupload(uploadId=guid'${uploadId}')`,
             headers: {
               'accept': 'application/json;odata=nometadata'
             }
@@ -276,7 +276,7 @@ class SpoFileAddCommand extends SpoCommand {
         const bodyLength: number = fileBody.byteLength;
 
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderPath)}')/Files/Add(url='${formatting.encodeQueryParameter(fileName)}', overwrite=true)`,
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderPath)}')/Files/Add(url='${formatting.encodeQueryParameter(fileName)}', overwrite=true)`,
           data: fileBody,
           headers: {
             'accept': 'application/json;odata=nometadata',
@@ -326,7 +326,7 @@ class SpoFileAddCommand extends SpoCommand {
 
         // approve the existing file with given comment
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/approve(comment='${formatting.encodeQueryParameter(args.options.approveComment || '')}')`,
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/approve(comment='${formatting.encodeQueryParameter(args.options.approveComment || '')}')`,
           headers: {
             'accept': 'application/json;odata=nometadata'
           },
@@ -346,7 +346,7 @@ class SpoFileAddCommand extends SpoCommand {
 
         // publish the existing file with given comment
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/publish(comment='${formatting.encodeQueryParameter(args.options.publishComment || '')}')`,
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/publish(comment='${formatting.encodeQueryParameter(args.options.publishComment || '')}')`,
           headers: {
             'accept': 'application/json;odata=nometadata'
           },
@@ -362,7 +362,7 @@ class SpoFileAddCommand extends SpoCommand {
         // then have to rollback the checkout
 
         const requestOptions: any = {
-          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/UndoCheckOut()`
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/UndoCheckOut()`
         };
 
         try {
@@ -407,7 +407,7 @@ class SpoFileAddCommand extends SpoCommand {
   private async fileCheckOut(fileName: string, webUrl: string, folder: string): Promise<void> {
     // check if file already exists, otherwise it can't be checked out
     const requestOptionsGetFile: CliRequestOptions = {
-      url: `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folder)}')/Files('${formatting.encodeQueryParameter(fileName)}')`,
+      url: `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folder)}')/Files('${formatting.encodeQueryParameter(fileName)}')`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       }
@@ -416,7 +416,7 @@ class SpoFileAddCommand extends SpoCommand {
     await request.get<void>(requestOptionsGetFile);
 
     const requestOptionsCheckOut: CliRequestOptions = {
-      url: `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folder)}')/Files('${formatting.encodeQueryParameter(fileName)}')/CheckOut()`,
+      url: `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folder)}')/Files('${formatting.encodeQueryParameter(fileName)}')/CheckOut()`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },
@@ -444,7 +444,7 @@ class SpoFileAddCommand extends SpoCommand {
       }
 
       const requestOptions: CliRequestOptions = {
-        url: `${info.WebUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(info.FolderPath)}')/Files('${formatting.encodeQueryParameter(info.Name)}')/${isLastChunk ? 'Finish' : 'Continue'}Upload(uploadId=guid'${info.Id}',fileOffset=${offset})`,
+        url: `${info.WebUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(info.FolderPath)}')/Files('${formatting.encodeQueryParameter(info.Name)}')/${isLastChunk ? 'Finish' : 'Continue'}Upload(uploadId=guid'${info.Id}',fileOffset=${offset})`,
         data: fileBuffer,
         headers: {
           'accept': 'application/json;odata=nometadata',
@@ -506,7 +506,7 @@ class SpoFileAddCommand extends SpoCommand {
     }
 
     const requestOptions: CliRequestOptions = {
-      url: `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folder)}')/Files('${formatting.encodeQueryParameter(fileName)}')/ListItemAllFields/ParentList?$Select=Id,EnableModeration,EnableVersioning,EnableMinorVersions`,
+      url: `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folder)}')/Files('${formatting.encodeQueryParameter(fileName)}')/ListItemAllFields/ParentList?$Select=Id,EnableModeration,EnableVersioning,EnableMinorVersions`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },
@@ -534,7 +534,7 @@ class SpoFileAddCommand extends SpoCommand {
 
     // update the existing file list item fields
     const requestOptions: CliRequestOptions = {
-      url: `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/ListItemAllFields/ValidateUpdateListItem()`,
+      url: `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderPath)}')/Files('${formatting.encodeQueryParameter(fileName)}')/ListItemAllFields/ValidateUpdateListItem()`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },
@@ -555,7 +555,7 @@ class SpoFileAddCommand extends SpoCommand {
 
   private async fileCheckIn(args: any, fileName: string): Promise<void> {
     const requestOptions: CliRequestOptions = {
-      url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(args.options.folder)}')/Files('${formatting.encodeQueryParameter(fileName)}')/CheckIn(comment='${formatting.encodeQueryParameter(args.options.checkInComment || '')}',checkintype=0)`,
+      url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(args.options.folder)}')/Files('${formatting.encodeQueryParameter(fileName)}')/CheckIn(comment='${formatting.encodeQueryParameter(args.options.checkInComment || '')}',checkintype=0)`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },

--- a/src/m365/spo/commands/file/file-checkin.spec.ts
+++ b/src/m365/spo/commands/file/file-checkin.spec.ts
@@ -24,7 +24,7 @@ describe(commands.FILE_CHECKIN, () => {
         throw getFileByServerRelativeUrlResp;
       }
       else {
-        if ((opts.url as string).indexOf('/_api/web/GetFileByServerRelativeUrl(') > -1) {
+        if ((opts.url as string).indexOf('/_api/web/GetFileByServerRelativePath(DecodedUrl=') > -1) {
           return;
         }
       }
@@ -172,7 +172,7 @@ describe(commands.FILE_CHECKIN, () => {
         webUrl: 'https://contoso.sharepoint.com/sites/project-x'
       }
     });
-    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkin(comment='',checkintype=1)");
+    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkin(comment='',checkintype=1)");
   });
 
   it('should call the correct API url when tenant root URL option is passed', async () => {
@@ -184,7 +184,7 @@ describe(commands.FILE_CHECKIN, () => {
         webUrl: 'https://contoso.sharepoint.com'
       }
     });
-    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/_api/web/GetFileByServerRelativeUrl('%2FDocuments%2FTest1.docx')/checkin(comment='',checkintype=1)");
+    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='%2FDocuments%2FTest1.docx')/checkin(comment='',checkintype=1)");
   });
 
   it('should call correctly the API when type is minor', async () => {
@@ -197,7 +197,7 @@ describe(commands.FILE_CHECKIN, () => {
         type: 'minor'
       }
     });
-    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkin(comment='',checkintype=0)");
+    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkin(comment='',checkintype=0)");
   });
 
   it('should call correctly the API when type is overwrite', async () => {
@@ -210,7 +210,7 @@ describe(commands.FILE_CHECKIN, () => {
         type: 'overwrite'
       }
     });
-    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkin(comment='',checkintype=2)");
+    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkin(comment='',checkintype=2)");
   });
 
   it('should call correctly the API when comment specified', async () => {
@@ -223,7 +223,7 @@ describe(commands.FILE_CHECKIN, () => {
         comment: 'abc1'
       }
     });
-    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkin(comment='abc1',checkintype=1)");
+    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkin(comment='abc1',checkintype=1)");
   });
 
   it('should call correctly the API when type is minor (id)', async () => {

--- a/src/m365/spo/commands/file/file-checkin.ts
+++ b/src/m365/spo/commands/file/file-checkin.ts
@@ -138,7 +138,7 @@ class SpoFileCheckinCommand extends SpoCommand {
 
     if (args.options.url) {
       const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.url);
-      requestUrl = `${args.options.webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativePath)}')/checkin(comment='${comment}',checkintype=${type})`;
+      requestUrl = `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/checkin(comment='${comment}',checkintype=${type})`;
     }
 
     const requestOptions: CliRequestOptions = {

--- a/src/m365/spo/commands/file/file-checkout.spec.ts
+++ b/src/m365/spo/commands/file/file-checkout.spec.ts
@@ -24,7 +24,7 @@ describe(commands.FILE_CHECKOUT, () => {
         throw getFileByServerRelativeUrlResp;
       }
       else {
-        if ((opts.url as string).indexOf('/_api/web/GetFileByServerRelativeUrl(') > -1) {
+        if ((opts.url as string).indexOf('/_api/web/GetFileByServerRelativePath(DecodedUrl=') > -1) {
           return;
         }
       }
@@ -171,7 +171,7 @@ describe(commands.FILE_CHECKOUT, () => {
         webUrl: 'https://contoso.sharepoint.com/sites/project-x'
       }
     });
-    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkout");
+    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx')/checkout");
   });
 
   it('should call the correct API url when tenant root URL option is passed', async () => {
@@ -183,7 +183,7 @@ describe(commands.FILE_CHECKOUT, () => {
         webUrl: 'https://contoso.sharepoint.com'
       }
     });
-    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/_api/web/GetFileByServerRelativeUrl('%2FDocuments%2FTest1.docx')/checkout");
+    assert.strictEqual(postStub.lastCall.args[0].url, "https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='%2FDocuments%2FTest1.docx')/checkout");
   });
 
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {

--- a/src/m365/spo/commands/file/file-checkout.ts
+++ b/src/m365/spo/commands/file/file-checkout.ts
@@ -94,7 +94,7 @@ class SpoFileCheckoutCommand extends SpoCommand {
 
     if (args.options.url) {
       const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.url);
-      requestUrl = `${args.options.webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativePath)}')/checkout`;
+      requestUrl = `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/checkout`;
     }
 
     const requestOptions: CliRequestOptions = {

--- a/src/m365/spo/commands/file/file-list.spec.ts
+++ b/src/m365/spo/commands/file/file-list.spec.ts
@@ -133,7 +133,7 @@ describe(commands.FILE_LIST, () => {
 
   it('retrieves files from a folder when --recursive option is not supplied', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=0&$top=5000`) {
         return fileShortArrayResponse;
       }
 
@@ -152,7 +152,7 @@ describe(commands.FILE_LIST, () => {
 
   it('retrieves empty list of files from a folder', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=0&$top=5000`) {
         return { value: [] };
       }
 
@@ -171,7 +171,7 @@ describe(commands.FILE_LIST, () => {
 
   it('retrieves files from a folder with filter and fields option, requesting the ListItemAllFields Id property', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000&$expand=ListItemAllFields&$select=ListItemAllFields/Id,Name&$filter=name eq 'Test.docx'`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=0&$top=5000&$expand=ListItemAllFields&$select=ListItemAllFields/Id,Name&$filter=name eq 'Test.docx'`) {
         return {
           value: [
             {
@@ -211,7 +211,7 @@ describe(commands.FILE_LIST, () => {
 
   it('retrieves files from a folder with filter and fields option, requesting the ListItemAllFields Title property', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000&$expand=ListItemAllFields&$select=ListItemAllFields/Title&$filter=name eq 'Test.docx'`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=0&$top=5000&$expand=ListItemAllFields&$select=ListItemAllFields/Title&$filter=name eq 'Test.docx'`) {
         return {
           value: [
             {
@@ -240,11 +240,11 @@ describe(commands.FILE_LIST, () => {
 
   it('retrieves files from a folder in multiple pages', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=0&$top=5000`) {
         return fileFullPageResponse;
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=5000&$top=5000`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=5000&$top=5000`) {
         return fileShortArrayResponse;
       }
 
@@ -264,25 +264,25 @@ describe(commands.FILE_LIST, () => {
 
   it('retrieves files from a folder recursively in multiple pages', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=0&$top=5000`) {
         return fileShortArrayResponse;
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000&$select=ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Folders?$skip=0&$top=5000&$select=ServerRelativeUrl`) {
         return folderFullPageResponse;
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=5000&$top=5000&$select=ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Folders?$skip=5000&$top=5000&$select=ServerRelativeUrl`) {
         return folderShortArrayResponse;
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder'&$skip=0&$top=5000&$select=ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder')/Folders?$skip=0&$top=5000&$select=ServerRelativeUrl`) {
         return {
           value: []
         };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder'&$skip=0&$top=5000`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder')/Files?$skip=0&$top=5000`) {
         return {
           value: []
         };
@@ -305,7 +305,7 @@ describe(commands.FILE_LIST, () => {
 
   it('retrieves files from a folder when --recursive option is not supplied and output option is text', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000&$select=UniqueId,Name,ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=0&$top=5000&$select=UniqueId,Name,ServerRelativeUrl`) {
         return fileTextResponse;
       }
       throw `Invalid request ${opts.url}`;
@@ -324,21 +324,21 @@ describe(commands.FILE_LIST, () => {
   // Test for --recursive option. Uses onCall() method on stub to simulate recursion
   it('retrieves files from a folder and all the folders below it recursively when --recursive option is supplied and output option is json', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000&$select=ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Folders?$skip=0&$top=5000&$select=ServerRelativeUrl`) {
         return folderShortArrayResponse;
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder'&$skip=0&$top=5000&$select=ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder')/Folders?$skip=0&$top=5000&$select=ServerRelativeUrl`) {
         return {
           value: []
         };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}'&$skip=0&$top=5000`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/project-x/' + folder)}')/Files?$skip=0&$top=5000`) {
         return fileShortArrayResponse;
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder'&$skip=0&$top=5000`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder')/Files?$skip=0&$top=5000`) {
         return fileShortArrayResponse;
       }
 
@@ -358,21 +358,21 @@ describe(commands.FILE_LIST, () => {
 
   it('retrieves files from a folder and all the folders below it recursively when --recursive option is supplied and output option is text', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(`/sites/project-x/Shared Documents`)}'&$skip=0&$top=5000&$select=ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(`/sites/project-x/Shared Documents`)}')/Folders?$skip=0&$top=5000&$select=ServerRelativeUrl`) {
         return folderShortArrayResponse;
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder'&$skip=0&$top=5000&$select=ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder')/Folders?$skip=0&$top=5000&$select=ServerRelativeUrl`) {
         return {
           value: []
         };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter(`/sites/project-x/Shared Documents`)}'&$skip=0&$top=5000&$select=UniqueId,Name,ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(`/sites/project-x/Shared Documents`)}')/Files?$skip=0&$top=5000&$select=UniqueId,Name,ServerRelativeUrl`) {
         return fileTextResponse;
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder'&$skip=0&$top=5000&$select=UniqueId,Name,ServerRelativeUrl`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%20documents%2FLevel1-Folder')/Files?$skip=0&$top=5000&$select=UniqueId,Name,ServerRelativeUrl`) {
         return fileTextResponse;
       }
 
@@ -402,7 +402,7 @@ describe(commands.FILE_LIST, () => {
       }
     };
     sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativeUrl') > -1) {
+      if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativePath') > -1) {
         throw error;
       }
 

--- a/src/m365/spo/commands/file/file-list.ts
+++ b/src/m365/spo/commands/file/file-list.ts
@@ -137,7 +137,7 @@ class SpoFileListCommand extends SpoCommand {
 
     const allFiles: FileProperties[] = [];
     const serverRelativePath: string = urlUtil.getServerRelativePath(args.options.webUrl, folderUrl);
-    const requestUrl = `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Files?@url='${formatting.encodeQueryParameter(serverRelativePath)}'`;
+    const requestUrl = `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/Files`;
     const queryParams = [`$skip=${skip}`, `$top=${SpoFileListCommand.pageSize}`];
 
     if (fieldProperties.expandProperties.length > 0) {
@@ -153,7 +153,7 @@ class SpoFileListCommand extends SpoCommand {
     }
 
     const requestOptions: CliRequestOptions = {
-      url: `${requestUrl}&${queryParams.join('&')}`,
+      url: `${requestUrl}?${queryParams.join('&')}`,
       method: 'GET',
       headers: {
         'accept': 'application/json;odata=nometadata'
@@ -180,10 +180,10 @@ class SpoFileListCommand extends SpoCommand {
 
     const allFolders: string[] = [];
     const serverRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, folderUrl);
-    const requestUrl = `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(serverRelativeUrl)}'`;
+    const requestUrl = `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/Folders`;
 
     const requestOptions: CliRequestOptions = {
-      url: `${requestUrl}&$skip=${skip}&$top=${SpoFileListCommand.pageSize}&$select=ServerRelativeUrl`,
+      url: `${requestUrl}?$skip=${skip}&$top=${SpoFileListCommand.pageSize}&$select=ServerRelativeUrl`,
       method: 'GET',
       headers: {
         'accept': 'application/json;odata=nometadata'

--- a/src/m365/spo/commands/file/file-move.spec.ts
+++ b/src/m365/spo/commands/file/file-move.spec.ts
@@ -48,7 +48,7 @@ describe(commands.FILE_MOVE, () => {
 
   const stubAllGetRequests: any = (fileExists: any = null) => {
     return sinon.stub(request, 'get').callsFake((opts) => {
-      if ((opts.url as string).indexOf('GetFileByServerRelativeUrl') > -1) {
+      if ((opts.url as string).indexOf('GetFileByServerRelativePath') > -1) {
         if (fileExists) {
           return fileExists;
         }

--- a/src/m365/spo/commands/file/file-move.ts
+++ b/src/m365/spo/commands/file/file-move.ts
@@ -110,7 +110,7 @@ class SpoFileMoveCommand extends SpoCommand {
       const requestOptions: CliRequestOptions = {
         url: requestUrl,
         headers: {
-          'accept': 'application/json;odata=nometadata'
+          accept: 'application/json;odata=nometadata'
         },
         data: {
           exportObjectUris: [sourceAbsoluteUrl],
@@ -152,7 +152,7 @@ class SpoFileMoveCommand extends SpoCommand {
    * Checks if a file exists on the server relative url
    */
   private fileExists(webUrl: string, sourceUrl: string): Promise<void> {
-    const requestUrl = `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(sourceUrl)}')/`;
+    const requestUrl = `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(sourceUrl)}')/`;
     const requestOptions: CliRequestOptions = {
       url: requestUrl,
       method: 'GET',

--- a/src/m365/spo/commands/file/file-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-remove.spec.ts
@@ -155,7 +155,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -173,7 +173,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -189,7 +189,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -207,7 +207,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -223,7 +223,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -241,7 +241,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -257,7 +257,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -275,7 +275,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -291,7 +291,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -308,7 +308,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -324,7 +324,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -342,7 +342,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -358,7 +358,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -375,7 +375,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -391,7 +391,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -408,7 +408,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -424,7 +424,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -441,7 +441,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -457,7 +457,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1) {
+      if ((opts.url as string).indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -474,7 +474,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`GetFileByServerRelativeUrl('${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
+      if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -517,7 +517,7 @@ describe(commands.FILE_REMOVE, () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       requests.push(opts);
 
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativeUrl('`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='`) > -1) {
         if (opts.headers &&
           opts.headers.accept &&
           (opts.headers.accept as string).indexOf('application/json') === 0) {
@@ -534,7 +534,7 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
     let correctRequestIssued = false;
     requests.forEach(r => {
-      if (r.url.indexOf(`/_api/web/GetFileByServerRelativeUrl('`) > -1 &&
+      if (r.url.indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='`) > -1 &&
         r.headers.accept &&
         r.headers.accept.indexOf('application/json') === 0) {
         correctRequestIssued = true;
@@ -628,7 +628,7 @@ describe(commands.FILE_REMOVE, () => {
 
   it('uses correct API url when url option is passed', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/GetFileByServerRelativeUrl(') > -1) {
+      if ((opts.url as string).indexOf('/_api/web/GetFileByServerRelativePath(DecodedUrl=') > -1) {
         return;
       }
 

--- a/src/m365/spo/commands/file/file-remove.ts
+++ b/src/m365/spo/commands/file/file-remove.ts
@@ -45,10 +45,10 @@ class SpoFileRemoveCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        id: (!(!args.options.id)).toString(),
-        url: (!(!args.options.url)).toString(),
-        recycle: (!(!args.options.recycle)).toString(),
-        confirm: (!(!args.options.confirm)).toString()
+        id: typeof args.options.id !== 'undefined',
+        url: typeof args.options.url !== 'undefined',
+        recycle: !!args.options.recycle,
+        confirm: !!args.options.confirm
       });
     });
   }
@@ -112,7 +112,7 @@ class SpoFileRemoveCommand extends SpoCommand {
       }
       else {
         const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.url!);
-        requestUrl = `${args.options.webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativePath)}')`;
+        requestUrl = `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')`;
       }
 
       if (args.options.recycle) {
@@ -146,7 +146,7 @@ class SpoFileRemoveCommand extends SpoCommand {
         type: 'confirm',
         name: 'continue',
         default: false,
-        message: `Are you sure you want to ${args.options.recycle ? "recycle" : "remove"} the file ${args.options.id || args.options.url} located in site ${args.options.webUrl}?`
+        message: `Are you sure you want to ${args.options.recycle ? 'recycle' : 'remove'} the file ${args.options.id || args.options.url} located in site ${args.options.webUrl}?`
       });
 
       if (result.continue) {

--- a/src/m365/spo/commands/file/file-rename.spec.ts
+++ b/src/m365/spo/commands/file/file-rename.spec.ts
@@ -95,14 +95,14 @@ describe(commands.FILE_RENAME, () => {
     sinon.stub(Cli, 'executeCommand').resolves();
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')/ListItemAllFields/ValidateUpdateListItem()') {
+      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativePath(DecodedUrl=\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')/ListItemAllFields/ValidateUpdateListItem()') {
         return renameValue;
       }
       throw 'Invalid request';
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')?$select=UniqueId') {
+      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativePath(DecodedUrl=\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')?$select=UniqueId') {
         return;
       }
       throw 'Invalid request';
@@ -122,14 +122,14 @@ describe(commands.FILE_RENAME, () => {
 
   it('renames file from a non-root site in the root folder of a document library when a file with the same name doesn\'t exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')/ListItemAllFields/ValidateUpdateListItem()') {
+      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativePath(DecodedUrl=\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')/ListItemAllFields/ValidateUpdateListItem()') {
         return renameValue;
       }
       throw 'Invalid request';
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')?$select=UniqueId') {
+      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativePath(DecodedUrl=\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')?$select=UniqueId') {
         return;
       }
       throw 'Invalid request';
@@ -155,14 +155,14 @@ describe(commands.FILE_RENAME, () => {
     sinon.stub(Cli, 'executeCommand').rejects(fileDeleteError);
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')/ListItemAllFields/ValidateUpdateListItem()') {
+      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativePath(DecodedUrl=\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')/ListItemAllFields/ValidateUpdateListItem()') {
         return renameValue;
       }
       throw 'Invalid request';
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')?$select=UniqueId') {
+      if ((opts.url as string) === 'https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativePath(DecodedUrl=\'%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf\')?$select=UniqueId') {
         return;
       }
       throw 'Invalid request';
@@ -191,7 +191,7 @@ describe(commands.FILE_RENAME, () => {
     sinon.stub(Cli, 'executeCommand').rejects(fileDeleteError);
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string) === `https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf')?$select=UniqueId`) {
+      if ((opts.url as string) === `https://contoso.sharepoint.com/sites/portal/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fportal%2FShared%20Documents%2Fabc.pdf')?$select=UniqueId`) {
         return;
       }
       throw 'Invalid request';

--- a/src/m365/spo/commands/file/file-rename.ts
+++ b/src/m365/spo/commands/file/file-rename.ts
@@ -103,7 +103,7 @@ class SpoFileRenameCommand extends SpoCommand {
       };
 
       const requestOptions: CliRequestOptions = {
-        url: `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(originalFileServerRelativePath)}')/ListItemAllFields/ValidateUpdateListItem()`,
+        url: `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(originalFileServerRelativePath)}')/ListItemAllFields/ValidateUpdateListItem()`,
         headers: {
           'accept': 'application/json;odata=nometadata'
         },
@@ -120,7 +120,7 @@ class SpoFileRenameCommand extends SpoCommand {
   }
 
   private async getFile(originalFileServerRelativeUrl: string, webUrl: string): Promise<FileProperties> {
-    const requestUrl = `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(originalFileServerRelativeUrl)}')?$select=UniqueId`;
+    const requestUrl = `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(originalFileServerRelativeUrl)}')?$select=UniqueId`;
     const requestOptions: CliRequestOptions = {
       url: requestUrl,
       headers: {

--- a/src/m365/spo/commands/file/file-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-ensure.spec.ts
@@ -114,7 +114,7 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the retentionlabel from a file based on fileUrl', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
         return fileResponse;
       }
 
@@ -171,7 +171,7 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the event based retentionlabel from a file based on fileUrl with assetId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
         return fileResponse;
       }
 

--- a/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
@@ -135,7 +135,7 @@ class SpoFileRetentionLabelEnsureCommand extends SpoCommand {
     }
     else {
       const serverRelativeUrl = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl!);
-      requestUrl += `GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
+      requestUrl += `GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
     }
 
     const requestOptions: AxiosRequestConfig = {

--- a/src/m365/spo/commands/file/file-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-remove.spec.ts
@@ -115,7 +115,7 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
 
   it('removes the retentionlabel from a file based on fileUrl when prompt confirmed', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
         return fileResponse;
       }
 

--- a/src/m365/spo/commands/file/file-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-remove.ts
@@ -150,7 +150,7 @@ class SpoFileRetentionLabelRemoveCommand extends SpoCommand {
     }
     else {
       const serverRelativeUrl = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl!);
-      requestUrl += `GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
+      requestUrl += `GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
     }
 
     requestOptions.url = `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`;

--- a/src/m365/spo/commands/file/file-roleassignment-add.spec.ts
+++ b/src/m365/spo/commands/file/file-roleassignment-add.spec.ts
@@ -130,7 +130,7 @@ describe(commands.FILE_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly adds role assignment specifying principalId and role definition name', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url as string === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2Fdocuments%2FTest1.docx')/ListItemAllFields/roleassignments/addroleassignment(principalid='10',roledefid='1073741827')`) {
+      if (opts.url as string === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2Fdocuments%2FTest1.docx')/ListItemAllFields/roleassignments/addroleassignment(principalid='10',roledefid='1073741827')`) {
         return;
       }
 
@@ -159,7 +159,7 @@ describe(commands.FILE_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly adds role assignment specifying principalId and role definition name, retrieving file by the ID', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url as string === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2Fdocuments%2FTest1.docx')/ListItemAllFields/roleassignments/addroleassignment(principalid='10',roledefid='1073741827')`) {
+      if (opts.url as string === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2Fdocuments%2FTest1.docx')/ListItemAllFields/roleassignments/addroleassignment(principalid='10',roledefid='1073741827')`) {
         return;
       }
 
@@ -193,7 +193,7 @@ describe(commands.FILE_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly adds role assignment specifying upn and role definition id', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url as string === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2Fdocuments%2FTest1.docx')/ListItemAllFields/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
+      if (opts.url as string === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2Fdocuments%2FTest1.docx')/ListItemAllFields/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
@@ -242,7 +242,7 @@ describe(commands.FILE_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly adds role assignment specifying groupName and role definition id', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url as string === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl('%2Fsites%2Fproject-x%2Fdocuments%2FTest1.docx')/ListItemAllFields/roleassignments/addroleassignment(principalid='5',roledefid='1073741827')`) {
+      if (opts.url as string === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2Fdocuments%2FTest1.docx')/ListItemAllFields/roleassignments/addroleassignment(principalid='5',roledefid='1073741827')`) {
         return;
       }
 

--- a/src/m365/spo/commands/file/file-roleassignment-add.ts
+++ b/src/m365/spo/commands/file/file-roleassignment-add.ts
@@ -155,7 +155,7 @@ class SpoFileRoleAssignmentAddCommand extends SpoCommand {
 
   private async addRoleAssignment(fileUrl: string, webUrl: string, principalId: number, roleDefinitionId: number): Promise<void> {
     const requestOptions: CliRequestOptions = {
-      url: `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/roleassignments/addroleassignment(principalid='${principalId}',roledefid='${roleDefinitionId}')`,
+      url: `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/roleassignments/addroleassignment(principalid='${principalId}',roledefid='${roleDefinitionId}')`,
       method: 'POST',
       headers: {
         'accept': 'application/json;odata=nometadata',

--- a/src/m365/spo/commands/file/file-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-roleassignment-remove.spec.ts
@@ -136,7 +136,7 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
   it('remove role assignment from the file by relative URL and principal Id when prompt confirmed (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       const serverRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, fileUrl);
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/roleassignments/removeroleassignment(principalid='${principalId}')`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/roleassignments/removeroleassignment(principalid='${principalId}')`) {
         return;
       }
 
@@ -175,7 +175,7 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
       const serverRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, fileUrl);
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/roleassignments/removeroleassignment(principalid='${principalId}')`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/roleassignments/removeroleassignment(principalid='${principalId}')`) {
         return;
       }
 
@@ -212,7 +212,7 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
       const serverRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, fileUrl);
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/roleassignments/removeroleassignment(principalid='${principalId}')`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/roleassignments/removeroleassignment(principalid='${principalId}')`) {
         return;
       }
 

--- a/src/m365/spo/commands/file/file-roleassignment-remove.ts
+++ b/src/m365/spo/commands/file/file-roleassignment-remove.ts
@@ -136,7 +136,7 @@ class SpoFileRoleAssignmentRemoveCommand extends SpoCommand {
 
         const serverRelativePath: string = urlUtil.getServerRelativePath(args.options.webUrl, fileURL);
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativePath)}')/ListItemAllFields/roleassignments/removeroleassignment(principalid='${principalId}')`,
+          url: `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/ListItemAllFields/roleassignments/removeroleassignment(principalid='${principalId}')`,
           headers: {
             accept: 'application/json;odata=nometadata'
           },

--- a/src/m365/spo/commands/file/file-roleinheritance-break.spec.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-break.spec.ts
@@ -122,7 +122,7 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
 
   it('breaks role inheritance clearing existing permissions on file by relative URL (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/breakroleinheritance(false)`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/breakroleinheritance(false)`) {
         return;
       }
 
@@ -142,7 +142,7 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
 
   it('breaks role inheritance keeping existing permissions on file by relative URL (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
         return;
       }
 
@@ -172,7 +172,7 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
         return;
       }
 

--- a/src/m365/spo/commands/file/file-roleinheritance-break.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-break.ts
@@ -104,7 +104,7 @@ class SpoFileRoleInheritanceBreakCommand extends SpoCommand {
         const keepExistingPermissions: boolean = !args.options.clearExistingPermissions;
 
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileURL)}')/ListItemAllFields/breakroleinheritance(${keepExistingPermissions})`,
+          url: `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileURL)}')/ListItemAllFields/breakroleinheritance(${keepExistingPermissions})`,
           headers: {
             accept: 'application/json;odata=nometadata'
           },

--- a/src/m365/spo/commands/file/file-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-reset.spec.ts
@@ -121,7 +121,7 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
 
   it('resets role inheritance on file by relative URL (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/resetroleinheritance`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/resetroleinheritance`) {
         return;
       }
 
@@ -150,7 +150,7 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/resetroleinheritance`) {
+      if (opts.url === `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')/ListItemAllFields/resetroleinheritance`) {
         return;
       }
 

--- a/src/m365/spo/commands/file/file-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-reset.ts
@@ -97,7 +97,7 @@ class SpoFileRoleInheritanceResetCommand extends SpoCommand {
         const fileURL: string = await this.getFileURL(args);
 
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(fileURL)}')/ListItemAllFields/resetroleinheritance`,
+          url: `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileURL)}')/ListItemAllFields/resetroleinheritance`,
           headers: {
             accept: 'application/json;odata=nometadata'
           },

--- a/src/m365/spo/commands/file/file-version-clear.spec.ts
+++ b/src/m365/spo/commands/file/file-version-clear.spec.ts
@@ -131,7 +131,7 @@ describe(commands.FILE_VERSION_CLEAR, () => {
 
   it('deletes all version history from a file with the fileUrl options', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(validFileUrl)}')/versions/DeleteAll()`) {
+      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(validFileUrl)}')/versions/DeleteAll()`) {
         return { statusCode: 200 };
       }
       throw 'Invalid request';
@@ -169,7 +169,7 @@ describe(commands.FILE_VERSION_CLEAR, () => {
 
   it('deletes all version history from a file with the fileUrl options asking to confirm', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(validFileUrl)}')/versions/DeleteAll()`) {
+      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(validFileUrl)}')/versions/DeleteAll()`) {
         return { statusCode: 200 };
       }
       throw 'Invalid request';

--- a/src/m365/spo/commands/file/file-version-clear.ts
+++ b/src/m365/spo/commands/file/file-version-clear.ts
@@ -111,7 +111,7 @@ class SpoFileVersionClearCommand extends SpoCommand {
     let requestUrl: string = `${args.options.webUrl}/_api/web/`;
     if (args.options.fileUrl) {
       const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl);
-      requestUrl += `GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativePath)}')/versions/DeleteAll()`;
+      requestUrl += `GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/versions/DeleteAll()`;
     }
     else {
       requestUrl += `GetFileById('${args.options.fileId}')/versions/DeleteAll()`;

--- a/src/m365/spo/commands/file/file-version-get.spec.ts
+++ b/src/m365/spo/commands/file/file-version-get.spec.ts
@@ -110,7 +110,7 @@ describe(commands.FILE_VERSION_GET, () => {
 
   it('retrieves version from a file with the fileUrl options', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(validFileUrl)}')/versions/?$filter=VersionLabel eq '${validLabel}'`) {
+      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(validFileUrl)}')/versions/?$filter=VersionLabel eq '${validLabel}'`) {
         return fileVersionResponse;
       }
       throw 'Invalid request';
@@ -148,7 +148,7 @@ describe(commands.FILE_VERSION_GET, () => {
 
   it('properly escapes single quotes in fileUrl', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url = `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('Shared%20Documents%2FFo''lde''r')/versions/?$filter=VersionLabel eq '${validLabel}'`) {
+      if (opts.url = `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='Shared%20Documents%2FFo''lde''r')/versions/?$filter=VersionLabel eq '${validLabel}'`) {
         return fileVersionResponse;
       }
       throw 'Invalid request';

--- a/src/m365/spo/commands/file/file-version-get.ts
+++ b/src/m365/spo/commands/file/file-version-get.ts
@@ -101,7 +101,7 @@ class SpoFileVersionGetCommand extends SpoCommand {
     let requestUrl: string = `${args.options.webUrl}/_api/web/`;
     if (args.options.fileUrl) {
       const serverRelUrl = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl);
-      requestUrl += `GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelUrl)}')/versions/?$filter=VersionLabel eq '${args.options.label}'`;
+      requestUrl += `GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelUrl)}')/versions/?$filter=VersionLabel eq '${args.options.label}'`;
     }
     else {
       requestUrl += `GetFileById('${args.options.fileId}')/versions/?$filter=VersionLabel eq '${args.options.label}'`;

--- a/src/m365/spo/commands/file/file-version-list.spec.ts
+++ b/src/m365/spo/commands/file/file-version-list.spec.ts
@@ -122,7 +122,7 @@ describe(commands.FILE_VERSION_LIST, () => {
 
   it('retrieves versions from a file with the fileUrl option', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(validFileUrl)}')/versions`) {
+      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(validFileUrl)}')/versions`) {
         return fileVersionResponse;
       }
       throw 'Invalid request';

--- a/src/m365/spo/commands/file/file-version-list.ts
+++ b/src/m365/spo/commands/file/file-version-list.ts
@@ -87,7 +87,7 @@ class SpoFileVersionListCommand extends SpoCommand {
       let requestUrl = `${args.options.webUrl}/_api/web`;
       if (args.options.fileUrl) {
         const serverRelativeUrl = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl);
-        requestUrl += `/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
+        requestUrl += `/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
       }
       else {
         requestUrl += `/GetFileById('${args.options.fileId}')`;

--- a/src/m365/spo/commands/file/file-version-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-version-remove.spec.ts
@@ -135,7 +135,7 @@ describe(commands.FILE_VERSION_REMOVE, () => {
 
   it('deletes a version from a file with the fileUrl options', async () => {
     sinon.stub(request, 'delete').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(validFileUrl)}')/versions/DeleteByLabel('${validLabel}')`) {
+      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(validFileUrl)}')/versions/DeleteByLabel('${validLabel}')`) {
         return { statusCode: 200 };
       }
       throw 'Invalid request';
@@ -175,7 +175,7 @@ describe(commands.FILE_VERSION_REMOVE, () => {
 
   it('deletes a version from a file with the fileUrl options asking to confirm', async () => {
     sinon.stub(request, 'delete').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(validFileUrl)}')/versions/DeleteByLabel('${validLabel}')`) {
+      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(validFileUrl)}')/versions/DeleteByLabel('${validLabel}')`) {
         return { statusCode: 200 };
       }
       throw 'Invalid request';

--- a/src/m365/spo/commands/file/file-version-remove.ts
+++ b/src/m365/spo/commands/file/file-version-remove.ts
@@ -120,7 +120,7 @@ class SpoFileVersionRemoveCommand extends SpoCommand {
     let requestUrl: string = `${args.options.webUrl}/_api/web/`;
     if (args.options.fileUrl) {
       const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl);
-      requestUrl += `GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativePath)}')/versions/DeleteByLabel('${args.options.label}')`;
+      requestUrl += `GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/versions/DeleteByLabel('${args.options.label}')`;
     }
     else {
       requestUrl += `GetFileById('${args.options.fileId}')/versions/DeleteByLabel('${args.options.label}')`;

--- a/src/m365/spo/commands/file/file-version-restore.spec.ts
+++ b/src/m365/spo/commands/file/file-version-restore.spec.ts
@@ -135,7 +135,7 @@ describe(commands.FILE_VERSION_RESTORE, () => {
 
   it('restores a version from a file with the fileUrl options', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(validFileUrl)}')/versions/RestoreByLabel('${validLabel}')`) {
+      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(validFileUrl)}')/versions/RestoreByLabel('${validLabel}')`) {
         return { statusCode: 200 };
       }
       throw 'Invalid request';
@@ -175,7 +175,7 @@ describe(commands.FILE_VERSION_RESTORE, () => {
 
   it('restores a version from a file with the fileUrl options asking to confirm', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(validFileUrl)}')/versions/RestoreByLabel('${validLabel}')`) {
+      if (opts.url === `${validWebUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(validFileUrl)}')/versions/RestoreByLabel('${validLabel}')`) {
         return { statusCode: 200 };
       }
       throw 'Invalid request';

--- a/src/m365/spo/commands/file/file-version-restore.ts
+++ b/src/m365/spo/commands/file/file-version-restore.ts
@@ -120,7 +120,7 @@ class SpoFileVersionRestoreCommand extends SpoCommand {
     let requestUrl: string = `${args.options.webUrl}/_api/web/`;
     if (args.options.fileUrl) {
       const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.fileUrl);
-      requestUrl += `GetFileByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativePath)}')/versions/RestoreByLabel('${args.options.label}')`;
+      requestUrl += `GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/versions/RestoreByLabel('${args.options.label}')`;
     }
     else {
       requestUrl += `GetFileById('${args.options.fileId}')/versions/RestoreByLabel('${args.options.label}')`;

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -533,7 +533,6 @@ export const spo = {
     * @param siteRelativeUrl site relative url e.g. /Shared Documents/Folder1
     * @param formDigestValue formDigestValue
     */
-
   getFolderIdentity(webObjectIdentity: string, webUrl: string, siteRelativeUrl: string, formDigestValue: string): Promise<IdentityResponse> {
     const serverRelativePath: string = urlUtil.getServerRelativePath(webUrl, siteRelativeUrl);
 


### PR DESCRIPTION
Closes #4968

---

### Remarks

- `spo file move` was not updated. More research is needed to see which API we can use that does support special URL chars. Since this will likely be a breaking change, this cannot be included in this PR.