### PR TITLE
Fixes use of special chars in 'spo folder' commands

### DIFF
--- a/docs/docs/cmd/spo/folder/folder-add.mdx
+++ b/docs/docs/cmd/spo/folder/folder-add.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # spo folder add
 
@@ -17,7 +19,7 @@ m365 spo folder add [options]
 : The URL of the site where the folder will be created.
 
 `-p, --parentFolderUrl <parentFolderUrl>`
-: The server- or site-relative URL of the parent folder.
+: The server- or site-relative decoded URL of the parent folder.
 
 `-n, --name <name>`
 : Name of the new folder to be created
@@ -38,3 +40,76 @@ Creates folder in a specific folder within the site
 ```sh
 m365 spo folder add --webUrl https://contoso.sharepoint.com/sites/project-x --parentFolderUrl '/sites/project-x/Shared Documents/Reports' --name 'Financial reports'
 ```
+
+## Response
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ```json
+  {
+    "Exists": true,
+    "ExistsAllowThrowForPolicyFailures": true,
+    "IsWOPIEnabled": false,
+    "ItemCount": 0,
+    "Name": "My new folder",
+    "ProgID": null,
+    "ServerRelativeUrl": "/sites/project-x/Shared Documents/My new folder",
+    "TimeCreated": "2023-07-20T19:29:16Z",
+    "TimeLastModified": "2023-07-20T19:29:16Z",
+    "UniqueId": "94a9aa56-f0b5-4268-941f-737c841ba7c7",
+    "WelcomePage": ""
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="Text">
+
+  ```text
+  Exists                           : true
+  ExistsAllowThrowForPolicyFailures: true
+  IsWOPIEnabled                    : false
+  ItemCount                        : 0
+  Name                             : My new folder
+  ProgID                           : null
+  ServerRelativeUrl                : /sites/project-x/Shared Documents/My new folder
+  TimeCreated                      : 2023-07-20T19:29:16Z
+  TimeLastModified                 : 2023-07-20T19:29:16Z
+  UniqueId                         : 94a9aa56-f0b5-4268-941f-737c841ba7c7
+  WelcomePage                      :
+  ```
+
+  </TabItem>
+  <TabItem value="CSV">
+
+  ```csv
+  Exists,ExistsAllowThrowForPolicyFailures,IsWOPIEnabled,ItemCount,Name,ServerRelativeUrl,TimeCreated,TimeLastModified,UniqueId,WelcomePage
+  1,1,,0,My new folder,/sites/project-x/Shared Documents/My new folder,2023-07-20T19:29:16Z,2023-07-20T19:29:16Z,94a9aa56-f0b5-4268-941f-737c841ba7c7,
+  ```
+
+  </TabItem>
+  <TabItem value="Markdown">
+
+  ```md
+  # spo folder add --webUrl "https://contoso.sharepoint.com/sites/project-x" --parentFolderUrl "/sites/project-x/Shared Documents" --name "My new folder"
+
+  Date: 20/7/2023
+
+  ## My new folder (94a9aa56-f0b5-4268-941f-737c841ba7c7)
+
+  Property | Value
+  ---------|-------
+  Exists | true
+  ExistsAllowThrowForPolicyFailures | true
+  IsWOPIEnabled | false
+  ItemCount | 0
+  Name | My new folder
+  ServerRelativeUrl | /sites/project-x/Shared Documents/My new folder
+  TimeCreated | 2023-07-20T19:29:16Z
+  TimeLastModified | 2023-07-20T19:29:16Z
+  UniqueId | 94a9aa56-f0b5-4268-941f-737c841ba7c7
+  WelcomePage |
+  ```
+
+  </TabItem>
+</Tabs>

--- a/docs/docs/cmd/spo/folder/folder-get.mdx
+++ b/docs/docs/cmd/spo/folder/folder-get.mdx
@@ -17,7 +17,7 @@ m365 spo folder get [options]
 : The URL of the site where the folder is located.
 
 `-f, --url [url]`
-: The server- or site-relative URL of the folder to retrieve. Specify either `folderUrl` or `id` but not both.
+: The server- or site-relative decoded URL of the folder to retrieve. Specify either `folderUrl` or `id` but not both.
 
 `-i, --id [id]`
 : The UniqueId (GUID) of the folder to retrieve. Specify either `url` or `id` but not both.

--- a/docs/docs/cmd/spo/folder/folder-list.mdx
+++ b/docs/docs/cmd/spo/folder/folder-list.mdx
@@ -19,7 +19,7 @@ m365 spo folder list [options]
 : The URL of the site where the folders to list are located.
 
 `-p, --parentFolderUrl <parentFolderUrl>`
-: The server- or site-relative URL of the parent folder.
+: The server- or site-relative decoded URL of the parent folder.
 
 `-f, --fields [fields]`
 : Comma-separated list of fields to retrieve. Will retrieve all fields if not specified and json output is requested.

--- a/docs/docs/cmd/spo/folder/folder-remove.mdx
+++ b/docs/docs/cmd/spo/folder/folder-remove.mdx
@@ -17,7 +17,7 @@ m365 spo folder remove [options]
 : The URL of the site where the folder to be deleted is located.
 
 `-f, --url <url>`
-: The server- or site-relative URL of the folder to delete.
+: The server- or site-relative decoded URL of the folder to delete.
 
 `--recycle`
 : Recycles the folder instead of actually deleting it.

--- a/docs/docs/cmd/spo/folder/folder-rename.mdx
+++ b/docs/docs/cmd/spo/folder/folder-rename.mdx
@@ -17,7 +17,7 @@ m365 spo folder rename [options]
 : The URL of the site where the folder to be renamed is located.
 
 `-f, --url <url>`
-: The server- or site-relative URL of the folder (including the folder).
+: The server- or site-relative decoded URL of the folder (including the folder).
 
 `-n, --name <name>`
 : New name for the target folder.
@@ -38,3 +38,7 @@ Renames a folder with a specific server-relative URL
 ```sh
 m365 spo folder rename --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/Shared Documents/My Folder 1' --name 'My Folder 2'
 ```
+
+## Response
+
+The command won't return a response on success.

--- a/docs/docs/cmd/spo/folder/folder-retentionlabel-ensure.mdx
+++ b/docs/docs/cmd/spo/folder/folder-retentionlabel-ensure.mdx
@@ -17,7 +17,7 @@ m365 spo folder retentionlabel ensure [options]
 : URL of the site where the retention label from a file to apply is located
 
 `--folderUrl [folderUrl]`
-: The server- or site-relative URL of the folder that should be labelled. Specify either `folderUrl` or `folderId` but not both.
+: The server- or site-relative decoded URL of the folder that should be labelled. Specify either `folderUrl` or `folderId` but not both.
 
 `i, --folderId [folderId]`
 : The UniqueId (GUID) of the folder that should be labelled. Specify either `folderUrl` or `folderId` but not both.

--- a/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.mdx
+++ b/docs/docs/cmd/spo/folder/folder-retentionlabel-remove.mdx
@@ -17,7 +17,7 @@ m365 spo folder retentionlabel remove [options]
 : The url of the web.
 
 `--folderUrl [folderUrl]`
-: The server- or site-relative URL of the folder of which the label should be removed. Specify either `folderUrl` or `folderId` but not both.
+: The server- or site-relative decoded URL of the folder of which the label should be removed. Specify either `folderUrl` or `folderId` but not both.
 
 `-i, --folderId [folderId]`
 : The UniqueId (GUID) of the folder of which the label should be removed. Specify either `folderUrl` or `folderId` but not both.

--- a/docs/docs/cmd/spo/folder/folder-roleassignment-add.mdx
+++ b/docs/docs/cmd/spo/folder/folder-roleassignment-add.mdx
@@ -17,7 +17,7 @@ m365 spo folder roleassignment add [options]
 : The URL of the site where the folder is located.
 
 `-f, --folderUrl <folderUrl>`
-: The server- or site-relative URL of the folder.
+: The server- or site-relative decoded URL of the folder.
 
 `--principalId [principalId]`
 : The SharePoint principal id. It may be either an user id or group id for which the role assignment will be addd. Specify either upn, groupName or principalId but not multiple.
@@ -32,7 +32,7 @@ m365 spo folder roleassignment add [options]
 : ID of the role definition. Specify either roleDefinitionId or roleDefinitionName but not both.
 
 `--roleDefinitionName [roleDefinitionName]`
-: The name of the role definition. E.g. 'Contribute', 'Read'. Specify either roleDefinitionId or roleDefinitionName but not both
+: The name of the role definition. E.g. 'Contribute', 'Read'. Specify either roleDefinitionId or roleDefinitionName but not both.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/folder/folder-roleassignment-remove.mdx
+++ b/docs/docs/cmd/spo/folder/folder-roleassignment-remove.mdx
@@ -17,7 +17,7 @@ m365 spo folder roleassignment remove [options]
 : The URL of the site where the folder is located.
 
 `-f, --folderUrl <folderUrl>`
-: The server- or site-relative URL of the folder.
+: The server- or site-relative decoded URL of the folder.
 
 `--principalId [principalId]`
 : The SharePoint principal id. It may be either an user id or group id for which the role assignment will be removed. Specify either upn, groupName or principalId but not multiple.

--- a/docs/docs/cmd/spo/folder/folder-roleinheritance-break.mdx
+++ b/docs/docs/cmd/spo/folder/folder-roleinheritance-break.mdx
@@ -17,7 +17,7 @@ m365 spo folder roleinheritance break [options]
 : URL of the site where the folder is located.
 
 `-f, --folderUrl <folderUrl>`
-: The server- or site-relative URL of the folder.
+: The server- or site-relative decoded URL of the folder.
 
 `-c, --clearExistingPermissions`
 : Clear all existing permissions from the folder.

--- a/docs/docs/cmd/spo/folder/folder-roleinheritance-reset.mdx
+++ b/docs/docs/cmd/spo/folder/folder-roleinheritance-reset.mdx
@@ -17,7 +17,7 @@ m365 spo folder roleinheritance reset [options]
 : URL of the site where the folder is located.
 
 `-f, --folderUrl <folderUrl>`
-: The server- or site-relative URL of the folder.
+: The server- or site-relative decoded URL of the folder.
 
 `--confirm`
 : Don't prompt for confirmation to reset role inheritance of the folder.

--- a/src/m365/spo/commands/folder/folder-add.spec.ts
+++ b/src/m365/spo/commands/folder/folder-add.spec.ts
@@ -11,6 +11,7 @@ import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
 import commands from '../../commands';
+import { formatting } from '../../../../utils/formatting';
 const command: Command = require('./folder-add');
 
 describe(commands.FOLDER_ADD, () => {
@@ -127,10 +128,9 @@ describe(commands.FOLDER_ADD, () => {
       }
     });
     assert(request.calledWith({
-      url: 'https://contoso.sharepoint.com/_api/web/folders',
+      url: `https://contoso.sharepoint.com/_api/web/folders/addUsingPath(decodedUrl='${formatting.encodeQueryParameter('/Shared Documents/abc')}')`,
       headers:
         { accept: 'application/json;odata=nometadata' },
-      data: { ServerRelativeUrl: '/Shared Documents/abc' },
       responseType: 'json'
     }));
   });
@@ -147,10 +147,9 @@ describe(commands.FOLDER_ADD, () => {
       }
     });
     assert(request.calledWith({
-      url: 'https://contoso.sharepoint.com/sites/test1/_api/web/folders',
+      url: `https://contoso.sharepoint.com/sites/test1/_api/web/folders/addUsingPath(decodedUrl='${formatting.encodeQueryParameter('/sites/test1/Shared Documents/abc')}')`,
       headers:
         { accept: 'application/json;odata=nometadata' },
-      data: { ServerRelativeUrl: '/sites/test1/Shared Documents/abc' },
       responseType: 'json'
     }));
   });

--- a/src/m365/spo/commands/folder/folder-add.ts
+++ b/src/m365/spo/commands/folder/folder-add.ts
@@ -1,6 +1,7 @@
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
+import { formatting } from '../../../../utils/formatting';
 import { urlUtil } from '../../../../utils/urlUtil';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
@@ -60,14 +61,11 @@ class SpoFolderAddCommand extends SpoCommand {
 
     const parentFolderServerRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.parentFolderUrl);
     const serverRelativeUrl: string = `${parentFolderServerRelativeUrl}/${args.options.name}`;
-    const requestUrl: string = `${args.options.webUrl}/_api/web/folders`;
+    const requestUrl: string = `${args.options.webUrl}/_api/web/folders/addUsingPath(decodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
     const requestOptions: CliRequestOptions = {
       url: requestUrl,
       headers: {
         'accept': 'application/json;odata=nometadata'
-      },
-      data: {
-        'ServerRelativeUrl': serverRelativeUrl
       },
       responseType: 'json'
     };

--- a/src/m365/spo/commands/folder/folder-get.spec.ts
+++ b/src/m365/spo/commands/folder/folder-get.spec.ts
@@ -367,7 +367,7 @@ describe(commands.FOLDER_GET, () => {
 
     stubGetResponses = (getResp: any = null) => {
       return sinon.stub(request, 'get').callsFake(async (opts) => {
-        if ((opts.url as string).indexOf('GetFolderByServerRelativeUrl') > -1 || (opts.url as string).indexOf('GetFolderById') > -1) {
+        if ((opts.url as string).indexOf('GetFolderByServerRelativePath(') > -1 || (opts.url as string).indexOf('GetFolderById') > -1) {
           if (getResp) {
             return getResp;
           }
@@ -492,7 +492,7 @@ describe(commands.FOLDER_GET, () => {
       }
     });
     const lastCall: any = request.lastCall.args[0];
-    assert.strictEqual(lastCall.url, 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents\')');
+    assert.strictEqual(lastCall.url, 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents\')');
   });
 
   it('should pass the correct url params to request (sites/test1)', async () => {
@@ -506,7 +506,7 @@ describe(commands.FOLDER_GET, () => {
       }
     });
     const lastCall: any = request.lastCall.args[0];
-    assert.strictEqual(lastCall.url, 'https://contoso.sharepoint.com/sites/test1/_api/web/GetFolderByServerRelativeUrl(\'%2Fsites%2Ftest1%2FShared%20Documents\')');
+    assert.strictEqual(lastCall.url, 'https://contoso.sharepoint.com/sites/test1/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2Fsites%2Ftest1%2FShared%20Documents\')');
   });
 
   it('retrieves details of folder if folder url and withPermissions option is passed', async () => {
@@ -526,7 +526,7 @@ describe(commands.FOLDER_GET, () => {
     const error = "Please ensure the specified folder URL or folder Id does not refer to a root folder. Use \'spo list get\' with withPermissions instead.";
 
     sinon.stub(request, 'get').callsFake(async opts => {
-      if ((opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl('%2FShared%20Documents')?$expand=ListItemAllFields/HasUniqueRoleAssignments,ListItemAllFields/RoleAssignments/Member,ListItemAllFields/RoleAssignments/RoleDefinitionBindings`)) {
+      if ((opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2FShared%20Documents')?$expand=ListItemAllFields/HasUniqueRoleAssignments,ListItemAllFields/RoleAssignments/Member,ListItemAllFields/RoleAssignments/RoleDefinitionBindings`)) {
         return { "data": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 2, "Name": "Shared Documents", "ProgID": null, "ServerRelativeUrl": "/Shared Documents", "TimeCreated": "2018-05-02T23:21:45Z", "TimeLastModified": "2018-05-02T23:21:45Z", "UniqueId": "0ac3da45-cacf-4c31-9b38-9ef3697d5a66", "WelcomePage": "" } };
       }
       throw error;

--- a/src/m365/spo/commands/folder/folder-get.ts
+++ b/src/m365/spo/commands/folder/folder-get.ts
@@ -102,7 +102,7 @@ class SpoFolderGetCommand extends SpoCommand {
     }
     else if (args.options.url) {
       const serverRelativePath: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.url);
-      requestUrl += `/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativePath)}')`;
+      requestUrl += `/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')`;
     }
     if (args.options.withPermissions) {
       requestUrl += `?$expand=ListItemAllFields/HasUniqueRoleAssignments,ListItemAllFields/RoleAssignments/Member,ListItemAllFields/RoleAssignments/RoleDefinitionBindings`;

--- a/src/m365/spo/commands/folder/folder-list.spec.ts
+++ b/src/m365/spo/commands/folder/folder-list.spec.ts
@@ -19,7 +19,7 @@ describe(commands.FOLDER_LIST, () => {
   const webUrl = 'https://contoso.sharepoint.com';
   const parentFolderUrl = '/Shared Documents';
   const serverRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, parentFolderUrl);
-  const requestUrl: string = `${webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(serverRelativeUrl)}'&$skip=0&$top=5000`;
+  const requestUrl: string = `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/Folders?$skip=0&$top=5000`;
 
   const folderListOutput = {
     value: [
@@ -133,7 +133,7 @@ describe(commands.FOLDER_LIST, () => {
 
   it('retrieves folders with filter and fields option, requesting the ListItemAllFields Id property', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(serverRelativeUrl)}'&$skip=0&$top=5000&$expand=ListItemAllFields&$select=ListItemAllFields/Id,Name&$filter=name eq 'Folder1'`) {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/Folders?$skip=0&$top=5000&$expand=ListItemAllFields&$select=ListItemAllFields/Id,Name&$filter=name eq 'Folder1'`) {
         return {
           value: [
             {
@@ -177,11 +177,11 @@ describe(commands.FOLDER_LIST, () => {
     };
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(serverRelativeUrl)}'&$skip=0&$top=5000`) {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/Folders?$skip=0&$top=5000`) {
         return folderThresholdLimitOutput;
       }
 
-      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(serverRelativeUrl)}'&$skip=5000&$top=5000`) {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/Folders?$skip=5000&$top=5000`) {
         return folderListOutput;
       }
 
@@ -218,9 +218,9 @@ describe(commands.FOLDER_LIST, () => {
   });
 
   it('returns all information recursive for output type json', async () => {
-    const serverRelativeUrlLevel1First: string = `${webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(urlUtil.getServerRelativePath(webUrl, `${parentFolderUrl}/Test`))}'&$skip=0&$top=5000`;
-    const serverRelativeUrlLevel2First: string = `${webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(urlUtil.getServerRelativePath(webUrl, `${parentFolderUrl}/Test/Test2`))}'&$skip=0&$top=5000`;
-    const serverRelativeUrlLevel2Second: string = `${webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(urlUtil.getServerRelativePath(webUrl, `${parentFolderUrl}/Test/Test3`))}'&$skip=0&$top=5000`;
+    const serverRelativeUrlLevel1First: string = `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(urlUtil.getServerRelativePath(webUrl, `${parentFolderUrl}/Test`))}')/Folders?$skip=0&$top=5000`;
+    const serverRelativeUrlLevel2First: string = `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(urlUtil.getServerRelativePath(webUrl, `${parentFolderUrl}/Test/Test2`))}')/Folders?$skip=0&$top=5000`;
+    const serverRelativeUrlLevel2Second: string = `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(urlUtil.getServerRelativePath(webUrl, `${parentFolderUrl}/Test/Test3`))}')/Folders?$skip=0&$top=5000`;
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === requestUrl) {
         return folderListOutputSingleFolder;
@@ -277,7 +277,7 @@ describe(commands.FOLDER_LIST, () => {
   it('should send correct request params when /sites/abc', async () => {
     const webUrl = 'https://contoso.sharepoint.com/sites/abc';
     const serverRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, parentFolderUrl);
-    const requestUrl: string = `${webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(serverRelativeUrl)}'&$skip=0&$top=5000`;
+    const requestUrl: string = `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/Folders?$skip=0&$top=5000`;
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === requestUrl) {
         return folderListOutput;

--- a/src/m365/spo/commands/folder/folder-list.ts
+++ b/src/m365/spo/commands/folder/folder-list.ts
@@ -114,7 +114,7 @@ class SpoFolderListCommand extends SpoCommand {
 
     const allFolders: FolderProperties[] = [];
     const serverRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, parentFolderUrl);
-    const requestUrl = `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl(@url)/Folders?@url='${formatting.encodeQueryParameter(serverRelativeUrl)}'`;
+    const requestUrl = `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/Folders`;
     const queryParams = [`$skip=${skip}`, `$top=${SpoFolderListCommand.pageSize}`];
 
     if (fieldProperties.expandProperties.length > 0) {
@@ -130,7 +130,7 @@ class SpoFolderListCommand extends SpoCommand {
     }
 
     const requestOptions: CliRequestOptions = {
-      url: `${requestUrl}&${queryParams.join('&')}`,
+      url: `${requestUrl}?${queryParams.join('&')}`,
       method: 'GET',
       headers: {
         'accept': 'application/json;odata=nometadata'

--- a/src/m365/spo/commands/folder/folder-remove.ts
+++ b/src/m365/spo/commands/folder/folder-remove.ts
@@ -39,8 +39,8 @@ class SpoFolderRemoveCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        recycle: (!(!args.options.recycle)).toString(),
-        confirm: (!(!args.options.confirm)).toString()
+        recycle: !!args.options.recycle,
+        confirm: !!args.options.confirm
       });
     });
   }
@@ -68,6 +68,10 @@ class SpoFolderRemoveCommand extends SpoCommand {
     );
   }
 
+  protected getExcludedOptionsWithUrls(): string[] | undefined {
+    return ['url'];
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (args.options.confirm) {
       await this.removeFolder(logger, args.options);
@@ -91,8 +95,8 @@ class SpoFolderRemoveCommand extends SpoCommand {
       logger.logToStderr(`Removing folder in site at ${options.webUrl}...`);
     }
 
-    const serverRelativeUrl: string = urlUtil.getServerRelativePath(options.webUrl, options.url);
-    let requestUrl: string = `${options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
+    const serverRelativePath: string = urlUtil.getServerRelativePath(options.webUrl, options.url);
+    let requestUrl: string = `${options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')`;
     if (options.recycle) {
       requestUrl += `/recycle()`;
     }

--- a/src/m365/spo/commands/folder/folder-rename.spec.ts
+++ b/src/m365/spo/commands/folder/folder-rename.spec.ts
@@ -6,99 +6,32 @@ import { Cli } from '../../../../cli/Cli';
 import { CommandInfo } from '../../../../cli/CommandInfo';
 import { Logger } from '../../../../cli/Logger';
 import Command, { CommandError } from '../../../../Command';
-import config from '../../../../config';
 import request from '../../../../request';
 import { pid } from '../../../../utils/pid';
 import { session } from '../../../../utils/session';
 import { sinonUtil } from '../../../../utils/sinonUtil';
-import { spo } from '../../../../utils/spo';
 import commands from '../../commands';
+import { formatting } from '../../../../utils/formatting';
 
 const command: Command = require('./folder-rename');
 
 describe(commands.FOLDER_RENAME, () => {
   let log: string[];
   let logger: Logger;
-  let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let stubAllPostRequests: any;
+
+  const webUrl = 'https://contoso.sharepoint.com/sites/project-x';
+  const folderRelSiteUrl = '/Shared Documents/Folder1';
+  const folderRelServerUrl = '/sites/project-x/Shared Documents/Folder1';
+  const newFolderName = 'New name';
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(spo, 'getRequestDigest').resolves({
-      FormDigestValue: 'abc',
-      FormDigestTimeoutSeconds: 1800,
-      FormDigestExpiresAt: new Date(),
-      WebFullUrl: 'https://contoso.sharepoint.com'
-    });
+
     auth.service.connected = true;
-
-    stubAllPostRequests = (
-      requestObjectIdentityResp: any = null,
-      folderObjectIdentityResp: any = null,
-      folderRenameResp: any = null
-    ): sinon.SinonStub => {
-      return sinon.stub(request, 'post').callsFake(async (opts) => {
-        // fake requestObjectIdentity
-        if (opts.data.indexOf('3747adcd-a3c3-41b9-bfab-4a64dd2f1e0a') > -1) {
-          if (requestObjectIdentityResp) {
-            return requestObjectIdentityResp;
-          }
-          else {
-            return JSON.stringify([{
-              "SchemaVersion": "15.0.0.0",
-              "LibraryVersion": "16.0.7331.1206",
-              "ErrorInfo": null,
-              "TraceCorrelationId": "38e4499e-10a2-5000-ce25-77d4ccc2bd96"
-            }, 7, {
-              "_ObjectType_": "SP.Web",
-              "_ObjectIdentity_": "38e4499e-10a2-5000-ce25-77d4ccc2bd96|740c6a0b-85e2-48a0-a494-e0f1759d4a77:site:f3806c23-0c9f-42d3-bc7d-3895acc06d73:web:5a39e548-b3d7-4090-9cb9-0ce7cd85d275",
-              "ServerRelativeUrl": "\u002fsites\u002fabc"
-            }]);
-          }
-        }
-
-        // fake requestFolderObjectIdentity
-        if (opts.data.indexOf('GetFolderByServerRelativeUrl') > -1) {
-          if (folderObjectIdentityResp) {
-            return folderObjectIdentityResp;
-          }
-          else {
-            return JSON.stringify([
-              {
-                "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.7618.1204", "ErrorInfo": null, "TraceCorrelationId": "e52c649e-a019-5000-c38d-8d334a079fd2"
-              }, 27, {
-                "IsNull": false
-              }, 28, {
-                "_ObjectIdentity_": "e52c649e-a019-5000-c38d-8d334a079fd2|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:7f1c42fe-5933-430d-bafb-6c839aa87a5c:web:30a3906a-a55e-4f48-aaae-ecf45346bf53:folder:10c46485-5035-475f-a40f-d842bab30708"
-              }, 29, {
-                "_ObjectType_": "SP.Folder", "_ObjectIdentity_": "e52c649e-a019-5000-c38d-8d334a079fd2|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:7f1c42fe-5933-430d-bafb-6c839aa87a5c:web:30a3906a-a55e-4f48-aaae-ecf45346bf53:folder:10c46485-5035-475f-a40f-d842bab30708", "Name": "Test2", "ServerRelativeUrl": "\u002fsites\u002fabc\u002fShared Documents\u002fTest2"
-              }
-            ]);
-          }
-        }
-
-        // fake folder rename/move success
-        if (opts.data.indexOf('Name="MoveTo"') > -1) {
-          if (folderRenameResp) {
-            return folderRenameResp;
-          }
-          else {
-
-            return JSON.stringify([
-              {
-                "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.7618.1204", "ErrorInfo": null, "TraceCorrelationId": "e52c649e-5023-5000-c38d-86fa815f3928"
-              }
-            ]);
-          }
-        }
-
-        throw 'Invalid request';
-      });
-    };
     commandInfo = Cli.getCommandInfo(command);
   });
 
@@ -115,12 +48,11 @@ describe(commands.FOLDER_RENAME, () => {
         log.push(msg);
       }
     };
-    loggerLogSpy = sinon.spy(logger, 'log');
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      request.post
+      request.patch
     ]);
   });
 
@@ -130,147 +62,68 @@ describe(commands.FOLDER_RENAME, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name.startsWith(commands.FOLDER_RENAME), true);
+    assert.strictEqual(command.name, commands.FOLDER_RENAME);
   });
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('should send correct folder remove request data', async () => {
-    const requestStub: sinon.SinonStub = stubAllPostRequests();
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com/sites/abc',
-      url: '/Shared Documents/Test2',
-      name: 'test1',
-      verbose: true,
-      debug: true
-    };
-    const folderObjectIdentity: string = "e52c649e-a019-5000-c38d-8d334a079fd2|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:7f1c42fe-5933-430d-bafb-6c839aa87a5c:web:30a3906a-a55e-4f48-aaae-ecf45346bf53:folder:10c46485-5035-475f-a40f-d842bab30708";
+  it('renames folder correctly by using server relative URL', async () => {
+    const patchStub = sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/Web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderRelServerUrl)}')/ListItemAllFields`) {
+        return;
+      }
 
-    await command.action(logger, { options: options } as any);
-    const bodyPayload = `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="MoveTo" Id="32" ObjectPathId="26"><Parameters><Parameter Type="String">/sites/abc/Shared Documents/test1</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="26" Name="${folderObjectIdentity}" /></ObjectPaths></Request>`;
-    assert.strictEqual(requestStub.lastCall.args[0].data, bodyPayload);
+      throw 'Invalid request URL: ' + opts.url;
+    });
+
+    await command.action(logger, {
+      options:
+      {
+        verbose: true,
+        webUrl: webUrl,
+        url: folderRelServerUrl,
+        name: newFolderName
+      }
+    });
+    assert(patchStub.called);
+    assert.deepStrictEqual(patchStub.lastCall.args[0].data, { FileLeafRef: newFolderName, Title: newFolderName });
   });
 
-  it('should not display anything when folder removed, but not verbose', async () => {
-    stubAllPostRequests();
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com/sites/abc',
-      url: '/Shared Documents/Test2',
-      name: 'test1'
-    };
+  it('renames folder correctly by using site relative URL', async () => {
+    const patchStub = sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/Web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderRelServerUrl)}')/ListItemAllFields`) {
+        return;
+      }
 
-    await command.action(logger, { options: options } as any);
-    assert.strictEqual(loggerLogSpy.called, false);
+      throw 'Invalid request URL: ' + opts.url;
+    });
+
+    await command.action(logger, {
+      options:
+      {
+        webUrl: webUrl,
+        url: folderRelSiteUrl,
+        name: newFolderName
+      }
+    });
+    assert(patchStub.called);
+    assert.deepStrictEqual(patchStub.lastCall.args[0].data, { FileLeafRef: newFolderName, Title: newFolderName });
   });
 
-  it('should correctly handle requestObjectIdentity reject promise', async () => {
-    stubAllPostRequests(new Promise<any>((resolve, reject) => { return reject('requestObjectIdentity error'); }));
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'test1',
-      verbose: true
-    };
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('requestObjectIdentity error'));
-  });
+  it('handles API error correctly', async () => {
+    sinon.stub(request, 'patch').resolves({ 'odata.null': true });
 
-  it('should correctly handle requestObjectIdentity ClientSvc error response', async () => {
-    const error = JSON.stringify([{ "ErrorInfo": { "ErrorMessage": "requestObjectIdentity ClientSvc error" } }]);
-    stubAllPostRequests(error);
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'test1',
-      verbose: true
-    };
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('requestObjectIdentity ClientSvc error'));
-  });
-
-  it('should correctly handle requestFolderObjectIdentity reject promise', async () => {
-    stubAllPostRequests(null, new Promise<any>((resolve, reject) => { return reject('abc 1'); }));
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'test1',
-      verbose: true
-    };
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('abc 1'));
-  });
-
-  it('should correctly handle requestFolderObjectIdentity ClientSvc error response', async () => {
-    const error = JSON.stringify([{ "ErrorInfo": { "ErrorMessage": "requestFolderObjectIdentity error" } }]);
-    stubAllPostRequests(null, error);
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'test1',
-      verbose: true
-    };
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('requestFolderObjectIdentity error'));
-  });
-
-  it('should correctly handle requestFolderObjectIdentity ClientSvc empty error response', async () => {
-    const error = JSON.stringify([{ "ErrorInfo": { "ErrorMessage": "" } }]);
-    stubAllPostRequests(null, error);
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'test1',
-      verbose: true
-    };
-
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('ClientSvc unknown error'));
-  });
-
-  it('should requestFolderObjectIdentity reject promise if _ObjectIdentity_ not found', async () => {
-    stubAllPostRequests(null, '[{}]');
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'abc'
-    };
-
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('Cannot proceed. Folder _ObjectIdentity_ not found'));
-  });
-
-  it('should correctly handle folder remove reject promise response', async () => {
-    stubAllPostRequests(null, null, new Promise<any>((resolve, reject) => { return reject('folder remove promise error'); }));
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'abc'
-    };
-
-    await assert.rejects(command.action(logger, { options: options } as any), new CommandError('folder remove promise error'));
-  });
-
-  it('should correctly handle folder rename ClientSvc error response', async () => {
-    const error = JSON.stringify([{ "ErrorInfo": { "ErrorMessage": "File Not Found" } }]);
-    stubAllPostRequests(null, null, error);
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'abc'
-    };
-
-    await assert.rejects(command.action(logger, { options: options } as any),
-      new CommandError('File Not Found'));
-  });
-
-  it('should correctly handle ClientSvc empty error response', async () => {
-    const error = JSON.stringify([{ "ErrorInfo": { "ErrorMessage": "" } }]);
-    stubAllPostRequests(null, null, error);
-    const options = {
-      webUrl: 'https://contoso.sharepoint.com',
-      url: '/Shared Documents/test',
-      name: 'test1',
-      verbose: true
-    };
-
-    await assert.rejects(command.action(logger, { options: options } as any),
-      new CommandError('ClientSvc unknown error'));
+    await assert.rejects(command.action(logger, {
+      options:
+      {
+        debug: true,
+        webUrl: 'https://contoso.sharepoint.com',
+        url: '/Shared Documents/Folder1',
+        recycle: true
+      }
+    } as any), new CommandError('Folder not found.'));
   });
 
   it('fails validation if the webUrl option is not valid', async () => {

--- a/src/m365/spo/commands/folder/folder-rename.ts
+++ b/src/m365/spo/commands/folder/folder-rename.ts
@@ -1,8 +1,7 @@
 import { Logger } from '../../../../cli/Logger';
-import config from '../../../../config';
 import GlobalOptions from '../../../../GlobalOptions';
 import request, { CliRequestOptions } from '../../../../request';
-import { ClientSvcResponse, ClientSvcResponseContents, spo } from '../../../../utils/spo';
+import { formatting } from '../../../../utils/formatting';
 import { urlUtil } from '../../../../utils/urlUtil';
 import { validation } from '../../../../utils/validation';
 import SpoCommand from '../../../base/SpoCommand';
@@ -61,36 +60,31 @@ class SpoFolderRenameCommand extends SpoCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const contextResponse = await spo.getRequestDigest(args.options.webUrl);
-      const formDigestValue = contextResponse.FormDigestValue;
-      const webIdentityResp = await spo.getCurrentWebIdentity(args.options.webUrl, formDigestValue);
-      const folderObjectIdentity = await spo.getFolderIdentity(webIdentityResp.objectIdentity, args.options.webUrl, args.options.url, formDigestValue);
-
       if (this.verbose) {
         logger.logToStderr(`Renaming folder ${args.options.url} to ${args.options.name}`);
       }
 
-      const serverRelativePath: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.url);
-      const serverRelativeUrlWithoutOldFolder: string = serverRelativePath.substring(0, serverRelativePath.lastIndexOf('/'));
-      const renamedServerRelativeUrl: string = `${serverRelativeUrlWithoutOldFolder}/${args.options.name}`;
-
+      const serverRelativePath = urlUtil.getServerRelativePath(args.options.webUrl, args.options.url);
       const requestOptions: CliRequestOptions = {
-        url: `${args.options.webUrl}/_vti_bin/client.svc/ProcessQuery`,
+        url: `${args.options.webUrl}/_api/Web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')/ListItemAllFields`,
         headers: {
-          'X-RequestDigest': formDigestValue
+          accept: 'application/json;odata=nometadata',
+          'if-match': '*'
         },
-        data: `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><Method Name="MoveTo" Id="32" ObjectPathId="26"><Parameters><Parameter Type="String">${renamedServerRelativeUrl}</Parameter></Parameters></Method></Actions><ObjectPaths><Identity Id="26" Name="${folderObjectIdentity.objectIdentity}" /></ObjectPaths></Request>`
+        data: {
+          FileLeafRef: args.options.name,
+          Title: args.options.name
+        },
+        responseType: 'json'
       };
 
-      const res = await request.post<string>(requestOptions);
-      const json: ClientSvcResponse = JSON.parse(res);
-      const contents: ClientSvcResponseContents = json.find(x => { return x['ErrorInfo']; });
-      if (contents && contents.ErrorInfo) {
-        throw contents.ErrorInfo.ErrorMessage || 'ClientSvc unknown error';
+      const response = await request.patch<any>(requestOptions);
+      if (response && response['odata.null'] === true) {
+        throw 'Folder not found.';
       }
     }
     catch (err: any) {
-      this.handleRejectedPromise(err);
+      this.handleRejectedODataJsonPromise(err);
     }
   }
 }

--- a/src/m365/spo/commands/folder/folder-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-ensure.spec.ts
@@ -87,7 +87,7 @@ describe(commands.FOLDER_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the retentionlabel to a folder based on folderUrl', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
         return folderResponse;
       }
 

--- a/src/m365/spo/commands/folder/folder-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-ensure.ts
@@ -146,7 +146,7 @@ class SpoFolderRetentionLabelEnsureCommand extends SpoCommand {
     }
     else {
       const serverRelativeUrl = urlUtil.getServerRelativePath(args.options.webUrl, args.options.folderUrl!);
-      requestUrl += `GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
+      requestUrl += `GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
     }
 
     const requestOptions: CliRequestOptions = {

--- a/src/m365/spo/commands/folder/folder-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-remove.spec.ts
@@ -115,7 +115,7 @@ describe(commands.FOLDER_RETENTIONLABEL_REMOVE, () => {
 
   it('removes the retentionlabel from a folder based on folderUrl when prompt confirmed', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
         return folderResponse;
       }
 

--- a/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
@@ -164,7 +164,7 @@ class SpoFolderRetentionLabelRemoveCommand extends SpoCommand {
     }
     else {
       const serverRelativeUrl = urlUtil.getServerRelativePath(args.options.webUrl, args.options.folderUrl!);
-      requestUrl += `GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
+      requestUrl += `GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
     }
 
     const requestOptions: CliRequestOptions = {

--- a/src/m365/spo/commands/folder/folder-roleassignment-add.spec.ts
+++ b/src/m365/spo/commands/folder/folder-roleassignment-add.spec.ts
@@ -128,11 +128,11 @@ describe(commands.FOLDER_ROLEASSIGNMENT_ADD, () => {
 
   it('add the role assignment to the specified folder based on the upn and role definition id', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
         return;
       }
 
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
         return;
       }
 
@@ -197,11 +197,11 @@ describe(commands.FOLDER_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly handles error when upn does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents\')/ListItemAllFields/breakroleinheritance(true)') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents\')/ListItemAllFields/breakroleinheritance(true)') {
         return;
       }
 
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
         return;
       }
 
@@ -234,11 +234,11 @@ describe(commands.FOLDER_ROLEASSIGNMENT_ADD, () => {
 
   it('add the role assignment to the specified folder based on the group name and role definition id', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
         return;
       }
 
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
         return;
       }
 
@@ -273,11 +273,11 @@ describe(commands.FOLDER_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly handles error when group does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
         return;
       }
 
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
         return;
       }
 
@@ -310,11 +310,11 @@ describe(commands.FOLDER_ROLEASSIGNMENT_ADD, () => {
 
   it('add the role assignment to the specified folder based on the principal id and role definition name', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
         return;
       }
 
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
         return;
       }
 
@@ -349,11 +349,11 @@ describe(commands.FOLDER_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly handles error when role definition does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/breakroleinheritance(true)') {
         return;
       }
 
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') {
         return;
       }
 

--- a/src/m365/spo/commands/folder/folder-roleassignment-add.ts
+++ b/src/m365/spo/commands/folder/folder-roleassignment-add.ts
@@ -139,7 +139,7 @@ class SpoFolderRoleAssignmentAddCommand extends SpoCommand {
         requestUrl += `GetList('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
       }
       else {
-        requestUrl += `GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields`;
+        requestUrl += `GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields`;
       }
 
       const roleDefinitionId = await this.getRoleDefinitionId(args.options);

--- a/src/m365/spo/commands/folder/folder-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/folder/folder-roleassignment-remove.spec.ts
@@ -123,7 +123,7 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
 
   it('remove role assignment from folder by folderUrl', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
         return;
       }
 
@@ -143,7 +143,7 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
 
   it('remove role assignment from folder and get principal id by upn', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
         return;
       }
 
@@ -173,7 +173,7 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
 
   it('correctly handles error when upn does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
         return;
       }
 
@@ -202,7 +202,7 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
 
   it('remove role assignment from folder and get principal id by group name', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
         return;
       }
 
@@ -232,7 +232,7 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
 
   it('correctly handles error when group does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
         return;
       }
 
@@ -291,7 +291,7 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
 
   it('removes role assignment when prompt confirmed', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativeUrl(\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
+      if (opts.url === 'https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2FShared%20Documents%2FFolderPermission\')/ListItemAllFields/roleassignments/removeroleassignment(principalid=\'11\')') {
         return;
       }
 

--- a/src/m365/spo/commands/folder/folder-roleassignment-remove.ts
+++ b/src/m365/spo/commands/folder/folder-roleassignment-remove.ts
@@ -109,7 +109,7 @@ class SpoFolderRoleAssignmentRemoveCommand extends SpoCommand {
         logger.logToStderr(`Removing role assignment from folder in site at ${args.options.webUrl}...`);
       }
       const serverRelativeUrl: string = urlUtil.getServerRelativePath(args.options.webUrl, args.options.folderUrl);
-      const requestUrl: string = `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields`;
+      const requestUrl: string = `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields`;
 
       try {
         if (args.options.upn) {

--- a/src/m365/spo/commands/folder/folder-roleinheritance-break.spec.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-break.spec.ts
@@ -117,7 +117,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
   it('breaks role inheritance on folder by site-relative URL (debug)', async () => {
     const serverRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, folderUrl);
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
         return;
       }
 
@@ -137,7 +137,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
   it('breaks role inheritance on folder by site-relative URL when prompt confirmed', async () => {
     const serverRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, folderUrl);
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/breakroleinheritance(true)`) {
         return;
       }
 
@@ -178,7 +178,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
   it('breaks role inheritance and clears existing scopes on folder by site-relative URL when prompt confirmed', async () => {
     const serverRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, folderUrl);
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/breakroleinheritance(false)`) {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields/breakroleinheritance(false)`) {
         return;
       }
 

--- a/src/m365/spo/commands/folder/folder-roleinheritance-break.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-break.ts
@@ -80,7 +80,7 @@ class SpoFolderRoleInheritanceBreakCommand extends SpoCommand {
           requestUrl += `GetList('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
         }
         else {
-          requestUrl += `GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields`;
+          requestUrl += `GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields`;
         }
         const requestOptions: CliRequestOptions = {
           url: `${requestUrl}/breakroleinheritance(${keepExistingPermissions})`,

--- a/src/m365/spo/commands/folder/folder-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-reset.spec.ts
@@ -114,7 +114,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_RESET, () => {
 
   it('resets role inheritance on folder by site-relative URL (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl('%2Fsites%2Fproject-x%2FShared%20Documents%2FTestFolder')/ListItemAllFields/resetroleinheritance`) {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%20Documents%2FTestFolder')/ListItemAllFields/resetroleinheritance`) {
         return;
       }
 
@@ -133,7 +133,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_RESET, () => {
 
   it('resets role inheritance on folder by site-relative URL when prompt confirmed', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativeUrl('%2Fsites%2Fproject-x%2FShared%20Documents%2FTestFolder')/ListItemAllFields/resetroleinheritance`) {
+      if (opts.url === `${webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='%2Fsites%2Fproject-x%2FShared%20Documents%2FTestFolder')/ListItemAllFields/resetroleinheritance`) {
         return;
       }
 

--- a/src/m365/spo/commands/folder/folder-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-reset.ts
@@ -74,7 +74,7 @@ class SpoFolderRoleInheritanceResetCommand extends SpoCommand {
           requestUrl += `GetList('${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
         }
         else {
-          requestUrl += `GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields`;
+          requestUrl += `GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')/ListItemAllFields`;
         }
         const requestOptions: CliRequestOptions = {
           url: `${requestUrl}/resetroleinheritance`,

--- a/src/utils/spo.spec.ts
+++ b/src/utils/spo.spec.ts
@@ -29,7 +29,7 @@ const stubGetResponses: any = (
   getFolderByServerRelativeUrlResp: any = null
 ) => {
   return sinon.stub(request, 'get').callsFake((opts) => {
-    if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativeUrl(') > -1) {
+    if ((opts.url as string).indexOf('/_api/web/GetFolderByServerRelativePath(DecodedUrl=') > -1) {
       if (getFolderByServerRelativeUrlResp) {
         return getFolderByServerRelativeUrlResp;
       }
@@ -804,8 +804,8 @@ describe('utils/spo', () => {
     spo
       .ensureFolder("https://contoso.sharepoint.com/sites/Site1", "/folder2/folder3", logger, true)
       .then(() => {
-        assert.strictEqual(getStubs.getCall(0).args[0].url, 'https://contoso.sharepoint.com/sites/Site1/_api/web/GetFolderByServerRelativeUrl(\'%2Fsites%2FSite1%2Ffolder2\')');
-        assert.strictEqual(getStubs.getCall(1).args[0].url, 'https://contoso.sharepoint.com/sites/Site1/_api/web/GetFolderByServerRelativeUrl(\'%2Fsites%2FSite1%2Ffolder2%2Ffolder3\')');
+        assert.strictEqual(getStubs.getCall(0).args[0].url, 'https://contoso.sharepoint.com/sites/Site1/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2Fsites%2FSite1%2Ffolder2\')');
+        assert.strictEqual(getStubs.getCall(1).args[0].url, 'https://contoso.sharepoint.com/sites/Site1/_api/web/GetFolderByServerRelativePath(DecodedUrl=\'%2Fsites%2FSite1%2Ffolder2%2Ffolder3\')');
         done();
       }, (err: any) => {
         done(err);

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -401,7 +401,7 @@ export const spo = {
       const folderServerRelativeUrl = urlUtil.getServerRelativePath(webFullUrl, nextFolder);
 
       const requestOptions: any = {
-        url: `${webFullUrl}/_api/web/GetFolderByServerRelativeUrl('${formatting.encodeQueryParameter(folderServerRelativeUrl)}')`,
+        url: `${webFullUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderServerRelativeUrl)}')`,
         headers: {
           'accept': 'application/json;odata=nometadata'
         }


### PR DESCRIPTION
Closes #5328

---

### Remarks

It's worth noting that:

- `spo folder remove` had a bug where it was not possible to specify a site-relative URL (e.g. `/TestLib/FolderName`).
- `spo folder rename` used CSOM API request which did not support special URL characters (`#` and `%`). Updated the command to use SP REST API request that does support it.
- `spo folder add` used an API where you could only specify `ServerRelativeUrl` which does not support special URL chars. Changed the endpoint to another API that does support special URL chars. The output of the command is identical so this is **not** a breaking change.
- `spo folder copy` and `spo folder move` was not updated. More research is needed to see which API we can use that does support special URL chars. Since this will likely be a breaking change, this cannot be included in this PR.