### PR TITLE
Fixes planner util getPlansByRosterId to return a single plan. Closes #5335

### DIFF
--- a/src/m365/planner/commands/bucket/bucket-add.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.ts
@@ -140,7 +140,7 @@ class PlannerBucketAddCommand extends GraphCommand {
       return plan.id!;
     }
 
-    const plans = await planner.getPlansByRosterId(args.options.rosterId!);
+    const plans = await planner.getPlanByRosterId(args.options.rosterId!);
     return plans.id!;
   }
 

--- a/src/m365/planner/commands/bucket/bucket-add.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.ts
@@ -141,7 +141,7 @@ class PlannerBucketAddCommand extends GraphCommand {
     }
 
     const plans = await planner.getPlansByRosterId(args.options.rosterId!);
-    return plans[0].id!;
+    return plans.id!;
   }
 
   private async getGroupId(args: CommandArgs): Promise<string> {

--- a/src/m365/planner/commands/bucket/bucket-get.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.ts
@@ -183,7 +183,7 @@ class PlannerBucketGetCommand extends GraphCommand {
     }
 
     const plans = await planner.getPlansByRosterId(rosterId!);
-    return plans[0].id!;
+    return plans.id!;
   }
 
   private async getBucketById(id: string): Promise<PlannerBucket> {

--- a/src/m365/planner/commands/bucket/bucket-get.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.ts
@@ -182,7 +182,7 @@ class PlannerBucketGetCommand extends GraphCommand {
       return plan.id!;
     }
 
-    const plans = await planner.getPlansByRosterId(rosterId!);
+    const plans = await planner.getPlanByRosterId(rosterId!);
     return plans.id!;
   }
 

--- a/src/m365/planner/commands/bucket/bucket-list.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.ts
@@ -118,7 +118,7 @@ class PlannerBucketListCommand extends GraphCommand {
       return plan.id!;
     }
 
-    const plans = await planner.getPlansByRosterId(args.options.rosterId!);
+    const plans = await planner.getPlanByRosterId(args.options.rosterId!);
     return plans.id!;
   }
 

--- a/src/m365/planner/commands/bucket/bucket-list.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.ts
@@ -119,7 +119,7 @@ class PlannerBucketListCommand extends GraphCommand {
     }
 
     const plans = await planner.getPlansByRosterId(args.options.rosterId!);
-    return plans[0].id!;
+    return plans.id!;
   }
 
   private async getGroupId(args: CommandArgs): Promise<string> {

--- a/src/m365/planner/commands/bucket/bucket-remove.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.ts
@@ -219,7 +219,7 @@ class PlannerBucketRemoveCommand extends GraphCommand {
     }
 
     const plans = await planner.getPlansByRosterId(rosterId!);
-    return plans[0].id!;
+    return plans.id!;
   }
 
   private async getGroupId(args: CommandArgs): Promise<string> {

--- a/src/m365/planner/commands/bucket/bucket-remove.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.ts
@@ -218,7 +218,7 @@ class PlannerBucketRemoveCommand extends GraphCommand {
       return plan.id!;
     }
 
-    const plans = await planner.getPlansByRosterId(rosterId!);
+    const plans = await planner.getPlanByRosterId(rosterId!);
     return plans.id!;
   }
 

--- a/src/m365/planner/commands/bucket/bucket-set.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.ts
@@ -213,7 +213,7 @@ class PlannerBucketSetCommand extends GraphCommand {
     }
 
     const plans = await planner.getPlansByRosterId(rosterId!);
-    return plans[0].id!;
+    return plans.id!;
   }
 
   private async getGroupId(args: CommandArgs): Promise<string> {

--- a/src/m365/planner/commands/bucket/bucket-set.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.ts
@@ -212,7 +212,7 @@ class PlannerBucketSetCommand extends GraphCommand {
       return plan.id!;
     }
 
-    const plans = await planner.getPlansByRosterId(rosterId!);
+    const plans = await planner.getPlanByRosterId(rosterId!);
     return plans.id!;
   }
 

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -110,7 +110,7 @@ class PlannerPlanGetCommand extends GraphCommand {
       else {
         let plan: PlannerPlan = {};
         if (args.options.rosterId) {
-          plan = await planner.getPlansByRosterId(args.options.rosterId);
+          plan = await planner.getPlanByRosterId(args.options.rosterId);
         }
         else {
           let groupId = undefined;

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -110,8 +110,7 @@ class PlannerPlanGetCommand extends GraphCommand {
       else {
         let plan: PlannerPlan = {};
         if (args.options.rosterId) {
-          const plans: PlannerPlan[] = await planner.getPlansByRosterId(args.options.rosterId);
-          plan = plans[0];
+          plan = await planner.getPlansByRosterId(args.options.rosterId);
         }
         else {
           let groupId = undefined;

--- a/src/m365/planner/commands/plan/plan-list.spec.ts
+++ b/src/m365/planner/commands/plan/plan-list.spec.ts
@@ -92,6 +92,7 @@ describe(commands.PLAN_LIST, () => {
       }
     ]
   };
+
   const formattedResponse = [{
     "createdDateTime": "2021-03-10T17:39:43.1045549Z",
     "owner": "233e43d0-dc6a-482e-9b4e-0de7a7bce9b4",
@@ -276,7 +277,7 @@ describe(commands.PLAN_LIST, () => {
     };
 
     await command.action(logger, { options: options } as any);
-    assert(loggerLogSpy.calledWith(formattedResponse));
+    assert(loggerLogSpy.calledWith(formattedResponse[0]));
   });
 
   it('correctly handles no plan found with given ownerGroupId', async () => {

--- a/src/m365/planner/commands/plan/plan-list.ts
+++ b/src/m365/planner/commands/plan/plan-list.ts
@@ -90,7 +90,7 @@ class PlannerPlanListCommand extends GraphCommand {
         }
       }
       else {
-        plannerPlans = await planner.getPlansByRosterId(args.options.rosterId!);
+        plannerPlans = await planner.getPlanByRosterId(args.options.rosterId!);
 
         if (plannerPlans) {
           logger.log(plannerPlans);

--- a/src/m365/planner/commands/plan/plan-list.ts
+++ b/src/m365/planner/commands/plan/plan-list.ts
@@ -84,13 +84,17 @@ class PlannerPlanListCommand extends GraphCommand {
       if (args.options.ownerGroupId || args.options.ownerGroupName) {
         const groupId = await this.getGroupId(args);
         plannerPlans = await planner.getPlansByGroupId(groupId);
+
+        if (plannerPlans && plannerPlans.length > 0) {
+          logger.log(plannerPlans);
+        }
       }
       else {
         plannerPlans = await planner.getPlansByRosterId(args.options.rosterId!);
-      }
 
-      if (plannerPlans && plannerPlans.length > 0) {
-        logger.log(plannerPlans);
+        if (plannerPlans) {
+          logger.log(plannerPlans);
+        }
       }
     }
     catch (err: any) {

--- a/src/m365/planner/commands/plan/plan-set.ts
+++ b/src/m365/planner/commands/plan/plan-set.ts
@@ -189,8 +189,8 @@ class PlannerPlanSetCommand extends GraphCommand {
     let groupId: string = '';
 
     if (args.options.rosterId) {
-      const plans: PlannerPlan[] = await planner.getPlansByRosterId(args.options.rosterId);
-      return plans[0].id!;
+      const plan: PlannerPlan = await planner.getPlansByRosterId(args.options.rosterId);
+      return plan.id!;
     }
     else {
       groupId = await this.getGroupId(args);

--- a/src/m365/planner/commands/plan/plan-set.ts
+++ b/src/m365/planner/commands/plan/plan-set.ts
@@ -189,7 +189,7 @@ class PlannerPlanSetCommand extends GraphCommand {
     let groupId: string = '';
 
     if (args.options.rosterId) {
-      const plan: PlannerPlan = await planner.getPlansByRosterId(args.options.rosterId);
+      const plan: PlannerPlan = await planner.getPlanByRosterId(args.options.rosterId);
       return plan.id!;
     }
     else {

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -41,7 +41,7 @@ export const planner = {
    * Get all Planner plans for a specific roster.
    * @param rosterId Roster ID.
    */
-  async getPlansByRosterId(rosterId: string, metadata: 'none' | 'minimal' | 'full' = 'none'): Promise<PlannerPlan> {
+  async getPlanByRosterId(rosterId: string, metadata: 'none' | 'minimal' | 'full' = 'none'): Promise<PlannerPlan> {
     const plans = await odata.getAllItems<PlannerPlan>(`${graphResource}/beta/planner/rosters/${rosterId}/plans`, metadata);
     return plans[0];
   },

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -41,8 +41,9 @@ export const planner = {
    * Get all Planner plans for a specific roster.
    * @param rosterId Roster ID.
    */
-  getPlansByRosterId(rosterId: string, metadata: 'none' | 'minimal' | 'full' = 'none'): Promise<PlannerPlan[]> {
-    return odata.getAllItems<PlannerPlan>(`${graphResource}/beta/planner/rosters/${rosterId}/plans`, metadata);
+  async getPlansByRosterId(rosterId: string, metadata: 'none' | 'minimal' | 'full' = 'none'): Promise<PlannerPlan> {
+    const plans = await odata.getAllItems<PlannerPlan>(`${graphResource}/beta/planner/rosters/${rosterId}/plans`, metadata);
+    return plans[0];
   },
 
   /**


### PR DESCRIPTION
Fixes planner util `getPlansByRosterId` to return a single plan. Closes #5335