### PR TITLE
Fixes 'getAppCatalogSiteUrl'

### DIFF
--- a/src/m365/base/ContextCommand.spec.ts
+++ b/src/m365/base/ContextCommand.spec.ts
@@ -48,6 +48,10 @@ describe('ContextCommand', () => {
     ]);
   });
 
+  after(() => {
+    sinon.restore();
+  });
+
   it('logs an error if an error occurred while reading the .m365rc.json', () => {
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'readFileSync').throws(new Error('An error has occurred'));

--- a/src/m365/spo/commands/app/SpoAppBaseCommand.spec.ts
+++ b/src/m365/spo/commands/app/SpoAppBaseCommand.spec.ts
@@ -1,0 +1,138 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import request from '../../../../request';
+import { SpoAppBaseCommand } from './SpoAppBaseCommand';
+import { sinonUtil } from '../../../../utils/sinonUtil';
+
+class MockCommand extends SpoAppBaseCommand {
+  public get name(): string {
+    return 'mock';
+  }
+
+  public get description(): string {
+    return 'Mock command';
+  }
+
+  public async commandAction(): Promise<void> {
+  }
+
+  public commandHelp(): void {
+  }
+}
+
+describe('SpoAppBaseCommand', () => {
+  const authSiteUrl = 'https://contoso.sharepoint.com';
+  const tenantAppCatalogUrl = 'https://contoso.sharepoint.com/sites/apps';
+
+  const cmd: any = new MockCommand();
+  const logger = {
+    log: () => { },
+    logRaw: () => { },
+    logToStderr: () => { }
+  };
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+  });
+
+  it('returns site collection URL correctly', async () => {
+    const actual = await cmd.getAppCatalogSiteUrl(logger, authSiteUrl, {
+      options: {
+        appCatalogUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        appCatalogScope: 'sitecollection'
+      }
+    });
+
+    assert.strictEqual(actual, 'https://contoso.sharepoint.com/sites/project-x');
+  });
+
+  it('returns site collection URL correctly when it has a trailing slash', async () => {
+    const actual = await cmd.getAppCatalogSiteUrl(logger, authSiteUrl, {
+      options: {
+        appCatalogUrl: 'https://contoso.sharepoint.com/sites/project-x/',
+        appCatalogScope: 'sitecollection'
+      }
+    });
+
+    assert.strictEqual(actual, 'https://contoso.sharepoint.com/sites/project-x');
+  });
+
+  it('returns site collection URL correctly when site collection app catalog URL is specified', async () => {
+    const actual = await cmd.getAppCatalogSiteUrl(logger, authSiteUrl, {
+      options: {
+        appCatalogUrl: 'https://contoso.sharepoint.com/sites/project-x/AppCatalog',
+        appCatalogScope: 'sitecollection'
+      }
+    });
+
+    assert.strictEqual(actual, 'https://contoso.sharepoint.com/sites/project-x');
+  });
+
+  it('returns site collection URL correctly when site collection app catalog URL is specified with trailing slash', async () => {
+    const actual = await cmd.getAppCatalogSiteUrl(logger, authSiteUrl, {
+      options: {
+        appCatalogUrl: 'https://contoso.sharepoint.com/sites/project-x/AppCatalog/',
+        appCatalogScope: 'sitecollection'
+      }
+    });
+
+    assert.strictEqual(actual, 'https://contoso.sharepoint.com/sites/project-x');
+  });
+
+  it(`returns site collection URL correctly when site collection is called 'appcatalog'`, async () => {
+    const actual = await cmd.getAppCatalogSiteUrl(logger, authSiteUrl, {
+      options: {
+        appCatalogUrl: 'https://contoso.sharepoint.com/sites/AppCatalog',
+        appCatalogScope: 'sitecollection'
+      }
+    });
+
+    assert.strictEqual(actual, 'https://contoso.sharepoint.com/sites/AppCatalog');
+  });
+
+  it(`returns site collection URL correctly when site collection is called 'appcatalog' and app catalog URL is specified with trailing slash`, async () => {
+    const actual = await cmd.getAppCatalogSiteUrl(logger, authSiteUrl, {
+      options: {
+        appCatalogUrl: 'https://contoso.sharepoint.com/sites/AppCatalog/AppCatalog/',
+        appCatalogScope: 'sitecollection'
+      }
+    });
+
+    assert.strictEqual(actual, 'https://contoso.sharepoint.com/sites/AppCatalog');
+  });
+
+  it('returns tenant app catalog URL correctly', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `${authSiteUrl}/_api/SP_TenantSettings_Current`) {
+        return {
+          CorporateCatalogUrl: tenantAppCatalogUrl
+        };
+      }
+
+      throw 'Invalid request URL: ' + opts.url;
+    });
+
+    const actual = await cmd.getAppCatalogSiteUrl(logger, authSiteUrl, { options: {} });
+    assert.strictEqual(actual, tenantAppCatalogUrl);
+  });
+
+  it('throws error when there is no tenant app catalog', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `${authSiteUrl}/_api/SP_TenantSettings_Current`) {
+        return {
+          CorporateCatalogUrl: null
+        };
+      }
+
+      throw 'Invalid request URL: ' + opts.url;
+    });
+
+    await assert.rejects(cmd.getAppCatalogSiteUrl(logger, authSiteUrl, { options: {} }), new Error('Tenant app catalog is not configured.'));
+  });
+});

--- a/src/m365/spo/commands/app/SpoAppBaseCommand.ts
+++ b/src/m365/spo/commands/app/SpoAppBaseCommand.ts
@@ -1,6 +1,6 @@
 import { Logger } from '../../../../cli/Logger';
 import GlobalOptions from '../../../../GlobalOptions';
-import request from '../../../../request';
+import request, { CliRequestOptions } from '../../../../request';
 import SpoCommand from '../../../base/SpoCommand';
 
 interface CommandArgs {
@@ -13,36 +13,39 @@ interface Options extends GlobalOptions {
 }
 
 export abstract class SpoAppBaseCommand extends SpoCommand {
-  public getAppCatalogSiteUrl(logger: Logger, authSiteUrl: string, args: CommandArgs): Promise<string> {
-    return new Promise<string>((resolve: (appCatalogSiteUrl: string) => void, reject: (error: any) => void): void => {
-      if (args.options.appCatalogScope === 'sitecollection') {
-        return resolve((args.options.appCatalogUrl as string).toLowerCase().replace('/appcatalog', ''));
+  protected async getAppCatalogSiteUrl(logger: Logger, authSiteUrl: string, args: CommandArgs): Promise<string> {
+    if (args.options.appCatalogScope === 'sitecollection') {
+      // Trim any trailing slashes if there are any
+      const appCatalogUrl = args.options.appCatalogUrl!.replace(/\/$/, '');
+      const appCatalogUrlChunks = appCatalogUrl.split('/');
+
+      // Trim the last part of the URL if it ends on '/appcatalog', but don't trim it if the site URL is called like that (/sites/appcatalog).
+      if (appCatalogUrl.toLowerCase().endsWith('/appcatalog') && appCatalogUrlChunks.length !== 5) {
+        return appCatalogUrl.substring(0, appCatalogUrl.lastIndexOf('/'));
       }
+    }
 
-      if (args.options.appCatalogUrl) {
-        return resolve(args.options.appCatalogUrl);
-      }
+    if (args.options.appCatalogUrl) {
+      return args.options.appCatalogUrl!.replace(/\/$/, '');
+    }
 
-      const requestOptions: any = {
-        url: `${authSiteUrl}/_api/SP_TenantSettings_Current`,
-        headers: {
-          accept: 'application/json;odata=nometadata'
-        },
-        responseType: 'json'
-      };
+    if (this.verbose) {
+      logger.logToStderr('Getting tenant app catalog url...');
+    }
 
-      request
-        .get<{ CorporateCatalogUrl?: string }>(requestOptions)
-        .then((res: { CorporateCatalogUrl?: string }) => {
-          if (res.CorporateCatalogUrl) {
-            return resolve(res.CorporateCatalogUrl);
-          }
+    const requestOptions: CliRequestOptions = {
+      url: `${authSiteUrl}/_api/SP_TenantSettings_Current`,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
 
-          reject('Tenant app catalog is not configured.');
-        })
-        .catch((err: any) => {
-          reject(err);
-        });
-    });
+    const response = await request.get<{ CorporateCatalogUrl?: string }>(requestOptions);
+    if (response.CorporateCatalogUrl) {
+      return response.CorporateCatalogUrl;
+    }
+
+    throw new Error('Tenant app catalog is not configured.');
   }
 }


### PR DESCRIPTION
Closes #5399

---

### Remarks

- Refactored the affected function `getAppCatalogSiteUrl` to async/await.
- Made some small improvements to the affected command `spo app add`.
- Noticed there was no test file for `SpoAppBaseCommand.ts`, created one and added some important tests.