### PR TITLE
Enhances 'teams team list' command

### DIFF
--- a/docs/docs/cmd/teams/team/team-list.mdx
+++ b/docs/docs/cmd/teams/team/team-list.mdx
@@ -16,27 +16,60 @@ m365 teams team list [options]
 
 ```md definition-list
 `-j, --joined`
-: Show only joined teams.
+: Show only teams that the user is a direct member of. Specify either `joined` or `associated` but not both.
+
+`-a, --associated`
+: Show only teams that the user is associated with. This includes teams with direct membership and shared channels. Specify either `joined` or `associated` but not both.
+
+`--userId [userId]`
+: The ID of the user. Specify either `userId` or `userName` but not both. Specify only when using `joined` or `associated` options.
+
+`--userName [userName]`
+: The user principal name of the user. Specify either `userId` or `userName` but not both. Specify only when using `joined` or `associated` options.
 ```
 
 <Global />
 
 ## Remarks
 
+:::note
+
+To list `joined` or `associated` teams of another user, you have to be a Teams Administrator or use application permissions.
+
+:::
+
 You can only see the details or archived status of the Microsoft Teams you are a member of.
 
 ## Examples
 
-List all Microsoft Teams in the tenant.
+List all Microsoft Teams in the tenant
 
 ```sh
 m365 teams team list
 ```
 
-List all Microsoft Teams in the tenant you are a member of.
+List all Microsoft Teams teams you are a direct member of
 
 ```sh
 m365 teams team list --joined
+```
+
+List all Microsoft Teams teams you are a direct member of or are associated with via a shared channel
+
+```sh
+m365 teams team list --associated
+```
+
+List all Microsoft Teams teams another user is member of
+
+```sh
+m365 teams team list --joined --userName john.doe@contoso.com
+```
+
+List all Microsoft Teams teams where another user is a direct member of or is associated with via a shared channel
+
+```sh
+m365 teams team list --associated --userId e3aca2a8-625a-449b-bb86-cfa84c5d08de
 ```
 
 ## Response
@@ -99,17 +132,17 @@ m365 teams team list --joined
   <TabItem value="Text">
 
   ```text
-  id                                    displayName       isArchived  description
-  ------------------------------------  ----------------  ----------  ---------------------------------------
-  5dc7ba76-b9aa-4fdd-9e91-9fe7d0e8dca3  Architecture      false       Architecture Discussion
+  id                                    displayName   isArchived  description
+  ------------------------------------  ------------  ----------  -----------------------
+  5dc7ba76-b9aa-4fdd-9e91-9fe7d0e8dca3  Architecture  false       Architecture Discussion
   ```
 
   </TabItem>
   <TabItem value="CSV">
 
   ```csv
-  id,displayName,isArchived,description
-  5dc7ba76-b9aa-4fdd-9e91-9fe7d0e8dca3,Architecture,,Architecture Discussion
+  id,createdDateTime,displayName,description,internalId,specialization,visibility,webUrl,isArchived,isMembershipLimitedToOwners
+  5dc7ba76-b9aa-4fdd-9e91-9fe7d0e8dca3,2022-12-08T09:17:55.039Z,Architecture,Architecture Discussion,19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2,none,public,https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35,,
   ```
 
   </TabItem>
@@ -125,23 +158,15 @@ m365 teams team list --joined
   Property | Value
   ---------|-------
   id | 5dc7ba76-b9aa-4fdd-9e91-9fe7d0e8dca3
-  createdDateTime | null
+  createdDateTime | 2022-12-08T09:17:55.039Z
   displayName | Architecture
   description | Architecture Discussion
-  internalId | null
-  classification | null
-  specialization | null
-  visibility | null
-  webUrl | null
+  internalId | 19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2
+  specialization | none
+  visibility | public
+  webUrl | https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35
   isArchived | false
-  tenantId | 92e59666-257b-49c3-b1fa-1bae8107f6ba
-  isMembershipLimitedToOwners | null
-  memberSettings | null
-  guestSettings | null
-  messagingSettings | null
-  funSettings | null
-  discoverySettings | null
-  summary | null
+  isMembershipLimitedToOwners | false
   ```
 
   </TabItem>

--- a/src/m365/teams/commands/team/team-list.spec.ts
+++ b/src/m365/teams/commands/team/team-list.spec.ts
@@ -8,13 +8,200 @@ import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
+import { Cli } from '../../../../cli/Cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import commands from '../../commands.js';
+import { formatting } from '../../../../utils/formatting.js';
 import command from './team-list.js';
 
 describe(commands.TEAM_LIST, () => {
+  const userId = '2630257f-11d4-4244-b4a1-3707b79f142d';
+  const userName = 'john.doe@contoso.com';
+
+  //#region mock http responses
+  const groupIdResponse = {
+    value: [
+      { id: 'dbeea07d-d766-43b3-b6c8-0ccc22e36803' },
+      { id: 'f3c7e9f3-443c-4ebc-8e8f-3fcf0b1f9b1a' },
+      { id: '0d788de6-8832-4061-bfd3-1834de48967d' }
+    ]
+  };
+
+  const batchResponse = {
+    responses: [
+      {
+        id: '0',
+        status: 200,
+        headers: {
+          'OData-Version': '4.0',
+          'Content-Type': 'application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false;charset=utf-8'
+        },
+        body: {
+          id: groupIdResponse.value[0],
+          createdDateTime: '2020-09-07T07:32:51.001Z',
+          displayName: 'My Team',
+          description: 'My Team description',
+          internalId: '19:42bca71a4d84496a95b1364ed462c2eb@thread.tacv2',
+          classification: null,
+          specialization: 'none',
+          visibility: 'private',
+          webUrl: `https://teams.microsoft.com/l/team/19%3a42bca71a4d84496a95b1364ed462c2eb%40thread.tacv2/conversations?groupId=${groupIdResponse.value[0]}&tenantId=076d38cd-55b0-462f-960f-e11a369a651c`,
+          isArchived: false,
+          isMembershipLimitedToOwners: false,
+          discoverySettings: {
+            showInTeamsSearchAndSuggestions: false
+          },
+          memberSettings: {
+            allowCreateUpdateChannels: true,
+            allowCreatePrivateChannels: true,
+            allowDeleteChannels: true,
+            allowAddRemoveApps: true,
+            allowCreateUpdateRemoveTabs: true,
+            allowCreateUpdateRemoveConnectors: true
+          },
+          guestSettings: {
+            allowCreateUpdateChannels: false,
+            allowDeleteChannels: false
+          },
+          messagingSettings: {
+            allowUserEditMessages: true,
+            allowUserDeleteMessages: true,
+            allowOwnerDeleteMessages: true,
+            allowTeamMentions: true,
+            allowChannelMentions: true
+          },
+          funSettings: {
+            allowGiphy: true,
+            giphyContentRating: 'moderate',
+            allowStickersAndMemes: true,
+            allowCustomMemes: true
+          },
+          summary: {
+            ownersCount: 2,
+            membersCount: 2,
+            guestsCount: 0
+          }
+        }
+      },
+      {
+        id: '1',
+        status: 200,
+        headers: {
+          'OData-Version': '4.0',
+          'Content-Type': 'application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false;charset=utf-8'
+        },
+        body: {
+          id: groupIdResponse.value[1],
+          createdDateTime: '2020-09-07T07:32:51.001Z',
+          displayName: 'My Team 3',
+          description: 'My Team 3 description',
+          internalId: '19:42bca71a4d84496a95b1364ed462c2eb@thread.tacv2',
+          classification: null,
+          specialization: 'none',
+          visibility: 'private',
+          webUrl: `https://teams.microsoft.com/l/team/19%3a42bca71a4d84496a95b1364ed462c2eb%40thread.tacv2/conversations?groupId=${groupIdResponse.value[1]}&tenantId=076d38cd-55b0-462f-960f-e11a369a651c`,
+          isArchived: false,
+          isMembershipLimitedToOwners: false,
+          discoverySettings: {
+            showInTeamsSearchAndSuggestions: false
+          },
+          memberSettings: {
+            allowCreateUpdateChannels: true,
+            allowCreatePrivateChannels: true,
+            allowDeleteChannels: true,
+            allowAddRemoveApps: true,
+            allowCreateUpdateRemoveTabs: true,
+            allowCreateUpdateRemoveConnectors: true
+          },
+          guestSettings: {
+            allowCreateUpdateChannels: false,
+            allowDeleteChannels: false
+          },
+          messagingSettings: {
+            allowUserEditMessages: true,
+            allowUserDeleteMessages: true,
+            allowOwnerDeleteMessages: true,
+            allowTeamMentions: true,
+            allowChannelMentions: true
+          },
+          funSettings: {
+            allowGiphy: true,
+            giphyContentRating: 'moderate',
+            allowStickersAndMemes: true,
+            allowCustomMemes: true
+          },
+          summary: {
+            ownersCount: 2,
+            membersCount: 2,
+            guestsCount: 0
+          }
+        }
+      },
+      {
+        id: '2',
+        status: 200,
+        headers: {
+          'OData-Version': '4.0',
+          'Content-Type': 'application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false;charset=utf-8'
+        },
+        body: {
+          id: groupIdResponse.value[2],
+          createdDateTime: '2020-09-07T07:32:51.001Z',
+          displayName: 'My Team 2',
+          description: 'My Team 2 description',
+          internalId: '19:42bca71a4d84496a95b1364ed462c2eb@thread.tacv2',
+          classification: null,
+          specialization: 'none',
+          visibility: 'private',
+          webUrl: `https://teams.microsoft.com/l/team/19%3a42bca71a4d84496a95b1364ed462c2eb%40thread.tacv2/conversations?groupId=${groupIdResponse.value[2]}&tenantId=076d38cd-55b0-462f-960f-e11a369a651c`,
+          isArchived: false,
+          isMembershipLimitedToOwners: false,
+          discoverySettings: {
+            showInTeamsSearchAndSuggestions: false
+          },
+          memberSettings: {
+            allowCreateUpdateChannels: true,
+            allowCreatePrivateChannels: true,
+            allowDeleteChannels: true,
+            allowAddRemoveApps: true,
+            allowCreateUpdateRemoveTabs: true,
+            allowCreateUpdateRemoveConnectors: true
+          },
+          guestSettings: {
+            allowCreateUpdateChannels: false,
+            allowDeleteChannels: false
+          },
+          messagingSettings: {
+            allowUserEditMessages: true,
+            allowUserDeleteMessages: true,
+            allowOwnerDeleteMessages: true,
+            allowTeamMentions: true,
+            allowChannelMentions: true
+          },
+          funSettings: {
+            allowGiphy: true,
+            giphyContentRating: 'moderate',
+            allowStickersAndMemes: true,
+            allowCustomMemes: true
+          },
+          summary: {
+            ownersCount: 2,
+            membersCount: 2,
+            guestsCount: 0
+          }
+        }
+      }
+    ]
+  };
+
+  const commandResponse = batchResponse.responses.map(r => r.body).sort((x: any, y: any) => x.displayName.localeCompare(y.displayName));
+  //#endregion
+
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+  let postStub: sinon.SinonStub;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -22,6 +209,9 @@ describe(commands.TEAM_LIST, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
+    commandInfo = Cli.getCommandInfo(command);
+    const cli = Cli.getInstance();
+    sinon.stub(cli, 'getSettingWithDefaultValue').returnsArg(1);
   });
 
   beforeEach(() => {
@@ -39,11 +229,20 @@ describe(commands.TEAM_LIST, () => {
     };
     loggerLogSpy = sinon.spy(logger, 'log');
     (command as any).items = [];
+
+    postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/$batch') {
+        return batchResponse;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get
+      request.get,
+      request.post
     ]);
   });
 
@@ -64,595 +263,223 @@ describe(commands.TEAM_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'displayName', 'isArchived', 'description']);
   });
 
-  it('lists Microsoft Teams in the tenant', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$select=id,displayName,description,resourceProvisioningOptions`) {
-        return {
-          "value": [
-            {
-              "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-              "description": "Team 1 description",
-              "displayName": "Team 1",
-              "resourceProvisioningOptions": ["Team"]
-            }
-          ]
-        };
-      }
-      else if ((opts.url as string).startsWith(`https://graph.microsoft.com/v1.0/teams/`)) {
-        const id: string = (<string>opts.url).substring((<string>opts.url).lastIndexOf(`/`) + 1);
-        return {
-          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-          "id": id,
-          "createdDateTime": "2022-12-08T09:17:55.039Z",
-          "displayName": id === "02bd9fd6-8f93-4758-87c3-1fb73740a315" ? "Team 1" : "Team 2",
-          "description": id === "02bd9fd6-8f93-4758-87c3-1fb73740a315" ? "Team 1 description" : "Team 2 description",
-          "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-          "classification": null,
-          "specialization": "none",
-          "visibility": "public",
-          "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-          "isArchived": false,
-          "isMembershipLimitedToOwners": false,
-          "discoverySettings": {
-            "showInTeamsSearchAndSuggestions": true
-          },
-          "memberSettings": {
-            "allowCreateUpdateChannels": true,
-            "allowDeleteChannels": true,
-            "allowAddRemoveApps": true,
-            "allowCreateUpdateRemoveTabs": true,
-            "allowCreateUpdateRemoveConnectors": true
-          },
-          "guestSettings": {
-            "allowCreateUpdateChannels": false,
-            "allowDeleteChannels": false
-          },
-          "messagingSettings": {
-            "allowUserEditMessages": false,
-            "allowUserDeleteMessages": false,
-            "allowOwnerDeleteMessages": false,
-            "allowTeamMentions": true,
-            "allowChannelMentions": true
-          },
-          "funSettings": {
-            "allowGiphy": true,
-            "giphyContentRating": "moderate",
-            "allowStickersAndMemes": true,
-            "allowCustomMemes": false
-          }
-        };
-      }
-
-      throw 'Invalid request';
-    });
-
-    await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith([
-      {
-        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-        "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-        "createdDateTime": "2022-12-08T09:17:55.039Z",
-        "displayName": "Team 1",
-        "description": "Team 1 description",
-        "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-        "classification": null,
-        "specialization": "none",
-        "visibility": "public",
-        "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-        "isArchived": false,
-        "isMembershipLimitedToOwners": false,
-        "discoverySettings": {
-          "showInTeamsSearchAndSuggestions": true
-        },
-        "memberSettings": {
-          "allowCreateUpdateChannels": true,
-          "allowDeleteChannels": true,
-          "allowAddRemoveApps": true,
-          "allowCreateUpdateRemoveTabs": true,
-          "allowCreateUpdateRemoveConnectors": true
-        },
-        "guestSettings": {
-          "allowCreateUpdateChannels": false,
-          "allowDeleteChannels": false
-        },
-        "messagingSettings": {
-          "allowUserEditMessages": false,
-          "allowUserDeleteMessages": false,
-          "allowOwnerDeleteMessages": false,
-          "allowTeamMentions": true,
-          "allowChannelMentions": true
-        },
-        "funSettings": {
-          "allowGiphy": true,
-          "giphyContentRating": "moderate",
-          "allowStickersAndMemes": true,
-          "allowCustomMemes": false
-        }
-      }
-    ]));
+  it('fails validation if userId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { joined: true, userId: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
   });
 
-  it('correctly handles when listing a team a user is not member of', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$select=id,displayName,description,resourceProvisioningOptions`) {
-        return {
-          "value": [
-            {
-              "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-              "description": "Team 1 description",
-              "displayName": "Team 1",
-              "resourceProvisioningOptions": ["Team"]
-            }
-          ]
-        };
-      }
-      else if (opts.url === `https://graph.microsoft.com/v1.0/teams/02bd9fd6-8f93-4758-87c3-1fb73740a315`) {
-        throw { statusCode: 403 };
-      }
-
-      throw 'Invalid request';
-    });
-
-    await command.action(logger, { options: {} });
-    assert(loggerLogSpy.calledWith([
-      {
-        "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-        "displayName": "Team 1",
-        "description": "Team 1 description",
-        "isArchived": undefined
-      }
-    ]));
+  it('fails validation if userName is not a valid UPN', async () => {
+    const actual = await command.validate({ options: { joined: true, userName: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
   });
 
-  it('correctly handles when listing a team a user is not member of, and the graph returns an unexpected error', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$select=id,displayName,description,resourceProvisioningOptions`) {
-        return {
-          "value": [
-            {
-              "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-              "description": "Team 1 description",
-              "displayName": "Team 1",
-              "resourceProvisioningOptions": ["Team"]
-            }
-          ]
-        };
-      }
-
-      throw 'Invalid request';
-    });
-
-    await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('Invalid request'));
+  it('fails validation userName is used without joined or associated option', async () => {
+    const actual = await command.validate({ options: { userName: userName } }, commandInfo);
+    assert.notStrictEqual(actual, true);
   });
 
-  it('lists Microsoft Teams in the tenant (debug)', async () => {
+  it('fails validation userId is used without joined or associated option', async () => {
+    const actual = await command.validate({ options: { userId: userId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both userId and userName are used', async () => {
+    const actual = await command.validate({ options: { joined: true, userId: userId, userName: userName } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both joined and associated options are used', async () => {
+    const actual = await command.validate({ options: { joined: true, associated: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if userId is used with joined option', async () => {
+    const actual = await command.validate({ options: { joined: true, userId: userId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if userName is used with associated option', async () => {
+    const actual = await command.validate({ options: { associated: true, userName: userName } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if only joined option is used', async () => {
+    const actual = await command.validate({ options: { joined: true } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if only associated option is used', async () => {
+    const actual = await command.validate({ options: { associated: true } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('retrieves all teams in the tenant', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$select=id,displayName,description,resourceProvisioningOptions`) {
-        return {
-          "value": [
-            {
-              "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-              "description": "Team 1 description",
-              "displayName": "Team 1",
-              "resourceProvisioningOptions": ["Team"]
-            },
-            {
-              "id": "13be6971-79db-4f33-9d41-b25589ca25af",
-              "description": "Team 2 description",
-              "displayName": "Team 2",
-              "resourceProvisioningOptions": ["Team"]
-            }
-          ]
-        };
-      }
-      else if ((opts.url as string).startsWith(`https://graph.microsoft.com/v1.0/teams/`)) {
-        const id: string = (<string>opts.url).substring((<string>opts.url).lastIndexOf(`/`) + 1);
-        return {
-          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-          "id": id,
-          "createdDateTime": "2022-12-08T09:17:55.039Z",
-          "displayName": id === "02bd9fd6-8f93-4758-87c3-1fb73740a315" ? "Team 1" : "Team 2",
-          "description": id === "02bd9fd6-8f93-4758-87c3-1fb73740a315" ? "Team 1 description" : "Team 2 description",
-          "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-          "classification": null,
-          "specialization": "none",
-          "visibility": "public",
-          "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-          "isArchived": false,
-          "isMembershipLimitedToOwners": false,
-          "discoverySettings": {
-            "showInTeamsSearchAndSuggestions": true
-          },
-          "memberSettings": {
-            "allowCreateUpdateChannels": true,
-            "allowDeleteChannels": true,
-            "allowAddRemoveApps": true,
-            "allowCreateUpdateRemoveTabs": true,
-            "allowCreateUpdateRemoveConnectors": true
-          },
-          "guestSettings": {
-            "allowCreateUpdateChannels": false,
-            "allowDeleteChannels": false
-          },
-          "messagingSettings": {
-            "allowUserEditMessages": false,
-            "allowUserDeleteMessages": false,
-            "allowOwnerDeleteMessages": false,
-            "allowTeamMentions": true,
-            "allowChannelMentions": true
-          },
-          "funSettings": {
-            "allowGiphy": true,
-            "giphyContentRating": "moderate",
-            "allowStickersAndMemes": true,
-            "allowCustomMemes": false
-          }
-        };
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$select=id&$filter=resourceProvisioningOptions/Any(x:x eq 'Team')`) {
+        return groupIdResponse;
       }
 
-      throw 'Invalid request';
+      throw 'Invalid request: ' + opts.url;
     });
 
-    await command.action(logger, { options: { debug: true } });
-    assert(loggerLogSpy.calledWith([
-      {
-        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-        "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-        "createdDateTime": "2022-12-08T09:17:55.039Z",
-        "displayName": "Team 1",
-        "description": "Team 1 description",
-        "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-        "classification": null,
-        "specialization": "none",
-        "visibility": "public",
-        "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-        "isArchived": false,
-        "isMembershipLimitedToOwners": false,
-        "discoverySettings": {
-          "showInTeamsSearchAndSuggestions": true
+    await command.action(logger, {
+      options: {
+        verbose: true
+      }
+    });
+
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      requests: groupIdResponse.value.map((obj, index) => ({
+        id: index.toString(),
+        method: 'GET',
+        headers: {
+          accept: 'application/json;odata.metadata=none'
         },
-        "memberSettings": {
-          "allowCreateUpdateChannels": true,
-          "allowDeleteChannels": true,
-          "allowAddRemoveApps": true,
-          "allowCreateUpdateRemoveTabs": true,
-          "allowCreateUpdateRemoveConnectors": true
+        url: `/teams/${obj.id}`
+      }))
+    });
+    assert(loggerLogSpy.calledOnceWith(commandResponse));
+  });
+
+  it('retrieves all joined teams for the current logged in user', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/me/joinedTeams?$select=id`) {
+        return groupIdResponse;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        joined: true
+      }
+    });
+
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      requests: groupIdResponse.value.map((obj, index) => ({
+        id: index.toString(),
+        method: 'GET',
+        headers: {
+          accept: 'application/json;odata.metadata=none'
         },
-        "guestSettings": {
-          "allowCreateUpdateChannels": false,
-          "allowDeleteChannels": false
+        url: `/teams/${obj.id}`
+      }))
+    });
+    assert(loggerLogSpy.calledOnceWith(commandResponse));
+  });
+
+  it('retrieves all joined teams for a specified user by UPN', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userName)}/joinedTeams?$select=id`) {
+        return groupIdResponse;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        userName: userName,
+        joined: true
+      }
+    });
+
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      requests: groupIdResponse.value.map((obj, index) => ({
+        id: index.toString(),
+        method: 'GET',
+        headers: {
+          accept: 'application/json;odata.metadata=none'
         },
-        "messagingSettings": {
-          "allowUserEditMessages": false,
-          "allowUserDeleteMessages": false,
-          "allowOwnerDeleteMessages": false,
-          "allowTeamMentions": true,
-          "allowChannelMentions": true
+        url: `/teams/${obj.id}`
+      }))
+    });
+    assert(loggerLogSpy.calledOnceWith(commandResponse));
+  });
+
+  it('retrieves all associated teams for the current logged in user', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/me/teamwork/associatedTeams?$select=id`) {
+        return groupIdResponse;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        associated: true
+      }
+    });
+
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      requests: groupIdResponse.value.map((obj, index) => ({
+        id: index.toString(),
+        method: 'GET',
+        headers: {
+          accept: 'application/json;odata.metadata=none'
         },
-        "funSettings": {
-          "allowGiphy": true,
-          "giphyContentRating": "moderate",
-          "allowStickersAndMemes": true,
-          "allowCustomMemes": false
-        }
+        url: `/teams/${obj.id}`
+      }))
+    });
+    assert(loggerLogSpy.calledOnceWith(commandResponse));
+  });
+
+  it('retrieves all associated teams for a specified user by id', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${userId}/teamwork/associatedTeams?$select=id`) {
+        return groupIdResponse;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        userId: userId,
+        associated: true
+      }
+    });
+
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      requests: groupIdResponse.value.map((obj, index) => ({
+        id: index.toString(),
+        method: 'GET',
+        headers: {
+          accept: 'application/json;odata.metadata=none'
+        },
+        url: `/teams/${obj.id}`
+      }))
+    });
+    assert(loggerLogSpy.calledOnceWith(commandResponse));
+  });
+
+  it('handles API error correctly', async () => {
+    postStub.restore();
+
+    const failedResponse: any = { ...batchResponse };
+    failedResponse.responses[1] = {
+      id: '0',
+      status: 404,
+      headers: {
+        'OData-Version': '4.0',
+        'Content-Type': 'application/json;odata.metadata=none;odata.streaming=true;IEEE754Compatible=false;charset=utf-8'
       },
-      {
-        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-        "id": "13be6971-79db-4f33-9d41-b25589ca25af",
-        "createdDateTime": "2022-12-08T09:17:55.039Z",
-        "displayName": "Team 2",
-        "description": "Team 2 description",
-        "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-        "classification": null,
-        "specialization": "none",
-        "visibility": "public",
-        "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-        "isArchived": false,
-        "isMembershipLimitedToOwners": false,
-        "discoverySettings": {
-          "showInTeamsSearchAndSuggestions": true
-        },
-        "memberSettings": {
-          "allowCreateUpdateChannels": true,
-          "allowDeleteChannels": true,
-          "allowAddRemoveApps": true,
-          "allowCreateUpdateRemoveTabs": true,
-          "allowCreateUpdateRemoveConnectors": true
-        },
-        "guestSettings": {
-          "allowCreateUpdateChannels": false,
-          "allowDeleteChannels": false
-        },
-        "messagingSettings": {
-          "allowUserEditMessages": false,
-          "allowUserDeleteMessages": false,
-          "allowOwnerDeleteMessages": false,
-          "allowTeamMentions": true,
-          "allowChannelMentions": true
-        },
-        "funSettings": {
-          "allowGiphy": true,
-          "giphyContentRating": "moderate",
-          "allowStickersAndMemes": true,
-          "allowCustomMemes": false
+      body: {
+        error: {
+          message: 'Resource not found.'
         }
       }
-    ]));
-  });
+    };
 
-  it('lists joined Microsoft Teams in the tenant', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$select=id,displayName,description,resourceProvisioningOptions`) {
-        return {
-          "value": [
-            {
-              "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-              "description": "Team 1 description",
-              "displayName": "Team 1",
-              "resourceProvisioningOptions": ["Team"]
-            },
-            {
-              "id": "13be6971-79db-4f33-9d41-b25589ca25af",
-              "description": "Team 2 description",
-              "displayName": "Team 2",
-              "resourceProvisioningOptions": ["Team"]
-            }
-          ]
-        };
-      }
-      else if ((opts.url as string).startsWith(`https://graph.microsoft.com/v1.0/teams/`)) {
-        const id: string = (<string>opts.url).substring((<string>opts.url).lastIndexOf(`/`) + 1);
-        return {
-          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-          "id": id,
-          "createdDateTime": "2022-12-08T09:17:55.039Z",
-          "displayName": id === "02bd9fd6-8f93-4758-87c3-1fb73740a315" ? "Team 1" : "Team 2",
-          "description": id === "02bd9fd6-8f93-4758-87c3-1fb73740a315" ? "Team 1 description" : "Team 2 description",
-          "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-          "classification": null,
-          "specialization": "none",
-          "visibility": "public",
-          "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-          "isArchived": false,
-          "isMembershipLimitedToOwners": false,
-          "discoverySettings": {
-            "showInTeamsSearchAndSuggestions": true
-          },
-          "memberSettings": {
-            "allowCreateUpdateChannels": true,
-            "allowDeleteChannels": true,
-            "allowAddRemoveApps": true,
-            "allowCreateUpdateRemoveTabs": true,
-            "allowCreateUpdateRemoveConnectors": true
-          },
-          "guestSettings": {
-            "allowCreateUpdateChannels": false,
-            "allowDeleteChannels": false
-          },
-          "messagingSettings": {
-            "allowUserEditMessages": false,
-            "allowUserDeleteMessages": false,
-            "allowOwnerDeleteMessages": false,
-            "allowTeamMentions": true,
-            "allowChannelMentions": true
-          },
-          "funSettings": {
-            "allowGiphy": true,
-            "giphyContentRating": "moderate",
-            "allowStickersAndMemes": true,
-            "allowCustomMemes": false
-          }
-        };
-      }
-      else if (opts.url === `https://graph.microsoft.com/v1.0/me/joinedTeams`) {
-        return {
-          "value": [
-            {
-              "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-              "displayName": "Team 1",
-              "description": "Team 1 description",
-              "isArchived": false
-            },
-            {
-              "id": "13be6971-79db-4f33-9d41-b25589ca25af",
-              "displayName": "Team 2",
-              "description": "Team 2 description",
-              "isArchived": false
-            }
-          ]
-        };
-      }
+    sinon.stub(request, 'post').resolves(failedResponse);
+    sinon.stub(request, 'get').resolves(groupIdResponse);
 
-      throw 'Invalid request';
-    });
-
-    await command.action(logger, { options: { joined: true } });
-    assert(loggerLogSpy.calledWith([
-      {
-        "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-        "displayName": "Team 1",
-        "description": "Team 1 description",
-        "isArchived": false
-      },
-      {
-        "id": "13be6971-79db-4f33-9d41-b25589ca25af",
-        "displayName": "Team 2",
-        "description": "Team 2 description",
-        "isArchived": false
-      }
-    ]));
-  });
-
-  it('lists all properties for output json', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$select=id,displayName,description,resourceProvisioningOptions`) {
-        return {
-          "value": [
-            {
-              "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-              "description": "Team 1 description",
-              "displayName": "Team 1",
-              "resourceProvisioningOptions": ["Team"]
-            },
-            {
-              "id": "13be6971-79db-4f33-9d41-b25589ca25af",
-              "description": "Team 2 description",
-              "displayName": "Team 2",
-              "resourceProvisioningOptions": ["Team"]
-            }
-          ]
-        };
-      }
-      else if ((opts.url as string).startsWith(`https://graph.microsoft.com/v1.0/teams/`)) {
-        const id: string = (<string>opts.url).substring((<string>opts.url).lastIndexOf(`/`) + 1);
-        return {
-          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-          "id": id,
-          "createdDateTime": "2022-12-08T09:17:55.039Z",
-          "displayName": id === "02bd9fd6-8f93-4758-87c3-1fb73740a315" ? "Team 1" : "Team 2",
-          "description": id === "02bd9fd6-8f93-4758-87c3-1fb73740a315" ? "Team 1 description" : "Team 2 description",
-          "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-          "classification": null,
-          "specialization": "none",
-          "visibility": "public",
-          "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-          "isArchived": false,
-          "isMembershipLimitedToOwners": false,
-          "discoverySettings": {
-            "showInTeamsSearchAndSuggestions": true
-          },
-          "memberSettings": {
-            "allowCreateUpdateChannels": true,
-            "allowDeleteChannels": true,
-            "allowAddRemoveApps": true,
-            "allowCreateUpdateRemoveTabs": true,
-            "allowCreateUpdateRemoveConnectors": true
-          },
-          "guestSettings": {
-            "allowCreateUpdateChannels": false,
-            "allowDeleteChannels": false
-          },
-          "messagingSettings": {
-            "allowUserEditMessages": false,
-            "allowUserDeleteMessages": false,
-            "allowOwnerDeleteMessages": false,
-            "allowTeamMentions": true,
-            "allowChannelMentions": true
-          },
-          "funSettings": {
-            "allowGiphy": true,
-            "giphyContentRating": "moderate",
-            "allowStickersAndMemes": true,
-            "allowCustomMemes": false
-          }
-        };
-      }
-      else if (opts.url === `https://graph.microsoft.com/v1.0/me/joinedTeams`) {
-        return {
-          "value": [
-            {
-              "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-              "displayName": "Team 1",
-              "description": "Team 1 description",
-              "isArchived": false
-            },
-            {
-              "id": "13be6971-79db-4f33-9d41-b25589ca25af",
-              "displayName": "Team 2",
-              "description": "Team 2 description",
-              "isArchived": false
-            }
-          ]
-        };
-      }
-
-      throw 'Invalid request';
-    });
-
-    await command.action(logger, { options: { output: 'json' } });
-    assert(loggerLogSpy.calledWith([
-      {
-        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-        "id": "02bd9fd6-8f93-4758-87c3-1fb73740a315",
-        "createdDateTime": "2022-12-08T09:17:55.039Z",
-        "displayName": "Team 1",
-        "description": "Team 1 description",
-        "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-        "classification": null,
-        "specialization": "none",
-        "visibility": "public",
-        "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-        "isArchived": false,
-        "isMembershipLimitedToOwners": false,
-        "discoverySettings": {
-          "showInTeamsSearchAndSuggestions": true
-        },
-        "memberSettings": {
-          "allowCreateUpdateChannels": true,
-          "allowDeleteChannels": true,
-          "allowAddRemoveApps": true,
-          "allowCreateUpdateRemoveTabs": true,
-          "allowCreateUpdateRemoveConnectors": true
-        },
-        "guestSettings": {
-          "allowCreateUpdateChannels": false,
-          "allowDeleteChannels": false
-        },
-        "messagingSettings": {
-          "allowUserEditMessages": false,
-          "allowUserDeleteMessages": false,
-          "allowOwnerDeleteMessages": false,
-          "allowTeamMentions": true,
-          "allowChannelMentions": true
-        },
-        "funSettings": {
-          "allowGiphy": true,
-          "giphyContentRating": "moderate",
-          "allowStickersAndMemes": true,
-          "allowCustomMemes": false
-        }
-      },
-      {
-        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/$entity",
-        "id": "13be6971-79db-4f33-9d41-b25589ca25af",
-        "createdDateTime": "2022-12-08T09:17:55.039Z",
-        "displayName": "Team 2",
-        "description": "Team 2 description",
-        "internalId": "19:pLknmKPPkvgeaG0FtegLfjoDINeY3gvmitMkNG9H3X41@thread.tacv2",
-        "classification": null,
-        "specialization": "none",
-        "visibility": "public",
-        "webUrl": "https://teams.microsoft.com/l/team/19:a5c6eccad3fb401997756a1501d561aa%40thread.skype/conversations?groupId=8090c93e-ba7c-433e-9f39-08c7ba07c0b3&tenantId=dcd219dd-bc68-4b9b-bf0b-4a33a796be35",
-        "isArchived": false,
-        "isMembershipLimitedToOwners": false,
-        "discoverySettings": {
-          "showInTeamsSearchAndSuggestions": true
-        },
-        "memberSettings": {
-          "allowCreateUpdateChannels": true,
-          "allowDeleteChannels": true,
-          "allowAddRemoveApps": true,
-          "allowCreateUpdateRemoveTabs": true,
-          "allowCreateUpdateRemoveConnectors": true
-        },
-        "guestSettings": {
-          "allowCreateUpdateChannels": false,
-          "allowDeleteChannels": false
-        },
-        "messagingSettings": {
-          "allowUserEditMessages": false,
-          "allowUserDeleteMessages": false,
-          "allowOwnerDeleteMessages": false,
-          "allowTeamMentions": true,
-          "allowChannelMentions": true
-        },
-        "funSettings": {
-          "allowGiphy": true,
-          "giphyContentRating": "moderate",
-          "allowStickersAndMemes": true,
-          "allowCustomMemes": false
-        }
-      }
-    ]));
+    await assert.rejects(command.action(logger, { options: {} }), new CommandError('Resource not found.'));
   });
 });


### PR DESCRIPTION
Closes #5377

---

### Remarks

- Added 2 extra options `userId` and `userName`, because you can list teams of another user as well.
- Gave the command a facelift to use Graph batch requests instead of firing single requests.
- Improved the API request to retrieve all groups with a team.