### PR TITLE
Updates spo retentionlabel commands to use bulk-endpoint. Closes #4633

### DIFF
--- a/src/m365/spo/commands/file/file-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-ensure.spec.ts
@@ -12,7 +12,6 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import spoListItemRetentionLabelEnsureCommand from '../listitem/listitem-retentionlabel-ensure.js';
 import command from './file-retentionlabel-ensure.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
@@ -22,12 +21,13 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
   const fileId = 'b2307a39-e878-458b-bc90-03bc578531d6';
   const listId = 1;
   const retentionlabelName = "retentionlabel";
-  const SpoListItemRetentionLabelEnsureCommandOutput = `{ "stdout": "", "stderr": "" }`;
   const fileResponse = {
     ListItemAllFields: {
       Id: listId,
       ParentList: {
-        Id: '75c4d697-bbff-40b8-a740-bf9b9294e5aa'
+        RootFolder: {
+          ServerRelativeUrl: "/Shared Documents"
+        }
       }
     }
   };
@@ -94,7 +94,7 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      Cli.executeCommandWithOutput,
+      request.post,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -114,21 +114,20 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the retentionlabel from a file based on fileUrl', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return fileResponse;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListItemRetentionLabelEnsureCommand) {
-        return ({
-          stdout: SpoListItemRetentionLabelEnsureCommandOutput
-        });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"${retentionlabelName}","itemIds":[1]}`) {
+        return;
       }
 
-      throw new CommandError('Unknown case');
+      throw 'Invalid request';
     });
 
     await assert.doesNotReject(command.action(logger, {
@@ -142,21 +141,20 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the retentionlabel from a file based on fileId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileById('${fileId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileById('${fileId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return fileResponse;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListItemRetentionLabelEnsureCommand) {
-        return ({
-          stdout: SpoListItemRetentionLabelEnsureCommandOutput
-        });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"${retentionlabelName}","itemIds":[1]}`) {
+        return;
       }
 
-      throw new CommandError('Unknown case');
+      throw 'Invalid request';
     });
 
     await assert.doesNotReject(command.action(logger, {
@@ -171,7 +169,7 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the event based retentionlabel from a file based on fileUrl with assetId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return fileResponse;
       }
 
@@ -182,19 +180,12 @@ describe(commands.FILE_RETENTIONLABEL_ENSURE, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListItemRetentionLabelEnsureCommand) {
-        return ({
-          stdout: SpoListItemRetentionLabelEnsureCommandOutput
-        });
-      }
-
-      throw new CommandError('Unknown case');
-    });
-
-
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'${fileResponse.ListItemAllFields.ParentList.Id}')/items(${listId})/ValidateUpdateListItem()`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"${retentionlabelName}","itemIds":[1]}`) {
+        return;
+      }
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetList(@listUrl)/items(${listId})/ValidateUpdateListItem()?@listUrl='${formatting.encodeQueryParameter(fileResponse.ListItemAllFields.ParentList.RootFolder.ServerRelativeUrl)}'`) {
         return {
           "value": [
             {

--- a/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
@@ -1,16 +1,14 @@
-import { AxiosRequestConfig } from 'axios';
-import { Cli } from '../../../../cli/Cli.js';
+import * as url from 'url';
 import { Logger } from '../../../../cli/Logger.js';
-import Command from '../../../../Command.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { formatting } from '../../../../utils/formatting.js';
-import { urlUtil } from '../../../../utils/urlUtil.js';
 import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
-import spoListItemRetentionLabelEnsureCommand, { Options as SpoListItemRetentionLabelEnsureCommandOptions } from '../listitem/listitem-retentionlabel-ensure.js';
 import { FileProperties } from './FileProperties.js';
+import { formatting } from '../../../../utils/formatting.js';
+import { urlUtil } from '../../../../utils/urlUtil.js';
+import { spo } from '../../../../utils/spo.js';
 
 interface CommandArgs {
   options: Options;
@@ -97,32 +95,22 @@ class SpoFileRetentionLabelEnsureCommand extends SpoCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const fileProperties = await this.getFileProperties(logger, args);
+      const parsedUrl = url.parse(args.options.webUrl);
+      const tenantUrl: string = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+      const listAbsoluteUrl = urlUtil.urlCombine(tenantUrl, fileProperties.listServerRelativeUrl);
 
       if (args.options.assetId) {
-        await this.applyAssetId(args.options.webUrl, fileProperties.ListItemAllFields.ParentList.Id, fileProperties.ListItemAllFields.Id, args.options.assetId);
+        await this.applyAssetId(args.options.webUrl, fileProperties.listServerRelativeUrl, fileProperties.listItemId, args.options.assetId);
       }
 
-      const options: SpoListItemRetentionLabelEnsureCommandOptions = {
-        webUrl: args.options.webUrl,
-        listId: fileProperties.ListItemAllFields.ParentList.Id,
-        listItemId: fileProperties.ListItemAllFields.Id,
-        name: args.options.name,
-        output: 'json',
-        debug: this.debug,
-        verbose: this.verbose
-      };
-
-      const spoListItemRetentionLabelEnsureCommandOutput = await Cli.executeCommandWithOutput(spoListItemRetentionLabelEnsureCommand as Command, { options: { ...options, _: [] } });
-      if (this.verbose) {
-        await logger.logToStderr(spoListItemRetentionLabelEnsureCommandOutput.stderr);
-      }
+      await spo.applyRetentionLabelToListItems(args.options.webUrl, args.options.name, listAbsoluteUrl, [parseInt(fileProperties.listItemId)], logger, args.options.verbose);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
   }
 
-  private async getFileProperties(logger: Logger, args: CommandArgs): Promise<FileProperties> {
+  private async getFileProperties(logger: Logger, args: CommandArgs): Promise<{ listItemId: string, listServerRelativeUrl: string }> {
     if (this.verbose) {
       await logger.logToStderr(`Retrieving list and item information for file '${args.options.fileId || args.options.fileUrl}' in site at ${args.options.webUrl}...`);
     }
@@ -137,24 +125,23 @@ class SpoFileRetentionLabelEnsureCommand extends SpoCommand {
       requestUrl += `GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
     }
 
-    const requestOptions: AxiosRequestConfig = {
-      url: `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`,
+    const requestOptions: CliRequestOptions = {
+      url: `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },
       responseType: 'json'
     };
 
-    return request.get<FileProperties>(requestOptions);
+    const response = await request.get<FileProperties>(requestOptions);
+    return { listItemId: response.ListItemAllFields.Id, listServerRelativeUrl: response.ListItemAllFields.ParentList.RootFolder.ServerRelativeUrl };
   }
 
-  private async applyAssetId(webUrl: string, listId: string, listItemId: string, assetId: string): Promise<void> {
-    const requestUrl = `${webUrl}/_api/web/lists(guid'${formatting.encodeQueryParameter(listId)}')`;
-
+  private async applyAssetId(webUrl: string, listServerRelativeUrl: string, listItemId: string, assetId: string): Promise<void> {
     const requestBody = { "formValues": [{ "FieldName": "ComplianceAssetId", "FieldValue": assetId }] };
 
     const requestOptions: CliRequestOptions = {
-      url: `${requestUrl}/items(${listItemId})/ValidateUpdateListItem()`,
+      url: `${webUrl}/_api/web/GetList(@listUrl)/items(${listItemId})/ValidateUpdateListItem()?@listUrl='${formatting.encodeQueryParameter(listServerRelativeUrl)}'`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },

--- a/src/m365/spo/commands/file/file-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-remove.spec.ts
@@ -12,7 +12,6 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import spoListItemRetentionLabelRemoveCommand from '../listitem/listitem-retentionlabel-remove.js';
 import command from './file-retentionlabel-remove.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
@@ -21,12 +20,13 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
   const fileUrl = `/Shared Documents/Fo'lde'r/Document.docx`;
   const fileId = 'b2307a39-e878-458b-bc90-03bc578531d6';
   const listId = 1;
-  const SpoListItemRetentionLabelRemoveCommandOutput = `{ "stdout": "", "stderr": "" }`;
   const fileResponse = {
     ListItemAllFields: {
       Id: listId,
       ParentList: {
-        Id: '75c4d697-bbff-40b8-a740-bf9b9294e5aa'
+        RootFolder: {
+          ServerRelativeUrl: "/Shared Documents"
+        }
       }
     }
   };
@@ -70,6 +70,7 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
+      request.post,
       Cli.promptForConfirmation,
       Cli.executeCommandWithOutput,
       cli.getSettingWithDefaultValue
@@ -111,7 +112,7 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
 
   it('removes the retentionlabel from a file based on fileUrl when prompt confirmed', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return fileResponse;
       }
 
@@ -121,14 +122,13 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
     sinonUtil.restore(Cli.promptForConfirmation);
     sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListItemRetentionLabelRemoveCommand) {
-        return ({
-          stdout: SpoListItemRetentionLabelRemoveCommandOutput
-        });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"","itemIds":[1]}`) {
+        return;
       }
 
-      throw new CommandError('Unknown case');
+      throw 'Invalid request';
     });
 
     await assert.doesNotReject(command.action(logger, {
@@ -141,7 +141,7 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
 
   it('removes the retentionlabel from a file based on fileId when prompt confirmed', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileById('${fileId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileById('${fileId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return fileResponse;
       }
 
@@ -151,14 +151,13 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
     sinonUtil.restore(Cli.promptForConfirmation);
     sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListItemRetentionLabelRemoveCommand) {
-        return ({
-          stdout: SpoListItemRetentionLabelRemoveCommandOutput
-        });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"","itemIds":[1]}`) {
+        return;
       }
 
-      throw new CommandError('Unknown case');
+      throw 'Invalid request';
     });
 
     await assert.doesNotReject(command.action(logger, {
@@ -172,22 +171,22 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
 
   it('removes the retentionlabel from a file based on fileId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileById('${fileId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileById('${fileId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return fileResponse;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListItemRetentionLabelRemoveCommand) {
-        return ({
-          stdout: SpoListItemRetentionLabelRemoveCommandOutput
-        });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"","itemIds":[1]}`) {
+        return;
       }
 
-      throw new CommandError('Unknown case');
+      throw 'Invalid request';
     });
+
 
     await assert.doesNotReject(command.action(logger, {
       options: {

--- a/src/m365/spo/commands/file/file-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-remove.ts
@@ -1,15 +1,14 @@
-import { AxiosRequestConfig } from 'axios';
+import * as url from 'url';
 import { Cli } from '../../../../cli/Cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import Command from '../../../../Command.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
-import request from '../../../../request.js';
+import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { spo } from '../../../../utils/spo.js';
 import { urlUtil } from '../../../../utils/urlUtil.js';
 import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
-import spoListItemRetentionLabelRemoveCommand, { Options as SpoListItemRetentionLabelRemoveCommandOptions } from '../listitem/listitem-retentionlabel-remove.js';
 import { FileProperties } from './FileProperties.js';
 
 interface CommandArgs {
@@ -104,38 +103,23 @@ class SpoFileRetentionLabelRemoveCommand extends SpoCommand {
   }
 
   private async removeFileRetentionLabel(logger: Logger, args: CommandArgs): Promise<void> {
-    if (this.verbose) {
-      await logger.logToStderr(`Removing retention label from file ${args.options.fileId || args.options.fileUrl} in site at ${args.options.webUrl}...`);
-    }
     try {
-      const fileProperties = await this.getFileProperties(args);
-      const options: SpoListItemRetentionLabelRemoveCommandOptions = {
-        webUrl: args.options.webUrl,
-        listId: fileProperties.listId,
-        listItemId: fileProperties.id,
-        force: true,
-        output: 'json',
-        debug: this.debug,
-        verbose: this.verbose
-      };
+      const fileProperties = await this.getFileProperties(logger, args);
+      const parsedUrl = url.parse(args.options.webUrl);
+      const tenantUrl: string = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+      const listAbsoluteUrl = urlUtil.urlCombine(tenantUrl, fileProperties.listServerRelativeUrl);
 
-      const spoListItemRetentionLabelRemoveCommandOutput = await Cli.executeCommandWithOutput(spoListItemRetentionLabelRemoveCommand as Command, { options: { ...options, _: [] } });
-      if (this.verbose) {
-        await logger.logToStderr(spoListItemRetentionLabelRemoveCommandOutput.stderr);
-      }
+      await spo.removeRetentionLabelFromListItems(args.options.webUrl, listAbsoluteUrl, [parseInt(fileProperties.listItemId)], logger, args.options.verbose);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
   }
 
-  private async getFileProperties(args: CommandArgs): Promise<{ id: string, listId: string }> {
-    const requestOptions: AxiosRequestConfig = {
-      headers: {
-        'accept': 'application/json;odata=nometadata'
-      },
-      responseType: 'json'
-    };
+  private async getFileProperties(logger: Logger, args: CommandArgs): Promise<{ listItemId: string, listServerRelativeUrl: string }> {
+    if (this.verbose) {
+      logger.logToStderr(`Retrieving list and item information for file '${args.options.fileId || args.options.fileUrl}' in site at ${args.options.webUrl}...`);
+    }
 
     let requestUrl = `${args.options.webUrl}/_api/web/`;
 
@@ -147,10 +131,16 @@ class SpoFileRetentionLabelRemoveCommand extends SpoCommand {
       requestUrl += `GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativeUrl)}')`;
     }
 
-    requestOptions.url = `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ListItemAllFields/ParentList/Id,ListItemAllFields/Id`;
+    const requestOptions: CliRequestOptions = {
+      url: `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
 
     const response = await request.get<FileProperties>(requestOptions);
-    return { id: response.ListItemAllFields.Id, listId: response.ListItemAllFields.ParentList.Id };
+    return { listItemId: response.ListItemAllFields.Id, listServerRelativeUrl: response.ListItemAllFields.ParentList.RootFolder.ServerRelativeUrl };
   }
 }
 

--- a/src/m365/spo/commands/folder/FolderProperties.ts
+++ b/src/m365/spo/commands/folder/FolderProperties.ts
@@ -32,4 +32,9 @@ interface Member {
 
 interface ParentListFields {
   Id: string;
+  RootFolder: RootFolderFields;
+}
+
+export interface RootFolderFields {
+  ServerRelativeUrl: string;
 }

--- a/src/m365/spo/commands/folder/folder-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-ensure.spec.ts
@@ -12,8 +12,6 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import spoListRetentionLabelEnsureCommand from '../list/list-retentionlabel-ensure.js';
-import spoListItemRetentionLabelEnsureCommand from '../listitem/listitem-retentionlabel-ensure.js';
 import command from './folder-retentionlabel-ensure.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
@@ -23,13 +21,14 @@ describe(commands.FOLDER_RETENTIONLABEL_ENSURE, () => {
   const folderId = 'b2307a39-e878-458b-bc90-03bc578531d6';
   const listId = 1;
   const retentionlabelName = "retentionlabel";
-  const SpoListItemRetentionLabelEnsureCommandOutput = `{ "stdout": "", "stderr": "" }`;
-  const SpoListRetentionLabelEnsureCommandOutput = `{ "stdout": "", "stderr": "" }`;
   const folderResponse = {
     ListItemAllFields: {
       Id: listId,
       ParentList: {
-        Id: '75c4d697-bbff-40b8-a740-bf9b9294e5aa'
+        Id: '75c4d697-bbff-40b8-a740-bf9b9294e5aa',
+        RootFolder: {
+          ServerRelativeUrl: '/Shared Documents'
+        }
       }
     }
   };
@@ -67,6 +66,7 @@ describe(commands.FOLDER_RETENTIONLABEL_ENSURE, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
+      request.post,
       Cli.executeCommandWithOutput,
       cli.getSettingWithDefaultValue
     ]);
@@ -87,21 +87,20 @@ describe(commands.FOLDER_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the retentionlabel to a folder based on folderUrl', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(folderUrl)}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return folderResponse;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListItemRetentionLabelEnsureCommand) {
-        return ({
-          stdout: SpoListItemRetentionLabelEnsureCommandOutput
-        });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"${retentionlabelName}","itemIds":[1]}`) {
+        return;
       }
 
-      throw new CommandError('Unknown case');
+      throw 'Invalid request';
     });
 
     await assert.doesNotReject(command.action(logger, {
@@ -115,21 +114,20 @@ describe(commands.FOLDER_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the retentionlabel to a folder based on folderId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return folderResponse;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListItemRetentionLabelEnsureCommand) {
-        return ({
-          stdout: SpoListItemRetentionLabelEnsureCommandOutput
-        });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"${retentionlabelName}","itemIds":[1]}`) {
+        return;
       }
 
-      throw new CommandError('Unknown case');
+      throw 'Invalid request';
     });
 
     await assert.doesNotReject(command.action(logger, {
@@ -144,21 +142,20 @@ describe(commands.FOLDER_RETENTIONLABEL_ENSURE, () => {
 
   it('adds the retentionlabel to a folder if the folder is the rootfolder of a document library based on folderId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderById('${folderId}')?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`) {
         return { ServerRelativeUrl: '/Shared Documents' };
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoListRetentionLabelEnsureCommand) {
-        return ({
-          stdout: SpoListRetentionLabelEnsureCommandOutput
-        });
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`
+        && JSON.stringify(opts.data) === `{"listUrl":"https://contoso.sharepoint.com/Shared Documents","complianceTagValue":"${retentionlabelName}","blockDelete":false,"blockEdit":false,"syncToItems":false}`) {
+        return;
       }
 
-      throw new CommandError('Unknown case');
+      throw 'Invalid request';
     });
 
     await assert.doesNotReject(command.action(logger, {

--- a/src/m365/spo/commands/folder/folder-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-ensure.ts
@@ -1,15 +1,13 @@
-import Command from '../../../../Command.js';
+import * as url from 'url';
 import GlobalOptions from '../../../../GlobalOptions.js';
-import { Cli } from '../../../../cli/Cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { spo } from '../../../../utils/spo.js';
 import { urlUtil } from '../../../../utils/urlUtil.js';
 import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
-import spoListRetentionLabelEnsureCommand, { Options as SpoListRetentionLabelEnsureCommandOptions } from '../list/list-retentionlabel-ensure.js';
-import spoListItemRetentionLabelEnsureCommand, { Options as SpoListItemRetentionLabelEnsureCommandOptions } from '../listitem/listitem-retentionlabel-ensure.js';
 import { FolderProperties } from './FolderProperties.js';
 
 interface CommandArgs {
@@ -94,37 +92,16 @@ class SpoFolderRetentionLabelEnsureCommand extends SpoCommand {
       const folderProperties = await this.getFolderProperties(logger, args);
 
       if (folderProperties.ListItemAllFields) {
-        const options: SpoListItemRetentionLabelEnsureCommandOptions = {
-          webUrl: args.options.webUrl,
-          listId: folderProperties.ListItemAllFields.ParentList.Id,
-          listItemId: folderProperties.ListItemAllFields.Id,
-          name: args.options.name,
-          output: 'json',
-          debug: this.debug,
-          verbose: this.verbose
-        };
+        const parsedUrl = url.parse(args.options.webUrl);
+        const tenantUrl: string = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+        const listAbsoluteUrl = urlUtil.urlCombine(tenantUrl, folderProperties.ListItemAllFields.ParentList.RootFolder.ServerRelativeUrl);
 
-        const spoListItemRetentionLabelEnsureCommandOutput = await Cli.executeCommandWithOutput(spoListItemRetentionLabelEnsureCommand as Command, { options: { ...options, _: [] } });
-
-        if (this.verbose) {
-          await logger.logToStderr(spoListItemRetentionLabelEnsureCommandOutput.stderr);
-        }
+        await spo.applyRetentionLabelToListItems(args.options.webUrl, args.options.name, listAbsoluteUrl, [parseInt(folderProperties.ListItemAllFields.Id)], logger, args.options.verbose);
       }
       else {
-        const options: SpoListRetentionLabelEnsureCommandOptions = {
-          webUrl: args.options.webUrl,
-          listUrl: folderProperties.ServerRelativeUrl,
-          name: args.options.name,
-          output: 'json',
-          debug: this.debug,
-          verbose: this.verbose
-        };
+        const listAbsoluteUrl: string = urlUtil.getAbsoluteUrl(args.options.webUrl, folderProperties.ServerRelativeUrl);
 
-        const spoListRetentionLabelEnsureCommandOutput = await Cli.executeCommandWithOutput(spoListRetentionLabelEnsureCommand as Command, { options: { ...options, _: [] } });
-
-        if (this.verbose) {
-          await logger.logToStderr(spoListRetentionLabelEnsureCommandOutput.stderr);
-        }
+        await spo.applyDefaultRetentionLabelToList(args.options.webUrl, args.options.name, listAbsoluteUrl, false, logger, args.options.verbose);
       }
     }
     catch (err: any) {
@@ -148,7 +125,7 @@ class SpoFolderRetentionLabelEnsureCommand extends SpoCommand {
     }
 
     const requestOptions: CliRequestOptions = {
-      url: `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`,
+      url: `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },

--- a/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
@@ -1,15 +1,14 @@
-import Command from '../../../../Command.js';
+import * as url from 'url';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import { Cli } from '../../../../cli/Cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { spo } from '../../../../utils/spo.js';
 import { urlUtil } from '../../../../utils/urlUtil.js';
 import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
-import spoListRetentionLabelRemoveCommand, { Options as SpoListRetentionLabelRemoveCommandOptions } from '../list/list-retentionlabel-remove.js';
-import spoListItemRetentionLabelRemoveCommand, { Options as SpoListItemRetentionLabelRemoveCommandOptions } from '../listitem/listitem-retentionlabel-remove.js';
 import { FolderProperties } from './FolderProperties.js';
 
 interface CommandArgs {
@@ -108,36 +107,16 @@ class SpoFolderRetentionLabelRemoveCommand extends SpoCommand {
       const folderProperties = await this.getFolderProperties(logger, args);
 
       if (folderProperties.ListItemAllFields) {
-        const options: SpoListItemRetentionLabelRemoveCommandOptions = {
-          webUrl: args.options.webUrl,
-          listId: folderProperties.ListItemAllFields.ParentList.Id,
-          listItemId: folderProperties.ListItemAllFields.Id,
-          force: true,
-          output: 'json',
-          debug: this.debug,
-          verbose: this.verbose
-        };
+        const parsedUrl = url.parse(args.options.webUrl);
+        const tenantUrl: string = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+        const listAbsoluteUrl = urlUtil.urlCombine(tenantUrl, folderProperties.ListItemAllFields.ParentList.RootFolder.ServerRelativeUrl);
 
-        const spoListItemRetentionLabelRemoveCommandOutput = await Cli.executeCommandWithOutput(spoListItemRetentionLabelRemoveCommand as Command, { options: { ...options, _: [] } });
-        if (this.verbose) {
-          await logger.logToStderr(spoListItemRetentionLabelRemoveCommandOutput.stderr);
-        }
+        await spo.removeRetentionLabelFromListItems(args.options.webUrl, listAbsoluteUrl, [parseInt(folderProperties.ListItemAllFields.Id)], logger, args.options.verbose);
       }
       else {
-        const options: SpoListRetentionLabelRemoveCommandOptions = {
-          webUrl: args.options.webUrl,
-          listUrl: folderProperties.ServerRelativeUrl,
-          force: true,
-          output: 'json',
-          debug: this.debug,
-          verbose: this.verbose
-        };
+        const listAbsoluteUrl: string = urlUtil.getAbsoluteUrl(args.options.webUrl, folderProperties.ServerRelativeUrl);
 
-        const spoListRetentionLabelEnsureCommandOutput = await Cli.executeCommandWithOutput(spoListRetentionLabelRemoveCommand as Command, { options: { ...options, _: [] } });
-
-        if (this.verbose) {
-          await logger.logToStderr(spoListRetentionLabelEnsureCommandOutput.stderr);
-        }
+        await spo.removeDefaultRetentionLabelFromList(args.options.webUrl, listAbsoluteUrl, logger, args.options.verbose);
       }
     }
     catch (err: any) {
@@ -161,7 +140,7 @@ class SpoFolderRetentionLabelRemoveCommand extends SpoCommand {
     }
 
     const requestOptions: CliRequestOptions = {
-      url: `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList&$select=ServerRelativeUrl,ListItemAllFields/ParentList/Id,ListItemAllFields/Id`,
+      url: `${requestUrl}?$expand=ListItemAllFields,ListItemAllFields/ParentList/RootFolder&$select=ServerRelativeUrl,ListItemAllFields/ParentList/RootFolder/ServerRelativeUrl,ListItemAllFields/Id`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },

--- a/src/m365/spo/commands/list/list-retentionlabel-ensure.spec.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-ensure.spec.ts
@@ -85,7 +85,7 @@ describe(commands.LIST_RETENTIONLABEL_ENSURE, () => {
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
         return { "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } };
       }
 
@@ -95,6 +95,7 @@ describe(commands.LIST_RETENTIONLABEL_ENSURE, () => {
     await assert.rejects(command.action(logger, {
       options: {
         webUrl: 'https://contoso.sharepoint.com/sites/team1',
+        name: 'abc',
         listTitle: 'MyLibrary'
       }
     } as any), new CommandError("Can not find compliance tag with value: abc. SiteSubscriptionId: ea1787c6-7ce2-4e71-be47-5e0deb30f9e4"));
@@ -103,7 +104,7 @@ describe(commands.LIST_RETENTIONLABEL_ENSURE, () => {
   it('should handle error if list does not exist', async () => {
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
         throw new Error("404 - \"404 FILE NOT FOUND\"");
       }
 
@@ -130,7 +131,7 @@ describe(commands.LIST_RETENTIONLABEL_ENSURE, () => {
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
         return { "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } };
       }
 
@@ -161,7 +162,7 @@ describe(commands.LIST_RETENTIONLABEL_ENSURE, () => {
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists/getByTitle('MyLibrary')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
         return { "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } };
       }
 
@@ -192,7 +193,7 @@ describe(commands.LIST_RETENTIONLABEL_ENSURE, () => {
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists(guid'4d535433-2a7b-40b0-9dad-8f0f8f3b3841')/?$expand=RootFolder&$select=RootFolder`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team1/_api/web/lists(guid'4d535433-2a7b-40b0-9dad-8f0f8f3b3841')/?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`) {
         return { "RootFolder": { "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "MyLibrary", "ProgID": null, "ServerRelativeUrl": "/sites/team1/MyLibrary", "TimeCreated": "2019-01-11T10:03:19Z", "TimeLastModified": "2019-01-11T10:03:20Z", "UniqueId": "faaa6af2-0157-4e9a-a352-6165195923c8", "WelcomePage": "" } };
       }
 
@@ -232,6 +233,8 @@ describe(commands.LIST_RETENTIONLABEL_ENSURE, () => {
     const lastCall = postStub.lastCall.args[0];
     assert.strictEqual(lastCall.data.listUrl, 'https://contoso.sharepoint.com/sites/team1/MyLibrary');
     assert.strictEqual(lastCall.data.complianceTagValue, 'abc');
+    assert.strictEqual(lastCall.data.blockDelete, false);
+    assert.strictEqual(lastCall.data.blockEdit, false);
     assert.strictEqual(lastCall.data.syncToItems, true);
   });
 

--- a/src/m365/spo/commands/list/list-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-remove.ts
@@ -7,6 +7,7 @@ import { urlUtil } from '../../../../utils/urlUtil.js';
 import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
+import { spo } from '../../../../utils/spo.js';
 import { ListInstance } from './ListInstance.js';
 
 interface CommandArgs {
@@ -108,22 +109,7 @@ class SpoListRetentionLabelRemoveCommand extends SpoCommand {
       const listServerRelativeUrl: string = await this.getListServerRelativeUrl(args, logger);
       const listAbsoluteUrl: string = urlUtil.getAbsoluteUrl(args.options.webUrl, listServerRelativeUrl);
 
-      const requestOptions: CliRequestOptions = {
-        url: `${args.options.webUrl}/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`,
-        headers: {
-          'accept': 'application/json;odata=nometadata'
-        },
-        data: {
-          listUrl: listAbsoluteUrl,
-          complianceTagValue: '',
-          blockDelete: false,
-          blockEdit: false,
-          syncToItems: false
-        },
-        responseType: 'json'
-      };
-
-      await request.post(requestOptions);
+      await spo.removeDefaultRetentionLabelFromList(args.options.webUrl, listAbsoluteUrl, logger, args.options.verbose);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
@@ -139,23 +125,24 @@ class SpoListRetentionLabelRemoveCommand extends SpoCommand {
       return urlUtil.getServerRelativePath(args.options.webUrl, args.options.listUrl);
     }
 
-    let listRestUrl = '';
+    let requestUrl = `${args.options.webUrl}/_api/web/`;
+
     if (args.options.listId) {
-      listRestUrl = `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/`;
+      requestUrl += `lists(guid'${formatting.encodeQueryParameter(args.options.listId)}')/`;
     }
     else {
-      listRestUrl = `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/`;
+      requestUrl += `lists/getByTitle('${formatting.encodeQueryParameter(args.options.listTitle as string)}')/`;
     }
 
     const requestOptions: CliRequestOptions = {
-      url: `${args.options.webUrl}/_api/web/${listRestUrl}?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`,
+      url: `${requestUrl}?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl`,
       headers: {
         'accept': 'application/json;odata=nometadata'
       },
       responseType: 'json'
     };
 
-    const listInstance: ListInstance = await request.get<ListInstance>(requestOptions);
+    const listInstance = await request.get<ListInstance>(requestOptions);
     return listInstance.RootFolder.ServerRelativeUrl;
   }
 }

--- a/src/utils/spo.spec.ts
+++ b/src/utils/spo.spec.ts
@@ -1967,7 +1967,7 @@ describe('utils/spo', () => {
     }
   });
 
-  it(`retrieves web properties susccessfully`, async () => {
+  it(`retrieves web properties successfully`, async () => {
     const webResponse = {
       value: [{
         AllowRssFeeds: false,
@@ -2015,5 +2015,57 @@ describe('utils/spo', () => {
 
     const actual = await spo.getWeb('https://contoso.sharepoint.com', logger, true);
     assert.deepStrictEqual(actual, webResponse);
+  });
+
+  it(`applies a retention label to list items successfully`, async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === '{"listUrl":"https://contoso.sharepoint.com/sites/project-x/list","complianceTagValue":"Some label","itemIds":[1]}') {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.doesNotReject(spo.applyRetentionLabelToListItems('https://contoso.sharepoint.com/sites/project-x', 'Some label', 'https://contoso.sharepoint.com/sites/project-x/list', [1], logger, true));
+  });
+
+  it(`removes a retention label from list items successfully`, async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`
+        && JSON.stringify(opts.data) === '{"listUrl":"https://contoso.sharepoint.com/sites/project-x/list","complianceTagValue":"","itemIds":[1]}') {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.doesNotReject(spo.removeRetentionLabelFromListItems('https://contoso.sharepoint.com/sites/project-x', 'https://contoso.sharepoint.com/sites/project-x/list', [1], logger, true));
+  });
+
+  it(`applies a default retention label to a list successfully`, async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`
+        && JSON.stringify(opts.data) === '{"listUrl":"https://contoso.sharepoint.com/sites/project-x/list","complianceTagValue":"Some label","blockDelete":false,"blockEdit":false,"syncToItems":true}') {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.doesNotReject(spo.applyDefaultRetentionLabelToList('https://contoso.sharepoint.com/sites/project-x', 'Some label', 'https://contoso.sharepoint.com/sites/project-x/list', true, logger, true));
+  });
+
+  it(`removes a default retention label from a list successfully`, async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/project-x/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`
+        && JSON.stringify(opts.data) === '{"listUrl":"https://contoso.sharepoint.com/sites/project-x/list","complianceTagValue":"","blockDelete":false,"blockEdit":false,"syncToItems":false}') {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.doesNotReject(spo.removeDefaultRetentionLabelFromList('https://contoso.sharepoint.com/sites/project-x', 'https://contoso.sharepoint.com/sites/project-x/list', logger, true));
   });
 });

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -1453,5 +1453,126 @@ export const spo = {
     const webProperties: WebProperties = await request.get<WebProperties>(requestOptions);
 
     return webProperties;
+  },
+
+  /**
+   * Applies the retention label to the items in the given list.
+   * @param webUrl The url of the web
+   * @param name The name of the label
+   * @param listAbsoluteUrl The absolute Url to the list
+   * @param itemIds The list item Ids to apply the label to. (A maximum 100 is allowed)
+   * @param logger The logger object
+   * @param verbose Set for verbose logging
+   */
+  async applyRetentionLabelToListItems(webUrl: string, name: string, listAbsoluteUrl: string, itemIds: number[], logger?: Logger, verbose?: boolean): Promise<void> {
+    if (verbose && logger) {
+      logger.logToStderr(`Applying retention label '${name}' to item(s) in list '${listAbsoluteUrl}'...`);
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${webUrl}/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      data: {
+        listUrl: listAbsoluteUrl,
+        complianceTagValue: name,
+        itemIds: itemIds
+      },
+      responseType: 'json'
+    };
+
+    await request.post(requestOptions);
+  },
+
+  /**
+   * Removes the retention label from the items in the given list.
+   * @param webUrl The url of the web
+   * @param listAbsoluteUrl The absolute Url to the list
+   * @param itemIds The list item Ids to clear the label from (A maximum 100 is allowed)
+   * @param logger The logger object
+   * @param verbose Set for verbose logging
+   */
+  async removeRetentionLabelFromListItems(webUrl: string, listAbsoluteUrl: string, itemIds: number[], logger?: Logger, verbose?: boolean): Promise<void> {
+    if (verbose && logger) {
+      logger.logToStderr(`Removing retention label from item(s) in list '${listAbsoluteUrl}'...`);
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${webUrl}/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetComplianceTagOnBulkItems`,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      data: {
+        listUrl: listAbsoluteUrl,
+        complianceTagValue: '',
+        itemIds: itemIds
+      },
+      responseType: 'json'
+    };
+
+    await request.post(requestOptions);
+  },
+
+  /**
+   * Applies a default retention label to a list or library.
+   * @param webUrl The url of the web
+   * @param name The name of the label
+   * @param listAbsoluteUrl The absolute Url to the list
+   * @param syncToItems If the label needs to be synced to existing items/files.
+   * @param logger The logger object
+   * @param verbose Set for verbose logging
+   */
+  async applyDefaultRetentionLabelToList(webUrl: string, name: string, listAbsoluteUrl: string, syncToItems?: boolean, logger?: Logger, verbose?: boolean): Promise<void> {
+    if (verbose && logger) {
+      logger.logToStderr(`Applying default retention label '${name}' to the list '${listAbsoluteUrl}'...`);
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${webUrl}/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      data: {
+        listUrl: listAbsoluteUrl,
+        complianceTagValue: name,
+        blockDelete: false,
+        blockEdit: false,
+        syncToItems: syncToItems || false
+      },
+      responseType: 'json'
+    };
+
+    await request.post(requestOptions);
+  },
+
+  /**
+   * Removes the default retention label from a list or library.
+   * @param webUrl The url of the web
+   * @param listAbsoluteUrl The absolute Url to the list
+   * @param logger The logger object
+   * @param verbose Set for verbose logging
+   */
+  async removeDefaultRetentionLabelFromList(webUrl: string, listAbsoluteUrl: string, logger?: Logger, verbose?: boolean): Promise<void> {
+    if (verbose && logger) {
+      logger.logToStderr(`Removing the default retention label from the list '${listAbsoluteUrl}'...`);
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${webUrl}/_api/SP_CompliancePolicy_SPPolicyStoreProxy_SetListComplianceTag`,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      data: {
+        listUrl: listAbsoluteUrl,
+        complianceTagValue: '',
+        blockDelete: false,
+        blockEdit: false,
+        syncToItems: false
+      },
+      responseType: 'json'
+    };
+
+    await request.post(requestOptions);
   }
 };


### PR DESCRIPTION
Closes #4633

Updates spo retentionlabel commands to use the newer `SetComplianceTagOnBulkItems`-endpoint. 

I've also moved the apply/remove code to the `spo` shared util, because there was a lot of shared code.
