### PR TITLE
Adds new eslint rule: Prevent usage of 'ByServerRelativeUrl' endpoint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -136,6 +136,7 @@ module.exports = {
   "rules": {
     "cli-microsoft365/correct-command-class-name": ["error", sortedDictionary, capitalized],
     "cli-microsoft365/correct-command-name": "error",
+    "cli-microsoft365/no-by-server-relative-url-usage": "error",
     "indent": "off",
     "@typescript-eslint/indent": [
       "error",

--- a/eslint-rules/lib/index.js
+++ b/eslint-rules/lib/index.js
@@ -1,4 +1,5 @@
 module.exports.rules = {
   'correct-command-class-name': require('./rules/correct-command-class-name'),
-  'correct-command-name': require('./rules/correct-command-name')
+  'correct-command-name': require('./rules/correct-command-name'),
+  'no-by-server-relative-url-usage': require('./rules/no-by-server-relative-url-usage')
 };

--- a/eslint-rules/lib/rules/no-by-server-relative-url-usage.js
+++ b/eslint-rules/lib/rules/no-by-server-relative-url-usage.js
@@ -1,0 +1,55 @@
+function reportIncorrectEndpoint(context, node, urlEndpoint, pathEndpoint, updatedValue) {
+  context.report({
+    node,
+    messageId: 'incorrectEndpoint',
+    data: { urlEndpoint, pathEndpoint },
+    fix: fixer => fixer.replaceText(node, updatedValue),
+  });
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: "Prevent usage of 'ByServerRelativeUrl' endpoint",
+      recommended: true
+    },
+    fixable: 'code',
+    messages: {
+      incorrectEndpoint: `Avoid "{{ urlEndpoint }}" endpoint. Instead, use "{{ pathEndpoint }}". Reference issue #5333 for more information.`
+    }
+  },
+  create: context => {
+    return {
+      TemplateLiteral(node) {
+        const sourceCodeText = context.getSourceCode().getText(node);
+        const updatedValue = sourceCodeText
+          .replace(/GetFileByServerRelativeUrl\(/ig, 'GetFileByServerRelativePath(DecodedUrl=')
+          .replace(/GetFolderByServerRelativeUrl\(/ig, 'GetFolderByServerRelativePath(DecodedUrl=');
+
+        if (updatedValue !== sourceCodeText) {
+          const templateValue = node.quasis.map(quasi => quasi.value.raw).join('');
+          const urlEndpoint = templateValue.match(/GetFileByServerRelativeUrl\(/i) ? "GetFileByServerRelativeUrl('url')" : "GetFolderByServerRelativeUrl('url')";
+          const pathEndpoint = urlEndpoint.replace("Url('url')", "Path(DecodedUrl='url')");
+
+          reportIncorrectEndpoint(context, node, urlEndpoint, pathEndpoint, updatedValue);
+        }
+      },
+      VariableDeclarator(node) {
+        const { init } = node;
+        if (
+          init && init.type === 'Literal' &&
+          (String(init.value).match(/GetFileByServerRelativeUrl\(/i) || String(init.value).match(/GetFolderByServerRelativeUrl\(/i))
+        ) {
+          const urlEndpoint = String(init.value).match(/GetFileByServerRelativeUrl\(/i) ? "GetFileByServerRelativeUrl('url')" : "GetFolderByServerRelativeUrl('url')";
+          const pathEndpoint = urlEndpoint.replace("Url('url')", "Path(DecodedUrl='url')");
+          const updatedValue = String(init.value)
+            .replace(/GetFileByServerRelativeUrl\(/i, 'GetFileByServerRelativePath(DecodedUrl=')
+            .replace(/GetFolderByServerRelativeUrl\(/i, 'GetFolderByServerRelativePath(DecodedUrl=');
+
+          reportIncorrectEndpoint(context, init, urlEndpoint, pathEndpoint, `'${updatedValue}'`);
+        }
+      }
+    };
+  },
+};

--- a/src/m365/spo/commands/app/app-deploy.spec.ts
+++ b/src/m365/spo/commands/app/app-deploy.spec.ts
@@ -195,7 +195,7 @@ describe(commands.APP_DEPLOY, () => {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
         return { UniqueId: 'b2307a39-e878-458b-bc90-03bc578531d6' };
       }
 
@@ -224,7 +224,7 @@ describe(commands.APP_DEPLOY, () => {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
         return { UniqueId: 'b2307a39-e878-458b-bc90-03bc578531d6' };
       }
 
@@ -253,7 +253,7 @@ describe(commands.APP_DEPLOY, () => {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
         return { UniqueId: 'b2307a39-e878-458b-bc90-03bc578531d6' };
       }
 
@@ -282,7 +282,7 @@ describe(commands.APP_DEPLOY, () => {
       if ((opts.url as string).indexOf('SP_TenantSettings_Current') > -1) {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" };
       }
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
         return { UniqueId: 'b2307a39-e878-458b-bc90-03bc578531d6' };
       }
 
@@ -608,7 +608,7 @@ describe(commands.APP_DEPLOY, () => {
       if ((opts.url as string).indexOf('SP_TenantSettings_Current') > -1) {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" };
       }
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
         throw {
           error: {
             "odata.error": {
@@ -634,7 +634,7 @@ describe(commands.APP_DEPLOY, () => {
       if ((opts.url as string).indexOf('SP_TenantSettings_Current') > -1) {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" };
       }
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) > -1) {
         throw {
           error: {
             "odata.error": {

--- a/src/m365/spo/commands/app/app-deploy.ts
+++ b/src/m365/spo/commands/app/app-deploy.ts
@@ -124,7 +124,7 @@ class SpoAppDeployCommand extends SpoAppBaseCommand {
         }
 
         const requestOptions: CliRequestOptions = {
-          url: `${appCatalogUrl}/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('${args.options.name}')?$select=UniqueId`,
+          url: `${appCatalogUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('${args.options.name}')?$select=UniqueId`,
           headers: {
             accept: 'application/json;odata=nometadata'
           },

--- a/src/m365/spo/commands/app/app-get.spec.ts
+++ b/src/m365/spo/commands/app/app-get.spec.ts
@@ -207,7 +207,7 @@ describe(commands.APP_GET, () => {
         }
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
         return { UniqueId: 'b2307a39-e878-458b-bc90-03bc578531d6' };
       }
 
@@ -242,7 +242,7 @@ describe(commands.APP_GET, () => {
         }
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/site1/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/site1/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
         return { UniqueId: 'b2307a39-e878-458b-bc90-03bc578531d6' };
       }
 
@@ -276,7 +276,7 @@ describe(commands.APP_GET, () => {
         }
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
         return { UniqueId: 'b2307a39-e878-458b-bc90-03bc578531d6' };
       }
 
@@ -294,7 +294,7 @@ describe(commands.APP_GET, () => {
 
   it('should handle getfolderbyserverrelativeurl error', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
         throw {
           error: {
             'odata.error': {
@@ -320,7 +320,7 @@ describe(commands.APP_GET, () => {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/apps/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('solution.sppkg')?$select=UniqueId`) {
         return { UniqueId: 'b2307a39-e878-458b-bc90-03bc578531d6' };
       }
 

--- a/src/m365/spo/commands/app/app-get.ts
+++ b/src/m365/spo/commands/app/app-get.ts
@@ -115,7 +115,7 @@ class SpoAppGetCommand extends SpoAppBaseCommand {
         }
 
         const requestOptions: CliRequestOptions = {
-          url: `${appCatalogSiteUrl}/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('${args.options.name}')?$select=UniqueId`,
+          url: `${appCatalogSiteUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('${args.options.name}')?$select=UniqueId`,
           headers: {
             accept: 'application/json;odata=nometadata'
           },

--- a/src/m365/spo/commands/app/app-teamspackage-download.spec.ts
+++ b/src/m365/spo/commands/app/app-teamspackage-download.spec.ts
@@ -201,7 +201,7 @@ describe(commands.APP_TEAMSPACKAGE_DOWNLOAD, () => {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/appcatalog" };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
         return {
           "Id": 2,
           "ID": 2
@@ -239,7 +239,7 @@ describe(commands.APP_TEAMSPACKAGE_DOWNLOAD, () => {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/appcatalog" };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
         return {
           "Id": 2,
           "ID": 2
@@ -357,7 +357,7 @@ describe(commands.APP_TEAMSPACKAGE_DOWNLOAD, () => {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/appcatalog" };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
         return {
           "Id": 2,
           "ID": 2
@@ -414,7 +414,7 @@ describe(commands.APP_TEAMSPACKAGE_DOWNLOAD, () => {
 
   it(`handles error when the specified app catalog doesn't exist`, async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
         return Promise.reject('404 FILE NOT FOUND');
       }
 
@@ -485,7 +485,7 @@ describe(commands.APP_TEAMSPACKAGE_DOWNLOAD, () => {
         return { "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/appcatalog" };
       }
 
-      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/getfolderbyserverrelativeurl('AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/appcatalog/_api/web/GetFolderByServerRelativePath(DecodedUrl='AppCatalog')/files('m365-spfx-wellbeing.sppkg')/ListItemAllFields?$select=Id`) {
         throw {
           error: {
             "odata.error": {

--- a/src/m365/spo/commands/app/app-teamspackage-download.ts
+++ b/src/m365/spo/commands/app/app-teamspackage-download.ts
@@ -182,7 +182,7 @@ class SpoAppTeamsPackageDownloadCommand extends SpoAppBaseCommand {
       url += `GetList('${serverRelativeAppCatalogListUrl}')/GetItemById(${args.options.appItemId})?$expand=File&$select=File/Name`;
     }
     else if (args.options.appName) {
-      url += `getfolderbyserverrelativeurl('${appCatalogListName}')/files('${formatting.encodeQueryParameter(args.options.appName)}')/ListItemAllFields?$select=Id`;
+      url += `GetFolderByServerRelativePath(DecodedUrl='${appCatalogListName}')/files('${formatting.encodeQueryParameter(args.options.appName)}')/ListItemAllFields?$select=Id`;
     }
 
     const requestOptions: CliRequestOptions = {

--- a/src/m365/spo/commands/apppage/apppage-add.spec.ts
+++ b/src/m365/spo/commands/apppage/apppage-add.spec.ts
@@ -81,7 +81,7 @@ describe(commands.APPPAGE_ADD, () => {
       throw 'Invalid request';
     });
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/SitePages/lp4blf70.aspx')?$expand=ListItemAllFields`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/lp4blf70.aspx')?$expand=ListItemAllFields`) > -1) {
         return {
           "ListItemAllFields": {
             "FileSystemObjectType": 0,
@@ -166,7 +166,7 @@ describe(commands.APPPAGE_ADD, () => {
       throw 'Invalid request';
     });
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/SitePages/lp4blf70.aspx')?$expand=ListItemAllFields`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/lp4blf70.aspx')?$expand=ListItemAllFields`) > -1) {
         return {
           "ListItemAllFields": {
             "FileSystemObjectType": 0,
@@ -252,7 +252,7 @@ describe(commands.APPPAGE_ADD, () => {
       throw 'Invalid request';
     });
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/SitePages/lp4blf70.aspx')?$expand=ListItemAllFields`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/lp4blf70.aspx')?$expand=ListItemAllFields`) > -1) {
         throw 'Page not found';
       }
       throw 'Invalid request';
@@ -275,7 +275,7 @@ describe(commands.APPPAGE_ADD, () => {
       throw 'Invalid request';
     });
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/SitePages/lp4blf70.aspx')?$expand=ListItemAllFields`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/lp4blf70.aspx')?$expand=ListItemAllFields`) > -1) {
         return {
           "ListItemAllFields": {
             "FileSystemObjectType": 0,

--- a/src/m365/spo/commands/apppage/apppage-add.ts
+++ b/src/m365/spo/commands/apppage/apppage-add.ts
@@ -92,7 +92,7 @@ class SpoAppPageAddCommand extends SpoCommand {
       const pageUrl: string = page.value;
 
       let requestOptions: CliRequestOptions = {
-        url: `${args.options.webUrl}/_api/web/getfilebyserverrelativeurl('${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/${pageUrl}')?$expand=ListItemAllFields`,
+        url: `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/${pageUrl}')?$expand=ListItemAllFields`,
         headers: {
           'content-type': 'application/json;charset=utf-8',
           accept: 'application/json;odata=nometadata'

--- a/src/m365/spo/commands/page/Page.spec.ts
+++ b/src/m365/spo/commands/page/Page.spec.ts
@@ -54,7 +54,7 @@ describe('Page', () => {
     let getCallIssued = false;
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/_api/web/getfilebyserverrelativeurl('/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         getCallIssued = true;
         return {
           "ListItemAllFields": {
@@ -135,7 +135,7 @@ describe('Page', () => {
     let getCallIssued = false;
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         getCallIssued = true;
         return {
           "ListItemAllFields": {

--- a/src/m365/spo/commands/page/Page.ts
+++ b/src/m365/spo/commands/page/Page.ts
@@ -19,7 +19,7 @@ export class Page {
     const pageName: string = this.getPageNameWithExtension(name);
 
     const requestOptions: CliRequestOptions = {
-      url: `${webUrl}/_api/web/getfilebyserverrelativeurl('${urlUtil.getServerRelativeSiteUrl(webUrl)}/SitePages/${formatting.encodeQueryParameter(pageName)}')?$expand=ListItemAllFields/ClientSideApplicationId`,
+      url: `${webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${urlUtil.getServerRelativeSiteUrl(webUrl)}/SitePages/${formatting.encodeQueryParameter(pageName)}')?$expand=ListItemAllFields/ClientSideApplicationId`,
       headers: {
         'content-type': 'application/json;charset=utf-8',
         accept: 'application/json;odata=nometadata'

--- a/src/m365/spo/commands/page/page-add.spec.ts
+++ b/src/m365/spo/commands/page/page-add.spec.ts
@@ -76,7 +76,7 @@ describe(commands.PAGE_ADD, () => {
 
   it('creates new modern page', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -147,7 +147,7 @@ describe(commands.PAGE_ADD, () => {
 
   it('creates new modern page (debug)', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -249,7 +249,7 @@ describe(commands.PAGE_ADD, () => {
         return;
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sitepages/page.aspx',
           templateFileType: 3
@@ -317,7 +317,7 @@ describe(commands.PAGE_ADD, () => {
 
   it('automatically appends the .aspx extension', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -375,7 +375,7 @@ describe(commands.PAGE_ADD, () => {
 
   it('sets page title when specified', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -450,7 +450,7 @@ describe(commands.PAGE_ADD, () => {
         return;
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -531,7 +531,7 @@ describe(commands.PAGE_ADD, () => {
         return;
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -627,7 +627,7 @@ describe(commands.PAGE_ADD, () => {
         return;
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -722,7 +722,7 @@ describe(commands.PAGE_ADD, () => {
         return;
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -790,7 +790,7 @@ describe(commands.PAGE_ADD, () => {
 
   it('creates new modern page with comments enabled', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -850,7 +850,7 @@ describe(commands.PAGE_ADD, () => {
     let savedAsDraft = false;
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -941,7 +941,7 @@ describe(commands.PAGE_ADD, () => {
 
   it('creates new modern page and publishes it', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -1052,7 +1052,7 @@ describe(commands.PAGE_ADD, () => {
         return;
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3
@@ -1120,7 +1120,7 @@ describe(commands.PAGE_ADD, () => {
 
   it('escapes special characters in user input', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfolderbyserverrelativeurl('/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFolderByServerRelativePath(DecodedUrl='/sites/team-a/sitepages')/files/AddTemplateFile`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           urlOfFile: '/sites/team-a/sitepages/page.aspx',
           templateFileType: 3

--- a/src/m365/spo/commands/page/page-add.ts
+++ b/src/m365/spo/commands/page/page-add.ts
@@ -150,7 +150,7 @@ class SpoPageAddCommand extends SpoCommand {
       requestDigest = reqDigest.FormDigestValue;
 
       let requestOptions: CliRequestOptions = {
-        url: `${args.options.webUrl}/_api/web/getfolderbyserverrelativeurl('${serverRelativeSiteUrl}/sitepages')/files/AddTemplateFile`,
+        url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${serverRelativeSiteUrl}/sitepages')/files/AddTemplateFile`,
         headers: {
           'X-RequestDigest': requestDigest,
           'content-type': 'application/json;odata=nometadata',

--- a/src/m365/spo/commands/page/page-column-get.spec.ts
+++ b/src/m365/spo/commands/page/page-column-get.spec.ts
@@ -131,7 +131,7 @@ describe(commands.PAGE_COLUMN_GET, () => {
 
   it('Get information about the specific column of a modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -150,7 +150,7 @@ describe(commands.PAGE_COLUMN_GET, () => {
 
   it('Get information about the specific column of a modern page - no sections available', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "FileSystemObjectType": 0,
@@ -221,7 +221,7 @@ describe(commands.PAGE_COLUMN_GET, () => {
 
   it('Get information about the specific column of a modern page - no columns available', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "FileSystemObjectType": 0,
@@ -292,7 +292,7 @@ describe(commands.PAGE_COLUMN_GET, () => {
 
   it('Get information about the specific column of a modern page (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -310,7 +310,7 @@ describe(commands.PAGE_COLUMN_GET, () => {
 
   it('Get information about the specific column of a modern page when the specified page name doesn\'t contain extension', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -329,7 +329,7 @@ describe(commands.PAGE_COLUMN_GET, () => {
 
   it('Get information about the specific column of a modern page in json output mode', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -348,7 +348,7 @@ describe(commands.PAGE_COLUMN_GET, () => {
 
   it('shows error when the specified page is a classic page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "CommentsDisabled": false,

--- a/src/m365/spo/commands/page/page-column-list.spec.ts
+++ b/src/m365/spo/commands/page/page-column-list.spec.ts
@@ -131,7 +131,7 @@ describe(commands.PAGE_COLUMN_LIST, () => {
 
   it('lists columns on the modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -155,7 +155,7 @@ describe(commands.PAGE_COLUMN_LIST, () => {
 
   it('lists columns on the modern page - no sections available', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "FileSystemObjectType": 0,
@@ -226,7 +226,7 @@ describe(commands.PAGE_COLUMN_LIST, () => {
 
   it('lists columns on the modern page (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -250,7 +250,7 @@ describe(commands.PAGE_COLUMN_LIST, () => {
 
   it('lists columns on the modern page when the specified page name doesn\'t contain extension', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -274,7 +274,7 @@ describe(commands.PAGE_COLUMN_LIST, () => {
 
   it('lists all information about columns on the modern page in json output mode', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -300,7 +300,7 @@ describe(commands.PAGE_COLUMN_LIST, () => {
 
   it('shows error when the specified page is a classic page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "CommentsDisabled": false,

--- a/src/m365/spo/commands/page/page-get.spec.ts
+++ b/src/m365/spo/commands/page/page-get.spec.ts
@@ -70,7 +70,7 @@ describe(commands.PAGE_GET, () => {
 
   it('gets information about a modern page including all returned properties', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return pageListItemMock;
       }
 
@@ -88,7 +88,7 @@ describe(commands.PAGE_GET, () => {
 
   it('gets information about a modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return pageListItemMock;
       }
 
@@ -109,7 +109,7 @@ describe(commands.PAGE_GET, () => {
 
   it('gets information about a modern page on root of tenant', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/home.aspx')`) > -1) {
         return pageListItemMock;
       }
 
@@ -130,7 +130,7 @@ describe(commands.PAGE_GET, () => {
 
   it('gets information about a modern page when the specified page name doesn\'t contain extension', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return pageListItemMock;
       }
 
@@ -151,7 +151,7 @@ describe(commands.PAGE_GET, () => {
 
   it('check if section and control HTML parsing gets skipped for metadata only mode', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return pageListItemMock;
       }
 
@@ -164,7 +164,7 @@ describe(commands.PAGE_GET, () => {
 
   it('shows error when the specified page is a classic page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return classicPage;
       }
 

--- a/src/m365/spo/commands/page/page-get.ts
+++ b/src/m365/spo/commands/page/page-get.ts
@@ -69,7 +69,7 @@ class SpoPageGetCommand extends SpoCommand {
 
     try {
       let requestOptions: any = {
-        url: `${args.options.webUrl}/_api/web/getfilebyserverrelativeurl('${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/SitePages/${formatting.encodeQueryParameter(pageName)}')?$expand=ListItemAllFields/ClientSideApplicationId,ListItemAllFields/PageLayoutType,ListItemAllFields/CommentsDisabled`,
+        url: `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/SitePages/${formatting.encodeQueryParameter(pageName)}')?$expand=ListItemAllFields/ClientSideApplicationId,ListItemAllFields/PageLayoutType,ListItemAllFields/CommentsDisabled`,
         headers: {
           'content-type': 'application/json;charset=utf-8',
           accept: 'application/json;odata=nometadata'

--- a/src/m365/spo/commands/page/page-header-set.spec.ts
+++ b/src/m365/spo/commands/page/page-header-set.spec.ts
@@ -228,7 +228,7 @@ describe(commands.PAGE_HEADER_SET, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
         return {
           ListId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
           UniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
@@ -273,7 +273,7 @@ describe(commands.PAGE_HEADER_SET, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
         return {
           ListId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
           UniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
@@ -318,7 +318,7 @@ describe(commands.PAGE_HEADER_SET, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
         return {
           ListId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
           UniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
@@ -373,7 +373,7 @@ describe(commands.PAGE_HEADER_SET, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
         return {
           ListId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
           UniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
@@ -469,7 +469,7 @@ describe(commands.PAGE_HEADER_SET, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
         throw { error: { 'odata.error': { message: { value: 'An error has occurred' } } } };
       }
 

--- a/src/m365/spo/commands/page/page-header-set.ts
+++ b/src/m365/spo/commands/page/page-header-set.ts
@@ -451,7 +451,7 @@ class SpoPageHeaderSetCommand extends SpoCommand {
     }
 
     const requestOptions: any = {
-      url: `${siteUrl}/_api/web/getfilebyserverrelativeurl('${formatting.encodeQueryParameter(imageUrl)}')?$select=ListId,UniqueId`,
+      url: `${siteUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(imageUrl)}')?$select=ListId,UniqueId`,
       headers: {
         accept: 'application/json;odata=nometadata'
       },

--- a/src/m365/spo/commands/page/page-remove.spec.ts
+++ b/src/m365/spo/commands/page/page-remove.spec.ts
@@ -24,7 +24,7 @@ describe(commands.PAGE_REMOVE, () => {
 
   const fakeRestCalls: (pageName?: string) => sinon.SinonStub = (pageName: string = 'page.aspx') => {
     return sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/${pageName}')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/${pageName}')`) > -1) {
         return '';
       }
 
@@ -118,7 +118,7 @@ describe(commands.PAGE_REMOVE, () => {
 
   it('removes a modern page (debug) without confirm prompt on root of tenant', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sitepages/page.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sitepages/page.aspx')`) > -1) {
         return '';
       }
 

--- a/src/m365/spo/commands/page/page-remove.ts
+++ b/src/m365/spo/commands/page/page-remove.ts
@@ -91,7 +91,7 @@ class SpoPageRemoveCommand extends SpoCommand {
 
       const requestOptions: CliRequestOptions = {
         url: `${args.options
-          .webUrl}/_api/web/getfilebyserverrelativeurl('${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/sitepages/${pageName}')`,
+          .webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/sitepages/${pageName}')`,
         headers: {
           'X-RequestDigest': requestDigest,
           'X-HTTP-Method': 'DELETE',

--- a/src/m365/spo/commands/page/page-section-get.spec.ts
+++ b/src/m365/spo/commands/page/page-section-get.spec.ts
@@ -131,7 +131,7 @@ describe(commands.PAGE_SECTION_GET, () => {
 
   it('lists sections on the modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -154,7 +154,7 @@ describe(commands.PAGE_SECTION_GET, () => {
 
   it('lists sections on the modern page - no sections available', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "FileSystemObjectType": 0,
@@ -225,7 +225,7 @@ describe(commands.PAGE_SECTION_GET, () => {
 
   it('lists sections on the modern page (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -250,7 +250,7 @@ describe(commands.PAGE_SECTION_GET, () => {
 
   it('lists sections on the modern page when the specified page name doesn\'t contain extension', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -275,7 +275,7 @@ describe(commands.PAGE_SECTION_GET, () => {
 
   it('lists all information about sections on the modern page in json output mode', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -302,7 +302,7 @@ describe(commands.PAGE_SECTION_GET, () => {
 
   it('shows error when the specified page is a classic page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "CommentsDisabled": false,

--- a/src/m365/spo/commands/page/page-section-list.spec.ts
+++ b/src/m365/spo/commands/page/page-section-list.spec.ts
@@ -127,7 +127,7 @@ describe(commands.PAGE_SECTION_LIST, () => {
 
   it('lists sections on the modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -147,7 +147,7 @@ describe(commands.PAGE_SECTION_LIST, () => {
 
   it('lists sections on the modern page - no sections available', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "FileSystemObjectType": 0,
@@ -218,7 +218,7 @@ describe(commands.PAGE_SECTION_LIST, () => {
 
   it('lists sections on the modern page (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -238,7 +238,7 @@ describe(commands.PAGE_SECTION_LIST, () => {
 
   it('lists sections on the modern page when the specified page name doesn\'t contain extension', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -258,7 +258,7 @@ describe(commands.PAGE_SECTION_LIST, () => {
 
   it('lists all information about sections on the modern page in json output mode', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return apiResponse;
       }
 
@@ -300,7 +300,7 @@ describe(commands.PAGE_SECTION_LIST, () => {
 
   it('shows error when the specified page is a classic page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/home.aspx')`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/home.aspx')`) > -1) {
         return {
           "ListItemAllFields": {
             "CommentsDisabled": false,

--- a/src/m365/spo/commands/page/page-set.spec.ts
+++ b/src/m365/spo/commands/page/page-set.spec.ts
@@ -54,8 +54,8 @@ describe(commands.PAGE_SET, () => {
     loggerLogSpy = sinon.spy(logger, 'log');
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/article.aspx')/ListItemAllFields`) > -1 ||
-        (opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sitepages/article.aspx')/ListItemAllFields`) > -1) &&
+      if (((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/article.aspx')/ListItemAllFields`) > -1 ||
+        (opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sitepages/article.aspx')/ListItemAllFields`) > -1) &&
         JSON.stringify(opts.data) === JSON.stringify({
           PageLayoutType: 'Article',
           PromotedState: 0,
@@ -232,7 +232,7 @@ describe(commands.PAGE_SET, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
         opts.data.PromotedState === 2 &&
         opts.data.FirstPublishedDate) {
         return;
@@ -267,7 +267,7 @@ describe(commands.PAGE_SET, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
         !opts.data) {
         return { Id: '1' };
       }
@@ -307,7 +307,7 @@ describe(commands.PAGE_SET, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
           PageLayoutType: 'Home'
         })) {
@@ -353,7 +353,7 @@ describe(commands.PAGE_SET, () => {
     sinonUtil.restore([request.post]);
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields/SetCommentsDisabled(false)`) > -1) {
+      if ((opts.url as string).indexOf(`_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields/SetCommentsDisabled(false)`) > -1) {
         return;
       }
 
@@ -407,8 +407,8 @@ describe(commands.PAGE_SET, () => {
         };
       }
 
-      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields" ||
-        opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields/SetCommentsDisabled(true)" ||
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields" ||
+        opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields/SetCommentsDisabled(true)" ||
         opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/SitePages/Pages(1)/SavePageAsDraft") {
         return;
       }
@@ -450,7 +450,7 @@ describe(commands.PAGE_SET, () => {
     const newPageTitle = "updated title";
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields/SetCommentsDisabled(false)`) > -1) {
+      if ((opts.url as string).indexOf(`_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields/SetCommentsDisabled(false)`) > -1) {
         return;
       }
 
@@ -488,7 +488,7 @@ describe(commands.PAGE_SET, () => {
     sinonUtil.restore([request.post]);
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1) {
         return;
       }
 
@@ -512,7 +512,7 @@ describe(commands.PAGE_SET, () => {
         return;
       }
 
-      if ((opts.url as string).indexOf(`_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/CheckIn(comment=@a1,checkintype=@a2)?@a1=\'\'&@a2=1`) > -1) {
+      if ((opts.url as string).indexOf(`_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/CheckIn(comment=@a1,checkintype=@a2)?@a1=\'\'&@a2=1`) > -1) {
         return;
       }
 
@@ -547,7 +547,7 @@ describe(commands.PAGE_SET, () => {
         return;
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/CheckIn(comment=@a1,checkintype=@a2)?@a1='Initial%20version'&@a2=1`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/CheckIn(comment=@a1,checkintype=@a2)?@a1='Initial%20version'&@a2=1`) > -1) {
         return;
       }
 
@@ -561,7 +561,7 @@ describe(commands.PAGE_SET, () => {
     sinonUtil.restore([request.post]);
     const comment = `Don't tell`;
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/CheckIn(comment=@a1,checkintype=@a2)?@a1='${formatting.encodeQueryParameter(comment)}'&@a2=1`) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/CheckIn(comment=@a1,checkintype=@a2)?@a1='${formatting.encodeQueryParameter(comment)}'&@a2=1`) {
         return;
       }
 

--- a/src/m365/spo/commands/page/page-set.ts
+++ b/src/m365/spo/commands/page/page-set.ts
@@ -323,7 +323,7 @@ class SpoPageSetCommand extends SpoCommand {
 
       if (typeof args.options.commentsEnabled !== 'undefined') {
         const requestOptions: CliRequestOptions = {
-          url: `${args.options.webUrl}/_api/web/getfilebyserverrelativeurl('${serverRelativeFileUrl}')/ListItemAllFields/SetCommentsDisabled(${args.options.commentsEnabled === false})`,
+          url: `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${serverRelativeFileUrl}')/ListItemAllFields/SetCommentsDisabled(${args.options.commentsEnabled === false})`,
           headers: {
             'X-RequestDigest': requestDigest,
             'content-type': 'application/json;odata=nometadata',
@@ -368,7 +368,7 @@ class SpoPageSetCommand extends SpoCommand {
       }
       else {
         requestOptions = {
-          url: `${args.options.webUrl}/_api/web/getfilebyserverrelativeurl('${serverRelativeFileUrl}')/CheckIn(comment=@a1,checkintype=@a2)?@a1='${formatting.encodeQueryParameter(args.options.publishMessage || '')}'&@a2=1`,
+          url: `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${serverRelativeFileUrl}')/CheckIn(comment=@a1,checkintype=@a2)?@a1='${formatting.encodeQueryParameter(args.options.publishMessage || '')}'&@a2=1`,
           headers: {
             'X-RequestDigest': requestDigest,
             'content-type': 'application/json;odata=nometadata',

--- a/src/m365/spo/commands/page/page-text-add.spec.ts
+++ b/src/m365/spo/commands/page/page-text-add.spec.ts
@@ -75,7 +75,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('adds text to an empty modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -141,7 +141,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
         return {};
       }
 
@@ -161,7 +161,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('adds text to an empty modern page (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -227,7 +227,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
         JSON.stringify(opts.data).indexOf(`&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;\\"><div data-sp-rte=\\"\\"><p>Hello world</p></div></div></div>"}`) > -1) {
         return {};
       }
@@ -249,7 +249,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('adds text to an empty modern page on root of tenant (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/_api/web/getfilebyserverrelativeurl('/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -315,7 +315,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/_api/web/getfilebyserverrelativeurl('/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
+      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
         JSON.stringify(opts.data).indexOf(`&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;\\"><div data-sp-rte=\\"\\"><p>Hello world</p></div></div></div>"}`) > -1) {
         return {};
       }
@@ -339,7 +339,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (
         (opts.url as string).indexOf(
-          `/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
+          `/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
         ) > -1
       ) {
         return {
@@ -407,7 +407,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
         return {};
       }
 
@@ -429,7 +429,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (
         (opts.url as string).indexOf(
-          `/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
+          `/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
         ) > -1
       ) {
         return {
@@ -497,7 +497,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
         return {};
       }
 
@@ -520,7 +520,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (
         (opts.url as string).indexOf(
-          `/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
+          `/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
         ) > -1
       ) {
         return {
@@ -588,7 +588,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/getfilebyserverrelativeurl('/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
         return {};
       }
 
@@ -608,7 +608,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles OData error when adding text to a non-existing page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/foo.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/foo.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         throw { error: { 'odata.error': { message: { value: 'The file /sites/team-a/SitePages/foo.aspx does not exist' } } } };
       }
 
@@ -627,7 +627,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles OData error when adding text to a page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -708,7 +708,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles error if target page is not a modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -777,7 +777,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles invalid section error when adding text to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -855,7 +855,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles invalid column error when adding text to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -934,7 +934,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles error when parsing modern page contents', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/getfilebyserverrelativeurl('/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,

--- a/src/m365/spo/commands/page/page-text-add.ts
+++ b/src/m365/spo/commands/page/page-text-add.ts
@@ -163,7 +163,7 @@ class SpoPageTextAddCommand extends SpoCommand {
 
     const requestOptions: any = {
       url: `${args.options
-        .webUrl}/_api/web/getfilebyserverrelativeurl('${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/sitepages/${pageName}')/ListItemAllFields`,
+        .webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${urlUtil.getServerRelativeSiteUrl(args.options.webUrl)}/sitepages/${pageName}')/ListItemAllFields`,
       headers: {
         'X-RequestDigest': requestDigest,
         'content-type': 'application/json;odata=nometadata',


### PR DESCRIPTION
Closes #5333

Also resolved all the cases where this new eslint threw an error.