### PR TITLE
Fixes redundant white spaces in docs

### DIFF
--- a/docs/docs/cmd/aad/policy/policy-list.mdx
+++ b/docs/docs/cmd/aad/policy/policy-list.mdx
@@ -35,10 +35,6 @@ Returns claim-mapping policies from Azure AD
 m365 aad policy list --type "claimsMapping"
 ```
 
-## More information
-
-- Microsoft Graph Azure AD policy overview: [https://docs.microsoft.com/en-us/graph/api/resources/policy-overview?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/policy-overview?view=graph-rest-1.0)
-
 ## Response
 
 <Tabs>
@@ -113,3 +109,7 @@ m365 aad policy list --type "claimsMapping"
 
   </TabItem>
 </Tabs>
+
+## More information
+
+- Microsoft Graph Azure AD policy overview: [https://docs.microsoft.com/en-us/graph/api/resources/policy-overview?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/policy-overview?view=graph-rest-1.0)

--- a/docs/docs/cmd/cli/config/config-list.mdx
+++ b/docs/docs/cmd/cli/config/config-list.mdx
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 
 # cli config list
 
-List all self set CLI for Microsoft 365 configurations
+List all self-set CLI for Microsoft 365 configurations
 
 ## Usage
 

--- a/docs/src/remark/definitionLists.mjs
+++ b/docs/src/remark/definitionLists.mjs
@@ -27,7 +27,7 @@ export default function plugin() {
 
       parent.children[index] = {
         type: 'html',
-        value: `<dl>${items.join('')}</dl>`
+        value: `<dl class="cli-definitionList">${items.join('')}</dl>`
       };
     });
   };

--- a/docs/src/scss/Global.module.scss
+++ b/docs/src/scss/Global.module.scss
@@ -89,16 +89,22 @@
 
 //* Definition list
 
-dl {
-  margin-bottom: 0px;
+:global {
+  dl.cli-definitionList {
+    margin-bottom: 0px;
+  
+    dd {
+      padding-bottom: 15px;
+      padding-top: 5px;
+    }
+  
+    + dl {
+      margin-top: 0px;
+    }
 
-  dd {
-    padding-bottom: 15px;
-    padding-top: 5px;
-  }
-
-  + dl {
-    margin-top: 0px;
+    p {
+      margin: 0px;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #5418

---

The issue occurred because we relied on a CSS style from Mendable that was removed in one of the previous releases.