### PR TITLE
Removes 'deleted' option from 'aad group list' command. Closes #5429

### DIFF
--- a/docs/docs/cmd/aad/group/group-list.mdx
+++ b/docs/docs/cmd/aad/group/group-list.mdx
@@ -14,11 +14,6 @@ m365 aad group list [options]
 
 ## Options
 
-```md definition-list
-`-d, --deleted`
-: Use to retrieve deleted groups
-```
-
 <Global />
 
 ## Examples
@@ -27,12 +22,6 @@ Lists all groups defined in Azure Active Directory.
 
 ```sh
 m365 aad group list
-```
-
-List all recently deleted groups in the tenant
-
-```sh
-m365 aad group list --deleted
 ```
 
 ## Response

--- a/docs/docs/v7-upgrade-guidance.mdx
+++ b/docs/docs/v7-upgrade-guidance.mdx
@@ -303,13 +303,17 @@ Remove the references to the option `schemaXml` from your scripts. Verify that y
 
 In the previous version of CLI for Microsoft 365, you could get deleted users in Azure AD using the command `aad user list` and providing an option `deleted`. In the latest release, we have removed that option from the command. To get all deleted users in your tenant, you can now use the command [aad user recyclebinitem list](./cmd/aad/user/user-recyclebinitem-list.mdx).
 
+### What action do I need to take?
+
+Remove the references to the `deleted` option in your scripts. Verify that your scripts are using the command [aad user recyclebinitem list](./cmd/aad/user/user-recyclebinitem-list.mdx) instead.
+
 ## Removed `deleted` option from `aad group list` command
 
 In the previous version of CLI for Microsoft 365, you could get deleted groups in Azure AD using the command `aad group list` and providing an option `deleted`. In the latest release, we have removed that option from the command. To get all deleted groups in your tenant, you can now use the command [aad m365group recyclebinitem list](./cmd/aad/m365group/m365group-recyclebinitem-list.mdx).
 
 ### What action do I need to take?
 
-Remove the references to the `deleted` option in your scripts. Verify that your scripts are using the command [aad user recyclebinitem list](./cmd/aad/user/user-recyclebinitem-list.mdx) instead.
+Remove the references to the `deleted` option in your scripts. Verify that your scripts are using the command [aad m365group recyclebinitem list](./cmd/aad/m365group/m365group-recyclebinitem-list.mdx) instead.
 
 ## Updated `spo tenant commandset set` command with more options
 

--- a/docs/docs/v7-upgrade-guidance.mdx
+++ b/docs/docs/v7-upgrade-guidance.mdx
@@ -303,6 +303,10 @@ Remove the references to the option `schemaXml` from your scripts. Verify that y
 
 In the previous version of CLI for Microsoft 365, you could get deleted users in Azure AD using the command `aad user list` and providing an option `deleted`. In the latest release, we have removed that option from the command. To get all deleted users in your tenant, you can now use the command [aad user recyclebinitem list](./cmd/aad/user/user-recyclebinitem-list.mdx).
 
+## Removed `deleted` option from `aad group list` command
+
+In the previous version of CLI for Microsoft 365, you could get deleted groups in Azure AD using the command `aad group list` and providing an option `deleted`. In the latest release, we have removed that option from the command. To get all deleted groups in your tenant, you can now use the command [aad m365group recyclebinitem list](./cmd/aad/m365group/m365group-recyclebinitem-list.mdx).
+
 ### What action do I need to take?
 
 Remove the references to the `deleted` option in your scripts. Verify that your scripts are using the command [aad user recyclebinitem list](./cmd/aad/user/user-recyclebinitem-list.mdx) instead.

--- a/src/m365/aad/commands/group/group-list.spec.ts
+++ b/src/m365/aad/commands/group/group-list.spec.ts
@@ -170,69 +170,6 @@ describe(commands.GROUP_LIST, () => {
     ]));
   });
 
-  it('lists deleted groups in the tenant with the default properties', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/directory/deletedItems/microsoft.graph.group`) {
-        return {
-          "value": [
-            {
-              "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
-              "description": "Code Challenge",
-              "displayName": "Code Challenge",
-              "groupTypes": [
-                "Unified"
-              ],
-              "mail": "CodeChallenge@dev1802.onmicrosoft.com",
-              "mailEnabled": true,
-              "mailNickname": "CodeChallenge",
-              "securityEnabled": false
-            },
-            {
-              "id": "2f64f70d-386b-489f-805a-670cad739fde",
-              "description": "The Jumping Jacks",
-              "displayName": "The Jumping Jacks",
-              "groupTypes": [
-              ],
-              "mail": "TheJumpingJacks@dev1802.onmicrosoft.com",
-              "mailEnabled": true,
-              "mailNickname": "TheJumpingJacks",
-              "securityEnabled": true
-            }
-          ]
-        };
-      }
-
-      throw 'Invalid request';
-    });
-
-    await command.action(logger, { options: { deleted: true } });
-    assert(loggerLogSpy.calledWith([
-      {
-        "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
-        "description": "Code Challenge",
-        "displayName": "Code Challenge",
-        "groupTypes": [
-          "Unified"
-        ],
-        "mail": "CodeChallenge@dev1802.onmicrosoft.com",
-        "mailEnabled": true,
-        "mailNickname": "CodeChallenge",
-        "securityEnabled": false
-      },
-      {
-        "id": "2f64f70d-386b-489f-805a-670cad739fde",
-        "description": "The Jumping Jacks",
-        "displayName": "The Jumping Jacks",
-        "groupTypes": [
-        ],
-        "mail": "TheJumpingJacks@dev1802.onmicrosoft.com",
-        "mailEnabled": true,
-        "mailNickname": "TheJumpingJacks",
-        "securityEnabled": true
-      }
-    ]));
-  });
-
   it('lists aad Groups in the tenant (text)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups`) {

--- a/src/m365/aad/commands/group/group-list.ts
+++ b/src/m365/aad/commands/group/group-list.ts
@@ -7,11 +7,7 @@ import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
 interface CommandArgs {
-  options: Options;
-}
-
-interface Options extends GlobalOptions {
-  deleted?: boolean;
+  options: GlobalOptions;
 }
 
 interface ExtendedGroup extends Group {
@@ -27,36 +23,13 @@ class AadGroupListCommand extends GraphCommand {
     return 'Lists all groups defined in Azure Active Directory.';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        deleted: args.options.deleted
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      { option: '-d, --deleted' }
-    );
-  }
-
   public defaultProperties(): string[] | undefined {
     return ['id', 'displayName', 'groupType'];
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    const endpoint: string = args.options.deleted ? 'directory/deletedItems/microsoft.graph.group' : 'groups';
-
     try {
-      const groups = await odata.getAllItems<Group>(`${this.resource}/v1.0/${endpoint}`);
+      const groups = await odata.getAllItems<Group>(`${this.resource}/v1.0/groups`);
 
       if (Cli.shouldTrimOutput(args.options.output)) {
         groups.forEach((group: ExtendedGroup) => {


### PR DESCRIPTION
Removes `deleted` option from `aad group list` command. Closes #5429