### PR TITLE
Extends 'teams app remove' command with support for name option. Closes #5445

### DIFF
--- a/docs/docs/cmd/teams/app/app-remove.mdx
+++ b/docs/docs/cmd/teams/app/app-remove.mdx
@@ -13,8 +13,11 @@ m365 teams app remove [options]
 ## Options
 
 ```md definition-list
-`-i, --id <id>`
-: ID of the Teams app to remove. Needs to be available in your organization\'s app catalog.
+`-i, --id [id]`
+: ID of the Teams app to remove. Needs to be available in your organization\'s app catalog. Specify either `id` or `name`.
+
+`--name [name]`
+: Name of the Teams app to remove. Needs to be available in your organization\'s app catalog. Specify either `id` or `name`.
 
 `-f, --force`
 : Don't prompt for confirming removing the app
@@ -28,16 +31,16 @@ You can only remove a Teams app as a global administrator.
 
 ## Examples
 
-Remove the Teams app with ID _83cece1e-938d-44a1-8b86-918cf6151957_ from the organization's app catalog. Will prompt for confirmation before actually removing the app.
+Remove the Teams app by ID from the organization's app catalog. Will prompt for confirmation before actually removing the app.
 
 ```sh
 m365 teams app remove --id 83cece1e-938d-44a1-8b86-918cf6151957
 ```
 
-Remove the Teams app with ID _83cece1e-938d-44a1-8b86-918cf6151957_ from the organization's app catalog. Don't prompt for confirmation.
+Remove the Teams app by name from the organization's app catalog. Don't prompt for confirmation.
 
 ```sh
-m365 teams app remove --id 83cece1e-938d-44a1-8b86-918cf6151957 --force
+m365 teams app remove --name HelloWorld --force
 ```
 
 ## Response

--- a/docs/docs/cmd/teams/app/app-remove.mdx
+++ b/docs/docs/cmd/teams/app/app-remove.mdx
@@ -16,11 +16,11 @@ m365 teams app remove [options]
 `-i, --id [id]`
 : ID of the Teams app to remove. Needs to be available in your organization\'s app catalog. Specify either `id` or `name`.
 
-`--name [name]`
+`-n, --name [name]`
 : Name of the Teams app to remove. Needs to be available in your organization\'s app catalog. Specify either `id` or `name`.
 
 `-f, --force`
-: Don't prompt for confirming removing the app
+: Don't prompt for confirming removing the app.
 ```
 
 <Global />

--- a/src/m365/teams/commands/app/app-remove.spec.ts
+++ b/src/m365/teams/commands/app/app-remove.spec.ts
@@ -143,7 +143,7 @@ describe(commands.APP_REMOVE, () => {
     let removeTeamsAppCalled = false;
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?$filter=displayName eq 'TeamsApp'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?$filter=displayName eq 'TeamsApp'&$select=id`) {
         return {
           "value": [
             {
@@ -173,7 +173,7 @@ describe(commands.APP_REMOVE, () => {
 
   it('fails to get Teams app when app does not exists', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?$filter=displayName eq 'TeamsApp'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?$filter=displayName eq 'TeamsApp'&$select=id`) {
         return { value: [] };
       }
       throw 'Invalid request';
@@ -190,7 +190,7 @@ describe(commands.APP_REMOVE, () => {
 
   it('handles error when multiple Teams apps with the specified name found', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?$filter=displayName eq 'TeamsApp'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?$filter=displayName eq 'TeamsApp'&$select=id`) {
         return {
           "value": [
             {
@@ -213,7 +213,7 @@ describe(commands.APP_REMOVE, () => {
         name: 'TeamsApp',
         force: true
       }
-    } as any), new CommandError('Multiple Teams apps with name TeamsApp found. Please choose one of these ids: e3e29acb-8c79-412b-b746-e6c39ff4cd22, 5b31c38c-2584-42f0-aa47-657fb3a84230'));
+    } as any), new CommandError(`Multiple Teams apps with name 'TeamsApp' found.`));
   });
 
   it('correctly handles error when removing app', async () => {

--- a/src/m365/teams/commands/app/app-remove.spec.ts
+++ b/src/m365/teams/commands/app/app-remove.spec.ts
@@ -213,7 +213,7 @@ describe(commands.APP_REMOVE, () => {
         name: 'TeamsApp',
         force: true
       }
-    } as any), new CommandError(`Multiple Teams apps with name 'TeamsApp' found.`));
+    } as any), new CommandError(`Multiple Teams apps with name 'TeamsApp' found. Found: e3e29acb-8c79-412b-b746-e6c39ff4cd22, 5b31c38c-2584-42f0-aa47-657fb3a84230.`));
   });
 
   it('correctly handles error when removing app', async () => {

--- a/src/m365/teams/commands/app/app-remove.ts
+++ b/src/m365/teams/commands/app/app-remove.ts
@@ -141,7 +141,7 @@ class TeamsAppRemoveCommand extends GraphCommand {
         resultAsKeyValuePair[obj.id] = obj;
       });
 
-      return Cli.handleMultipleResultsFound(`Multiple Teams apps with name '${options.name}' found. Choose the correct ID:`, `Multiple Teams apps with name '${options.name}' found.`, resultAsKeyValuePair);
+      return Cli.handleMultipleResultsFound(`Multiple Teams apps with name '${options.name}' found.`, resultAsKeyValuePair);
     }
 
     return app.id;

--- a/src/m365/teams/commands/app/app-remove.ts
+++ b/src/m365/teams/commands/app/app-remove.ts
@@ -2,6 +2,7 @@ import { Cli } from '../../../../cli/Cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
+import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
@@ -12,7 +13,8 @@ interface CommandArgs {
 
 interface Options extends GlobalOptions {
   force?: boolean;
-  id: string;
+  id?: string;
+  name?: string;
 }
 
 class TeamsAppRemoveCommand extends GraphCommand {
@@ -30,12 +32,15 @@ class TeamsAppRemoveCommand extends GraphCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        force: (!(!args.options.force)).toString()
+        force: (!(!args.options.force)).toString(),
+        id: typeof args.options.id !== 'undefined',
+        name: typeof args.options.name !== 'undefined'
       });
     });
   }
@@ -43,7 +48,10 @@ class TeamsAppRemoveCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-i, --id <id>'
+        option: '-i, --id [id]'
+      },
+      {
+        option: '--name [name]'
       },
       {
         option: '-f, --force'
@@ -54,7 +62,7 @@ class TeamsAppRemoveCommand extends GraphCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.id)) {
+        if (args.options.id && !validation.isValidGuid(args.options.id)) {
           return `${args.options.id} is not a valid GUID`;
         }
 
@@ -63,22 +71,26 @@ class TeamsAppRemoveCommand extends GraphCommand {
     );
   }
 
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['id', 'name'] });
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    const { id: appId } = args.options;
-
     const removeApp = async (): Promise<void> => {
-      if (this.verbose) {
-        await logger.logToStderr(`Removing app with ID ${args.options.id}`);
-      }
-
-      const requestOptions: CliRequestOptions = {
-        url: `${this.resource}/v1.0/appCatalogs/teamsApps/${appId}`,
-        headers: {
-          accept: 'application/json;odata.metadata=none'
-        }
-      };
-
       try {
+        const appId: string = await this.getAppId(args);
+
+        if (this.verbose) {
+          await logger.logToStderr(`Removing app with ID ${args.options.id}`);
+        }
+
+        const requestOptions: CliRequestOptions = {
+          url: `${this.resource}/v1.0/appCatalogs/teamsApps/${appId}`,
+          headers: {
+            accept: 'application/json;odata.metadata=none'
+          }
+        };
+
         await request.delete(requestOptions);
       }
       catch (err: any) {
@@ -94,13 +106,40 @@ class TeamsAppRemoveCommand extends GraphCommand {
         type: 'confirm',
         name: 'continue',
         default: false,
-        message: `Are you sure you want to remove the Teams app ${appId} from the app catalog?`
+        message: `Are you sure you want to remove the Teams app ${args.options.id || args.options.name} from the app catalog?`
       });
 
       if (result.continue) {
         await removeApp();
       }
     }
+  }
+
+  private async getAppId(args: CommandArgs): Promise<string> {
+    if (args.options.id) {
+      return args.options.id;
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${this.resource}/v1.0/appCatalogs/teamsApps?$filter=displayName eq '${formatting.encodeQueryParameter(args.options.name as string)}'`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    const response = await request.get<{ value: { id: string; }[] }>(requestOptions);
+    const app: { id: string; } | undefined = response.value[0];
+
+    if (!app) {
+      throw `The specified Teams app does not exist`;
+    }
+
+    if (response.value.length > 1) {
+      throw `Multiple Teams apps with name ${args.options.name} found. Please choose one of these ids: ${response.value.map(x => x.id).join(', ')}`;
+    }
+
+    return app.id;
   }
 }
 


### PR DESCRIPTION
Extends `teams app remove` command with support for specifying the `name` option. Closes #5445