### PR TITLE
Fixes dark theme syntax highlighting

### DIFF
--- a/docs/src/config/darkCodeTheme.js
+++ b/docs/src/config/darkCodeTheme.js
@@ -105,6 +105,13 @@ const darkCodeTheme = {
       }
     },
     {
+      types: ['property'],
+      languages: ['json'],
+      style: {
+        color: '#84BDDA'
+      }
+    },
+    {
       types: ['function'],
       languages: ['powershell'],
       style: {


### PR DESCRIPTION
Closes #5444

---

This occurred only in the dark theme. The light theme remained unaffected.