### PR TITLE
Documentation update - spo list contenttype remove

### DIFF
--- a/docs/docs/cmd/spo/list/list-contenttype-remove.mdx
+++ b/docs/docs/cmd/spo/list/list-contenttype-remove.mdx
@@ -51,7 +51,7 @@ m365 spo list contenttype remove --webUrl https://contoso.sharepoint.com/sites/p
 Remove content type with a specific id from the list retrieved by server relative URL in a specific site. This will not prompt for confirmation.
 
 ```sh
-m365 spo list contenttype remove --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents' --contentTypeId 0x010109010053EE7AEB1FC54A41B4D9F66ADBDC312A --force
+m365 spo list contenttype remove --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl 'sites/project-x/Documents' --id 0x010109010053EE7AEB1FC54A41B4D9F66ADBDC312A --force
 ```
 
 ## Response


### PR DESCRIPTION
Updated documentation of below command(s):
- `spo list contenttype remove`

Fixed issue with one of the examples in cmdlet documentation: cmdlet parameter used should be `--id` and not `--contentTypeId`.