### PR TITLE
Show login message using spinner. Closes #5484

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -420,7 +420,17 @@ export class Auth {
       await logger.logToStderr('');
     }
 
-    await logger.log(response.message);
+    const cli = Cli.getInstance();
+    cli.spinner.text = response.message;
+    cli.spinner.spinner = {
+      frames: ['🌶️  ']
+    };
+
+    // don't show spinner if running tests
+    /* c8 ignore next 3 */
+    if (!cli.spinner.isSpinning && typeof global.it === 'undefined') {
+      cli.spinner.start();
+    }
 
     if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false)) {
       browserUtil.open(response.verificationUri);

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -205,7 +205,7 @@ class LoginCommand extends Command {
       }
 
       if (this.debug) {
-        await logger.logToStderr({
+        await logger.log({
           connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
           authType: AuthType[auth.service.authType],
           appId: auth.service.appId,
@@ -215,7 +215,7 @@ class LoginCommand extends Command {
         });
       }
       else {
-        await logger.logToStderr({
+        await logger.log({
           connectedAs: accessToken.getUserNameFromAccessToken(auth.service.accessTokens[auth.defaultResource].accessToken),
           authType: AuthType[auth.service.authType],
           appId: auth.service.appId,


### PR DESCRIPTION
Closes #5484

Show login message using spinner. Fix bug where login output is written to `stderr`.