### PR TITLE
Enhances "aad m365group add" command by adding "visibilty" option. Closes #5477

### DIFF
--- a/docs/docs/cmd/aad/m365group/m365group-add.mdx
+++ b/docs/docs/cmd/aad/m365group/m365group-add.mdx
@@ -30,8 +30,8 @@ m365 aad m365group add [options]
 `--members [members]`
 : Comma-separated list of Microsoft 365 Group members
 
-`--isPrivate`
-: Specify, if the Microsoft 365 Group should be private. If not specified, will create a public group (default)
+`--visibility [visibility]`
+: Specifies the group join policy and group content visibility for groups. Possible values are: `Private`, `Public`, or `HiddenMembership`. Defaults to `Public`.
 
 `--allowMembersToPost [allowMembersToPost]`
 : Set if only group members should be able to post conversations to the group
@@ -53,8 +53,18 @@ m365 aad m365group add [options]
 
 ## Remarks
 
+You cannot change the group type when you choose `HiddenMembership` visibility. HiddenMembership can be set only for Microsoft 365 groups, when the groups are created. It can't be updated later.
+
 When specifying the path to the logo image you can use both relative and absolute paths. Note, that ~ in the path, will not be resolved and will most likely result in an error.
 If an invalid user is provided in the comma-separated list of Owners or Members, the command operation will fail and the Microsoft 365 Group will not be created.
+
+Group visibility options:
+
+Value	| Description
+-------|-------------
+Public | Anyone can join the group without needing owner permission. Anyone can view the attributes of the group. Anyone can see the members of the group.
+Private | Owner permission is needed to join the group. Anyone can view the attributes of the group. Anyone can see the members of the group.
+HiddenMembership | Owner permission is needed to join the group. Guest users cannot view the attributes of the group. Non-members cannot see the members of the group. Administrators (global, company, user, and helpdesk) can view the membership of the group. The group appears in the global address book (GAL).
 
 ## Examples
 
@@ -67,7 +77,7 @@ m365 aad m365group add --displayName Finance --description "This is the Contoso 
 Create a private Microsoft 365 Group
 
 ```sh
-m365 aad m365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --isPrivate
+m365 aad m365group add --displayName Finance --description "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more." --mailNickname finance --visibility "Private"
 ```
 
 Create a public Microsoft 365 Group and set specified users as its owners

--- a/docs/docs/sample-scripts/teams/create-team-and-add-members-and-owners/index.mdx
+++ b/docs/docs/sample-scripts/teams/create-team-and-add-members-and-owners/index.mdx
@@ -32,7 +32,7 @@ This sample script shows you how to create a Team and add members and owners usi
   $teamDisplayName = "Cool team"
   $teamDescription = "."
   $mailNickname = "uniqueNickname18"
-  $isPrivate = $true  
+  $visibility = "Private" # Specify either 'Private', 'Public', or 'HiddenMembership'  
   $removeYourSelfFromOwners = $false
   ## parameters for the Group end
 
@@ -56,9 +56,8 @@ This sample script shows you how to create a Team and add members and owners usi
   $members = ($membersList | where { $_.type -eq "member" } | Select-Object upn).upn -join ","
   $owners = ($membersList | where { $_.type -eq "owner" } | Select-Object upn).upn -join ","
 
-  $privateString = $(If ($isPrivate) {"true"} Else {"false"})
   Write-Host "Provisioning Group..."
-  $group = m365 aad m365group add --displayName $teamDisplayName --description $teamDescription --mailNickname $mailNickname --isPrivate $privateString --members $members --owners $owners | ConvertFrom-Json
+  $group = m365 aad m365group add --displayName $teamDisplayName --description $teamDescription --mailNickname $mailNickname --visibility $visibility --members $members --owners $owners | ConvertFrom-Json
 
   if ($Error.Count -gt 0) {
       Write-Host "Aborting operation..."

--- a/src/m365/aad/commands/m365group/m365group-add.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-add.spec.ts
@@ -129,7 +129,7 @@ describe(commands.M365GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', isPrivate: true } });
+    await command.action(logger, { options: { displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', visibility: 'Private' } });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, {
       description: 'My awesome group',
       displayName: 'My group',
@@ -697,6 +697,18 @@ describe(commands.M365GROUP_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if incorrect visibility is specified.', async () => {
+    const actual = await command.validate({
+      options: {
+        displayName: 'My group',
+        description: 'My awesome group',
+        mailNickname: 'my_group',
+        visibility: "invalid"
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('passes validation if logoPath points to an existing file', async () => {
     const stats: fs.Stats = new fs.Stats();
     sinon.stub(stats, 'isDirectory').callsFake(() => false);
@@ -769,7 +781,7 @@ describe(commands.M365GROUP_ADD, () => {
     const options = command.options;
     let containsOption = false;
     options.forEach(o => {
-      if (o.option.indexOf('--isPrivate') > -1) {
+      if (o.option.indexOf('--visibility') > -1) {
         containsOption = true;
       }
     });

--- a/src/m365/aad/commands/m365group/m365group-add.ts
+++ b/src/m365/aad/commands/m365group/m365group-add.ts
@@ -19,7 +19,7 @@ interface Options extends GlobalOptions {
   mailNickname: string;
   owners?: string;
   members?: string;
-  isPrivate?: boolean;
+  visibility?: string;
   logoPath?: string;
   allowMembersToPost?: boolean;
   hideGroupInOutlook?: boolean;
@@ -30,6 +30,7 @@ interface Options extends GlobalOptions {
 class AadM365GroupAddCommand extends GraphCommand {
   private static numRepeat: number = 15;
   private pollingInterval: number = 500;
+  private allowedVisibilities: string[] = ['Private', 'Public', 'HiddenMembership'];
 
   public get name(): string {
     return commands.M365GROUP_ADD;
@@ -54,7 +55,7 @@ class AadM365GroupAddCommand extends GraphCommand {
         owners: typeof args.options.owners !== 'undefined',
         members: typeof args.options.members !== 'undefined',
         logoPath: typeof args.options.logoPath !== 'undefined',
-        isPrivate: typeof args.options.isPrivate !== 'undefined',
+        visibility: typeof args.options.visibility !== 'undefined',
         allowMembersToPost: !!args.options.allowMembersToPost,
         hideGroupInOutlook: !!args.options.hideGroupInOutlook,
         subscribeNewGroupMembers: !!args.options.subscribeNewGroupMembers,
@@ -81,7 +82,8 @@ class AadM365GroupAddCommand extends GraphCommand {
         option: '--members [members]'
       },
       {
-        option: '--isPrivate'
+        option: '--visibility [visibility]',
+        autocomplete: this.allowedVisibilities
       },
       {
         option: '--allowMembersToPost [allowMembersToPost]',
@@ -146,6 +148,10 @@ class AadM365GroupAddCommand extends GraphCommand {
           }
         }
 
+        if (args.options.visibility && this.allowedVisibilities.map(x => x.toLowerCase()).indexOf(args.options.visibility.toLowerCase()) === -1) {
+          return `${args.options.visibility} is not a valid visibility. Allowed values are ${this.allowedVisibilities.join(', ')}`;
+        }
+
         return true;
       }
     );
@@ -156,6 +162,7 @@ class AadM365GroupAddCommand extends GraphCommand {
     let ownerIds: string[] = [];
     let memberIds: string[] = [];
     const resourceBehaviorOptionsCollection: string[] = [];
+    const resolvedVisibility = args.options.visibility || 'Public';
 
     if (this.verbose) {
       await logger.logToStderr('Creating Microsoft 365 Group...');
@@ -193,7 +200,7 @@ class AadM365GroupAddCommand extends GraphCommand {
         mailNickname: args.options.mailNickname,
         resourceBehaviorOptions: resourceBehaviorOptionsCollection,
         securityEnabled: false,
-        visibility: args.options.isPrivate ? 'Private' : 'Public'
+        visibility: resolvedVisibility
       }
     };
 


### PR DESCRIPTION
Enhances `aad m365group add` command by adding `visibilty` and removing `--isPrivate` option. Closes #5477