### PR TITLE
Fixes 'planner task list' command without options

### DIFF
--- a/src/m365/planner/commands/task/task-list.spec.ts
+++ b/src/m365/planner/commands/task/task-list.spec.ts
@@ -511,10 +511,7 @@ describe(commands.TASK_LIST, () => {
 
   it('passes validation when no arguments are specified', async () => {
     const actual = await command.validate({
-      options: {
-        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2',
-        bucketName: 'Planner Bucket A'
-      }
+      options: {}
     }, commandInfo);
     assert.strictEqual(actual, true);
   });

--- a/src/m365/planner/commands/task/task-list.ts
+++ b/src/m365/planner/commands/task/task-list.ts
@@ -101,7 +101,12 @@ class PlannerTaskListCommand extends GraphCommand {
 
   #initOptionSets(): void {
     this.optionSets.push(
-      { options: ['bucketId', 'bucketName'] },
+      {
+        options: ['bucketId', 'bucketName'],
+        runsWhen: (args) => {
+          return args.options.bucketId !== undefined || args.options.bucketName !== undefined;
+        }
+      },
       {
         options: ['planId', 'planTitle'],
         runsWhen: (args) => {


### PR DESCRIPTION
### Make 'planner task list' without options work again to return all tasks of the logged in user

- Fixes 'planner task list' command. Closes #5503

Closes #5503