### PR TITLE
Ensure that every `aad m365group` command only works for M365 groups

### DIFF
--- a/docs/docs/v7-upgrade-guidance.mdx
+++ b/docs/docs/v7-upgrade-guidance.mdx
@@ -419,7 +419,7 @@ If you are using one of the affected commands listed above, make sure to update 
 
 ## Added group check to `aad m365group` commands
 
-When currently calling the `aad m365group` commands, we wouldn't always check if the group that we are trying to retrieve, update or remove was effectively a m365 group. In version 7 of the CLI for Microsoft 365, we will throw an error telling that the group they are trying to update is not a valid Microsoft 365 group.
+Previously using the `aad m365group` commands allowed to retrieve, update, or remove other than just m365 groups. In version 7 of the CLI for Microsoft 365, we added additional validation that will throw an error saying that the group they are trying to update is not a valid Microsoft 365 group.
 
 We added this check to the following commands:
 

--- a/docs/docs/v7-upgrade-guidance.mdx
+++ b/docs/docs/v7-upgrade-guidance.mdx
@@ -417,6 +417,28 @@ We removed the `ID` property for the following commands:
 
 If you are using one of the affected commands listed above, make sure to update your scripts to use the `Id` property instead of `ID`.
 
+## Added group check to `aad m365group` commands
+
+When currently calling the `aad m365group` commands, we wouldn't always check if the group that we are trying to retrieve, update or remove was effectively a m365 group. In version 7 of the CLI for Microsoft 365, we will throw an error telling that the group they are trying to update is not a valid Microsoft 365 group.
+
+We added this check to the following commands:
+
+- [aad m365group get](./cmd/aad/m365group/m365group-get.mdx)
+- [aad m365group remove](./cmd/aad/m365group/m365group-remove.mdx)
+- [aad m365group renew](./cmd/aad/m365group/m365group-renew.mdx)
+- [aad m365group set](./cmd/aad/m365group/m365group-set.mdx)
+- [aad m365group teamify](./cmd/aad/m365group/m365group-teamify.mdx)
+- [aad m365group conversation list](./cmd/aad/m365group/m365group-conversation-list.mdx)
+- [aad m365group conversation post list](./cmd/aad/m365group/m365group-conversation-post-list.mdx)
+- [aad m365group user add](./cmd/aad/m365group/m365group-user-add.mdx)
+- [aad m365group user list](./cmd/aad/m365group/m365group-user-list.mdx)
+- [aad m365group user remove](./cmd/aad/m365group/m365group-user-remove.mdx)
+- [aad m365group user set](./cmd/aad/m365group/m365group-user-set.mdx)
+
+### What action do I need to take?
+
+If you are using one of the affected commands listed above, make sure to update your scripts to handle the error.
+
 ## Aligned options with naming convention
 
 In version 7 of the CLI for Microsoft 365, we have made updates to the options for certain commands, aligning with our naming convention. This includes renaming options to ensure consistency and improve the CLI experience. For example, the option `--environment` for the command `m365 pa app consent set` has been changed to `--environmentName`. These changes aim to make it easier for you to use the CLI.

--- a/src/m365/aad/commands/m365group/m365group-conversation-list.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-list.spec.ts
@@ -12,6 +12,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './m365group-conversation-list.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_CONVERSATION_LIST, () => {
   let log: string[];
@@ -48,6 +49,7 @@ describe(commands.M365GROUP_CONVERSATION_LIST, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-conversation-list.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-list.spec.ts
@@ -49,7 +49,7 @@ describe(commands.M365GROUP_CONVERSATION_LIST, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -125,4 +125,15 @@ describe(commands.M365GROUP_CONVERSATION_LIST, () => {
     await assert.rejects(command.action(logger, { options: { groupId: "00000000-0000-0000-0000-000000000000" } } as any),
       new CommandError('An error has occurred'));
   });
+
+  it('shows error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { groupId: groupId } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
+  });
+
 });

--- a/src/m365/aad/commands/m365group/m365group-conversation-list.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-list.ts
@@ -58,9 +58,11 @@ class AadM365GroupConversationListCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.groupId);
+
       if (!isUnifiedGroup) {
         throw Error(`Specified group with id '${args.options.groupId}' is not a Microsoft 365 group.`);
       }
+
       const conversations = await odata.getAllItems<Conversation>(`${this.resource}/v1.0/groups/${args.options.groupId}/conversations`);
       await logger.log(conversations);
     }

--- a/src/m365/aad/commands/m365group/m365group-conversation-list.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-list.ts
@@ -57,7 +57,10 @@ class AadM365GroupConversationListCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      await aadGroup.verifyGroupType(args.options.groupId);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.groupId);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${args.options.groupId}' is not a Microsoft 365 group.`);
+      }
       const conversations = await odata.getAllItems<Conversation>(`${this.resource}/v1.0/groups/${args.options.groupId}/conversations`);
       await logger.log(conversations);
     }

--- a/src/m365/aad/commands/m365group/m365group-conversation-list.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-list.ts
@@ -5,6 +5,7 @@ import { odata } from '../../../../utils/odata.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 interface CommandArgs {
   options: Options;
@@ -56,6 +57,7 @@ class AadM365GroupConversationListCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
+      await aadGroup.verifyGroupType(args.options.groupId);
       const conversations = await odata.getAllItems<Conversation>(`${this.resource}/v1.0/groups/${args.options.groupId}/conversations`);
       await logger.log(conversations);
     }

--- a/src/m365/aad/commands/m365group/m365group-conversation-post-list.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-post-list.spec.ts
@@ -82,7 +82,7 @@ describe(commands.M365GROUP_CONVERSATION_POST_LIST, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -217,5 +217,15 @@ describe(commands.M365GROUP_CONVERSATION_POST_LIST, () => {
         threadId: "AAQkADkwN2Q2NDg1LWQ3ZGYtNDViZi1iNGRiLTVhYjJmN2Q5NDkxZQAQAOnRAfDf71lIvrdK85FAn5E="
       }
     } as any), new CommandError('An error has occurred'));
+  });
+
+  it('shows error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { groupId: groupId, threadId: 'AAQkADkwN2Q2NDg1LWQ3ZGYtNDViZi1iNGRiLTVhYjJmN2Q5NDkxZQAQAOnRAfDf71lIvrdK85FAn5E=' } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-conversation-post-list.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-post-list.spec.ts
@@ -13,6 +13,7 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './m365group-conversation-post-list.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_CONVERSATION_POST_LIST, () => {
   let cli: Cli;
@@ -81,6 +82,7 @@ describe(commands.M365GROUP_CONVERSATION_POST_LIST, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-conversation-post-list.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-post-list.ts
@@ -82,6 +82,7 @@ class AadM365GroupConversationPostListCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const retrievedgroupId = await this.getGroupId(args);
+      await aadGroup.verifyGroupType(retrievedgroupId);
       const posts = await odata.getAllItems<Post>(`${this.resource}/v1.0/groups/${retrievedgroupId}/threads/${args.options.threadId}/posts`);
       await logger.log(posts);
     }

--- a/src/m365/aad/commands/m365group/m365group-conversation-post-list.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-post-list.ts
@@ -83,9 +83,11 @@ class AadM365GroupConversationPostListCommand extends GraphCommand {
     try {
       const retrievedgroupId = await this.getGroupId(args);
       const isUnifiedGroup = await aadGroup.isUnifiedGroup(retrievedgroupId);
+
       if (!isUnifiedGroup) {
         throw Error(`Specified group with id '${retrievedgroupId}' is not a Microsoft 365 group.`);
       }
+
       const posts = await odata.getAllItems<Post>(`${this.resource}/v1.0/groups/${retrievedgroupId}/threads/${args.options.threadId}/posts`);
       await logger.log(posts);
     }

--- a/src/m365/aad/commands/m365group/m365group-conversation-post-list.ts
+++ b/src/m365/aad/commands/m365group/m365group-conversation-post-list.ts
@@ -82,7 +82,10 @@ class AadM365GroupConversationPostListCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const retrievedgroupId = await this.getGroupId(args);
-      await aadGroup.verifyGroupType(retrievedgroupId);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(retrievedgroupId);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${retrievedgroupId}' is not a Microsoft 365 group.`);
+      }
       const posts = await odata.getAllItems<Post>(`${this.resource}/v1.0/groups/${retrievedgroupId}/threads/${args.options.threadId}/posts`);
       await logger.log(posts);
     }

--- a/src/m365/aad/commands/m365group/m365group-get.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-get.spec.ts
@@ -25,7 +25,7 @@ describe(commands.M365GROUP_GET, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -411,5 +411,15 @@ describe(commands.M365GROUP_GET, () => {
       }
     });
     assert(containsOption);
+  });
+
+  it('shows error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { id: groupId } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-get.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-get.spec.ts
@@ -12,6 +12,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './m365group-get.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_GET, () => {
   let log: string[];
@@ -24,6 +25,7 @@ describe(commands.M365GROUP_GET, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -381,41 +383,6 @@ describe(commands.M365GROUP_GET, () => {
       "visibility": "Public",
       "siteUrl": ""
     }));
-  });
-
-  it('throws error if retrieved group is not an M365 group', async () => {
-    const groupId = '1caf7dcd-7e83-4c3a-94f7-932a1299c844';
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups/1caf7dcd-7e83-4c3a-94f7-932a1299c844`) {
-        return {
-          "id": groupId,
-          "deletedDateTime": null,
-          "classification": null,
-          "createdDateTime": "2017-11-29T03:27:05Z",
-          "description": "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.",
-          "displayName": "Finance",
-          "groupTypes": [],
-          "mail": "finance@contoso.onmicrosoft.com",
-          "mailEnabled": true,
-          "mailNickname": "finance",
-          "onPremisesLastSyncDateTime": null,
-          "onPremisesProvisioningErrors": [],
-          "onPremisesSecurityIdentifier": null,
-          "onPremisesSyncEnabled": null,
-          "preferredDataLocation": null,
-          "proxyAddresses": [
-            "SMTP:finance@contoso.onmicrosoft.com"
-          ],
-          "renewedDateTime": "2017-11-29T03:27:05Z",
-          "securityEnabled": false,
-          "visibility": "Public"
-        };
-      }
-
-      throw 'Invalid request';
-    });
-
-    await assert.rejects(command.action(logger, { options: { id: groupId } }), new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 
   it('handles random API error', async () => {

--- a/src/m365/aad/commands/m365group/m365group-get.ts
+++ b/src/m365/aad/commands/m365group/m365group-get.ts
@@ -59,7 +59,10 @@ class AadM365GroupGetCommand extends GraphCommand {
     let group: GroupExtended;
 
     try {
-      await aadGroup.verifyGroupType(args.options.id);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.id);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${args.options.id}' is not a Microsoft 365 group.`);
+      }
 
       group = await aadGroup.getGroupById(args.options.id);
 

--- a/src/m365/aad/commands/m365group/m365group-get.ts
+++ b/src/m365/aad/commands/m365group/m365group-get.ts
@@ -59,11 +59,9 @@ class AadM365GroupGetCommand extends GraphCommand {
     let group: GroupExtended;
 
     try {
-      group = await aadGroup.getGroupById(args.options.id);
+      await aadGroup.verifyGroupType(args.options.id);
 
-      if (!group.groupTypes!.some(type => type === 'Unified')) {
-        throw `Specified group with id '${args.options.id}' is not a Microsoft 365 group.`;
-      }
+      group = await aadGroup.getGroupById(args.options.id);
 
       if (args.options.includeSiteUrl) {
         const requestOptions: CliRequestOptions = {

--- a/src/m365/aad/commands/m365group/m365group-remove.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-remove.spec.ts
@@ -26,7 +26,7 @@ describe(commands.M365GROUP_REMOVE, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -235,5 +235,15 @@ describe(commands.M365GROUP_REMOVE, () => {
   it('passes validation when the id is a valid GUID', async () => {
     const actual = await command.validate({ options: { id: '2c1ba4c4-cd9b-4417-832f-92a34bc34b2a' } }, commandInfo);
     assert.strictEqual(actual, true);
+  });
+
+  it('throws error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { id: groupId, force: true } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-remove.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-remove.spec.ts
@@ -12,6 +12,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './m365group-remove.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_REMOVE, () => {
   let log: string[];
@@ -25,6 +26,7 @@ describe(commands.M365GROUP_REMOVE, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-remove.ts
+++ b/src/m365/aad/commands/m365group/m365group-remove.ts
@@ -77,9 +77,11 @@ class AadM365GroupRemoveCommand extends GraphCommand {
 
       try {
         const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.id);
+
         if (!isUnifiedGroup) {
           throw Error(`Specified group with id '${args.options.id}' is not a Microsoft 365 group.`);
         }
+
         const requestOptions: CliRequestOptions = {
           url: `${this.resource}/v1.0/groups/${args.options.id}`,
           headers: {

--- a/src/m365/aad/commands/m365group/m365group-remove.ts
+++ b/src/m365/aad/commands/m365group/m365group-remove.ts
@@ -2,6 +2,7 @@ import { Cli } from '../../../../cli/Cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
@@ -75,6 +76,7 @@ class AadM365GroupRemoveCommand extends GraphCommand {
       }
 
       try {
+        await aadGroup.verifyGroupType(args.options.groupId);
         const requestOptions: CliRequestOptions = {
           url: `${this.resource}/v1.0/groups/${args.options.id}`,
           headers: {

--- a/src/m365/aad/commands/m365group/m365group-remove.ts
+++ b/src/m365/aad/commands/m365group/m365group-remove.ts
@@ -76,7 +76,10 @@ class AadM365GroupRemoveCommand extends GraphCommand {
       }
 
       try {
-        await aadGroup.verifyGroupType(args.options.groupId);
+        const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.id);
+        if (!isUnifiedGroup) {
+          throw Error(`Specified group with id '${args.options.id}' is not a Microsoft 365 group.`);
+        }
         const requestOptions: CliRequestOptions = {
           url: `${this.resource}/v1.0/groups/${args.options.id}`,
           headers: {

--- a/src/m365/aad/commands/m365group/m365group-renew.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-renew.spec.ts
@@ -12,6 +12,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './m365group-renew.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_RENEW, () => {
   let log: string[];
@@ -25,6 +26,7 @@ describe(commands.M365GROUP_RENEW, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-renew.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-renew.spec.ts
@@ -26,7 +26,7 @@ describe(commands.M365GROUP_RENEW, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -120,5 +120,15 @@ describe(commands.M365GROUP_RENEW, () => {
   it('passes validation when the id is a valid GUID', async () => {
     const actual = await command.validate({ options: { id: '2c1ba4c4-cd9b-4417-832f-92a34bc34b2a' } }, commandInfo);
     assert.strictEqual(actual, true);
+  });
+
+  it('throws error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { id: groupId } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-renew.ts
+++ b/src/m365/aad/commands/m365group/m365group-renew.ts
@@ -57,9 +57,11 @@ class AadM365GroupRenewCommand extends GraphCommand {
 
     try {
       const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.id);
+
       if (!isUnifiedGroup) {
         throw Error(`Specified group with id '${args.options.id}' is not a Microsoft 365 group.`);
       }
+
       const requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/groups/${args.options.id}/renew/`,
         headers: {

--- a/src/m365/aad/commands/m365group/m365group-renew.ts
+++ b/src/m365/aad/commands/m365group/m365group-renew.ts
@@ -1,6 +1,7 @@
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
@@ -55,6 +56,7 @@ class AadM365GroupRenewCommand extends GraphCommand {
     }
 
     try {
+      await aadGroup.verifyGroupType(args.options.groupId);
       const requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/groups/${args.options.id}/renew/`,
         headers: {

--- a/src/m365/aad/commands/m365group/m365group-renew.ts
+++ b/src/m365/aad/commands/m365group/m365group-renew.ts
@@ -56,7 +56,10 @@ class AadM365GroupRenewCommand extends GraphCommand {
     }
 
     try {
-      await aadGroup.verifyGroupType(args.options.groupId);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.id);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${args.options.id}' is not a Microsoft 365 group.`);
+      }
       const requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/groups/${args.options.id}/renew/`,
         headers: {

--- a/src/m365/aad/commands/m365group/m365group-set.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-set.spec.ts
@@ -572,7 +572,7 @@ describe(commands.M365GROUP_SET, () => {
     sinonUtil.restore(aadGroup.isUnifiedGroup);
     sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
 
-    await assert.rejects(command.action(logger, { options: { groupId: groupId, displayName: 'Updated title' } } as any),
+    await assert.rejects(command.action(logger, { options: { id: groupId, displayName: 'Updated title' } } as any),
       new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-set.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-set.spec.ts
@@ -14,6 +14,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './m365group-set.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_SET, () => {
   let log: string[];
@@ -27,6 +28,7 @@ describe(commands.M365GROUP_SET, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-set.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-set.spec.ts
@@ -28,7 +28,7 @@ describe(commands.M365GROUP_SET, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -564,5 +564,15 @@ describe(commands.M365GROUP_SET, () => {
       }
     });
     assert(containsOption);
+  });
+
+  it('throws error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { groupId: groupId, displayName: 'Updated title' } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-set.ts
+++ b/src/m365/aad/commands/m365group/m365group-set.ts
@@ -8,6 +8,7 @@ import request, { CliRequestOptions } from '../../../../request.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 interface CommandArgs {
   options: Options;
@@ -141,6 +142,8 @@ class AadM365GroupSetCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
+      await aadGroup.verifyGroupType(args.options.id);
+
       if (args.options.displayName || args.options.description || typeof args.options.isPrivate !== 'undefined') {
         if (this.verbose) {
           await logger.logToStderr(`Updating Microsoft 365 Group ${args.options.id}...`);

--- a/src/m365/aad/commands/m365group/m365group-set.ts
+++ b/src/m365/aad/commands/m365group/m365group-set.ts
@@ -142,9 +142,10 @@ class AadM365GroupSetCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.groupId);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.id);
+
       if (!isUnifiedGroup) {
-        throw Error(`Specified group with id '${args.options.groupId}' is not a Microsoft 365 group.`);
+        throw Error(`Specified group with id '${args.options.id}' is not a Microsoft 365 group.`);
       }
 
       if (args.options.displayName || args.options.description || typeof args.options.isPrivate !== 'undefined') {

--- a/src/m365/aad/commands/m365group/m365group-set.ts
+++ b/src/m365/aad/commands/m365group/m365group-set.ts
@@ -142,7 +142,10 @@ class AadM365GroupSetCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      await aadGroup.verifyGroupType(args.options.id);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.groupId);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${args.options.groupId}' is not a Microsoft 365 group.`);
+      }
 
       if (args.options.displayName || args.options.description || typeof args.options.isPrivate !== 'undefined') {
         if (this.verbose) {

--- a/src/m365/aad/commands/m365group/m365group-teamify.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-teamify.spec.ts
@@ -27,7 +27,7 @@ describe(commands.M365GROUP_TEAMIFY, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -626,5 +626,15 @@ describe(commands.M365GROUP_TEAMIFY, () => {
   it('passes validation if the id is a valid GUID', async () => {
     const actual = await command.validate({ options: { id: '8231f9f2-701f-4c6e-93ce-ecb563e3c1ee' } }, commandInfo);
     assert.strictEqual(actual, true);
+  });
+
+  it('throws error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { id: groupId } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-teamify.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-teamify.spec.ts
@@ -13,6 +13,7 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './m365group-teamify.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_TEAMIFY, () => {
   let cli: Cli;
@@ -26,6 +27,7 @@ describe(commands.M365GROUP_TEAMIFY, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-teamify.ts
+++ b/src/m365/aad/commands/m365group/m365group-teamify.ts
@@ -71,13 +71,13 @@ class AadM365GroupTeamifyCommand extends GraphCommand {
     this.optionSets.push({ options: ['id', 'mailNickname'] });
   }
 
-  private async getGroupId(args: CommandArgs): Promise<string> {
-    if (args.options.id) {
-      return args.options.id;
+  private async getGroupId(options: Options): Promise<string> {
+    if (options.id) {
+      return options.id;
     }
 
     const requestOptions: CliRequestOptions = {
-      url: `${this.resource}/v1.0/groups?$filter=mailNickname eq '${formatting.encodeQueryParameter(args.options.mailNickname as string)}'`,
+      url: `${this.resource}/v1.0/groups?$filter=mailNickname eq '${formatting.encodeQueryParameter(options.mailNickname as string)}'`,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },
@@ -93,7 +93,7 @@ class AadM365GroupTeamifyCommand extends GraphCommand {
 
     if (response.value.length > 1) {
       const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', response.value);
-      const result = await Cli.handleMultipleResultsFound<{ id: string }>(`Multiple Microsoft 365 Groups with name '${args.options.mailNickname}' found.`, resultAsKeyValuePair);
+      const result = await Cli.handleMultipleResultsFound<{ id: string }>(`Multiple Microsoft 365 Groups with name '${options.mailNickname}' found.`, resultAsKeyValuePair);
       return result.id;
     }
 
@@ -102,8 +102,9 @@ class AadM365GroupTeamifyCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const groupId = await this.getGroupId(args);
+      const groupId = await this.getGroupId(args.options);
       const isUnifiedGroup = await aadGroup.isUnifiedGroup(groupId);
+
       if (!isUnifiedGroup) {
         throw Error(`Specified group with id '${groupId}' is not a Microsoft 365 group.`);
       }

--- a/src/m365/aad/commands/m365group/m365group-teamify.ts
+++ b/src/m365/aad/commands/m365group/m365group-teamify.ts
@@ -103,7 +103,10 @@ class AadM365GroupTeamifyCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const groupId = await this.getGroupId(args);
-      await aadGroup.verifyGroupType(groupId);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(groupId);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${groupId}' is not a Microsoft 365 group.`);
+      }
 
       const data: any = {
         "memberSettings": {

--- a/src/m365/aad/commands/m365group/m365group-teamify.ts
+++ b/src/m365/aad/commands/m365group/m365group-teamify.ts
@@ -2,6 +2,7 @@ import { Cli } from '../../../../cli/Cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
@@ -101,6 +102,9 @@ class AadM365GroupTeamifyCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
+      const groupId = await this.getGroupId(args);
+      await aadGroup.verifyGroupType(groupId);
+
       const data: any = {
         "memberSettings": {
           "allowCreatePrivateChannels": true,
@@ -116,7 +120,7 @@ class AadM365GroupTeamifyCommand extends GraphCommand {
         }
       };
 
-      const groupId = await this.getGroupId(args);
+
       const requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/groups/${formatting.encodeQueryParameter(groupId)}/team`,
         headers: {

--- a/src/m365/aad/commands/m365group/m365group-user-add.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-add.spec.ts
@@ -28,7 +28,7 @@ describe(commands.M365GROUP_USER_ADD, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -331,5 +331,15 @@ describe(commands.M365GROUP_USER_ADD, () => {
 
     await assert.rejects(command.action(logger, { options: { teamId: "00000000-0000-0000-0000-000000000000", userName: "anne.matthews@contoso.onmicrosoft.com" } } as any),
       new CommandError('Invalid object identifier'));
+  });
+
+  it('throws error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { groupId: groupId, userName: 'anne.matthews@contoso.onmicrosoft.com' } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-user-add.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-add.spec.ts
@@ -14,6 +14,7 @@ import teamsCommands from '../../../teams/commands.js';
 import commands from '../../commands.js';
 import command from './m365group-user-add.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_USER_ADD, () => {
   let cli: Cli;
@@ -27,6 +28,7 @@ describe(commands.M365GROUP_USER_ADD, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-user-add.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-add.ts
@@ -98,7 +98,10 @@ class AadM365GroupUserAddCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const providedGroupId: string = (typeof args.options.groupId !== 'undefined') ? args.options.groupId : args.options.teamId as string;
-      await aadGroup.verifyGroupType(providedGroupId);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(providedGroupId);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${providedGroupId}' is not a Microsoft 365 group.`);
+      }
 
       let requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/users/${formatting.encodeQueryParameter(args.options.userName)}/id`,

--- a/src/m365/aad/commands/m365group/m365group-user-add.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-add.ts
@@ -1,6 +1,7 @@
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
@@ -97,6 +98,7 @@ class AadM365GroupUserAddCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const providedGroupId: string = (typeof args.options.groupId !== 'undefined') ? args.options.groupId : args.options.teamId as string;
+      await aadGroup.verifyGroupType(providedGroupId);
 
       let requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/users/${formatting.encodeQueryParameter(args.options.userName)}/id`,

--- a/src/m365/aad/commands/m365group/m365group-user-list.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-list.spec.ts
@@ -25,7 +25,7 @@ describe(commands.M365GROUP_USER_LIST, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -270,5 +270,15 @@ describe(commands.M365GROUP_USER_LIST, () => {
 
     await assert.rejects(command.action(logger, { options: { groupId: "00000000-0000-0000-0000-000000000000" } } as any),
       new CommandError('An error has occurred'));
+  });
+
+  it('throws error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { groupId: groupId } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-user-list.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-list.spec.ts
@@ -12,6 +12,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './m365group-user-list.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_USER_LIST, () => {
   let log: string[];
@@ -24,6 +25,7 @@ describe(commands.M365GROUP_USER_LIST, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-user-list.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-list.ts
@@ -5,6 +5,7 @@ import { odata } from '../../../../utils/odata.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 interface CommandArgs {
   options: Options;
@@ -72,6 +73,8 @@ class AadM365GroupUserListCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
+      await aadGroup.verifyGroupType(args.options.groupId);
+
       let users = await this.getOwners(args.options.groupId, logger);
 
       if (args.options.role !== 'Owner') {

--- a/src/m365/aad/commands/m365group/m365group-user-list.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-list.ts
@@ -73,7 +73,10 @@ class AadM365GroupUserListCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      await aadGroup.verifyGroupType(args.options.groupId);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(args.options.groupId);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${args.options.groupId}' is not a Microsoft 365 group.`);
+      }
 
       let users = await this.getOwners(args.options.groupId, logger);
 

--- a/src/m365/aad/commands/m365group/m365group-user-remove.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-remove.spec.ts
@@ -29,7 +29,7 @@ describe(commands.M365GROUP_USER_REMOVE, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -632,5 +632,15 @@ describe(commands.M365GROUP_USER_REMOVE, () => {
     sinon.stub(Cli, 'prompt').resolves({ continue: true });
 
     await assert.rejects(command.action(logger, { options: { debug: true, groupId: "00000000-0000-0000-0000-000000000000", userName: "anne.matthews@contoso.onmicrosoft.com" } } as any), new CommandError("Invalid request"));
+  });
+
+  it('throws error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { groupId: groupId, userName: 'anne.matthews@contoso.onmicrosoft.com', force: true } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/aad/commands/m365group/m365group-user-remove.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-remove.spec.ts
@@ -14,6 +14,7 @@ import teamsCommands from '../../../teams/commands.js';
 import commands from '../../commands.js';
 import command from './m365group-user-remove.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_USER_REMOVE, () => {
   let cli: Cli;
@@ -28,6 +29,7 @@ describe(commands.M365GROUP_USER_REMOVE, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-user-remove.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-remove.ts
@@ -98,7 +98,11 @@ class AadM365GroupUserRemoveCommand extends GraphCommand {
 
     const removeUser = async (): Promise<void> => {
       try {
-        await aadGroup.verifyGroupType(groupId);
+        const isUnifiedGroup = await aadGroup.isUnifiedGroup(groupId);
+        if (!isUnifiedGroup) {
+          throw Error(`Specified group with id '${groupId}' is not a Microsoft 365 group.`);
+        }
+
         // retrieve user
         const user: UserResponse = await request.get({
           url: `${this.resource}/v1.0/users/${formatting.encodeQueryParameter(args.options.userName)}/id`,

--- a/src/m365/aad/commands/m365group/m365group-user-remove.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-remove.ts
@@ -2,6 +2,7 @@ import { Cli } from '../../../../cli/Cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request from '../../../../request.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
@@ -97,6 +98,7 @@ class AadM365GroupUserRemoveCommand extends GraphCommand {
 
     const removeUser = async (): Promise<void> => {
       try {
+        await aadGroup.verifyGroupType(groupId);
         // retrieve user
         const user: UserResponse = await request.get({
           url: `${this.resource}/v1.0/users/${formatting.encodeQueryParameter(args.options.userName)}/id`,

--- a/src/m365/aad/commands/m365group/m365group-user-set.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-set.spec.ts
@@ -28,7 +28,7 @@ describe(commands.M365GROUP_USER_SET, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    sinon.stub(aadGroup, 'verifyGroupType').resolves();
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(true);
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });
@@ -410,4 +410,15 @@ describe(commands.M365GROUP_USER_SET, () => {
     await command.action(logger, { options: { debug: true, groupId: "00000000-0000-0000-0000-000000000000", userName: 'anne.matthews@contoso.onmicrosoft.com', role: 'Member' } } as any);
     assert(demoteOwnerIssued);
   });
+
+  it('throws error when the group is not a unified group', async () => {
+    const groupId = '3f04e370-cbc6-4091-80fe-1d038be2ad06';
+
+    sinonUtil.restore(aadGroup.isUnifiedGroup);
+    sinon.stub(aadGroup, 'isUnifiedGroup').resolves(false);
+
+    await assert.rejects(command.action(logger, { options: { groupId: groupId, userName: 'anne.matthews@contoso.onmicrosoft.com', role: 'Owner' } } as any),
+      new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
+  });
+
 });

--- a/src/m365/aad/commands/m365group/m365group-user-set.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-set.spec.ts
@@ -14,6 +14,7 @@ import teamsCommands from '../../../teams/commands.js';
 import commands from '../../commands.js';
 import command from './m365group-user-set.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 describe(commands.M365GROUP_USER_SET, () => {
   let cli: Cli;
@@ -27,6 +28,7 @@ describe(commands.M365GROUP_USER_SET, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(aadGroup, 'verifyGroupType').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
   });

--- a/src/m365/aad/commands/m365group/m365group-user-set.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-set.ts
@@ -7,6 +7,7 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import teamsCommands from '../../../teams/commands.js';
 import commands from '../../commands.js';
+import { aadGroup } from '../../../../utils/aadGroup.js';
 
 interface CommandArgs {
   options: Options;
@@ -96,6 +97,7 @@ class AadM365GroupUserSetCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const groupId: string = (typeof args.options.groupId !== 'undefined') ? args.options.groupId : args.options.teamId as string;
+      await aadGroup.verifyGroupType(groupId);
 
       let users = await this.getOwners(groupId, logger);
       const membersAndGuests = await this.getMembersAndGuests(groupId, logger);

--- a/src/m365/aad/commands/m365group/m365group-user-set.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-set.ts
@@ -97,7 +97,10 @@ class AadM365GroupUserSetCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const groupId: string = (typeof args.options.groupId !== 'undefined') ? args.options.groupId : args.options.teamId as string;
-      await aadGroup.verifyGroupType(groupId);
+      const isUnifiedGroup = await aadGroup.isUnifiedGroup(groupId);
+      if (!isUnifiedGroup) {
+        throw Error(`Specified group with id '${groupId}' is not a Microsoft 365 group.`);
+      }
 
       let users = await this.getOwners(groupId, logger);
       const membersAndGuests = await this.getMembersAndGuests(groupId, logger);

--- a/src/utils/aadGroup.spec.ts
+++ b/src/utils/aadGroup.spec.ts
@@ -207,4 +207,18 @@ describe('utils/aadGroup', () => {
     const actual = await aadGroup.getGroupByDisplayName(validGroupName);
     assert.deepStrictEqual(actual, singleGroupResponse);
   });
+
+  it('throws error message group is not a m365group', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validGroupId}?$select=groupTypes`) {
+        return {
+          groupTypes: []
+        };
+      }
+
+      return 'Invalid Request';
+    });
+
+    await assert.rejects(aadGroup.verifyGroupType(validGroupId), Error(`Specified group with id '${validGroupId}' is not a Microsoft 365 group.`));
+  });
 }); 

--- a/src/utils/aadGroup.spec.ts
+++ b/src/utils/aadGroup.spec.ts
@@ -208,7 +208,23 @@ describe('utils/aadGroup', () => {
     assert.deepStrictEqual(actual, singleGroupResponse);
   });
 
-  it('throws error message group is not a m365group', async () => {
+  it('returns true if group is a valid m365group', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validGroupId}?$select=groupTypes`) {
+        return {
+          groupTypes: [
+            'Unified'
+          ]
+        };
+      }
+
+      return 'Invalid Request';
+    });
+    const actual = await aadGroup.isUnifiedGroup(validGroupId);
+    assert.deepStrictEqual(actual, true);
+  });
+
+  it('returns false if group is not a m365group', async () => {
     sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validGroupId}?$select=groupTypes`) {
         return {
@@ -218,7 +234,7 @@ describe('utils/aadGroup', () => {
 
       return 'Invalid Request';
     });
-
-    await assert.rejects(aadGroup.verifyGroupType(validGroupId), Error(`Specified group with id '${validGroupId}' is not a Microsoft 365 group.`));
+    const actual = await aadGroup.isUnifiedGroup(validGroupId);
+    assert.deepStrictEqual(actual, false);
   });
 }); 

--- a/src/utils/aadGroup.ts
+++ b/src/utils/aadGroup.ts
@@ -96,11 +96,11 @@ export const aadGroup = {
   },
 
   /**
-   * Verifies that group is a m365 group.
+   * Checks if group is a m365 group.
    * @param groupId Group id.
-   * @throws Error when group is not a m365 group.
+   * @returns whether the group is a m365 group or not
    */
-  async verifyGroupType(groupId: string): Promise<void> {
+  async isUnifiedGroup(groupId: string): Promise<boolean> {
     const requestOptions: CliRequestOptions = {
       url: `${graphResource}/v1.0/groups/${groupId}?$select=groupTypes`,
       headers: {
@@ -110,8 +110,6 @@ export const aadGroup = {
     };
 
     const group = await request.get<{ groupTypes: string[] }>(requestOptions);
-    if (!group.groupTypes!.some(type => type === 'Unified')) {
-      throw Error(`Specified group with id '${groupId}' is not a Microsoft 365 group.`);
-    }
+    return group.groupTypes!.some(type => type === 'Unified');
   }
 };

--- a/src/utils/aadGroup.ts
+++ b/src/utils/aadGroup.ts
@@ -93,5 +93,25 @@ export const aadGroup = {
     };
 
     await request.patch(requestOptions);
+  },
+
+  /**
+   * Verifies that group is a m365 group.
+   * @param groupId Group id.
+   * @throws Error when group is not a m365 group.
+   */
+  async verifyGroupType(groupId: string): Promise<void> {
+    const requestOptions: CliRequestOptions = {
+      url: `${graphResource}/v1.0/groups/${groupId}?$select=groupTypes`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    const group = await request.get<{ groupTypes: string[] }>(requestOptions);
+    if (!group.groupTypes!.some(type => type === 'Unified')) {
+      throw Error(`Specified group with id '${groupId}' is not a Microsoft 365 group.`);
+    }
   }
 };


### PR DESCRIPTION
Closes #5438 

I've added a method `verifyGroupType` in the `aadGroup` util that will be called in the `aad m365group` commands and will throw an error when the specified group is not a m365 group.

Please note that I did not add this to all commands, for example - `m365group recyclebinitem clear` as the filtering is done in the command itself by adding it as a filter.