### PR TITLE
Renames option for 'spo user get'

### DIFF
--- a/docs/docs/cmd/spo/user/user-get.mdx
+++ b/docs/docs/cmd/spo/user/user-get.mdx
@@ -19,13 +19,13 @@ m365 spo user get [options]
 : URL of the web to get the user within
 
 `-i, --id [id]`
-: ID of the user to retrieve information for. Use either `email`, `id` or `userName`, but not all.
+: ID of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.
 
 `--email [email]`
-: Email of the user to retrieve information for. Use either `email`, `id` or `userName`, but not all.
+: Email of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.
 
-`--userName [userName]`
-: Login name of the user to retrieve information for. Use either `email`, `id` or `userName`, but not all.
+`--loginName [loginName]`
+: Login name of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.
 ```
 
 <Global />
@@ -38,16 +38,16 @@ Get user by email for a web
 m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --email john.doe@mytenant.onmicrosoft.com
 ```
 
-Get user with ID _6_ for a web
+Get user by ID for a web
 
 ```sh
 m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --id 6
 ```
 
-Get user with login name 'i:0#.f|membership|john.doe@mytenant.onmicrosoft.com' for a web
+Get user by login name for a web
 
 ```sh
-m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --userName "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
+m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --loginName "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
 ```
 
 ## Response
@@ -105,7 +105,7 @@ m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --user
   <TabItem value="Markdown">
 
   ```md
-  # spo user get --webUrl "https://contoso.sharepoint.com" --userName "i:0#.f|membership|john.doe@contoso.onmicrosoft.com"
+  # spo user get --webUrl "https://contoso.sharepoint.com" --loginName "i:0#.f|membership|john.doe@contoso.onmicrosoft.com"
 
   Date: 4/10/2023
 

--- a/docs/docs/v7-upgrade-guidance.mdx
+++ b/docs/docs/v7-upgrade-guidance.mdx
@@ -503,7 +503,6 @@ Command|Old option|New option
 [spo group member add](./cmd/spo/group/group-member-add.mdx)|`aadGroupId`|`aadGroupIds`
 [spo group member add](./cmd/spo/group/group-member-add.mdx)|`aadGroupName`|`aadGroupNames`
 [spo listitem attachment list](./cmd/spo/listitem/listitem-attachment-list.mdx)|`itemId`|`listItemId`
-[spo user get](./cmd/spo/user/user-get.mdx)|`loginName`|`userName`
 [teams channel member add](./cmd/teams/channel/channel-member-add.mdx)|`userId`|`userIds`
 [teams channel member add](./cmd/teams/channel/channel-member-add.mdx)|`userDisplayName`|`userDisplayNames`
 

--- a/src/m365/spo/commands/user/user-get.spec.ts
+++ b/src/m365/spo/commands/user/user-get.spec.ts
@@ -166,7 +166,7 @@ describe(commands.USER_GET, () => {
     }));
   });
 
-  it('retrieves user by userName with output option json', async () => {
+  it('retrieves user by loginName with output option json', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf('/_api/web/siteusers/GetByLoginName') > -1) {
         return {
@@ -194,7 +194,7 @@ describe(commands.USER_GET, () => {
         output: 'json',
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
-        userName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
+        loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
       }
     });
     assert(loggerLogSpy.calledWith({
@@ -223,7 +223,7 @@ describe(commands.USER_GET, () => {
     await assert.rejects(command.action(logger, {
       options: {
         webUrl: 'https://contoso.sharepoint.com',
-        userName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
+        loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
       }
     } as any), new CommandError('An error has occurred'));
   });
@@ -244,7 +244,7 @@ describe(commands.USER_GET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if id or email or userName options are not passed', async () => {
+  it('fails validation if id or email or loginName options are not passed', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -257,7 +257,7 @@ describe(commands.USER_GET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if id, email and userName options are passed (multiple options)', async () => {
+  it('fails validation if id, email and loginName options are passed (multiple options)', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -266,7 +266,7 @@ describe(commands.USER_GET, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1, email: "jonh.deo@mytenant.com", userName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1, email: "jonh.deo@mytenant.com", loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
@@ -283,7 +283,7 @@ describe(commands.USER_GET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if id and userName options are passed (multiple options)', async () => {
+  it('fails validation if id and loginName options are passed (multiple options)', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -292,11 +292,11 @@ describe(commands.USER_GET, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1, userName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1, loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if email and userName options are passed (multiple options)', async () => {
+  it('fails validation if email and loginName options are passed (multiple options)', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -305,7 +305,7 @@ describe(commands.USER_GET, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', email: "jonh.deo@mytenant.com", userName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', email: "jonh.deo@mytenant.com", loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
@@ -324,8 +324,8 @@ describe(commands.USER_GET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation if the url is valid and userName is passed', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', userName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
+  it('passes validation if the url is valid and loginName is passed', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 }); 

--- a/src/m365/spo/commands/user/user-get.ts
+++ b/src/m365/spo/commands/user/user-get.ts
@@ -1,6 +1,6 @@
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
-import request from '../../../../request.js';
+import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
@@ -13,8 +13,8 @@ interface CommandArgs {
 export interface Options extends GlobalOptions {
   webUrl: string;
   email?: string;
-  id: string | number | undefined;
-  userName?: string;
+  id?: number;
+  loginName?: string;
 }
 
 class SpoUserGetCommand extends SpoCommand {
@@ -38,9 +38,9 @@ class SpoUserGetCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        id: (!(!args.options.id)).toString(),
-        email: (!(!args.options.email)).toString(),
-        userName: (!(!args.options.userName)).toString()
+        id: typeof args.options.id !== 'undefined',
+        email: typeof args.options.email !== 'undefined',
+        loginName: typeof args.options.loginName !== 'undefined'
       });
     });
   }
@@ -57,7 +57,7 @@ class SpoUserGetCommand extends SpoCommand {
         option: '--email [email]'
       },
       {
-        option: '--userName [userName]'
+        option: '--loginName [loginName]'
       }
     );
   }
@@ -76,31 +76,31 @@ class SpoUserGetCommand extends SpoCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push({ options: ['id', 'email', 'userName'] });
+    this.optionSets.push({ options: ['id', 'email', 'loginName'] });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (this.verbose) {
-      await logger.logToStderr(`Retrieving information for list in site at ${args.options.webUrl}...`);
+      await logger.logToStderr(`Retrieving information for user in site '${args.options.webUrl}'...`);
     }
 
     let requestUrl: string = '';
 
     if (args.options.id) {
-      requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetById('${formatting.encodeQueryParameter(args.options.id as string)}')`;
+      requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetById('${formatting.encodeQueryParameter(args.options.id.toString())}')`;
     }
     else if (args.options.email) {
-      requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetByEmail('${formatting.encodeQueryParameter(args.options.email as string)}')`;
+      requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetByEmail('${formatting.encodeQueryParameter(args.options.email)}')`;
     }
-    else if (args.options.userName) {
-      requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetByLoginName('${formatting.encodeQueryParameter(args.options.userName as string)}')`;
+    else if (args.options.loginName) {
+      requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetByLoginName('${formatting.encodeQueryParameter(args.options.loginName)}')`;
     }
 
-    const requestOptions: any = {
+    const requestOptions: CliRequestOptions = {
       url: requestUrl,
       method: 'GET',
       headers: {
-        'accept': 'application/json;odata=nometadata'
+        accept: 'application/json;odata=nometadata'
       },
       responseType: 'json'
     };


### PR DESCRIPTION
Closes #5515

---

Seems like this option was renamed from `loginName` to `userName`. This clearly was a mistake since the expected value is not a UPN.