### PR TITLE
Implement disambiguation prompt in missing places. Closes #5490

### DIFF
--- a/src/m365/base/AppCommand.spec.ts
+++ b/src/m365/base/AppCommand.spec.ts
@@ -54,7 +54,8 @@ describe('AppCommand', () => {
     sinonUtil.restore([
       fs.existsSync,
       fs.readFileSync,
-      Cli.prompt
+      Cli.prompt,
+      Cli.handleMultipleResultsFound
     ]);
   });
 
@@ -115,7 +116,7 @@ describe('AppCommand', () => {
         }
       ]
     }));
-    const cliPromptStub = sinon.stub(Cli, 'prompt').callsFake(async () => (
+    const cliPromptStub = sinon.stub(Cli, 'handleMultipleResultsFound').callsFake(async () => (
       { appIdIndex: 0 }
     ));
     await assert.rejects(cmd.action(logger, { options: {} }));
@@ -136,7 +137,7 @@ describe('AppCommand', () => {
         }
       ]
     }));
-    sinon.stub(Cli, 'prompt').resolves({ appIdIndex: 1 });
+    sinon.stub(Cli, 'handleMultipleResultsFound').resolves({ appIdIndex: 1 });
     sinon.stub(Command.prototype, 'action').resolves();
 
     try {

--- a/src/m365/base/AppCommand.ts
+++ b/src/m365/base/AppCommand.ts
@@ -5,6 +5,7 @@ import Command, { CommandArgs, CommandError } from '../../Command.js';
 import GlobalOptions from '../../GlobalOptions.js';
 import { validation } from '../../utils/validation.js';
 import { M365RcJson, M365RcJsonApp } from './M365RcJson.js';
+import { formatting } from '../../utils/formatting.js';
 
 export interface AppCommandArgs {
   options: AppCommandOptions;
@@ -89,19 +90,8 @@ export default abstract class AppCommand extends Command {
     }
 
     if (this.m365rcJson.apps.length > 1) {
-      const result = await Cli.prompt<{ appIdIndex: number }>({
-        message: `Multiple Azure AD apps found in ${m365rcJsonPath}. Which app would you like to use?`,
-        type: 'list',
-        choices: this.m365rcJson.apps.map((app, i) => {
-          return {
-            name: `${app.name} (${app.appId})`,
-            value: i
-          };
-        }),
-        default: 0,
-        name: 'appIdIndex'
-      });
-
+      const resultAsKeyValuePair = formatting.convertArrayToHashTable('appIdIndex', this.m365rcJson.apps);
+      const result = await Cli.handleMultipleResultsFound<{ appIdIndex: number }>(`Multiple Azure AD apps found in ${m365rcJsonPath}.`, resultAsKeyValuePair);
       this.appId = ((this.m365rcJson as M365RcJson).apps as M365RcJsonApp[])[result.appIdIndex].appId;
       await super.action(logger, args);
     }

--- a/src/m365/teams/commands/app/app-update.spec.ts
+++ b/src/m365/teams/commands/app/app-update.spec.ts
@@ -53,7 +53,8 @@ describe(commands.APP_UPDATE, () => {
       request.put,
       fs.readFileSync,
       fs.existsSync,
-      cli.getSettingWithDefaultValue
+      cli.getSettingWithDefaultValue,
+      Cli.handleMultipleResultsFound
     ]);
   });
 
@@ -175,6 +176,14 @@ describe(commands.APP_UPDATE, () => {
   });
 
   it('handles error when multiple Teams apps with the specified name found', async () => {
+    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
+      if (settingName === settingsNames.prompt) {
+        return false;
+      }
+
+      return defaultValue;
+    });
+
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/v1.0/appCatalogs/teamsApps?$filter=displayName eq '`) > -1) {
         return {
@@ -199,7 +208,44 @@ describe(commands.APP_UPDATE, () => {
         name: 'Test app',
         filePath: 'teamsapp.zip'
       }
-    } as any), new CommandError('Multiple Teams apps with name Test app found. Please choose one of these ids: e3e29acb-8c79-412b-b746-e6c39ff4cd22, 5b31c38c-2584-42f0-aa47-657fb3a84230'));
+    } as any), new CommandError('Multiple Teams apps with name Test app found. Found: e3e29acb-8c79-412b-b746-e6c39ff4cd22, 5b31c38c-2584-42f0-aa47-657fb3a84230.'));
+  });
+
+  it('handles selecting single result when multiple Teams apps found with the specified name', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/v1.0/appCatalogs/teamsApps?$filter=displayName eq '`) > -1) {
+        return {
+          "value": [
+            {
+              "id": "e3e29acb-8c79-412b-b746-e6c39ff4cd22",
+              "displayName": "Test app"
+            },
+            {
+              "id": "5b31c38c-2584-42f0-aa47-657fb3a84230",
+              "displayName": "Test app"
+            }
+          ]
+        };
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(Cli, 'handleMultipleResultsFound').resolves({ id: '5b31c38c-2584-42f0-aa47-657fb3a84230' });
+
+    let updateTeamsAppCalled = false;
+    sinon.stub(request, 'put').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/5b31c38c-2584-42f0-aa47-657fb3a84230`) {
+        updateTeamsAppCalled = true;
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(fs, 'readFileSync').callsFake(() => '123');
+
+    await command.action(logger, { options: { filePath: 'teamsapp.zip', name: 'Test app' } });
+    assert(updateTeamsAppCalled);
   });
 
   it('update Teams app in the tenant app catalog by id', async () => {


### PR DESCRIPTION
## 🎯 Aim

The aim is to add disambiguation prompt in the `teams app update` and to all `m365 aad app... ` commands that base on `.m365rc.json` file

## 🔗 Related issue

Closes #5490

## 📷 Result

I had two AAD apps with name 'My single-page app' and this is the result 
![image](https://github.com/pnp/cli-microsoft365/assets/58668583/c855c1da-a575-4a3c-8560-ffe472cb6e8b)


