### PR TITLE
spo field get - documentation update

### DIFF
--- a/docs/docs/cmd/spo/field/field-get.mdx
+++ b/docs/docs/cmd/spo/field/field-get.mdx
@@ -31,7 +31,7 @@ m365 spo field get [options]
 : The ID of the field to retrieve. Specify `id` or `title` but not both.
 
 `-t, --title [title]`
-: The display name (case-sensitive) of the field to remove. Specify `id` or `title` but not both.
+: The display name (case-sensitive) of the field to retrieve. Specify `id` or `title` but not both.
 ```
 
 <Global />


### PR DESCRIPTION
Updated documentation of below command(s):
- `spo list contenttype remove`

Fixed typo in description of one of the options (`--title`) in cmdlet documentation.