### PR TITLE
Adds a config key to set the default login authType. Closes #5585

### DIFF
--- a/docs/docs/_clisettings.mdx
+++ b/docs/docs/_clisettings.mdx
@@ -1,5 +1,6 @@
 Setting name|Definition|Default value
 ------------|----------|-------------
+`authType`|Default login method to use when running `m365 login` without the `--authType` option.|`deviceCode`
 `autoOpenLinksInBrowser`|Automatically open the browser for all commands which return a url and expect the user to copy paste this to the browser. For example when logging in, using `m365 login` in device code mode.|`false`
 `copyDeviceCodeToClipboard`|Automatically copy the device code to the clipboard when running `m365 login` command in device code mode|`false`
 `csvEscape`|Single character used for escaping; only apply to characters matching the quote and the escape options|`"`

--- a/docs/docs/cmd/login.mdx
+++ b/docs/docs/cmd/login.mdx
@@ -52,7 +52,7 @@ m365 login [options]
 
 Using the `login` command you can log in to Microsoft 365.
 
-By default, the `login` command uses device code OAuth flow to log in to Microsoft 365. Alternatively, you can authenticate using a user name and password or certificate, which are convenient for CI/CD scenarios, but which come with their own [limitations](../user-guide/connecting-microsoft-365.mdx).
+By default, the `login` command uses device code OAuth flow to log in to Microsoft 365. Alternatively, you can authenticate using a user name and password or certificate, which are convenient for CI/CD scenarios, but which come with their own [limitations](../user-guide/connecting-microsoft-365.mdx). The default `authType` can be configured using `m365 cli config set`. This means you'll be able to run `m365 login` without specifying the `--authType` option.
 
 When logging in to Microsoft 365 using the user name and password, next to the access and refresh token, the CLI for Microsoft 365 will store the user credentials so that it can automatically re-authenticate if necessary. Similarly to the tokens, the credentials are removed by re-authenticating using the device code or by calling the [logout](logout.mdx) command.
 

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -423,7 +423,7 @@ export class Auth {
     const cli = Cli.getInstance();
     cli.spinner.text = response.message;
     cli.spinner.spinner = {
-      frames: ['🌶️']
+      frames: ['🌶️ ']
     };
 
     // don't show spinner if running tests

--- a/src/m365/cli/commands/config/config-set.spec.ts
+++ b/src/m365/cli/commands/config/config-set.spec.ts
@@ -168,6 +168,18 @@ describe(commands.CONFIG_SET, () => {
     assert.strictEqual(actualValue, false, 'Invalid value');
   });
 
+  it(`sets ${settingsNames.authType} property`, async () => {
+    const config = Cli.getInstance().config;
+    let actualKey: string = '', actualValue: any;
+    sinon.stub(config, 'set').callsFake(((key: string, value: any) => {
+      actualKey = key;
+      actualValue = value;
+    }) as any);
+    await command.action(logger, { options: { key: settingsNames.authType, value: 'deviceCode' } });
+    assert.strictEqual(actualKey, settingsNames.authType, 'Invalid key');
+    assert.strictEqual(actualValue, 'deviceCode', 'Invalid value');
+  });
+
   it('supports specifying key and value', () => {
     const options = command.options;
     let containsOptionKey = false;
@@ -216,6 +228,41 @@ describe(commands.CONFIG_SET, () => {
 
   it('passes validation for output type csv', async () => {
     const actual = await command.validate({ options: { key: settingsNames.output, value: 'csv' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if specified authType is invalid', async () => {
+    const actual = await command.validate({ options: { key: settingsNames.authType, value: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation for authType type deviceCode', async () => {
+    const actual = await command.validate({ options: { key: settingsNames.authType, value: 'deviceCode' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation for authType type browser', async () => {
+    const actual = await command.validate({ options: { key: settingsNames.authType, value: 'browser' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation for authType type certificate', async () => {
+    const actual = await command.validate({ options: { key: settingsNames.authType, value: 'certificate' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation for authType type password', async () => {
+    const actual = await command.validate({ options: { key: settingsNames.authType, value: 'password' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation for authType type identity', async () => {
+    const actual = await command.validate({ options: { key: settingsNames.authType, value: 'identity' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation for authType type secret', async () => {
+    const actual = await command.validate({ options: { key: settingsNames.authType, value: 'secret' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -75,6 +75,12 @@ class CliConfigSetCommand extends AnonymousCommand {
           return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${Cli.helpModes.join(', ')}`;
         }
 
+        const allowedAuthTypes = ['certificate', 'deviceCode', 'password', 'identity', 'browser', 'secret'];
+        if (args.options.key === settingsNames.authType &&
+          allowedAuthTypes.indexOf(args.options.value) === -1) {
+          return `${args.options.value} is not a valid value for the option ${args.options.key}. Allowed values: ${allowedAuthTypes.join(', ')}`;
+        }
+
         return true;
       }
     );

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -1,4 +1,5 @@
 const settingsNames = {
+  authType: 'authType',
   autoOpenLinksInBrowser: 'autoOpenLinksInBrowser',
   copyDeviceCodeToClipboard: 'copyDeviceCodeToClipboard',
   csvEscape: 'csvEscape',


### PR DESCRIPTION
Closes #5585

Adds a config key to set the default login authType.

Also re-added a space behind the chili icon before the device code message.
In bash the missing space looks ugly.