### PR TITLE
Speeds up loading commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ coverage
 docs/site
 # generated commands info
 commands.json
+allCommands.json
 
 # VS env folder
 .vs/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,16 @@
       "skipFiles": [
         "<node_internals>/**"
       ]
-    }
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Debug current file",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${file}",
+      "args": []
+    },
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "tsc -p . && node scripts/copy-files.js",
+    "build": "tsc -p . && node scripts/write-all-commands.js && node scripts/copy-files.js",
     "watch": "tsc -w -p .",
     "clean": "rimraf ./dist",
     "test": "npm run test:version && npm run lint && npm run test:cov",

--- a/scripts/write-all-commands.js
+++ b/scripts/write-all-commands.js
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import url, { pathToFileURL } from 'url';
+import Command from '../dist/Command.js';
+import { Cli } from '../dist/cli/Cli.js';
+import { fsUtil } from '../dist/utils/fsUtil.js';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+const commandsFolder = path.join(__dirname, '..', 'dist', 'm365');
+const commandHelpFolder = path.join(commandsFolder, '..', '..', 'docs', 'docs', 'cmd');
+
+async function loadAllCommands() {
+  const files = fsUtil.readdirR(commandsFolder);
+  const cli = Cli.getInstance();
+
+  await Promise.all(files.map(async (filePath) => {
+    const file = pathToFileURL(filePath).toString();
+    if (file.indexOf(`/commands/`) > -1 &&
+      file.indexOf(`/assets/`) < 0 &&
+      file.endsWith('.js') &&
+      !file.endsWith('.spec.js')) {
+
+      const command = await import(file);
+      if (command.default instanceof Command) {
+        const helpFilePath = path.relative(commandHelpFolder, getCommandHelpFilePath(command.default.name));
+        cli.commands.push(Cli.getCommandInfo(command.default, path.relative(commandsFolder, filePath), helpFilePath));
+      }
+    }
+  }));
+
+  cli.commands.forEach(c => {
+    delete c.command;
+    delete c.defaultProperties;
+    delete c.options;
+  });
+
+  fs.writeFileSync('allCommands.json', JSON.stringify(cli.commands));
+}
+
+function getCommandHelpFilePath(commandName) {
+  const commandNameWords = commandName.split(' ');
+  const pathChunks = [];
+
+  if (commandNameWords.length === 1) {
+    pathChunks.push(`${commandNameWords[0]}.mdx`);
+  }
+  else {
+    if (commandNameWords.length === 2) {
+      pathChunks.push(commandNameWords[0], `${commandNameWords.join('-')}.mdx`);
+    }
+    else {
+      pathChunks.push(commandNameWords[0], commandNameWords[1], commandNameWords.slice(1).join('-') + '.mdx');
+    }
+  }
+
+  const helpFilePath = path.join(commandHelpFolder, ...pathChunks);
+  return helpFilePath;
+}
+
+loadAllCommands();

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,17 +1,15 @@
 import { Cli, CommandOutput } from "./cli/Cli.js";
-import path from 'path';
 
-export function executeCommand(commandName: string, options: any, listener?: {
+export async function executeCommand(commandName: string, options: any, listener?: {
   stdout: (message: any) => void,
   stderr: (message: any) => void,
 }): Promise<CommandOutput> {
   const cli = Cli.getInstance();
-  cli.commandsFolder = path.join(__dirname, 'm365');
-  cli.commands = [];
-  cli.loadCommandFromArgs(commandName.split(' '));
-  if (cli.commands.length !== 1) {
+  cli.loadAllCommandsInfo();
+  await cli.loadCommandFromArgs(commandName.split(' '));
+  if (!cli.commandToExecute) {
     return Promise.reject(`Command not found: ${commandName}`);
   }
 
-  return Cli.executeCommandWithOutput(cli.commands[0].command, { options: options ?? {} }, listener);
+  return Cli.executeCommandWithOutput(cli.commandToExecute.command, { options: options ?? {} }, listener);
 }

--- a/src/autocomplete.spec.ts
+++ b/src/autocomplete.spec.ts
@@ -116,7 +116,7 @@ describe('autocomplete', () => {
 
   it('writes sh completion to disk', () => {
     const writeFileSyncStub = sinon.stub(fs, 'writeFileSync').callsFake(() => { });
-    (cli as any).loadCommand(new SimpleCommand());
+    cli.commands.push(Cli.getCommandInfo(new SimpleCommand(), 'command.js', 'command.mdx'));
     autocomplete.generateShCompletion();
     assert(writeFileSyncStub.calledWith(path.join(__dirname, `..${path.sep}commands.json`), JSON.stringify({
       cli: {
@@ -154,7 +154,7 @@ describe('autocomplete', () => {
   });
 
   it('builds clink completion', () => {
-    (cli as any).loadCommand(new SimpleCommand());
+    cli.commands.push(Cli.getCommandInfo(new SimpleCommand(), 'command.js', 'command.mdx'));
     const clink: string = autocomplete.getClinkCompletion();
 
     assert.strictEqual(clink, [
@@ -167,7 +167,7 @@ describe('autocomplete', () => {
   });
 
   it('includes long options in clink completion', () => {
-    (cli as any).loadCommand(new CommandWithOptions());
+    cli.commands.push(Cli.getCommandInfo(new CommandWithOptions(), 'command.js', 'command.mdx'));
     const clink: string = autocomplete.getClinkCompletion();
 
     assert.strictEqual(clink, [
@@ -180,7 +180,7 @@ describe('autocomplete', () => {
   });
 
   it('includes short options in clink completion', () => {
-    (cli as any).loadCommand(new CommandWithOptions());
+    cli.commands.push(Cli.getCommandInfo(new CommandWithOptions(), 'command.js', 'command.mdx'));
     const clink: string = autocomplete.getClinkCompletion();
 
     assert.strictEqual(clink, [
@@ -193,7 +193,7 @@ describe('autocomplete', () => {
   });
 
   it('includes autocomplete for options in clink completion', () => {
-    (cli as any).loadCommand(new CommandWithOptions());
+    cli.commands.push(Cli.getCommandInfo(new CommandWithOptions(), 'command.js', 'command.mdx'));
     const clink: string = autocomplete.getClinkCompletion();
 
     assert.strictEqual(clink, [
@@ -206,7 +206,7 @@ describe('autocomplete', () => {
   });
 
   it('includes command alias in clink completion', () => {
-    (cli as any).loadCommand(new CommandWithAlias());
+    cli.commands.push(Cli.getCommandInfo(new CommandWithAlias(), 'command.js', 'command.mdx'));
     const clink: string = autocomplete.getClinkCompletion();
 
     assert.strictEqual(clink, [

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -1,26 +1,30 @@
 import Configstore from 'configstore';
 import fs from 'fs';
 import minimist from 'minimist';
+import { createRequire } from 'module';
 import ora, { Options, Ora } from 'ora';
 import os from 'os';
 import path from 'path';
-import { pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import Command, { CommandArgs, CommandError, CommandTypes } from '../Command.js';
-import config from '../config.js';
 import GlobalOptions from '../GlobalOptions.js';
+import config from '../config.js';
 import { M365RcJson } from '../m365/base/M365RcJson.js';
 import request from '../request.js';
 import { settingsNames } from '../settingsNames.js';
 import { telemetry } from '../telemetry.js';
 import { app } from '../utils/app.js';
 import { formatting } from '../utils/formatting.js';
-import { fsUtil } from '../utils/fsUtil.js';
 import { md } from '../utils/md.js';
+import { prompt } from '../utils/prompt.js';
 import { validation } from '../utils/validation.js';
 import { CommandInfo } from './CommandInfo.js';
 import { CommandOptionInfo } from './CommandOptionInfo.js';
 import { Logger } from './Logger.js';
-import { prompt } from '../utils/prompt.js';
+import { timings } from './timings.js';
+const require = createRequire(import.meta.url);
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export interface CommandOutput {
   stdout: string;
@@ -32,13 +36,12 @@ export class Cli {
   /**
    * Command to execute
    */
-  private commandToExecute: CommandInfo | undefined;
+  public commandToExecute: CommandInfo | undefined;
   /**
    * Name of the command specified through args
    */
   public currentCommandName: string | undefined;
   private optionsFromArgs: { options: minimist.ParsedArgs } | undefined;
-  public commandsFolder: string = '';
   private static instance: Cli;
   private static defaultHelpMode = 'options';
   public static helpModes: string[] = ['options', 'examples', 'remarks', 'response', 'full'];
@@ -80,8 +83,10 @@ export class Cli {
     return Cli.instance;
   }
 
-  public async execute(commandsFolder: string, rawArgs: string[]): Promise<void> {
-    this.commandsFolder = commandsFolder;
+  public async execute(rawArgs: string[]): Promise<void> {
+    const start = process.hrtime.bigint();
+
+    this.loadAllCommandsInfo();
 
     // check if help for a specific command has been requested using the
     // 'm365 help xyz' format. If so, remove 'help' from the array of words
@@ -93,24 +98,11 @@ export class Cli {
       rawArgs.shift();
     }
 
-    // parse args to see if a command has been specified and can be loaded
-    // rather than loading all commands
+    // parse args to see if a command has been specified
     const parsedArgs: minimist.ParsedArgs = minimist(rawArgs);
 
-    // load commands
+    // load command
     await this.loadCommandFromArgs(parsedArgs._);
-
-    if (this.currentCommandName) {
-      for (let i = 0; i < this.commands.length; i++) {
-        const command: CommandInfo = this.commands[i];
-        if (command.name === this.currentCommandName ||
-          (command.aliases &&
-            command.aliases.indexOf(this.currentCommandName) > -1)) {
-          this.commandToExecute = command;
-          break;
-        }
-      }
-    }
 
     if (this.commandToExecute) {
       // we have found a command to execute. Parse args again taking into
@@ -129,6 +121,8 @@ export class Cli {
       }
     }
     else {
+      // we need this to properly support displaying commands
+      // from the current group
       this.optionsFromArgs = {
         options: parsedArgs
       };
@@ -156,13 +150,20 @@ export class Cli {
       return this.closeWithError(e, optionsWithoutShorts);
     }
 
+    const startProcessing = process.hrtime.bigint();
     try {
       // process options before passing them on to validation stage
       const contextCommandOptions = await this.loadOptionsFromContext(this.commandToExecute.options, optionsWithoutShorts.options.debug);
       optionsWithoutShorts.options = { ...contextCommandOptions, ...optionsWithoutShorts.options };
       await this.commandToExecute.command.processOptions(optionsWithoutShorts.options);
+
+      const endProcessing = process.hrtime.bigint();
+      timings.options.push(Number(endProcessing - startProcessing));
     }
     catch (e: any) {
+      const endProcessing = process.hrtime.bigint();
+      timings.options.push(Number(endProcessing - startProcessing));
+
       return this.closeWithError(e.message, optionsWithoutShorts, false);
     }
 
@@ -171,14 +172,41 @@ export class Cli {
       optionsWithoutShorts.options.output = this.getSettingWithDefaultValue<string | undefined>(settingsNames.output, 'json');
     }
 
+    const startValidation = process.hrtime.bigint();
     const validationResult = await this.commandToExecute.command.validate(optionsWithoutShorts, this.commandToExecute);
+    const endValidation = process.hrtime.bigint();
+    timings.validation.push(Number(endValidation - startValidation));
     if (validationResult !== true) {
       return this.closeWithError(validationResult, optionsWithoutShorts, true);
     }
 
-    return Cli
-      .executeCommand(this.commandToExecute.command, optionsWithoutShorts)
-      .then(_ => process.exit(0), err => this.closeWithError(err, optionsWithoutShorts));
+    const end = process.hrtime.bigint();
+    timings.core.push(Number(end - start));
+
+    try {
+      await Cli.executeCommand(this.commandToExecute.command, optionsWithoutShorts);
+      const endTotal = process.hrtime.bigint();
+      timings.total.push(Number(endTotal - start));
+      this.printTimings(rawArgs);
+      process.exit(0);
+    }
+    catch (err) {
+      const endTotal = process.hrtime.bigint();
+      timings.total.push(Number(endTotal - start));
+      this.printTimings(rawArgs);
+      await this.closeWithError(err, optionsWithoutShorts);
+      /* c8 ignore next */
+    }
+  }
+
+  private printTimings(rawArgs: string[]): void {
+    if (rawArgs.some(arg => arg === '--debug')) {
+      Cli.error('');
+      Cli.error('Timings:');
+      Object.getOwnPropertyNames(timings).forEach(key => {
+        Cli.error(`${key}: ${(timings as any)[key].reduce((a: number, b: number) => a + b, 0) / 1e6}ms`);
+      });
+    }
   }
 
   public static async executeCommand(command: Command, args: { options: minimist.ParsedArgs }): Promise<void> {
@@ -218,6 +246,7 @@ export class Cli {
       cli.spinner.start();
     }
 
+    const startCommand = process.hrtime.bigint();
     try {
       await command.action(logger, args as any);
 
@@ -234,6 +263,9 @@ export class Cli {
       if (cli.spinner.isSpinning) {
         cli.spinner.stop();
       }
+
+      const endCommand = process.hrtime.bigint();
+      timings.command.push(Number(endCommand - startCommand));
     }
   }
 
@@ -311,61 +343,29 @@ export class Cli {
     }
   }
 
-  public async loadAllCommands(): Promise<void> {
-    const files: string[] = fsUtil.readdirR(this.commandsFolder) as string[];
-
-    await Promise.all(files.map(async (filePath) => {
-      const file = pathToFileURL(filePath).toString();
-      if (file.indexOf(`/commands/`) > -1 &&
-        file.indexOf(`/assets/`) < 0 &&
-        file.endsWith('.js') &&
-        !file.endsWith('.spec.js')) {
-        try {
-          const command: any = await import(file);
-          if (command.default instanceof Command) {
-            this.loadCommand(command.default);
-          }
-        }
-        catch (e) {
-          this.closeWithError(e, { options: {} });
-        }
-      }
-    }));
+  public loadAllCommandsInfo(): void {
+    this.commands = require(path.join(__dirname, '../../allCommands.json'));
   }
 
   /**
    * Loads command files into CLI based on the specified arguments.
    *
    * @param commandNameWords Array of words specified as args
-   */
+  */
   public async loadCommandFromArgs(commandNameWords: string[]): Promise<void> {
+    if (commandNameWords.length === 0) {
+      return;
+    }
+
     this.currentCommandName = commandNameWords.join(' ');
 
-    if (commandNameWords.length === 0) {
-      await this.loadAllCommands();
-      return;
-    }
+    const commandFilePath = this.commands
+      .find(c => c.name === this.currentCommandName ||
+        c.aliases?.find(a => a === this.currentCommandName))?.file ?? '';
 
-    const isCompletionCommand: boolean = commandNameWords.indexOf('completion') > -1;
-    if (isCompletionCommand) {
-      await this.loadAllCommands();
-      return;
+    if (commandFilePath) {
+      await this.loadCommandFromFile(commandFilePath);
     }
-
-    let commandFilePath = '';
-    if (commandNameWords.length === 1) {
-      commandFilePath = path.join(this.commandsFolder, 'commands', `${commandNameWords[0]}.js`);
-    }
-    else {
-      if (commandNameWords.length === 2) {
-        commandFilePath = path.join(this.commandsFolder, commandNameWords[0], 'commands', `${commandNameWords.join('-')}.js`);
-      }
-      else {
-        commandFilePath = path.join(this.commandsFolder, commandNameWords[0], 'commands', commandNameWords[1], commandNameWords.slice(1).join('-') + '.js');
-      }
-    }
-
-    await this.loadCommandFromFile(commandFilePath);
   }
 
   private async loadOptionsFromContext(commandOptions: CommandOptionInfo[], debug: boolean | undefined): Promise<any> {
@@ -418,41 +418,39 @@ export class Cli {
    * Loads command from the specified file into CLI. If can't find the file
    * or the file doesn't contain a command, loads all available commands.
    *
-   * @param commandFilePath File path of the file with command to load
+   * @param commandFilePathUrl File path of the file with command to load
    */
-  private async loadCommandFromFile(commandFilePath: string): Promise<void> {
-    if (!fs.existsSync(commandFilePath)) {
-      await this.loadAllCommands();
+  private async loadCommandFromFile(commandFileUrl: string): Promise<void> {
+    const commandsFolder = path.join(__dirname, '../m365');
+    const filePath: string = path.join(commandsFolder, commandFileUrl);
+
+    if (!fs.existsSync(filePath)) {
+      // reset command name
+      this.currentCommandName = undefined;
       return;
     }
 
     try {
-      const commandFileUrl = pathToFileURL(commandFilePath).toString();
-      const command: any = await import(commandFileUrl);
+      const command: any = await import(pathToFileURL(filePath).toString());
       if (command.default instanceof Command) {
-        this.loadCommand(command.default);
-      }
-      else {
-        await this.loadAllCommands();
+        const commandInfo = this.commands.find(c => c.file === commandFileUrl);
+        this.commandToExecute = Cli.getCommandInfo(command.default, commandFileUrl, commandInfo?.help);
       }
     }
-    catch {
-      await this.loadAllCommands();
-    }
+    catch { }
   }
 
-  public static getCommandInfo(command: Command): CommandInfo {
+  public static getCommandInfo(command: Command, filePath: string = '', helpFilePath: string = ''): CommandInfo {
     return {
       aliases: command.alias(),
       name: command.name,
+      description: command.description,
       command: command,
       options: this.getCommandOptions(command),
-      defaultProperties: command.defaultProperties()
+      defaultProperties: command.defaultProperties(),
+      file: filePath,
+      help: helpFilePath
     };
-  }
-
-  private loadCommand(command: Command): void {
-    this.commands.push(Cli.getCommandInfo(command));
   }
 
   private static getCommandOptions(command: Command): CommandOptionInfo[] {
@@ -691,64 +689,44 @@ export class Cli {
   }
 
   private printCommandHelp(helpMode: string): void {
-    let helpFilePath = '';
-    let commandNameWords: string[] = [];
-    if (this.commandToExecute) {
-      commandNameWords = (this.commandToExecute.name).split(' ');
-    }
-    const pathChunks: string[] = [this.commandsFolder, '..', '..', 'docs', 'docs', 'cmd'];
-
-    if (commandNameWords.length === 1) {
-      pathChunks.push(`${commandNameWords[0]}.mdx`);
-    }
-    else {
-      if (commandNameWords.length === 2) {
-        pathChunks.push(commandNameWords[0], `${commandNameWords.join('-')}.mdx`);
-      }
-      else {
-        pathChunks.push(commandNameWords[0], commandNameWords[1], commandNameWords.slice(1).join('-') + '.mdx');
-      }
-    }
-
-    helpFilePath = path.join(...pathChunks);
+    const docsRootDir = path.join(__dirname, '..', '..', 'docs');
+    const helpFilePath = path.join(docsRootDir, 'docs', 'cmd', this.commandToExecute!.help!);
 
     if (fs.existsSync(helpFilePath)) {
       let helpContents = fs.readFileSync(helpFilePath, 'utf8');
       helpContents = this.getHelpSection(helpMode, helpContents);
-      helpContents = md.md2plain(helpContents, path.join(this.commandsFolder, '..', '..', 'docs'));
+      helpContents = md.md2plain(helpContents, docsRootDir);
       Cli.log();
       Cli.log(helpContents);
     }
   }
 
   private async getHelpMode(options: any): Promise<string> {
-    const h = options.h;
-    const help = options.help;
+    const { h, help } = options;
+
+    if (!h && !help) {
+      return this.getSettingWithDefaultValue<string>(settingsNames.helpMode, Cli.defaultHelpMode);
+    }
 
     // user passed -h or --help, let's see if they passed a specific mode
     // or requested the default
-    if (h || help) {
-      const helpMode: boolean | string = h ?? help;
+    const helpMode: boolean | string = h ?? help;
 
-      if (typeof helpMode === 'boolean' || typeof helpMode !== 'string') {
-        // requested default mode or passed a number, let's use default
-        return this.getSettingWithDefaultValue<string>(settingsNames.helpMode, Cli.defaultHelpMode);
-      }
-      else {
-        const lowerCaseHelpMode = helpMode.toLowerCase();
-
-        if (Cli.helpModes.indexOf(lowerCaseHelpMode) < 0) {
-          await Cli.getInstance().closeWithError(`Unknown help mode ${helpMode}. Allowed values are ${Cli.helpModes.join(', ')}`, { options }, false);
-          /* c8 ignore next 2 */
-          return ''; // noop
-        }
-        else {
-          return lowerCaseHelpMode;
-        }
-      }
+    if (typeof helpMode === 'boolean' || typeof helpMode !== 'string') {
+      // requested default mode or passed a number, let's use default
+      return this.getSettingWithDefaultValue<string>(settingsNames.helpMode, Cli.defaultHelpMode);
     }
     else {
-      return this.getSettingWithDefaultValue<string>(settingsNames.helpMode, Cli.defaultHelpMode);
+      const lowerCaseHelpMode = helpMode.toLowerCase();
+
+      if (Cli.helpModes.indexOf(lowerCaseHelpMode) < 0) {
+        await Cli.getInstance().closeWithError(`Unknown help mode ${helpMode}. Allowed values are ${Cli.helpModes.join(', ')}`, { options }, false);
+        /* c8 ignore next 2 */
+        return ''; // noop
+      }
+      else {
+        return lowerCaseHelpMode;
+      }
     }
   }
 
@@ -855,7 +833,7 @@ export class Cli {
 
       const sortedCommandNamesToPrint = Object.getOwnPropertyNames(commandsToPrint).sort();
       sortedCommandNamesToPrint.forEach(commandName => {
-        Cli.log(`  ${`${commandName} [options]`.padEnd(maxLength, ' ')}  ${commandsToPrint[commandName].command.description}`);
+        Cli.log(`  ${`${commandName} [options]`.padEnd(maxLength, ' ')}  ${commandsToPrint[commandName].description}`);
       });
     }
 

--- a/src/cli/CommandInfo.ts
+++ b/src/cli/CommandInfo.ts
@@ -5,6 +5,9 @@ export interface CommandInfo {
   aliases: string[] | undefined;
   command: Command;
   defaultProperties: string[] | undefined;
+  description: string;
+  file: string;
+  help?: string;
   name: string;
   options: CommandOptionInfo[];
 }

--- a/src/cli/timings.ts
+++ b/src/cli/timings.ts
@@ -1,0 +1,8 @@
+export const timings = {
+  api: [] as number[],
+  core: [] as number[],
+  command: [] as number[],
+  options: [] as number[],
+  total: [] as number[],
+  validation: [] as number[]
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,8 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
-import url from 'url';
 import { Cli } from './cli/Cli.js';
 import { telemetry } from './telemetry.js';
 import { app } from './utils/app.js';
-
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 // required to make console.log() in combination with piped output synchronous
 // on Windows/in PowerShell so that the output is not trimmed by calling
@@ -23,13 +18,11 @@ if (!process.env.CLIMICROSOFT365_NOUPDATE) {
   });
 }
 
-fs.realpath(__dirname, async (err: NodeJS.ErrnoException | null, resolvedPath: string): Promise<void> => {
-  try {
-    const cli: Cli = Cli.getInstance();
-    await cli.execute(path.join(resolvedPath, 'm365'), process.argv.slice(2));
-  }
-  catch (e: any) {
-    telemetry.trackException(e);
-    process.exit(1);
-  }
-});
+try {
+  const cli: Cli = Cli.getInstance();
+  cli.execute(process.argv.slice(2));
+}
+catch (e: any) {
+  telemetry.trackException(e);
+  process.exit(1);
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,6 +4,7 @@ import auth, { Auth, CloudType } from './Auth.js';
 import { Logger } from './cli/Logger.js';
 import { app } from './utils/app.js';
 import { formatting } from './utils/formatting.js';
+import { timings } from './cli/timings.js';
 
 export interface CliRequestOptions extends AxiosRequestConfig {
   fullResponse?: boolean;
@@ -151,6 +152,8 @@ class Request {
   }
 
   public execute<TResponse>(options: CliRequestOptions, resolve?: (res: TResponse) => void, reject?: (error: any) => void): Promise<TResponse> {
+    const start = process.hrtime.bigint();
+
     if (!this._logger) {
       return Promise.reject('Logger not set on the request object');
     }
@@ -187,6 +190,9 @@ class Request {
             resolve((options.responseType === 'stream' || options.fullResponse) ? res : res.data);
           }
           else {
+            const end = process.hrtime.bigint();
+            timings.api.push(Number(end - start));
+
             _resolve((options.responseType === 'stream' || options.fullResponse) ? res : res.data);
           }
         }, (error: AxiosError): void => {
@@ -209,6 +215,9 @@ class Request {
               reject(error);
             }
             else {
+              const end = process.hrtime.bigint();
+              timings.api.push(Number(end - start));
+
               _reject(error);
             }
           }


### PR DESCRIPTION
This PR proposes 2 changes:

- speed up loading commands by shipping a static list of commands and their file paths
- add timings to debug mode

## Rationale

Shipping a static list of commands along with the CLI makes perfect sense. After all, the list of commands for each CLI release is fixed and it doesn't make sense for us to resolve it dynamically on each command execution. By using a static list, we can significantly decrease the time of listing all commands (-3.2s) and loading a command from args (-0.2s).
The list is built by calling the `build` npm script and included in the .tar.gz.

Timings allow us to understand where the CLI is spending time on execution. If we notice that a particular command is slow, it'll help us understand whether it's caused by (temporary) slow API calls or the command's code that maybe inefficient. We'd collect timings on each execution (there's little overhead to it and allows us to simplify our code base) but only display them in debug mode.

@pnp/cli-for-microsoft-365-maintainers I'm looking forward to hearing what you think. If you're ok with the change, I'll finish the PR by taking care of tests and coverage.