### PR TITLE
Simplify MS Docs links

### DIFF
--- a/docs/docs/cmd/aad/approleassignment/approleassignment-add.mdx
+++ b/docs/docs/cmd/aad/approleassignment/approleassignment-add.mdx
@@ -124,4 +124,4 @@ m365 aad approleassignment add --appObjectId "57907bf8-73fa-43a6-89a5-1f603e29e4
 
 ## More information
 
-- Microsoft Graph permissions reference: [https://docs.microsoft.com/en-us/graph/permissions-reference](https://docs.microsoft.com/en-us/graph/permissions-reference)
+- Microsoft Graph permissions reference: [https://learn.microsoft.com/graph/permissions-reference](https://learn.microsoft.com/graph/permissions-reference)

--- a/docs/docs/cmd/aad/approleassignment/approleassignment-list.mdx
+++ b/docs/docs/cmd/aad/approleassignment/approleassignment-list.mdx
@@ -53,7 +53,7 @@ m365 aad approleassignment list --appObjectId b2307a39-e878-458b-bc90-03bc578531
 
 ## More information
 
-- Application and service principal objects in Azure Active Directory (Azure AD): [https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects)
+- Application and service principal objects in Azure Active Directory (Azure AD): [https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects](https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects)
 
 ## Response
 

--- a/docs/docs/cmd/aad/approleassignment/approleassignment-remove.mdx
+++ b/docs/docs/cmd/aad/approleassignment/approleassignment-remove.mdx
@@ -70,4 +70,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Microsoft Graph permissions reference: [https://docs.microsoft.com/en-us/graph/permissions-reference](https://docs.microsoft.com/en-us/graph/permissions-reference)
+- Microsoft Graph permissions reference: [https://learn.microsoft.com/graph/permissions-reference](https://learn.microsoft.com/graph/permissions-reference)

--- a/docs/docs/cmd/aad/oauth2grant/oauth2grant-add.mdx
+++ b/docs/docs/cmd/aad/oauth2grant/oauth2grant-add.mdx
@@ -55,4 +55,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Application and service principal objects in Azure Active Directory (Azure AD): [https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects)
+- Application and service principal objects in Azure Active Directory (Azure AD): [https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects](https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects)

--- a/docs/docs/cmd/aad/oauth2grant/oauth2grant-list.mdx
+++ b/docs/docs/cmd/aad/oauth2grant/oauth2grant-list.mdx
@@ -94,5 +94,5 @@ m365 aad oauth2grant list --spObjectId b2307a39-e878-458b-bc90-03bc578531d6
 
 ## More information
 
-- Application and service principal objects in Azure Active Directory (Azure AD): [https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects)
-- List oauth2PermissionGrants: [https://docs.microsoft.com/en-us/graph/api/oauth2permissiongrant-list?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/oauth2permissiongrant-list?view=graph-rest-1.0)
+- Application and service principal objects in Azure Active Directory (Azure AD): [https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects](https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects)
+- List oauth2PermissionGrants: [https://learn.microsoft.com/graph/api/oauth2permissiongrant-list?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/oauth2permissiongrant-list?view=graph-rest-1.0)

--- a/docs/docs/cmd/aad/oauth2grant/oauth2grant-remove.mdx
+++ b/docs/docs/cmd/aad/oauth2grant/oauth2grant-remove.mdx
@@ -52,5 +52,5 @@ The command won't return a response on success.
 
 ## More information
 
-- Application and service principal objects in Azure Active Directory (Azure AD): [https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects)
-- Delete a delegated permission grant (oAuth2PermissionGrant): [https://docs.microsoft.com/en-us/graph/api/oauth2permissiongrant-delete?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/oauth2permissiongrant-delete?view=graph-rest-1.0)
+- Application and service principal objects in Azure Active Directory (Azure AD): [https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects](https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects)
+- Delete a delegated permission grant (oAuth2PermissionGrant): [https://learn.microsoft.com/graph/api/oauth2permissiongrant-delete?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/oauth2permissiongrant-delete?view=graph-rest-1.0)

--- a/docs/docs/cmd/aad/oauth2grant/oauth2grant-set.mdx
+++ b/docs/docs/cmd/aad/oauth2grant/oauth2grant-set.mdx
@@ -46,5 +46,5 @@ The command won't return a response on success.
 
 ## More information
 
-- Application and service principal objects in Azure Active Directory (Azure AD): [https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects)
-- Update a delegated permission grant (oAuth2PermissionGrant): [https://docs.microsoft.com/en-us/graph/api/oauth2permissiongrant-update?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/oauth2permissiongrant-update?view=graph-rest-1.0)
+- Application and service principal objects in Azure Active Directory (Azure AD): [https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects](https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects)
+- Update a delegated permission grant (oAuth2PermissionGrant): [https://learn.microsoft.com/graph/api/oauth2permissiongrant-update?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/oauth2permissiongrant-update?view=graph-rest-1.0)

--- a/docs/docs/cmd/aad/policy/policy-list.mdx
+++ b/docs/docs/cmd/aad/policy/policy-list.mdx
@@ -112,4 +112,4 @@ m365 aad policy list --type "claimsMapping"
 
 ## More information
 
-- Microsoft Graph Azure AD policy overview: [https://docs.microsoft.com/en-us/graph/api/resources/policy-overview?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/policy-overview?view=graph-rest-1.0)
+- Microsoft Graph Azure AD policy overview: [https://learn.microsoft.com/graph/api/resources/policy-overview?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/resources/policy-overview?view=graph-rest-1.0)

--- a/docs/docs/cmd/aad/siteclassification/siteclassification-disable.mdx
+++ b/docs/docs/cmd/aad/siteclassification/siteclassification-disable.mdx
@@ -39,4 +39,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint "modern" sites classification: [https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/modern-experience-site-classification](https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/modern-experience-site-classification)
+- SharePoint "modern" sites classification: [https://learn.microsoft.com/sharepoint/dev/solution-guidance/modern-experience-site-classification](https://learn.microsoft.com/sharepoint/dev/solution-guidance/modern-experience-site-classification)

--- a/docs/docs/cmd/aad/siteclassification/siteclassification-enable.mdx
+++ b/docs/docs/cmd/aad/siteclassification/siteclassification-enable.mdx
@@ -54,4 +54,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint "modern" sites classification: [https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/modern-experience-site-classification](https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/modern-experience-site-classification)
+- SharePoint "modern" sites classification: [https://learn.microsoft.com/sharepoint/dev/solution-guidance/modern-experience-site-classification](https://learn.microsoft.com/sharepoint/dev/solution-guidance/modern-experience-site-classification)

--- a/docs/docs/cmd/aad/siteclassification/siteclassification-get.mdx
+++ b/docs/docs/cmd/aad/siteclassification/siteclassification-get.mdx
@@ -81,4 +81,4 @@ m365 aad siteclassification get
 
 ## More information
 
-- SharePoint "modern" sites classification: [https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/modern-experience-site-classification](https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/modern-experience-site-classification)
+- SharePoint "modern" sites classification: [https://learn.microsoft.com/sharepoint/dev/solution-guidance/modern-experience-site-classification](https://learn.microsoft.com/sharepoint/dev/solution-guidance/modern-experience-site-classification)

--- a/docs/docs/cmd/aad/siteclassification/siteclassification-set.mdx
+++ b/docs/docs/cmd/aad/siteclassification/siteclassification-set.mdx
@@ -61,4 +61,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint "modern" sites classification: [https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/modern-experience-site-classification](https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/modern-experience-site-classification)
+- SharePoint "modern" sites classification: [https://learn.microsoft.com/sharepoint/dev/solution-guidance/modern-experience-site-classification](https://learn.microsoft.com/sharepoint/dev/solution-guidance/modern-experience-site-classification)

--- a/docs/docs/cmd/aad/sp/sp-add.mdx
+++ b/docs/docs/cmd/aad/sp/sp-add.mdx
@@ -189,5 +189,5 @@ m365 aad sp add --objectId b2307a39-e878-458b-bc90-03bc578531d6
 
 ## More information
 
-- Application and service principal objects in Azure Active Directory (Azure AD): [https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects)
-- Create servicePrincipal: [https://docs.microsoft.com/en-us/graph/api/serviceprincipal-post-serviceprincipals?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/serviceprincipal-post-serviceprincipals?view=graph-rest-1.0)
+- Application and service principal objects in Azure Active Directory (Azure AD): [https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects](https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects)
+- Create servicePrincipal: [https://learn.microsoft.com/graph/api/serviceprincipal-post-serviceprincipals?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/serviceprincipal-post-serviceprincipals?view=graph-rest-1.0)

--- a/docs/docs/cmd/aad/sp/sp-get.mdx
+++ b/docs/docs/cmd/aad/sp/sp-get.mdx
@@ -217,5 +217,5 @@ m365 aad sp get --appObjectId b2307a39-e878-458b-bc90-03bc578531dd
 
 ## More information
 
-- Application and service principal objects in Azure Active Directory (Azure AD): [https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects)
-- Get servicePrincipal: [https://docs.microsoft.com/en-us/graph/api/serviceprincipal-get?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/serviceprincipal-get?view=graph-rest-1.0)
+- Application and service principal objects in Azure Active Directory (Azure AD): [https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects](https://learn.microsoft.com/azure/active-directory/develop/active-directory-application-objects)
+- Get servicePrincipal: [https://learn.microsoft.com/graph/api/serviceprincipal-get?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/serviceprincipal-get?view=graph-rest-1.0)

--- a/docs/docs/cmd/aad/user/user-add.mdx
+++ b/docs/docs/cmd/aad/user/user-add.mdx
@@ -43,7 +43,7 @@ m365 aad user add [options]
 : Whether the user should change his/her password on the next login and setup MFA.
 
 `--usageLocation [usageLocation]`
-: A two letter [country code](https://learn.microsoft.com/en-us/partner-center/commercial-marketplace-co-sell-location-codes#country-and-region-codes) (ISO standard 3166). Required for users that will be assigned licenses.
+: A two letter [country code](https://learn.microsoft.com/partner-center/commercial-marketplace-co-sell-location-codes#country-and-region-codes) (ISO standard 3166). Required for users that will be assigned licenses.
 
 `--officeLocation [officeLocation]` 
 : The office location in the user's place of business.
@@ -58,7 +58,7 @@ m365 aad user add [options]
 : The name for the department in which the user works. Maximum length is 64 characters.
 
 `--preferredLanguage [preferredLanguage]`
-: The preferred language for the user. Should follow [ISO 639-1 Code](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a). Example: `en-US`.
+: The preferred language for the user. Should follow [ISO 639-1 Code](https://learn.microsoft.com/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a). Example: `en-US`.
 
 `--managerUserId [managerUserId]`
 : User ID of the user's manager. Specify `managerUserId` or `managerUserName` but not both.
@@ -83,7 +83,7 @@ After running this command, it may take a minute before the user is effectively 
 
 :::
 
-This command allows using unknown options. For a comprehensive list of user properties, please refer to the [Graph documentation page](https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties).
+This command allows using unknown options. For a comprehensive list of user properties, please refer to the [Graph documentation page](https://learn.microsoft.com/graph/api/resources/user?view=graph-rest-1.0#properties).
 
 If the specified option is not found, you will receive a `Resource 'xyz' does not exist or one of its queried reference-property objects are not present.` error.
 

--- a/docs/docs/cmd/aad/user/user-guest-add.mdx
+++ b/docs/docs/cmd/aad/user/user-guest-add.mdx
@@ -31,7 +31,7 @@ m365 aad user guest add [options]
 : Additional recipients the invitation message should be sent to. Currently only 1 additional recipient is supported.
 
 `--messageLanguage [messageLanguage]`
-: The language you want to send the default message in. The language format should be in [ISO 639](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/ed06cf15-306c-43be-9053-ca81ca51e656). The default is `en-US`.
+: The language you want to send the default message in. The language format should be in [ISO 639](https://learn.microsoft.com/openspecs/office_standards/ms-oi29500/ed06cf15-306c-43be-9053-ca81ca51e656). The default is `en-US`.
 
 `--sendInvitationMessage`
 : Indicates whether an email should be sent to the user.

--- a/docs/docs/cmd/aad/user/user-set.mdx
+++ b/docs/docs/cmd/aad/user/user-set.mdx
@@ -47,7 +47,7 @@ m365 aad user set [options]
 : The user's surname (family name or last name). Maximum length is 64 characters.
 
 `--usageLocation [usageLocation]`
-: A two letter [country code](https://learn.microsoft.com/en-us/partner-center/commercial-marketplace-co-sell-location-codes#country-and-region-codes) (ISO standard 3166). Required for users that will be assigned licenses.
+: A two letter [country code](https://learn.microsoft.com/partner-center/commercial-marketplace-co-sell-location-codes#country-and-region-codes) (ISO standard 3166). Required for users that will be assigned licenses.
 
 `--officeLocation [officeLocation]` 
 : The office location in the user's place of business.
@@ -62,7 +62,7 @@ m365 aad user set [options]
 : The name for the department in which the user works. Maximum length is 64 characters.
 
 `--preferredLanguage [preferredLanguage]`
-: The preferred language for the user. Should follow [ISO 639-1 Code](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a). Example: `en-US`.
+: The preferred language for the user. Should follow [ISO 639-1 Code](https://learn.microsoft.com/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a). Example: `en-US`.
 
 `--managerUserId [managerUserId]`
 : User ID of the user's manager. Specify `managerUserId`, `managerUserName` or `removeManager` but not both.
@@ -78,7 +78,7 @@ m365 aad user set [options]
 
 ## Remarks
 
-This command allows using unknown options. For a comprehensive list of user properties, please refer to the [Graph documentation page](https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties).
+This command allows using unknown options. For a comprehensive list of user properties, please refer to the [Graph documentation page](https://learn.microsoft.com/graph/api/resources/user?view=graph-rest-1.0#properties).
 
 If the user with the specified ID or username doesn't exist, or if the specified option is not found, you will receive a `Resource 'xyz' does not exist or one of its queried reference-property objects are not present.` error.
 

--- a/docs/docs/cmd/graph/changelog/changelog-list.mdx
+++ b/docs/docs/cmd/graph/changelog/changelog-list.mdx
@@ -72,7 +72,7 @@ m365 graph changelog list --startDate '2021-01-01' --endDate '2021-05-01'
       "guid": "2693683c-f49a-4715-a649-edadd3f54aadv1.0",
       "category": "v1.0",
       "title": "Teamwork and communications",
-      "description": "Added the **chatMessageActions** enumeration type.\r\\\nAdded the [chatMessageHistoryItem](https://learn.microsoft.com/en-us/graph/api/resources/chatMessageHistoryItem?view=graph-rest-1.0) resource type.\r\\\nAdded the **messageHistory** property to the [chatMessage](https://learn.microsoft.com/en-us/graph/api/resources/chatMessage?view=graph-rest-1.0) resource.\r\\\n",
+      "description": "Added the **chatMessageActions** enumeration type.\r\\\nAdded the [chatMessageHistoryItem](https://learn.microsoft.com/graph/api/resources/chatMessageHistoryItem?view=graph-rest-1.0) resource type.\r\\\nAdded the **messageHistory** property to the [chatMessage](https://learn.microsoft.com/graph/api/resources/chatMessage?view=graph-rest-1.0) resource.\r\\\n",
       "pubDate": "2023-05-18T23:04:05.000Z"
     }
   ]
@@ -93,8 +93,8 @@ m365 graph changelog list --startDate '2021-01-01' --endDate '2021-05-01'
   ```csv
   guid,category,title,description
   2693683c-f49a-4715-a649-edadd3f54aadv1.0,v1.0,Teamwork and communications,"Added the **chatMessageActions** enumeration type.
-  Added the [chatMessageHistoryItem](https://learn.microsoft.com/en-us/graph/api/resources/chatMessageHistoryItem?view=graph-rest-1.0) resource type.
-  Added the **messageHistory** property to the [chatMessage](https://learn.microsoft.com/en-us/graph/api/resources/chatMessage?view=graph-rest-1.0) resource.
+  Added the [chatMessageHistoryItem](https://learn.microsoft.com/graph/api/resources/chatMessageHistoryItem?view=graph-rest-1.0) resource type.
+  Added the **messageHistory** property to the [chatMessage](https://learn.microsoft.com/graph/api/resources/chatMessage?view=graph-rest-1.0) resource.
   ```
 
   </TabItem>
@@ -113,8 +113,8 @@ m365 graph changelog list --startDate '2021-01-01' --endDate '2021-05-01'
   category | v1.0
   title | Teamwork and communications
   description | Added the \*\*chatMessageActions\*\* enumeration type.
-  <br>Added the [chatMessageHistoryItem](https://learn.microsoft.com/en-us/graph/api/resources/chatMessageHistoryItem?view=graph-rest-1.0) resource type.
-  <br>Added the \*\*messageHistory\*\* property to the [chatMessage](https://learn.microsoft.com/en-us/graph/api/resources/chatMessage?view=graph-rest-1.0) resource.
+  <br>Added the [chatMessageHistoryItem](https://learn.microsoft.com/graph/api/resources/chatMessageHistoryItem?view=graph-rest-1.0) resource type.
+  <br>Added the \*\*messageHistory\*\* property to the [chatMessage](https://learn.microsoft.com/graph/api/resources/chatMessage?view=graph-rest-1.0) resource.
   ```
 
   </TabItem>

--- a/docs/docs/cmd/onenote/notebook/notebook-list.mdx
+++ b/docs/docs/cmd/onenote/notebook/notebook-list.mdx
@@ -159,4 +159,4 @@ m365 onenote notebook list --webUrl https://contoso.sharepoint.com/sites/testsit
 
 ## More information
 
-- List notebooks (MS Graph docs): [https://docs.microsoft.com/en-us/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http](https://docs.microsoft.com/en-us/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http)
+- List notebooks (MS Graph docs): [https://learn.microsoft.com/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http](https://learn.microsoft.com/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http)

--- a/docs/docs/cmd/outlook/message/message-list.mdx
+++ b/docs/docs/cmd/outlook/message/message-list.mdx
@@ -163,4 +163,4 @@ m365 outlook message list --folderName inbox
 
 ## More information
 
-- Well-known folder names: [https://docs.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0)
+- Well-known folder names: [https://learn.microsoft.com/graph/api/resources/mailfolder?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/resources/mailfolder?view=graph-rest-1.0)

--- a/docs/docs/cmd/outlook/message/message-move.mdx
+++ b/docs/docs/cmd/outlook/message/message-move.mdx
@@ -58,4 +58,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Well-known folder names: [https://docs.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0)
+- Well-known folder names: [https://learn.microsoft.com/graph/api/resources/mailfolder?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/resources/mailfolder?view=graph-rest-1.0)

--- a/docs/docs/cmd/planner/bucket/bucket-add.mdx
+++ b/docs/docs/cmd/planner/bucket/bucket-add.mdx
@@ -34,7 +34,7 @@ m365 planner bucket add [options]
 : Name of the group to which the plan belongs. Specify `ownerGroupId` or `ownerGroupName` when using `planTitle`.
 
 `--orderHint [orderHint]`
-: Hint used to order items of this type in a list view. The format is defined as outlined [here](https://docs.microsoft.com/en-us/graph/api/resources/planner-order-hint-format?view=graph-rest-1.0).
+: Hint used to order items of this type in a list view. The format is defined as outlined [here](https://learn.microsoft.com/graph/api/resources/planner-order-hint-format?view=graph-rest-1.0).
 ```
 
 <Global />

--- a/docs/docs/cmd/planner/bucket/bucket-set.mdx
+++ b/docs/docs/cmd/planner/bucket/bucket-set.mdx
@@ -38,7 +38,7 @@ m365 planner bucket set [options]
 : New name of the bucket.
 
 `--orderHint [orderHint]`
-: Hint used to order items of this type in a list view. The format is defined as outlined [here](https://docs.microsoft.com/en-us/graph/api/resources/planner-order-hint-format?view=graph-rest-1.0).
+: Hint used to order items of this type in a list view. The format is defined as outlined [here](https://learn.microsoft.com/graph/api/resources/planner-order-hint-format?view=graph-rest-1.0).
 ```
 
 <Global />

--- a/docs/docs/cmd/planner/plan/plan-set.mdx
+++ b/docs/docs/cmd/planner/plan/plan-set.mdx
@@ -250,6 +250,6 @@ When we make use of the option `shareWithUserIds` or `shareWithUserNames` the re
 
 ## More information
 
-- Update plannerPlan: [https://learn.microsoft.com/en-us/graph/api/plannerplan-update?view=graph-rest-1.0&tabs=http](https://learn.microsoft.com/en-us/graph/api/plannerplan-update?view=graph-rest-1.0&tabs=http)
-- plannerPlanDetails resource type: [https://learn.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-1.0](https://learn.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-1.0)
-- plannerCategoryDescriptions resource type: [https://learn.microsoft.com/en-us/graph/api/resources/plannercategorydescriptions?view=graph-rest-1.0](https://learn.microsoft.com/en-us/graph/api/resources/plannercategorydescriptions?view=graph-rest-1.0)
+- Update plannerPlan: [https://learn.microsoft.com/graph/api/plannerplan-update?view=graph-rest-1.0&tabs=http](https://learn.microsoft.com/graph/api/plannerplan-update?view=graph-rest-1.0&tabs=http)
+- plannerPlanDetails resource type: [https://learn.microsoft.com/graph/api/resources/plannerplandetails?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/resources/plannerplandetails?view=graph-rest-1.0)
+- plannerCategoryDescriptions resource type: [https://learn.microsoft.com/graph/api/resources/plannercategorydescriptions?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/resources/plannercategorydescriptions?view=graph-rest-1.0)

--- a/docs/docs/cmd/planner/task/task-set.mdx
+++ b/docs/docs/cmd/planner/task/task-set.mdx
@@ -364,4 +364,4 @@ m365 planner task set --id "2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2" --percentComplete 50 -
 ## More information
 
 - Using order hints in Planner: [https://docs.microsoft.com/graph/api/resources/planner-order-hint-format?view=graph-rest-1.0](https://docs.microsoft.com/graph/api/resources/planner-order-hint-format?view=graph-rest-1.0)
-- Applied categories in Planner: [https://docs.microsoft.com/graph/api/resources/plannerappliedcategories?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/plannerappliedcategories?view=graph-rest-1.0)
+- Applied categories in Planner: [https://docs.microsoft.com/graph/api/resources/plannerappliedcategories?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/resources/plannerappliedcategories?view=graph-rest-1.0)

--- a/docs/docs/cmd/purview/auditlog/auditlog-list.mdx
+++ b/docs/docs/cmd/purview/auditlog/auditlog-list.mdx
@@ -31,7 +31,7 @@ m365 purview auditlog list [options]
 
 :::info
 
-Before you can access audit log data, you must enable unified audit logging for your Microsoft 365 tenant. For instructions, check out the page [Turn auditing on or off](https://learn.microsoft.com/en-us/microsoft-365/compliance/audit-log-enable-disable).
+Before you can access audit log data, you must enable unified audit logging for your Microsoft 365 tenant. For instructions, check out the page [Turn auditing on or off](https://learn.microsoft.com/microsoft-365/compliance/audit-log-enable-disable).
 
 :::
 
@@ -145,5 +145,5 @@ m365 purview auditlog list --contentType SharePoint --startTime "2023-01-01T00:0
 
 ## More information
 
-- Explanation of all available audit log activities/operations: https://learn.microsoft.com/en-us/purview/audit-log-activities
-- Explanation of all available audit log properties: https://learn.microsoft.com/en-us/purview/audit-log-detailed-properties
+- Explanation of all available audit log activities/operations: https://learn.microsoft.com/purview/audit-log-activities
+- Explanation of all available audit log properties: https://learn.microsoft.com/purview/audit-log-detailed-properties

--- a/docs/docs/cmd/purview/retentionevent/retentionevent-add.mdx
+++ b/docs/docs/cmd/purview/retentionevent/retentionevent-add.mdx
@@ -153,4 +153,4 @@ m365 purview retentionevent add --displayName 'Employee information expiration' 
 
 This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created.
 
-[Read more on event-based retention here](https://learn.microsoft.com/en-us/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)
+[Read more on event-based retention here](https://learn.microsoft.com/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)

--- a/docs/docs/cmd/purview/retentionevent/retentionevent-get.mdx
+++ b/docs/docs/cmd/purview/retentionevent/retentionevent-get.mdx
@@ -139,4 +139,4 @@ This command is based on an API that is currently in preview and is subject to c
 
 This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created.
 
-[Read more on event-based retention here](https://learn.microsoft.com/en-us/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)
+[Read more on event-based retention here](https://learn.microsoft.com/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-add.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-add.mdx
@@ -114,4 +114,4 @@ m365 purview retentioneventtype add --displayName 'Contract Expiry' --descriptio
 
 ## More information
 
-This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created. [Read more about event-based retention here](https://learn.microsoft.com/en-us/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)
+This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created. [Read more about event-based retention here](https://learn.microsoft.com/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-get.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-get.mdx
@@ -111,4 +111,4 @@ m365 purview retentioneventtype get --id c37d695e-d581-4ae9-82a0-9364eba4291e
 
 This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created.
 
-[Read more on event-based retention here](https://learn.microsoft.com/en-us/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)
+[Read more on event-based retention here](https://learn.microsoft.com/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-remove.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-remove.mdx
@@ -44,4 +44,4 @@ The command won't return a response on success.
 
 ## More information
 
-This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created. [Read more about event-based retention here](https://learn.microsoft.com/en-us/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)
+This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created. [Read more about event-based retention here](https://learn.microsoft.com/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-set.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-set.mdx
@@ -44,4 +44,4 @@ The command won't return a response on success.
 
 ## More information
 
-This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created. [Read more about event-based retention here](https://learn.microsoft.com/en-us/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)
+This command is part of a series of commands that have to do with event-based retention. Event-based retention is about starting a retention period when a specific event occurs, instead of the moment a document was labeled or created. [Read more about event-based retention here](https://learn.microsoft.com/microsoft-365/compliance/event-driven-retention?view=o365-worldwide)

--- a/docs/docs/cmd/purview/retentionlabel/retentionlabel-add.mdx
+++ b/docs/docs/cmd/purview/retentionlabel/retentionlabel-add.mdx
@@ -152,4 +152,4 @@ m365 purview retentionlabel add --displayName 'some label' --behaviorDuringReten
 
 ## More information
 
-- Create retentionLabel: [https://learn.microsoft.com/en-us/graph/api/security-retentionlabel-post?view=graph-rest-beta&tabs=http](https://learn.microsoft.com/en-us/graph/api/security-retentionlabel-post?view=graph-rest-beta&tabs=http)
+- Create retentionLabel: [https://learn.microsoft.com/graph/api/security-retentionlabel-post?view=graph-rest-beta&tabs=http](https://learn.microsoft.com/graph/api/security-retentionlabel-post?view=graph-rest-beta&tabs=http)

--- a/docs/docs/cmd/purview/sensitivitylabel/sensitivitylabel-policysettings-list.mdx
+++ b/docs/docs/cmd/purview/sensitivitylabel/sensitivitylabel-policysettings-list.mdx
@@ -66,7 +66,7 @@ m365 purview sensitivitylabel policysettings list --userName john.doe@contoso.co
   ```json
   {
     "id": "71F139249895C2F6DC861031DAC47E0C2C37C6595582D4248CC77FD7293681B5DE348BC71AEB44068CB397DB021CADB4",
-    "moreInfoUrl": "https://docs.microsoft.com/en-us/microsoft-365/compliance/get-started-with-sensitivity-labels?view=o365-worldwide#end-user-documentation-for-sensitivity-labels",
+    "moreInfoUrl": "https://learn.microsoft.com/microsoft-365/compliance/get-started-with-sensitivity-labels?view=o365-worldwide#end-user-documentation-for-sensitivity-labels",
     "isMandatory": true,
     "isDowngradeJustificationRequired": true,
     "defaultLabelId": "022bb90d-0cda-491d-b861-d195b14532dc"
@@ -82,7 +82,7 @@ m365 purview sensitivitylabel policysettings list --userName john.doe@contoso.co
   DB021CADB4
   isDowngradeJustificationRequired: true
   isMandatory                     : true
-  moreInfoUrl                     : https://docs.microsoft.com/en-us/microsoft-365/compliance/get-started-with-sensitivity-labels?view=o365-worldwide#end-user-documentation-for-sensitivity-labels
+  moreInfoUrl                     : https://learn.microsoft.com/microsoft-365/compliance/get-started-with-sensitivity-labels?view=o365-worldwide#end-user-documentation-for-sensitivity-labels
   ```
 
   </TabItem>
@@ -90,7 +90,7 @@ m365 purview sensitivitylabel policysettings list --userName john.doe@contoso.co
 
   ```csv
   id,moreInfoUrl,isMandatory,isDowngradeJustificationRequired,defaultLabelId
-  71F139249895C2F6DC861031DAC47E0C2C37C6595582D4248CC77FD7293681B5DE348BC71AEB44068CB397DB021CADB4,https://docs.microsoft.com/en-us/microsoft-365/compliance/get-started-with-sensitivity-labels?view=o365-worldwide#end-user-documentation-for-sensitivity-labels,1,1,022bb90d-0cda-491d-b861-d195b14532dc
+  71F139249895C2F6DC861031DAC47E0C2C37C6595582D4248CC77FD7293681B5DE348BC71AEB44068CB397DB021CADB4,https://learn.microsoft.com/microsoft-365/compliance/get-started-with-sensitivity-labels?view=o365-worldwide#end-user-documentation-for-sensitivity-labels,1,1,022bb90d-0cda-491d-b861-d195b14532dc
   ```
 
   </TabItem>
@@ -106,7 +106,7 @@ m365 purview sensitivitylabel policysettings list --userName john.doe@contoso.co
   Property | Value
   ---------|-------
   id | 71F139249895C2F6DC861031DAC47E0C2C37C6595582D4248CC77FD7293681B5DE348BC71AEB44068CB397DB021CADB4
-  moreInfoUrl | https://docs.microsoft.com/en-us/microsoft-365/compliance/get-started-with-sensitivity-labels?view=o365-worldwide#end-user-documentation-for-sensitivity-labels
+  moreInfoUrl | https://learn.microsoft.com/microsoft-365/compliance/get-started-with-sensitivity-labels?view=o365-worldwide#end-user-documentation-for-sensitivity-labels
   isMandatory | true
   isDowngradeJustificationRequired | true
   defaultLabelId | 022bb90d-0cda-491d-b861-d195b14532dc

--- a/docs/docs/cmd/spo/app/app-add.mdx
+++ b/docs/docs/cmd/spo/app/app-add.mdx
@@ -147,4 +147,4 @@ m365 spo app add --filePath c:\spfx.sppkg --appCatalogScope sitecollection --app
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/app/app-deploy.mdx
+++ b/docs/docs/cmd/spo/app/app-deploy.mdx
@@ -77,4 +77,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/app/app-get.mdx
+++ b/docs/docs/cmd/spo/app/app-get.mdx
@@ -171,4 +171,4 @@ m365 spo app get --id b2307a39-e878-458b-bc90-03bc578531d6 --appCatalogScope sit
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/app/app-install.mdx
+++ b/docs/docs/cmd/spo/app/app-install.mdx
@@ -49,4 +49,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/app/app-list.mdx
+++ b/docs/docs/cmd/spo/app/app-list.mdx
@@ -138,4 +138,4 @@ m365 spo app list --appCatalogScope sitecollection --appCatalogUrl https://conto
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/app/app-remove.mdx
+++ b/docs/docs/cmd/spo/app/app-remove.mdx
@@ -68,4 +68,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/app/app-retract.mdx
+++ b/docs/docs/cmd/spo/app/app-retract.mdx
@@ -68,4 +68,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/app/app-uninstall.mdx
+++ b/docs/docs/cmd/spo/app/app-uninstall.mdx
@@ -58,4 +58,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/app/app-upgrade.mdx
+++ b/docs/docs/cmd/spo/app/app-upgrade.mdx
@@ -49,4 +49,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Application Lifecycle Management (ALM) APIs: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins)
+- Application Lifecycle Management (ALM) APIs: [https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins](https://learn.microsoft.com/sharepoint/dev/apis/alm-api-for-spfx-add-ins)

--- a/docs/docs/cmd/spo/contenttype/contenttype-add.mdx
+++ b/docs/docs/cmd/spo/contenttype/contenttype-add.mdx
@@ -213,4 +213,4 @@ m365 spo contenttype add --webUrl https://contoso.sharepoint.com/sites/contoso-s
 
 ## More information
 
-- Content Type IDs: [https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/aa543822(v%3Doffice.14)](https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/aa543822(v%3Doffice.14))
+- Content Type IDs: [https://learn.microsoft.com/previous-versions/office/developer/sharepoint-2010/aa543822(v%3Doffice.14)](https://learn.microsoft.com/previous-versions/office/developer/sharepoint-2010/aa543822(v%3Doffice.14))

--- a/docs/docs/cmd/spo/contenttype/contenttype-set.mdx
+++ b/docs/docs/cmd/spo/contenttype/contenttype-set.mdx
@@ -41,7 +41,7 @@ m365 spo contenttype set [options]
 
 :::caution Updating child content types
 
-When specifying the `--updateChildren` flag, SharePoint will only propagate the changes that are made in the current request. If you want to know more about updating a content type and propagating changes to child content types, be sure to [read more here](https://learn.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ms442695(v=office.14)#considerations-when-updating-child-content-types). 
+When specifying the `--updateChildren` flag, SharePoint will only propagate the changes that are made in the current request. If you want to know more about updating a content type and propagating changes to child content types, be sure to [read more here](https://learn.microsoft.com/previous-versions/office/developer/sharepoint-2010/ms442695(v=office.14)#considerations-when-updating-child-content-types). 
 
 :::
 

--- a/docs/docs/cmd/spo/hidedefaultthemes/hidedefaultthemes-get.mdx
+++ b/docs/docs/cmd/spo/hidedefaultthemes/hidedefaultthemes-get.mdx
@@ -67,4 +67,4 @@ m365 spo hidedefaultthemes get
 
 ## More information
 
-- SharePoint site theming: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)
+- SharePoint site theming: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)

--- a/docs/docs/cmd/spo/hidedefaultthemes/hidedefaultthemes-set.mdx
+++ b/docs/docs/cmd/spo/hidedefaultthemes/hidedefaultthemes-set.mdx
@@ -41,4 +41,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint site theming: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)
+- SharePoint site theming: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)

--- a/docs/docs/cmd/spo/site/site-add.mdx
+++ b/docs/docs/cmd/spo/site/site-add.mdx
@@ -215,4 +215,4 @@ m365 spo site add --type ClassicSite --url https://contoso.sharepoint.com/sites/
 
 ## More information
 
-- Creating SharePoint Communication Site using REST: [https://docs.microsoft.com/en-us/sharepoint/dev/apis/communication-site-creation-rest](https://docs.microsoft.com/en-us/sharepoint/dev/apis/communication-site-creation-rest)
+- Creating SharePoint Communication Site using REST: [https://learn.microsoft.com/sharepoint/dev/apis/communication-site-creation-rest](https://learn.microsoft.com/sharepoint/dev/apis/communication-site-creation-rest)

--- a/docs/docs/cmd/spo/site/site-appcatalog-add.mdx
+++ b/docs/docs/cmd/spo/site/site-appcatalog-add.mdx
@@ -41,4 +41,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Use the site collection app catalog: [https://docs.microsoft.com/en-us/sharepoint/dev/general-development/site-collection-app-catalog](https://docs.microsoft.com/en-us/sharepoint/dev/general-development/site-collection-app-catalog)
+- Use the site collection app catalog: [https://learn.microsoft.com/sharepoint/dev/general-development/site-collection-app-catalog](https://learn.microsoft.com/sharepoint/dev/general-development/site-collection-app-catalog)

--- a/docs/docs/cmd/spo/site/site-appcatalog-remove.mdx
+++ b/docs/docs/cmd/spo/site/site-appcatalog-remove.mdx
@@ -43,4 +43,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Use the site collection app catalog: [https://docs.microsoft.com/en-us/sharepoint/dev/general-development/site-collection-app-catalog](https://docs.microsoft.com/en-us/sharepoint/dev/general-development/site-collection-app-catalog)
+- Use the site collection app catalog: [https://learn.microsoft.com/sharepoint/dev/general-development/site-collection-app-catalog](https://learn.microsoft.com/sharepoint/dev/general-development/site-collection-app-catalog)

--- a/docs/docs/cmd/spo/site/site-groupify.mdx
+++ b/docs/docs/cmd/spo/site/site-groupify.mdx
@@ -129,4 +129,4 @@ m365 spo site groupify --url https://contoso.sharepoin.com/sites/team-a --alias 
 
 ## More information
 
-- Overview of the "Log in to new Microsoft 365 group" feature: [https://docs.microsoft.com/en-us/sharepoint/dev/features/groupify/groupify-overview](https://docs.microsoft.com/en-us/sharepoint/dev/features/groupify/groupify-overview)
+- Overview of the "Log in to new Microsoft 365 group" feature: [https://learn.microsoft.com/sharepoint/dev/features/groupify/groupify-overview](https://learn.microsoft.com/sharepoint/dev/features/groupify/groupify-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-add.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-add.mdx
@@ -178,6 +178,6 @@ m365 spo sitedesign add --title "Contoso communication site" --webTemplate Commu
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
-- Customize a default site design: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/customize-default-site-design](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/customize-default-site-design)
-- Site design JSON schema: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-json-schema](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-json-schema)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)
+- Customize a default site design: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/customize-default-site-design](https://learn.microsoft.com/sharepoint/dev/declarative-customization/customize-default-site-design)
+- Site design JSON schema: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-json-schema](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-json-schema)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-apply.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-apply.mdx
@@ -166,4 +166,4 @@ When we make use of the option `asTask`, the response will differ.
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-get.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-get.mdx
@@ -159,4 +159,4 @@ m365 spo sitedesign get --title "Contoso Site Design"
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-list.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-list.mdx
@@ -118,4 +118,4 @@ m365 spo sitedesign list
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-remove.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-remove.mdx
@@ -46,4 +46,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-rights-grant.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-rights-grant.mdx
@@ -51,4 +51,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-rights-list.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-rights-list.mdx
@@ -89,4 +89,4 @@ m365 spo sitedesign rights list --siteDesignId 2c1ba4c4-cd9b-4417-832f-92a34bc34
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-rights-revoke.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-rights-revoke.mdx
@@ -53,4 +53,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-run-list.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-run-list.mdx
@@ -104,4 +104,4 @@ m365 spo sitedesign run list --webUrl https://contoso.sharepoint.com/sites/team-
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-run-status-get.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-run-status-get.mdx
@@ -101,4 +101,4 @@ m365 spo sitedesign run status get --webUrl https://contoso.sharepoint.com/sites
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-set.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-set.mdx
@@ -192,6 +192,6 @@ m365 spo sitedesign set --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --webTemplate 
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
-- Customize a default site design: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/customize-default-site-design](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/customize-default-site-design)
-- Site design JSON schema: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-json-schema](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-json-schema)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)
+- Customize a default site design: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/customize-default-site-design](https://learn.microsoft.com/sharepoint/dev/declarative-customization/customize-default-site-design)
+- Site design JSON schema: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-json-schema](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-json-schema)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-task-get.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-task-get.mdx
@@ -90,4 +90,4 @@ m365 spo sitedesign task get --id 6ec3ca5b-d04b-4381-b169-61378556d76e
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-task-list.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-task-list.mdx
@@ -89,4 +89,4 @@ m365 spo sitedesign task list --webUrl https://contoso.sharepoint.com/sites/team
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-task-remove.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-task-remove.mdx
@@ -42,4 +42,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitescript/sitescript-add.mdx
+++ b/docs/docs/cmd/spo/sitescript/sitescript-add.mdx
@@ -114,4 +114,4 @@ m365 spo sitescript add --title "Contoso" --description "Contoso theme script" -
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitescript/sitescript-get.mdx
+++ b/docs/docs/cmd/spo/sitescript/sitescript-get.mdx
@@ -95,4 +95,4 @@ m365 spo sitescript get --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitescript/sitescript-list.mdx
+++ b/docs/docs/cmd/spo/sitescript/sitescript-list.mdx
@@ -84,4 +84,4 @@ m365 spo sitescript list
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitescript/sitescript-remove.mdx
+++ b/docs/docs/cmd/spo/sitescript/sitescript-remove.mdx
@@ -46,4 +46,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/sitescript/sitescript-set.mdx
+++ b/docs/docs/cmd/spo/sitescript/sitescript-set.mdx
@@ -107,4 +107,4 @@ m365 spo sitescript set --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --title "Conto
 
 ## More information
 
-- SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)
+- SharePoint site design and site script overview: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/docs/cmd/spo/storageentity/storageentity-get.mdx
+++ b/docs/docs/cmd/spo/storageentity/storageentity-get.mdx
@@ -86,4 +86,4 @@ m365 spo storageentity get -k AnalyticsId
 
 ## More information
 
-- SharePoint Framework Tenant Properties: [https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties)
+- SharePoint Framework Tenant Properties: [https://learn.microsoft.com/sharepoint/dev/spfx/tenant-properties](https://learn.microsoft.com/sharepoint/dev/spfx/tenant-properties)

--- a/docs/docs/cmd/spo/storageentity/storageentity-list.mdx
+++ b/docs/docs/cmd/spo/storageentity/storageentity-list.mdx
@@ -87,4 +87,4 @@ m365 spo storageentity list -u https://contoso.sharepoint.com/sites/appcatalog
 
 ## More information
 
-- SharePoint Framework Tenant Properties: [https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties)
+- SharePoint Framework Tenant Properties: [https://learn.microsoft.com/sharepoint/dev/spfx/tenant-properties](https://learn.microsoft.com/sharepoint/dev/spfx/tenant-properties)

--- a/docs/docs/cmd/spo/storageentity/storageentity-remove.mdx
+++ b/docs/docs/cmd/spo/storageentity/storageentity-remove.mdx
@@ -55,4 +55,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint Framework Tenant Properties: [https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties)
+- SharePoint Framework Tenant Properties: [https://learn.microsoft.com/sharepoint/dev/spfx/tenant-properties](https://learn.microsoft.com/sharepoint/dev/spfx/tenant-properties)

--- a/docs/docs/cmd/spo/storageentity/storageentity-set.mdx
+++ b/docs/docs/cmd/spo/storageentity/storageentity-set.mdx
@@ -57,4 +57,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint Framework Tenant Properties: [https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties)
+- SharePoint Framework Tenant Properties: [https://learn.microsoft.com/sharepoint/dev/spfx/tenant-properties](https://learn.microsoft.com/sharepoint/dev/spfx/tenant-properties)

--- a/docs/docs/cmd/spo/theme/theme-apply.mdx
+++ b/docs/docs/cmd/spo/theme/theme-apply.mdx
@@ -86,5 +86,5 @@ m365 spo theme apply --name Blue --webUrl https://contoso.sharepoint.com/sites/p
 
 ## More information
 
-- SharePoint site theming: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)
+- SharePoint site theming: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)
 - Theme Generator: [https://aka.ms/themedesigner](https://aka.ms/themedesigner)

--- a/docs/docs/cmd/spo/theme/theme-get.mdx
+++ b/docs/docs/cmd/spo/theme/theme-get.mdx
@@ -111,4 +111,4 @@ m365 spo theme get --name Contoso-Blue
 
 ## More information
 
-- SharePoint site theming: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)
+- SharePoint site theming: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)

--- a/docs/docs/cmd/spo/theme/theme-list.mdx
+++ b/docs/docs/cmd/spo/theme/theme-list.mdx
@@ -84,4 +84,4 @@ m365 spo theme list
 
 ## More information
 
-- SharePoint site theming: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)
+- SharePoint site theming: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)

--- a/docs/docs/cmd/spo/theme/theme-remove.mdx
+++ b/docs/docs/cmd/spo/theme/theme-remove.mdx
@@ -50,4 +50,4 @@ The command won't return a response on success.
 
 ## More information
 
-- SharePoint site theming: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)
+- SharePoint site theming: [https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview](https://learn.microsoft.com/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-overview)

--- a/docs/docs/cmd/spo/user/user-remove.mdx
+++ b/docs/docs/cmd/spo/user/user-remove.mdx
@@ -52,4 +52,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Remove-PnPUser - [https://docs.microsoft.com/en-us/powershell/module/sharepoint-pnp/remove-pnpuser?view=sharepoint-ps](https://docs.microsoft.com/en-us/powershell/module/sharepoint-pnp/remove-pnpuser?view=sharepoint-ps)
+- Remove-PnPUser - [https://learn.microsoft.com/powershell/module/sharepoint-pnp/remove-pnpuser?view=sharepoint-ps](https://learn.microsoft.com/powershell/module/sharepoint-pnp/remove-pnpuser?view=sharepoint-ps)

--- a/docs/docs/cmd/spo/web/web-set.mdx
+++ b/docs/docs/cmd/spo/web/web-set.mdx
@@ -118,4 +118,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Web properties: [https://docs.microsoft.com/en-us/previous-versions/office/sharepoint-server/ee545886(v=office.15)](https://docs.microsoft.com/en-us/previous-versions/office/sharepoint-server/ee545886(v=office.15))
+- Web properties: [https://learn.microsoft.com/previous-versions/office/sharepoint-server/ee545886(v=office.15)](https://learn.microsoft.com/previous-versions/office/sharepoint-server/ee545886(v=office.15))

--- a/docs/docs/cmd/teams/channel/channel-remove.mdx
+++ b/docs/docs/cmd/teams/channel/channel-remove.mdx
@@ -67,4 +67,4 @@ The command won't return a response on success.
 
 ## More information
 
-- directory resource type (deleted items): [https://docs.microsoft.com/en-us/graph/api/resources/directory?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/directory?view=graph-rest-1.0)
+- directory resource type (deleted items): [https://learn.microsoft.com/graph/api/resources/directory?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/resources/directory?view=graph-rest-1.0)

--- a/docs/docs/cmd/teams/meeting/meeting-get.mdx
+++ b/docs/docs/cmd/teams/meeting/meeting-get.mdx
@@ -34,7 +34,7 @@ m365 teams meeting get [options]
 
 :::info
 
-When you connect with application permissions, you should [add an application access policy](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy) for the command to work.
+When you connect with application permissions, you should [add an application access policy](https://learn.microsoft.com/graph/cloud-communication-online-meeting-application-access-policy) for the command to work.
 
 :::
 

--- a/docs/docs/cmd/teams/meeting/meeting-transcript-list.mdx
+++ b/docs/docs/cmd/teams/meeting/meeting-transcript-list.mdx
@@ -54,7 +54,7 @@ This command is based on a Microsoft Graph API that is currently in preview and 
 
 :::caution
 
-To run this command with application permissions, tenant administrators must create an application access policy and grant it to a user. This authorizes the app configured in the policy to fetch online meetings and/or online meeting artifacts on behalf of that user. For more details, click [here](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy).
+To run this command with application permissions, tenant administrators must create an application access policy and grant it to a user. This authorizes the app configured in the policy to fetch online meetings and/or online meeting artifacts on behalf of that user. For more details, click [here](https://learn.microsoft.com/graph/cloud-communication-online-meeting-application-access-policy).
 
 :::
 

--- a/docs/docs/cmd/teams/report/report-pstncalls.mdx
+++ b/docs/docs/cmd/teams/report/report-pstncalls.mdx
@@ -52,7 +52,7 @@ m365 teams report pstncalls --fromDateTime 2020-10-31 --toDateTime 2020-12-31 --
 
 ## More information
 
-- List PSTN calls: [https://docs.microsoft.com/en-us/graph/api/callrecords-callrecord-getpstncalls?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/callrecords-callrecord-getpstncalls?view=graph-rest-1.0)
+- List PSTN calls: [https://learn.microsoft.com/graph/api/callrecords-callrecord-getpstncalls?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/callrecords-callrecord-getpstncalls?view=graph-rest-1.0)
 
 ## Response
 

--- a/docs/docs/cmd/teams/tab/tab-remove.mdx
+++ b/docs/docs/cmd/teams/tab/tab-remove.mdx
@@ -48,4 +48,4 @@ The command won't return a response on success.
 
 ## More information
 
-- Delete tab from channel: [https://docs.microsoft.com/en-us/graph/api/teamstab-delete?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/teamstab-delete?view=graph-rest-1.0)
+- Delete tab from channel: [https://learn.microsoft.com/graph/api/channel-delete-tabs](https://learn.microsoft.com/graph/api/channel-delete-tabs)

--- a/docs/docs/cmd/teams/team/team-remove.mdx
+++ b/docs/docs/cmd/teams/team/team-remove.mdx
@@ -57,4 +57,4 @@ The command won't return a response on success.
 
 ## More information
 
-- directory resource type (deleted items): [https://docs.microsoft.com/en-us/graph/api/resources/directory?view=graph-rest-1.0](https://docs.microsoft.com/en-us/graph/api/resources/directory?view=graph-rest-1.0)
+- directory resource type (deleted items): [https://learn.microsoft.com/graph/api/resources/directory?view=graph-rest-1.0](https://learn.microsoft.com/graph/api/resources/directory?view=graph-rest-1.0)

--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-healthissue-list.mdx
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-healthissue-list.mdx
@@ -121,4 +121,4 @@ m365 tenant serviceannouncement healthissue list --service "Microsoft Forms"
 
 ## More information
 
-- List serviceAnnouncement issues: [https://docs.microsoft.com/en-us/graph/api/serviceannouncement-list-issues](https://docs.microsoft.com/en-us/graph/api/serviceannouncement-list-issues)
+- List serviceAnnouncement issues: [https://learn.microsoft.com/graph/api/serviceannouncement-list-issues](https://learn.microsoft.com/graph/api/serviceannouncement-list-issues)

--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-message-get.mdx
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-message-get.mdx
@@ -123,5 +123,5 @@ m365 tenant serviceannouncement message get --id MC001337
 
 ## More information
 
-- Microsoft Graph REST API reference: [https://docs.microsoft.com/en-us/graph/api/serviceupdatemessage-get](https://docs.microsoft.com/en-us/graph/api/serviceupdatemessage-get)
+- Microsoft Graph REST API reference: [https://learn.microsoft.com/graph/api/serviceupdatemessage-get](https://learn.microsoft.com/graph/api/serviceupdatemessage-get)
 

--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-message-list.mdx
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-message-list.mdx
@@ -118,4 +118,4 @@ m365 tenant serviceannouncement message list --service "Microsoft Teams"
 
 ## More information
 
-- List serviceAnnouncement messages: [https://docs.microsoft.com/en-us/graph/api/serviceannouncement-list-messages](https://docs.microsoft.com/en-us/graph/api/serviceannouncement-list-messages)
+- List serviceAnnouncement messages: [https://learn.microsoft.com/graph/api/serviceannouncement-list-messages](https://learn.microsoft.com/graph/api/serviceannouncement-list-messages)

--- a/docs/docs/cmd/todo/task/task-set.mdx
+++ b/docs/docs/cmd/todo/task/task-set.mdx
@@ -59,7 +59,7 @@ m365 todo task set [options]
 
 ## Remarks
 
-When you specify the values for `categories`, each category can correspond to the displayName property of an [outlookCategory](https://learn.microsoft.com/en-us/graph/api/resources/outlookcategory?view=graph-rest-1.0). It is permissible to use distinct names.
+When you specify the values for `categories`, each category can correspond to the displayName property of an [outlookCategory](https://learn.microsoft.com/graph/api/resources/outlookcategory?view=graph-rest-1.0). It is permissible to use distinct names.
 
 ## Examples
 

--- a/docs/docs/contribute/expect-during-pr.mdx
+++ b/docs/docs/contribute/expect-during-pr.mdx
@@ -34,6 +34,6 @@ During the subsequent review, the maintainer will perform another round of evalu
 
 ## Response time for requested changes
 
-Reviewers will wait for four weeks after requesting changes before closing a PR. They will follow up with you before closing it. You can open a new PR at any time after syncing your fork. For guidance on syncing your fork, refer to this [guide](https://github.com/pnp/cli-microsoft365/blob/main/CONTRIBUTING.mdx#tips).
+Reviewers will wait for four weeks after requesting changes before closing a PR. They will follow up with you before closing it. You can open a new PR at any time after syncing your fork. For guidance on syncing your fork, refer to this [guide](https://github.com/pnp/cli-microsoft365/blob/main/CONTRIBUTING.md#tips).
 
 By following these steps and understanding the review process, we can collaborate effectively to incorporate your awesome contributions into the CLI for Microsoft 365.

--- a/docs/docs/sample-scripts/spo/grant-api-permissions-aad/index.mdx
+++ b/docs/docs/sample-scripts/spo/grant-api-permissions-aad/index.mdx
@@ -35,7 +35,7 @@ This trick is just for development purposes. In Production environment, you shou
 
 :::caution
 
-These permissions will be granted on the whole tenant and could be used by any script running in your tenant. More info [here](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-aadhttpclient#considerations).
+These permissions will be granted on the whole tenant and could be used by any script running in your tenant. More info [here](https://learn.microsoft.com/sharepoint/dev/spfx/use-aadhttpclient#considerations).
 
 :::
 

--- a/docs/docs/sample-scripts/spo/sync-splib-into-az-storage-container/index.mdx
+++ b/docs/docs/sample-scripts/spo/sync-splib-into-az-storage-container/index.mdx
@@ -17,7 +17,7 @@ This PowerShell script shows how to download and sync documents in a SharePoint 
 Prerequisites:
 
 - [Microsoft 365 CLI](https://pnp.github.io/cli-microsoft365/)
-- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest)
+- [Azure CLI](https://learn.microsoft.com/cli/azure/?view=azure-cli-latest)
 - SharePoint Online Site
 - Document Library with documents
 - Azure Storage Container

--- a/docs/docs/sample-scripts/teams/share-socialchampions/index.mdx
+++ b/docs/docs/sample-scripts/teams/share-socialchampions/index.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Share social champions to Teams
 
-Author: [Albert-Jan Schot](https://www.cloudappie.nl/recognize-contributions-clim365) Inspired by: [Emily Mancini](https://docs.microsoft.com/en-us/microsoft-365/community/identifying-your-sharepoint-champions)
+Author: [Albert-Jan Schot](https://www.cloudappie.nl/recognize-contributions-clim365) Inspired by: [Emily Mancini](https://learn.microsoft.com/microsoft-365/community/identifying-your-sharepoint-champions)
 
 Retrieves activities for SharePoint Online, Teams and Yammer and shares the top 3 contributors for each category as an adaptive card to the specified webhook url.
 


### PR DESCRIPTION
We still have a lot of MS doc links to refer to `https://docs.microsoft.com` instead of `https://learn.microsoft.com`. Although they get redirected properly to `https://learn.microsoft.com` it's more future-proof that all the links have the proper destination. 

I also removed all the language tags from the URLs as MS docs properly directs you to your preferred language so we don't need to include these.

Finally, found a few broken links that have been restored. 

- `docs\docs\contribute\expect-during-pr.mdx` the link to CONTRIBUTING.md had the wrong extension.
- `docs\docs\cmd\teams\tab\tab-remove.mdx` in more information the graph link didn't exist anymore so changed it to the one that associates with the used API.