### PR TITLE
Fixes anomalies for 'tenant people profilecardproperty' commands

### DIFF
--- a/docs/docs/cmd/tenant/people/people-profilecardproperty-add.mdx
+++ b/docs/docs/cmd/tenant/people/people-profilecardproperty-add.mdx
@@ -66,54 +66,6 @@ m365 tenant people profilecardproperty add --name customAttribute1 --displayName
 
 ## Response
 
-### Standard response
-
-<Tabs>
-  <TabItem value="JSON">
-
-  ```json
-  {
-    "directoryPropertyName": "UserPrincipalName",
-    "annotations": []
-  }
-  ```
-
-  </TabItem>
-  <TabItem value="Text">
-
-  ```text
-  annotations          : []
-  directoryPropertyName: UserPrincipalName
-  ```
-
-  </TabItem>
-  <TabItem value="CSV">
-
-  ```csv
-  directoryPropertyName
-  UserPrincipalName
-  ```
-
-  </TabItem>
-  <TabItem value="Markdown">
-
-  ```md
-  # tenant people profilecardproperty add --name 'UserPrincipalName'
-
-  Date: 11/2/2023
-
-  Property | Value
-  ---------|-------
-  directoryPropertyName | UserPrincipalName
-  ```
-
-  </TabItem>
-</Tabs>
-
-### Response with a customAttribute
-
-When we make use of one of the customAttributes, the response will differ. 
-
 <Tabs>
   <TabItem value="JSON">
 

--- a/docs/docs/cmd/tenant/people/people-profilecardproperty-get.mdx
+++ b/docs/docs/cmd/tenant/people/people-profilecardproperty-get.mdx
@@ -95,3 +95,7 @@ m365 tenant people profilecardproperty get --name customAttribute1
 
   </TabItem>
 </Tabs>
+
+## More information
+
+- https://learn.microsoft.com/graph/add-properties-profilecard

--- a/docs/docs/cmd/tenant/people/people-profilecardproperty-list.mdx
+++ b/docs/docs/cmd/tenant/people/people-profilecardproperty-list.mdx
@@ -38,8 +38,7 @@ m365 tenant people profilecardproperty list
   <TabItem value="JSON">
 
   ```json
-  {
-  "value": [
+  [
     {
       "directoryPropertyName": "customAttribute1",
       "annotations": [
@@ -53,13 +52,8 @@ m365 tenant people profilecardproperty list
           ]
         }
       ]
-    },
-    {
-      "directoryPropertyName": "Alias",
-      "annotations": []
     }
   ]
-}
   ```
 
   </TabItem>
@@ -69,7 +63,6 @@ m365 tenant people profilecardproperty list
   directoryPropertyName  displayName     displayName de
   ---------------------  --------------  --------------
   customAttribute1       Cost center     Kostenstelle
-  Alias
   ```
 
   </TabItem>
@@ -78,7 +71,6 @@ m365 tenant people profilecardproperty list
   ```csv
   directoryPropertyName,displayName,displayName de
   customAttribute1,Cost center,Kostenstelle
-  Alias,,
   ```
 
   </TabItem>
@@ -96,11 +88,11 @@ m365 tenant people profilecardproperty list
   directoryPropertyName | customAttribute1
   displayName | Cost center
   displayName de | Kostenstelle
-
-  Property | Value
-  ---------|-------
-  directoryPropertyName | Alias
   ```
 
   </TabItem>
 </Tabs>
+
+## More information
+
+- https://learn.microsoft.com/graph/add-properties-profilecard

--- a/src/m365/tenant/commands/people/people-profilecardproperty-add.spec.ts
+++ b/src/m365/tenant/commands/people/people-profilecardproperty-add.spec.ts
@@ -141,7 +141,7 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_ADD, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    await assert.doesNotReject(command.action(logger, { options: { name: 'userPrincipalName' } }));
+    await command.action(logger, { options: { name: 'userPrincipalName' } });
     assert(loggerLogSpy.calledOnceWithExactly(propertyResponse));
   });
 
@@ -154,7 +154,7 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_ADD, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    await assert.doesNotReject(command.action(logger, { options: { name: 'userPrincipalName', debug: true } }));
+    await command.action(logger, { options: { name: 'userPrincipalName', debug: true } });
     assert(loggerLogSpy.calledOnceWithExactly(propertyResponse));
   });
 
@@ -167,7 +167,7 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_ADD, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    await assert.doesNotReject(command.action(logger, { options: { name: 'fax' } }));
+    await command.action(logger, { options: { name: 'fax' } });
     assert(loggerLogSpy.calledOnceWithExactly(propertyResponse));
   });
 
@@ -247,6 +247,19 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_ADD, () => {
 
     await command.action(logger, { options: { name: 'customAttribute1', displayName: 'Cost center', 'displayName-nl-NL': 'Kostenplaats', output: 'text' } });
     assert(loggerLogSpy.calledOnceWithExactly(customAttributePropertyTextResponse));
+  });
+
+  it('uses correct casing for name when incorrect casing is used', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/people/profileCardProperties`) {
+        return customAttributePropertyResponse;
+      }
+
+      throw 'Invalid Request';
+    });
+
+    await command.action(logger, { options: { name: 'ALIAS', output: 'json' } });
+    assert.strictEqual(postStub.lastCall.args[0].data.directoryPropertyName, 'Alias');
   });
 
   it('fails when the addition conflicts with an existing property', async () => {

--- a/src/m365/tenant/commands/people/people-profilecardproperty-get.spec.ts
+++ b/src/m365/tenant/commands/people/people-profilecardproperty-get.spec.ts
@@ -129,6 +129,19 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_GET, () => {
     assert(loggerLogSpy.calledOnceWith(textOutput));
   });
 
+  it('uses correct casing for name when incorrect casing is used', async () => {
+    const getStub = sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/people/profileCardProperties/${profileCardPropertyName}`) {
+        return response;
+      }
+
+      throw 'Invalid Request';
+    });
+
+    await command.action(logger, { options: { name: profileCardPropertyName.toUpperCase() } });
+    assert(getStub.called);
+  });
+
   it('handles error when profile card property does not exist', async () => {
     sinon.stub(request, 'get').rejects({
       response: {

--- a/src/m365/tenant/commands/people/people-profilecardproperty-get.ts
+++ b/src/m365/tenant/commands/people/people-profilecardproperty-get.ts
@@ -56,8 +56,11 @@ class TenantPeopleProfileCardPropertyGetCommand extends GraphCommand {
         await logger.logToStderr(`Retrieving information about profile card property '${args.options.name}'...`);
       }
 
+      // Get the right casing for the profile card property name
+      const profileCardProperty = profileCardPropertyNames.find(p => p.toLowerCase() === args.options.name.toLowerCase());
+
       const requestOptions: CliRequestOptions = {
-        url: `${this.resource}/v1.0/admin/people/profileCardProperties/${args.options.name}`,
+        url: `${this.resource}/v1.0/admin/people/profileCardProperties/${profileCardProperty}`,
         headers: {
           accept: 'application/json;odata.metadata=none'
         },

--- a/src/m365/tenant/commands/people/people-profilecardproperty-list.spec.ts
+++ b/src/m365/tenant/commands/people/people-profilecardproperty-list.spec.ts
@@ -130,7 +130,7 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_LIST, () => {
     });
 
     await command.action(logger, { options: { verbose: true } });
-    assert(loggerLogSpy.calledOnceWith(response));
+    assert(loggerLogSpy.calledOnceWith(response.value));
   });
 
   it('lists profile card properties information for other than json output', async () => {

--- a/src/m365/tenant/commands/people/people-profilecardproperty-list.ts
+++ b/src/m365/tenant/commands/people/people-profilecardproperty-list.ts
@@ -1,9 +1,9 @@
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import GraphCommand from '../../../base/GraphCommand.js';
-import request, { CliRequestOptions } from '../../../../request.js';
 import { ProfileCardProperty } from './profileCardProperties.js';
 import commands from '../../commands.js';
+import { odata } from '../../../../utils/odata.js';
 
 interface CommandArgs {
   options: GlobalOptions;
@@ -18,29 +18,17 @@ class TenantPeopleProfileCardPropertyListCommand extends GraphCommand {
     return 'Lists all profile card properties';
   }
 
-  constructor() {
-    super();
-  }
-
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       if (this.verbose) {
-        await logger.logToStderr(`Lists all profile card properties...`);
+        await logger.logToStderr(`Listing all profile card properties...`);
       }
 
-      const requestOptions: CliRequestOptions = {
-        url: `${this.resource}/v1.0/admin/people/profileCardProperties`,
-        headers: {
-          accept: 'application/json;odata.metadata=none'
-        },
-        responseType: 'json'
-      };
-
-      const result = await request.get<ProfileCardProperty[]>(requestOptions);
+      const result = await odata.getAllItems<ProfileCardProperty>(`${this.resource}/v1.0/admin/people/profileCardProperties`);
       let output: any = result;
 
       if (args.options.output && args.options.output !== 'json') {
-        output = output.value.sort((n1: ProfileCardProperty, n2: ProfileCardProperty) => {
+        output = output.sort((n1: ProfileCardProperty, n2: ProfileCardProperty) => {
           const localizations1 = n1.annotations[0]?.localizations?.length ?? 0;
           const localizations2 = n2.annotations[0]?.localizations?.length ?? 0;
           if (localizations1 > localizations2) {

--- a/src/m365/tenant/commands/people/people-profilecardproperty-remove.spec.ts
+++ b/src/m365/tenant/commands/people/people-profilecardproperty-remove.spec.ts
@@ -76,7 +76,7 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_REMOVE, () => {
   });
 
   it('correctly removes profile card property for userPrincipalName', async () => {
-    sinon.stub(request, 'delete').callsFake(async (opts) => {
+    const removeStub = sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/admin/people/profileCardProperties/UserPrincipalName`) {
         return;
       }
@@ -84,11 +84,12 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_REMOVE, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    await assert.doesNotReject(command.action(logger, { options: { name: 'userPrincipalName' } }));
+    await command.action(logger, { options: { name: 'userPrincipalName' } });
+    assert(removeStub.called);
   });
 
   it('correctly removes profile card property for userPrincipalName (debug)', async () => {
-    sinon.stub(request, 'delete').callsFake(async (opts) => {
+    const removeStub = sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/admin/people/profileCardProperties/UserPrincipalName`) {
         return;
       }
@@ -96,11 +97,12 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_REMOVE, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    await assert.doesNotReject(command.action(logger, { options: { name: 'userPrincipalName', debug: true } }));
+    await command.action(logger, { options: { name: 'userPrincipalName', debug: true } });
+    assert(removeStub.called);
   });
 
   it('correctly removes profile card property for fax', async () => {
-    sinon.stub(request, 'delete').callsFake(async (opts) => {
+    const removeStub = sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/admin/people/profileCardProperties/Fax`) {
         return;
       }
@@ -108,11 +110,12 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_REMOVE, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    await assert.doesNotReject(command.action(logger, { options: { name: 'fax' } }));
+    await command.action(logger, { options: { name: 'fax' } });
+    assert(removeStub.called);
   });
 
   it('correctly removes profile card property for state with force', async () => {
-    sinon.stub(request, 'delete').callsFake(async (opts) => {
+    const removeStub = sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/admin/people/profileCardProperties/StateOrProvince`) {
         return;
       }
@@ -120,7 +123,21 @@ describe(commands.PEOPLE_PROFILECARDPROPERTY_REMOVE, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    await assert.doesNotReject(command.action(logger, { options: { name: 'StateOrProvince', force: true } }));
+    await command.action(logger, { options: { name: 'StateOrProvince', force: true } });
+    assert(removeStub.called);
+  });
+
+  it('uses correct casing for name when incorrect casing is used', async () => {
+    const deleteStub = sinon.stub(request, 'delete').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/people/profileCardProperties/StateOrProvince`) {
+        return;
+      }
+
+      throw 'Invalid Request';
+    });
+
+    await command.action(logger, { options: { name: 'STATEORPROVINCE', force: true } });
+    assert(deleteStub.called);
   });
 
   it('fails when the removal runs into a property that is not found', async () => {


### PR DESCRIPTION
In this PR I made the following changes for `tenant people profilecardproperty` commands.

- Removed the double response from the `add` command docs. We only use multiple responses if the output of the command changes. In this case, an empty array is not a structural output change.
- Added `More information` docs section to every page.
- Ensured that the `list` command outputs an array instead of an object.
- For the `list` command, removed extra response objects. We only display 1 object in the response preview.
- Made a small refactor in the `add` command to use a built-in function to get unknown properties.
- Added correct name casing check for `get` command.
- Added unknown options to telemetry for `add` command.
- Added tests to validate casing of property names.