### PR TITLE
Adds requiredWhen and whenPrompted functionality. Closes #5560, #5636

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,6 +13,7 @@
         "@azure/msal-node": "^1.18.3",
         "@inquirer/confirm": "^2.0.12",
         "@inquirer/input": "^1.2.11",
+        "@inquirer/password": "^1.1.13",
         "@inquirer/select": "^1.2.11",
         "@xmldom/xmldom": "^0.8.10",
         "adaptive-expressions": "^4.20.1",
@@ -367,17 +368,17 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-q2o4BcANKFyuUI5V6ejmPs1f9SdbJxfnLmhQVb72Fj7hOudoKsJpByJZ0imv9a/rpKDogA+93vtBBMqsnS7/Fg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.1.0.tgz",
+      "integrity": "sha512-EVnific72BhMOMo8mElvrYhGFWJZ73X6j0I+fITIPTsdAz6Z9A3w3csKy+XaH87/5QAEIQHR7RSCVXvQpIqNdQ==",
       "dependencies": {
-        "@inquirer/type": "^1.1.4",
-        "@types/mute-stream": "^0.0.1",
-        "@types/node": "^20.6.0",
+        "@inquirer/type": "^1.1.5",
+        "@types/mute-stream": "^0.0.2",
+        "@types/node": "^20.8.2",
         "@types/wrap-ansi": "^3.0.0",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
-        "cli-spinners": "^2.9.0",
+        "cli-spinners": "^2.9.1",
         "cli-width": "^4.1.0",
         "figures": "^3.2.0",
         "mute-stream": "^1.0.0",
@@ -391,9 +392,12 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "20.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.3.tgz",
-      "integrity": "sha512-HksnYH4Ljr4VQgEy2lTStbCKv/P590tmPe5HqOnv9Gprffgv5WXAY+Y5Gqniu0GGqeTCUdBnzC3QSrzPkBkAMA=="
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@inquirer/core/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -467,12 +471,12 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.11.tgz",
-      "integrity": "sha512-sV1nO6+RxMFTHAznmxMkbMkjGQ8NGMWr0mvXjU35YQ0OFEL+YlD+DPbNd9s3ltnswODZAcnM1yFvdko3S/Kj/w==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.13.tgz",
+      "integrity": "sha512-gALuvSpZRYfqygPjlYWodMZ4TXwALvw7Pk4tRFhE1oMN79rLVlg88Z/X6JCUh+uV2qLaxxgbeP+cgPWTvuWsCg==",
       "dependencies": {
-        "@inquirer/core": "^5.0.0",
-        "@inquirer/type": "^1.1.4",
+        "@inquirer/core": "^5.1.0",
+        "@inquirer/type": "^1.1.5",
         "chalk": "^4.1.2"
       },
       "engines": {
@@ -494,6 +498,49 @@
       }
     },
     "node_modules/@inquirer/input/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-1.1.13.tgz",
+      "integrity": "sha512-6STGbL4Vm6ohE2yDBOSENCpCeywnvPux5psZVpvblGDop1oPiZkdsVI+NhsA0c4BE6YT0fNVK8Oqxf5Dgt5k7g==",
+      "dependencies": {
+        "@inquirer/input": "^1.2.13",
+        "@inquirer/type": "^1.1.5",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/password/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/password/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -553,9 +600,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.4.tgz",
-      "integrity": "sha512-a6+RCiXBQEbiA73RT1pBfwiH2I+MPcoZoGKuuUYFkws+6ud7nb5kUQGHFGUSBim25IyVMT/mqbWIrkxetcIb/w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.5.tgz",
+      "integrity": "sha512-wmwHvHozpPo4IZkkNtbYenem/0wnfI6hvOcGKmPEa0DwuaH5XUQzFqy6OpEpjEegZMhYIk8HDYITI16BPLtrRA==",
       "engines": {
         "node": ">=14.18.0"
       }
@@ -923,9 +970,9 @@
       "dev": true
     },
     "node_modules/@types/mute-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.1.tgz",
-      "integrity": "sha512-0yQLzYhCqGz7CQPE3iDmYjhb7KMBFOP+tBkyw+/Y2YyDI5wpS7itXXxneN1zSsUwWx3Ji6YiVYrhAnpQGS/vkw==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.2.tgz",
+      "integrity": "sha512-FpiGjk6+IOrN0lZEfUUjdra1csU1VxwYFj4S0Zj+TJpu5x5mZW30RkEZojTadrNZHNmpCHgoE62IQZAH0OeuIA==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1842,9 +1889,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
-      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
+      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
       "engines": {
         "node": ">=6"
       },
@@ -5059,6 +5106,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unique-string": {
       "version": "3.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "@azure/msal-common": "^13.2.1",
         "@azure/msal-node": "^1.18.3",
+        "@inquirer/confirm": "^2.0.12",
+        "@inquirer/input": "^1.2.11",
+        "@inquirer/select": "^1.2.11",
         "@xmldom/xmldom": "^0.8.10",
         "adaptive-expressions": "^4.20.1",
         "adaptivecards": "^3.0.1",
@@ -23,7 +26,6 @@
         "configstore": "^6.0.0",
         "csv-stringify": "^6.4.4",
         "easy-table": "^1.2.0",
-        "inquirer": "^9.2.11",
         "jmespath": "^0.16.0",
         "json-to-ast": "^2.1.0",
         "minimist": "^1.2.8",
@@ -47,7 +49,6 @@
       "devDependencies": {
         "@microsoft/microsoft-graph-types": "^2.38.0",
         "@types/adm-zip": "^0.5.2",
-        "@types/inquirer": "^9.0.4",
         "@types/jmespath": "^0.15.0",
         "@types/json-to-ast": "^2.1.2",
         "@types/minimist": "^1.2.3",
@@ -323,6 +324,242 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.12.tgz",
+      "integrity": "sha512-Oxz3L0ti+0nWYHPPUIrPkxA2KnQZUGBHnk56yF5RjKqPGFrwvgLZdIXNe/w4I/OtdLeOBqHCrJ+kCvNvHVdk9g==",
+      "dependencies": {
+        "@inquirer/core": "^5.0.0",
+        "@inquirer/type": "^1.1.4",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/confirm/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/confirm/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.0.0.tgz",
+      "integrity": "sha512-q2o4BcANKFyuUI5V6ejmPs1f9SdbJxfnLmhQVb72Fj7hOudoKsJpByJZ0imv9a/rpKDogA+93vtBBMqsnS7/Fg==",
+      "dependencies": {
+        "@inquirer/type": "^1.1.4",
+        "@types/mute-stream": "^0.0.1",
+        "@types/node": "^20.6.0",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "cli-spinners": "^2.9.0",
+        "cli-width": "^4.1.0",
+        "figures": "^3.2.0",
+        "mute-stream": "^1.0.0",
+        "run-async": "^3.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "20.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.3.tgz",
+      "integrity": "sha512-HksnYH4Ljr4VQgEy2lTStbCKv/P590tmPe5HqOnv9Gprffgv5WXAY+Y5Gqniu0GGqeTCUdBnzC3QSrzPkBkAMA=="
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.11.tgz",
+      "integrity": "sha512-sV1nO6+RxMFTHAznmxMkbMkjGQ8NGMWr0mvXjU35YQ0OFEL+YlD+DPbNd9s3ltnswODZAcnM1yFvdko3S/Kj/w==",
+      "dependencies": {
+        "@inquirer/core": "^5.0.0",
+        "@inquirer/type": "^1.1.4",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/input/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/input/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.2.11.tgz",
+      "integrity": "sha512-LH2wzAsWfu/+wcapeht07zTDefuvGTpv0+9dCAQ68QigF+4gHzpWq5+AbBLbxzuH2Wz4WlHcti85nFUPPM1t3A==",
+      "dependencies": {
+        "@inquirer/core": "^5.0.0",
+        "@inquirer/type": "^1.1.4",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "figures": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.4.tgz",
+      "integrity": "sha512-a6+RCiXBQEbiA73RT1pBfwiH2I+MPcoZoGKuuUYFkws+6ud7nb5kUQGHFGUSBim25IyVMT/mqbWIrkxetcIb/w==",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -355,14 +592,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@ljharb/through": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.9.tgz",
-      "integrity": "sha512-yN599ZBuMPPK4tdoToLlvgJB4CLK8fGl7ntfy0Wn7U6ttNvHYurd81bfUiK/6sMkiIwm65R6ck4L6+Y3DfVbNQ==",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
@@ -639,16 +868,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
     },
-    "node_modules/@types/inquirer": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.4.tgz",
-      "integrity": "sha512-x8UgutCLm5tsp995aeYB8dlT+sGBCtv0zE43tHvo7OljtlA2Rn4+COyLKe9+YjB20uy0G14y0C9vCD2KtNtyGA==",
-      "dev": true,
-      "dependencies": {
-        "@types/through": "*",
-        "rxjs": "^7.2.0"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -703,6 +922,14 @@
       "integrity": "sha512-NaHL0+0lLNhX6d9rs+NSt97WH/gIlRHmszXbQ/8/MV/eVcFNdeJ/GYhrFuUc8K7WuPhRhTSdMkCp8VMzhUq85w==",
       "dev": true
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.1.tgz",
+      "integrity": "sha512-0yQLzYhCqGz7CQPE3iDmYjhb7KMBFOP+tBkyw+/Y2YyDI5wpS7itXXxneN1zSsUwWx3Ji6YiVYrhAnpQGS/vkw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.18.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.4.tgz",
@@ -750,15 +977,6 @@
       "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
     },
-    "node_modules/@types/through": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
-      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/update-notifier": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-6.0.5.tgz",
@@ -774,6 +992,11 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.5.tgz",
       "integrity": "sha512-xfHdwa1FMJ082prjSJpoEI57GZITiQz10r3vEJCHa2khEFQjKy91aWKz6+zybzssCvXUwE1LQWgWVwZ4nYUvHQ==",
       "dev": true
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
     },
     "node_modules/@types/xmldom": {
       "version": "0.1.31",
@@ -1539,11 +1762,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -2190,8 +2408,9 @@
       }
     },
     "node_modules/eslint-plugin-cli-microsoft365": {
-      "resolved": "eslint-rules",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:eslint-rules",
+      "dev": true
     },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.2.0",
@@ -2416,19 +2635,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2506,29 +2712,25 @@
       }
     },
     "node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
+        "escape-string-regexp": "^1.0.5"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2941,17 +3143,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3044,76 +3235,6 @@
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/inquirer": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.11.tgz",
-      "integrity": "sha512-B2LafrnnhbRzCWfAdOXisUzL89Kg8cVJlYmhqoi3flSiV/TveO+nsXwgKr9h9PIo+J1hz7nBSk6gegRIMBBf7g==",
-      "dependencies": {
-        "@ljharb/through": "^2.3.9",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^5.3.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^4.1.0",
-        "external-editor": "^3.1.0",
-        "figures": "^5.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "1.0.0",
-        "ora": "^5.4.1",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/inquirer/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/inquirer/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -3276,17 +3397,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -4038,14 +4148,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -4552,14 +4654,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4578,11 +4672,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -4881,17 +4970,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,7 +75,7 @@
     "eslint-rules": {
       "name": "eslint-plugin-cli-microsoft365",
       "version": "1.0.0",
-      "dev": true
+      "extraneous": true
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -933,8 +933,7 @@
     "node_modules/@types/node": {
       "version": "18.18.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.4.tgz",
-      "integrity": "sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ==",
-      "dev": true
+      "integrity": "sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ=="
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.7",

--- a/package.json
+++ b/package.json
@@ -248,6 +248,9 @@
   "dependencies": {
     "@azure/msal-common": "^13.2.1",
     "@azure/msal-node": "^1.18.3",
+    "@inquirer/confirm": "^2.0.12",
+    "@inquirer/input": "^1.2.11",
+    "@inquirer/select": "^1.2.11",
     "@xmldom/xmldom": "^0.8.10",
     "adaptive-expressions": "^4.20.1",
     "adaptivecards": "^3.0.1",
@@ -260,7 +263,6 @@
     "configstore": "^6.0.0",
     "csv-stringify": "^6.4.4",
     "easy-table": "^1.2.0",
-    "inquirer": "^9.2.11",
     "jmespath": "^0.16.0",
     "json-to-ast": "^2.1.0",
     "minimist": "^1.2.8",
@@ -278,7 +280,6 @@
   "devDependencies": {
     "@microsoft/microsoft-graph-types": "^2.38.0",
     "@types/adm-zip": "^0.5.2",
-    "@types/inquirer": "^9.0.4",
     "@types/jmespath": "^0.15.0",
     "@types/json-to-ast": "^2.1.2",
     "@types/minimist": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -250,6 +250,7 @@
     "@azure/msal-node": "^1.18.3",
     "@inquirer/confirm": "^2.0.12",
     "@inquirer/input": "^1.2.11",
+    "@inquirer/password": "^1.1.13",
     "@inquirer/select": "^1.2.11",
     "@xmldom/xmldom": "^0.8.10",
     "adaptive-expressions": "^4.20.1",

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -166,12 +166,9 @@ export default abstract class Command {
         Cli.error('🌶️  Provide values for the following parameters:');
       }
 
-      const missingRequireOptionValue = await prompt.forInput<{ missingRequireOptionValue: string }>({
-        name: 'missingRequireOptionValue',
-        message: `${command.options[i].name}: `
-      }).then(result => result.missingRequireOptionValue);
+      const answer = await prompt.forInput({ message: `${command.options[i].name}: ` });
 
-      args.options[command.options[i].name] = missingRequireOptionValue;
+      args.options[command.options[i].name] = answer;
     }
 
     if (prompted) {
@@ -221,34 +218,19 @@ export default abstract class Command {
   private async promptForOptionSetNameAndValue(args: CommandArgs, optionSet: OptionSet): Promise<void> {
     Cli.error(`🌶️  Please specify one of the following options:`);
 
-    const resultOptionName = await prompt.forInput<{ missingRequiredOptionName: string }>({
-      type: 'list',
-      name: 'missingRequiredOptionName',
-      message: `Option to use:`,
-      choices: optionSet.options
-    });
-    const missingRequiredOptionName = resultOptionName.missingRequiredOptionName;
+    const selectedOptionName = await prompt.forSelection<string>({ message: `Option to use:`, choices: optionSet.options.map((choice: any) => { return { name: choice, value: choice }; }) });
+    const optionValue = await prompt.forInput({ message: `${selectedOptionName}:` });
 
-    const resultOptionValue = await prompt.forInput<{ missingRequiredOptionValue: string }>({
-      name: 'missingRequiredOptionValue',
-      message: `${missingRequiredOptionName}:`
-    });
-
-    args.options[missingRequiredOptionName] = resultOptionValue.missingRequiredOptionValue;
+    args.options[selectedOptionName] = optionValue;
     Cli.error('');
   }
 
   private async promptForSpecificOption(args: CommandArgs, commonOptions: string[]): Promise<void> {
     Cli.error(`🌶️  Multiple options for an option set specified. Please specify the correct option that you wish to use.`);
 
-    const requiredOptionNameResult = await prompt.forInput<{ missingRequiredOptionName: string }>({
-      type: 'list',
-      name: 'missingRequiredOptionName',
-      message: `Option to use:`,
-      choices: commonOptions
-    });
+    const selectedOptionName = await prompt.forSelection({ message: `Option to use:`, choices: commonOptions.map((choice: any) => { return { name: choice, value: choice }; }) });
 
-    commonOptions.filter(y => y !== requiredOptionNameResult.missingRequiredOptionName).map(optionName => args.options[optionName] = undefined);
+    commonOptions.filter(y => y !== selectedOptionName).map(optionName => args.options[optionName] = undefined);
     Cli.error('');
   }
 

--- a/src/chili/chili.ts
+++ b/src/chili/chili.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import inquirer from 'inquirer';
 import ora from 'ora';
 import path from 'path';
 import url from 'url';
@@ -7,6 +6,7 @@ import { Cli } from '../cli/Cli.js';
 import request, { CliRequestOptions } from '../request.js';
 import { settingsNames } from '../settingsNames.js';
 import { md } from '../utils/md.js';
+import { prompt } from '../utils/prompt.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -118,12 +118,7 @@ async function startConversation(args: string[]): Promise<void> {
 }
 
 async function promptForPrompt(): Promise<string> {
-  const answer = await inquirer.prompt<{ prompt: string }>([{
-    type: 'input',
-    name: 'prompt',
-    message: '🌶️  How can I help you?'
-  }]);
-  return answer.prompt;
+  return await prompt.forInput({ message: '🌶️  How can I help you?' });
 }
 
 async function runConversationTurn(conversationId: number, question: string): Promise<void> {
@@ -169,63 +164,59 @@ async function runConversationTurn(conversationId: number, question: string): Pr
     console.log('');
   }
 
-  const result = await inquirer.prompt<{ chat: string }>([{
-    type: 'list',
-    name: 'chat',
-    message: 'What would you like to do next?',
-    choices: [
-      {
-        name: '📝 I want to know more',
-        value: 'ask'
-      },
-      {
-        name: '👋 I know enough. Thanks!',
-        value: 'end'
-      },
-      {
-        name: '🔄 I want to ask about something else',
-        value: 'new'
-      }
-    ]
-  }]);
+  const choices = [
+    {
+      name: '📝 I want to know more',
+      value: 'ask'
+    },
+    {
+      name: '👋 I know enough. Thanks!',
+      value: 'end'
+    },
+    {
+      name: '🔄 I want to ask about something else',
+      value: 'new'
+    }
+  ];
 
-  switch (result.chat) {
+  const result = await prompt.forSelection({ message: 'What would you like to do next?', choices });
+
+  switch (result) {
     case 'ask':
       const prompt = await promptForPrompt();
-      return await runConversationTurn(conversationId, prompt);
+      await runConversationTurn(conversationId, prompt);
+      break;
     case 'end':
       await endConversation(conversationId);
       console.log('');
       console.log('🌶️   Bye!');
-      return;
+      break;
     case 'new':
       initialPrompt = '';
-      return startConversation([]);
+      await startConversation([]);
+      break;
   }
 }
 
 async function rateResponse(messageId: number): Promise<void> {
-  const result = await inquirer.prompt<{ rating: number }>([{
-    type: 'list',
-    name: 'rating',
-    message: 'Was this helpful?',
-    choices: [
-      {
-        name: '👍 Yes',
-        value: 1
-      },
-      {
-        name: '👎 No',
-        value: -1
-      },
-      {
-        name: '🤔 Not sure/skip',
-        value: 0
-      }
-    ]
-  }]);
+  const choices = [
+    {
+      name: '👍 Yes',
+      value: 1
+    },
+    {
+      name: '👎 No',
+      value: -1
+    },
+    {
+      name: '🤔 Not sure/skip',
+      value: 0
+    }
+  ];
 
-  if (result.rating === 0) {
+  const rating = await prompt.forSelection({ message: 'Was this helpful?', choices });
+
+  if (rating === 0) {
     return;
   }
 
@@ -246,7 +237,7 @@ async function rateResponse(messageId: number): Promise<void> {
       // eslint-disable-next-line camelcase
       message_id: messageId,
       // eslint-disable-next-line camelcase
-      rating_value: result.rating
+      rating_value: rating
     }
   };
 

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -2,7 +2,6 @@ import assert from 'assert';
 import chalk from 'chalk';
 import Table from 'easy-table';
 import fs from 'fs';
-import { prompt } from '../utils/prompt.js';
 import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
@@ -19,6 +18,7 @@ import { session } from '../utils/session.js';
 import { sinonUtil } from '../utils/sinonUtil.js';
 import { Cli, CommandOutput } from './Cli.js';
 import { Logger } from './Logger.js';
+import { Choice, SelectionConfig, prompt } from '../utils/prompt.js';
 
 const require = createRequire(import.meta.url);
 const packageJSON = require('../../package.json');
@@ -167,12 +167,7 @@ class MockCommandWithPrompt extends AnonymousCommand {
     return 'Mock command with prompt';
   }
   public async commandAction(): Promise<void> {
-    await Cli.prompt({
-      type: 'confirm',
-      name: 'continue',
-      default: false,
-      message: `Continue?`
-    });
+    await Cli.promptForConfirmation({ message: `Continue?` });
   }
 }
 
@@ -283,7 +278,6 @@ describe('Cli', () => {
       Cli.executeCommand,
       fs.existsSync,
       fs.readFileSync,
-      prompt.forInput,
       // eslint-disable-next-line no-console
       console.log,
       // eslint-disable-next-line no-console
@@ -293,7 +287,9 @@ describe('Cli', () => {
       mockCommandWithValidation.validate,
       mockCommand.commandAction,
       mockCommand.processOptions,
-      Cli.prompt,
+      prompt.forInput,
+      prompt.forSelection,
+      prompt.forConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -852,7 +848,7 @@ describe('Cli', () => {
   });
 
   it(`prompts for required options`, (done) => {
-    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').callsFake(() => Promise.resolve({ missingRequireOptionValue: "test" }) as any);
+    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').resolves("test");
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return 'true';
@@ -875,19 +871,13 @@ describe('Cli', () => {
 
   it(`prompts for optionset name and value when optionset not specified`, async () => {
     let firstOptionValue = '', secondOptionValue = '';
-    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').callsFake((opts: any, _) => {
-      if (opts.type === 'list' && opts.name === 'missingRequiredOptionName') {
-        firstOptionValue = opts.choices[0];
-        secondOptionValue = opts.choices[1];
-        return { missingRequiredOptionName: opts.choices[0] } as any;
-      }
-
-      if (opts.name === 'missingRequiredOptionValue') {
-        return { missingRequiredOptionValue: 'Test 123' } as any;
-      }
-
-      throw 'Specific prompt not found';
+    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      firstOptionValue = (config.choices[0] as Choice<any>).value;
+      secondOptionValue = (config.choices[1] as Choice<any>).value;
+      return (config.choices[0] as Choice<any>).value;
     });
+
+    const promptInputStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').resolves('Test 123');
 
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
@@ -896,22 +886,19 @@ describe('Cli', () => {
       return defaultValue;
     });
     await cli.execute(rootFolder, ['cli', 'mock', 'optionsets']);
-    assert.strictEqual(promptStub.firstCall.args[0].choices[0], firstOptionValue);
-    assert.strictEqual(promptStub.firstCall.args[0].choices[1], secondOptionValue);
-    assert.strictEqual(promptStub.lastCall.args[0].message, `${firstOptionValue}:`);
-    assert(promptStub.calledTwice);
+    assert.strictEqual(promptStub.firstCall.args[0].choices[0].value, firstOptionValue);
+    assert.strictEqual(promptStub.firstCall.args[0].choices[1].value, secondOptionValue);
+    assert.strictEqual(promptInputStub.firstCall.args[0].message, `${firstOptionValue}:`);
+    assert(promptStub.calledOnce);
+    assert(promptInputStub.calledOnce);
   });
 
   it(`prompts to choose which option you wish to use when multiple options in a specific optionset are specified`, async () => {
     let firstOptionValue = '', secondOptionValue = '';
-    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').callsFake((opts: any, _) => {
-      if (opts.type === 'list' && opts.name === 'missingRequiredOptionName') {
-        firstOptionValue = opts.choices[0];
-        secondOptionValue = opts.choices[1];
-        return { missingRequiredOptionName: opts.choices[0] } as any;
-      }
-
-      throw 'Specific prompt not found';
+    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      firstOptionValue = (config.choices[0] as Choice<any>).value;
+      secondOptionValue = (config.choices[1] as Choice<any>).value;
+      return (config.choices[0] as Choice<any>).value;
     });
 
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
@@ -922,26 +909,20 @@ describe('Cli', () => {
     });
     await cli.execute(rootFolder, ['cli', 'mock', 'optionsets', '--opt1', 'testvalue', '--opt2', 'testvalue']);
     assert.strictEqual(promptStub.lastCall.args[0].message, `Option to use:`);
-    assert.strictEqual(promptStub.lastCall.args[0].choices[0], firstOptionValue);
-    assert.strictEqual(promptStub.lastCall.args[0].choices[1], secondOptionValue);
+    assert.strictEqual(promptStub.lastCall.args[0].choices[0].value, firstOptionValue);
+    assert.strictEqual(promptStub.lastCall.args[0].choices[1].value, secondOptionValue);
     assert(promptStub.calledOnce);
   });
 
   it(`prompts to choose runsWhen option from optionSet when dependant option is set and prompts for the value`, async () => {
     let firstOptionValue = '', secondOptionValue = '';
-    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').callsFake((opts: any, _) => {
-      if (opts.type === 'list' && opts.name === 'missingRequiredOptionName') {
-        firstOptionValue = opts.choices[0];
-        secondOptionValue = opts.choices[1];
-        return { missingRequiredOptionName: opts.choices[0] } as any;
-      }
-
-      if (opts.name === 'missingRequiredOptionValue') {
-        return { missingRequiredOptionValue: 'Test 123' } as any;
-      }
-
-      throw 'Specific prompt not found';
+    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      firstOptionValue = (config.choices[0] as Choice<any>).value;
+      secondOptionValue = (config.choices[1] as Choice<any>).value;
+      return (config.choices[0] as Choice<any>).value;
     });
+
+    const promptInputStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').resolves('Test 123');
 
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
@@ -951,21 +932,18 @@ describe('Cli', () => {
     });
     await cli.execute(rootFolder, ['cli', 'mock', 'optionsets', '--opt2', 'testvalue']);
     assert.strictEqual(promptStub.firstCall.args[0].message, `Option to use:`);
-    assert.strictEqual(promptStub.firstCall.args[0].choices[0], firstOptionValue);
-    assert.strictEqual(promptStub.firstCall.args[0].choices[1], secondOptionValue);
-    assert(promptStub.calledTwice);
+    assert.strictEqual(promptStub.firstCall.args[0].choices[0].value, firstOptionValue);
+    assert.strictEqual(promptStub.firstCall.args[0].choices[1].value, secondOptionValue);
+    assert(promptStub.calledOnce);
+    assert(promptInputStub.calledOnce);
   });
 
   it(`prompts to pick one of the options from an optionSet when runsWhen condition is matched`, async () => {
     let firstOptionValue = '', secondOptionValue = '';
-    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').callsFake((opts: any, _) => {
-      if (opts.type === 'list' && opts.name === 'missingRequiredOptionName') {
-        firstOptionValue = opts.choices[0];
-        secondOptionValue = opts.choices[1];
-        return { missingRequiredOptionName: opts.choices[0] } as any;
-      }
-
-      throw 'Specific prompt not found';
+    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      firstOptionValue = (config.choices[0] as Choice<any>).value;
+      secondOptionValue = (config.choices[1] as Choice<any>).value;
+      return (config.choices[0] as Choice<any>).value;
     });
 
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
@@ -975,8 +953,8 @@ describe('Cli', () => {
       return defaultValue;
     });
     await cli.execute(rootFolder, ['cli', 'mock', 'optionsets', '--opt2', 'testvalue', '--opt3', 'opt 3', '--opt4', 'opt 4']);
-    assert.strictEqual(promptStub.lastCall.args[0].choices[0], firstOptionValue);
-    assert.strictEqual(promptStub.lastCall.args[0].choices[1], secondOptionValue);
+    assert.strictEqual(promptStub.lastCall.args[0].choices[0].value, firstOptionValue);
+    assert.strictEqual(promptStub.lastCall.args[0].choices[1].value, secondOptionValue);
     assert(promptStub.calledOnce);
   });
 
@@ -1099,8 +1077,8 @@ describe('Cli', () => {
       }, e => done(e));
   });
 
-  it('calls inquirer when command shows prompt', (done) => {
-    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').callsFake(() => Promise.resolve() as any);
+  it('calls prompt tool when command shows prompt', (done) => {
+    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forConfirmation').resolves(true);
     const mockCommandWithPrompt = new MockCommandWithPrompt();
 
     Cli
@@ -1248,8 +1226,8 @@ describe('Cli', () => {
       }, e => done(e));
   });
 
-  it('calls inquirer when command shows prompt and executed with output', (done) => {
-    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').callsFake(() => Promise.resolve() as any);
+  it('calls prompt tool when command shows prompt and executed with output', (done) => {
+    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forConfirmation').resolves(true);
     const mockCommandWithPrompt = new MockCommandWithPrompt();
 
     Cli
@@ -1265,9 +1243,10 @@ describe('Cli', () => {
       }, e => done(e));
   });
 
-  it('calls inquirer when command shows interactive prompt and executed with output', async () => {
+  it('calls prompt tool when command shows interactive prompt and executed with output', async () => {
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((() => true));
-    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forInput').callsFake(() => Promise.resolve({ select: '1' }));
+
+    const promptStub: sinon.SinonStub = sinon.stub(prompt, 'forSelection').callsFake(() => Promise.resolve("test") as any);
     const mockCommandWithHandleMultipleResultsFound = new MockCommandWithHandleMultipleResultsFound();
 
     await Cli.executeCommandWithOutput(mockCommandWithHandleMultipleResultsFound, { options: { _: [] } });

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -20,7 +20,7 @@ import { validation } from '../utils/validation.js';
 import { CommandInfo } from './CommandInfo.js';
 import { CommandOptionInfo } from './CommandOptionInfo.js';
 import { Logger } from './Logger.js';
-import { prompt } from '../utils/prompt.js';
+import { SelectionConfig, ConfirmationConfig, prompt } from '../utils/prompt.js';
 
 export interface CommandOutput {
   stdout: string;
@@ -973,7 +973,7 @@ export class Cli {
     }
   }
 
-  public static async prompt<T>(options: any, answers?: any): Promise<T> {
+  public static async promptForSelection<T>(config: SelectionConfig<T>): Promise<T> {
     const cli = Cli.getInstance();
     const spinnerSpinning = cli.spinner.isSpinning;
 
@@ -982,7 +982,8 @@ export class Cli {
       cli.spinner.stop();
     }
 
-    const response = await prompt.forInput(options, answers) as T;
+    const answer = await prompt.forSelection<T>(config);
+    Cli.error('');
 
     // Restart the spinner if it was running before the prompt
     /* c8 ignore next 3 */
@@ -990,7 +991,49 @@ export class Cli {
       cli.spinner.start();
     }
 
-    return response;
+    return answer;
+  }
+
+  public static async promptForConfirmation(config: ConfirmationConfig): Promise<boolean> {
+    const cli = Cli.getInstance();
+    const spinnerSpinning = cli.spinner.isSpinning;
+
+    /* c8 ignore next 3 */
+    if (spinnerSpinning) {
+      cli.spinner.stop();
+    }
+
+    const answer = await prompt.forConfirmation(config);
+    Cli.error('');
+
+    // Restart the spinner if it was running before the prompt
+    /* c8 ignore next 3 */
+    if (spinnerSpinning) {
+      cli.spinner.start();
+    }
+
+    return answer;
+  }
+
+  // Obsolete, will be removed after rebase soon
+  /* c8 ignore next 18 */
+  public static async prompt<T>(options: any): Promise<T> {
+    const cli = Cli.getInstance();
+    const spinnerSpinning = cli.spinner.isSpinning;
+
+    if (spinnerSpinning) {
+      cli.spinner.stop();
+    }
+
+    const answer = await prompt.forConfirmation(options.message);
+    Cli.error('');
+
+    // Restart the spinner if it was running before the prompt
+    if (spinnerSpinning) {
+      cli.spinner.start();
+    }
+
+    return { continue: answer } as T;
   }
 
   public static async handleMultipleResultsFound<T>(message: string, values: { [key: string]: T }): Promise<T> {
@@ -999,16 +1042,11 @@ export class Cli {
       throw new Error(`${message} Found: ${Object.keys(values).join(', ')}.`);
     }
 
-    const response = await Cli.prompt<{ select: string }>({
-      type: 'list',
-      name: 'select',
-      default: 0,
-      prefix: '🌶️  ',
-      message: `${message} Please choose one:`,
-      choices: Object.keys(values)
-    });
+    Cli.error(`🌶️  ${message}`);
+    const choices = Object.keys(values).map((choice: any) => { return { name: choice, value: choice }; });
+    const response = await Cli.promptForSelection<string>({ message: `Please choose one:`, choices });
 
-    return values[response.select];
+    return values[response];
   }
 
   private static removeShortOptions(args: { options: minimist.ParsedArgs }): { options: minimist.ParsedArgs } {

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -480,7 +480,9 @@ export class Cli {
         long: long,
         name: name,
         required: required,
-        short: short
+        short: short,
+        whenPrompted: option.whenPrompted,
+        requiredWhen: option.requiredWhen
       });
     });
 

--- a/src/cli/CommandOptionInfo.ts
+++ b/src/cli/CommandOptionInfo.ts
@@ -1,7 +1,11 @@
+import { CommandArgs } from "../Command";
+
 export interface CommandOptionInfo {
   autocomplete: string[] | undefined;
   long?: string;
   name: string;
   required: boolean;
   short?: string;
+  whenPrompted?: (optionName: string, args: CommandArgs) => Promise<any>;
+  requiredWhen?: (args: CommandArgs) => boolean;
 }

--- a/src/m365/aad/commands/app/app-remove.ts
+++ b/src/m365/aad/commands/app/app-remove.ts
@@ -104,14 +104,9 @@ class AadAppRemoveCommand extends GraphCommand {
       await deleteApp();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the app?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the app?` });
 
-      if (result.continue) {
+      if (result) {
         await deleteApp();
       }
     }

--- a/src/m365/aad/commands/app/app-role-remove.ts
+++ b/src/m365/aad/commands/app/app-role-remove.ts
@@ -99,14 +99,9 @@ class AadAppRoleRemoveCommand extends GraphCommand {
       await deleteAppRole();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the app role ?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the app role ?` });
 
-      if (result.continue) {
+      if (result) {
         await deleteAppRole();
       }
     }

--- a/src/m365/aad/commands/approleassignment/approleassignment-remove.ts
+++ b/src/m365/aad/commands/approleassignment/approleassignment-remove.ts
@@ -197,15 +197,9 @@ class AadAppRoleAssignmentRemoveCommand extends GraphCommand {
       await removeAppRoleAssignment();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>(
-        {
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `Are you sure you want to remove the appRoleAssignment with scopes ${args.options.scopes} for resource ${args.options.resource}?`
-        });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the appRoleAssignment with scope ${args.options.scope} for resource ${args.options.resource}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeAppRoleAssignment();
       }
     }

--- a/src/m365/aad/commands/group/group-remove.ts
+++ b/src/m365/aad/commands/group/group-remove.ts
@@ -115,14 +115,9 @@ class AadGroupRemoveCommand extends GraphCommand {
       await removeGroup();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove group '${args.options.id || args.options.displayName}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove group '${args.options.id || args.options.displayName}'?` });
 
-      if (result.continue) {
+      if (result) {
         await removeGroup();
       }
     }

--- a/src/m365/aad/commands/groupsetting/groupsetting-remove.spec.ts
+++ b/src/m365/aad/commands/groupsetting/groupsetting-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.GROUPSETTING_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -43,18 +43,19 @@ describe(commands.GROUPSETTING_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
       global.setTimeout,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -71,7 +72,7 @@ describe(commands.GROUPSETTING_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('removes the specified group setting without prompting for confirmation when confirm option specified', async () => {
+  it('removes the specified group setting without prompting for confirmation when force option specified', async () => {
     const deleteRequestStub = sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/groupSettings/28beab62-7540-4db1-a23f-29a6018a3848') {
         return;
@@ -84,7 +85,7 @@ describe(commands.GROUPSETTING_REMOVE, () => {
     assert(deleteRequestStub.called);
   });
 
-  it('removes the specified group setting without prompting for confirmation when confirm option specified (debug)', async () => {
+  it('removes the specified group setting without prompting for confirmation when force option specified (debug)', async () => {
     const deleteRequestStub = sinon.stub(request, 'delete').callsFake(async (opts) => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/groupSettings/28beab62-7540-4db1-a23f-29a6018a3848') {
         return;
@@ -97,24 +98,14 @@ describe(commands.GROUPSETTING_REMOVE, () => {
     assert(deleteRequestStub.called);
   });
 
-  it('prompts before removing the specified group setting when confirm option not passed', async () => {
+  it('prompts before removing the specified group setting when force option not passed', async () => {
     await command.action(logger, { options: { id: '28beab62-7540-4db1-a23f-29a6018a3848' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('prompts before removing the specified group setting when confirm option not passed (debug)', async () => {
+  it('prompts before removing the specified group setting when force option not passed (debug)', async () => {
     await command.action(logger, { options: { debug: true, id: '28beab62-7540-4db1-a23f-29a6018a3848' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -136,8 +127,8 @@ describe(commands.GROUPSETTING_REMOVE, () => {
   it('removes the group setting when prompt confirmed', async () => {
     const postStub = sinon.stub(request, 'delete').callsFake(() => Promise.resolve());
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { id: '28beab62-7540-4db1-a23f-29a6018a3848' } });
     assert(postStub.called);
@@ -146,8 +137,8 @@ describe(commands.GROUPSETTING_REMOVE, () => {
   it('removes the group setting when prompt confirmed (debug)', async () => {
     const deleteStub = sinon.stub(request, 'delete').resolves();
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, id: '28beab62-7540-4db1-a23f-29a6018a3848' } });
     assert(deleteStub.called);

--- a/src/m365/aad/commands/groupsetting/groupsetting-remove.ts
+++ b/src/m365/aad/commands/groupsetting/groupsetting-remove.ts
@@ -88,14 +88,9 @@ class AadGroupSettingRemoveCommand extends GraphCommand {
       await removeGroupSetting();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the group setting ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the group setting ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeGroupSetting();
       }
     }

--- a/src/m365/aad/commands/m365group/m365group-recyclebinitem-clear.ts
+++ b/src/m365/aad/commands/m365group/m365group-recyclebinitem-clear.ts
@@ -61,14 +61,9 @@ class AadM365GroupRecycleBinItemClearCommand extends GraphCommand {
       await clearM365GroupRecycleBinItems();
     }
     else {
-      const response = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to clear all M365 Groups from recycle bin ?`
-      });
+      const response = await Cli.promptForConfirmation({ message: `Are you sure you want to clear all M365 Groups from recycle bin ?` });
 
-      if (response.continue) {
+      if (response) {
         await clearM365GroupRecycleBinItems();
       }
     }

--- a/src/m365/aad/commands/m365group/m365group-recyclebinitem-remove.ts
+++ b/src/m365/aad/commands/m365group/m365group-recyclebinitem-remove.ts
@@ -105,14 +105,9 @@ class AadM365GroupRecycleBinItemRemoveCommand extends GraphCommand {
       await removeGroup();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the group '${args.options.id || args.options.displayName || args.options.mailNickname}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the group '${args.options.id || args.options.displayName || args.options.mailNickname}'?` });
 
-      if (result.continue) {
+      if (result) {
         await removeGroup();
       }
     }

--- a/src/m365/aad/commands/m365group/m365group-recyclebinitem-restore.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-recyclebinitem-restore.spec.ts
@@ -70,6 +70,13 @@ describe(commands.M365GROUP_RECYCLEBINITEM_RESTORE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/aad/commands/m365group/m365group-remove.spec.ts
+++ b/src/m365/aad/commands/m365group/m365group-remove.spec.ts
@@ -21,7 +21,7 @@ describe(commands.M365GROUP_REMOVE, () => {
   let logger: Logger;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   const groupId = '3e6e705d-6fb5-4ca7-84dc-3c8f5154fe2c';
 
@@ -125,12 +125,13 @@ describe(commands.M365GROUP_REMOVE, () => {
     const futureDate = new Date();
     futureDate.setSeconds(futureDate.getSeconds() + 1800);
     sinon.stub(spo, 'ensureFormDigest').callsFake(() => { return Promise.resolve({ FormDigestValue: 'abc', FormDigestTimeoutSeconds: 1800, FormDigestExpiresAt: futureDate, WebFullUrl: 'https://contoso.sharepoint.com/teams/sales' }); });
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async () => {
+      promptIssued = true;
+      return false;
     });
+
+    promptIssued = false;
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    promptOptions = undefined;
   });
 
   afterEach(() => {
@@ -140,7 +141,7 @@ describe(commands.M365GROUP_REMOVE, () => {
       request.delete,
       spo.getSpoAdminUrl,
       spo.ensureFormDigest,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -168,13 +169,8 @@ describe(commands.M365GROUP_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified group when confirm option not passed', async () => {
+  it('prompts before removing the specified group when force option not passed', async () => {
     await command.action(logger, { options: { id: '28beab62-7540-4db1-a23f-29a6018a3848' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -190,10 +186,8 @@ describe(commands.M365GROUP_REMOVE, () => {
     defaultGetStub();
     const deletedGroupSpy: sinon.SinonStub = defaultPostStub();
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { id: groupId, verbose: true } });
     assert(deletedGroupSpy.calledOnce);
@@ -229,6 +223,8 @@ describe(commands.M365GROUP_REMOVE, () => {
 
   it('handles error if unexpected error occurs while deleting site from the recycle bin', async () => {
     const getCallStub: sinon.SinonStub = sinon.stub(request, 'get');
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     getCallStub.withArgs(sinon.match({ url: `https://graph.microsoft.com/v1.0/groups/${groupId}/drive?$select=webUrl` }))
       .resolves({ webUrl: "https://contoso.sharepoint.com/teams/sales/Shared%20Documents" });

--- a/src/m365/aad/commands/m365group/m365group-remove.ts
+++ b/src/m365/aad/commands/m365group/m365group-remove.ts
@@ -109,14 +109,9 @@ class AadM365GroupRemoveCommand extends GraphCommand {
       await removeGroup();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the group ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the group ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeGroup();
       }
     }

--- a/src/m365/aad/commands/m365group/m365group-user-remove.ts
+++ b/src/m365/aad/commands/m365group/m365group-user-remove.ts
@@ -162,14 +162,9 @@ class AadM365GroupUserRemoveCommand extends GraphCommand {
       await removeUser();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove ${args.options.userName} from the ${(typeof args.options.groupId !== 'undefined' ? 'group' : 'team')} ${groupId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove ${args.options.userName} from the ${(typeof args.options.groupId !== 'undefined' ? 'group' : 'team')} ${groupId}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeUser();
       }
     }

--- a/src/m365/aad/commands/oauth2grant/oauth2grant-remove.ts
+++ b/src/m365/aad/commands/oauth2grant/oauth2grant-remove.ts
@@ -66,14 +66,9 @@ class AadOAuth2GrantRemoveCommand extends GraphCommand {
       await removeOauth2Grant();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the OAuth2 permissions for ${args.options.grantId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the OAuth2 permissions for ${args.options.grantId}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeOauth2Grant();
       }
     }

--- a/src/m365/aad/commands/siteclassification/siteclassification-disable.spec.ts
+++ b/src/m365/aad/commands/siteclassification/siteclassification-disable.spec.ts
@@ -15,7 +15,7 @@ import command from './siteclassification-disable.js';
 describe(commands.SITECLASSIFICATION_DISABLE, () => {
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -38,18 +38,19 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -67,13 +68,8 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before disabling siteclassification when confirm option not passed', async () => {
+  it('prompts before disabling siteclassification when force option not passed', async () => {
     await command.action(logger, { options: {} });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -488,8 +484,8 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
 
   it('aborts removing the group when prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: {} });
     assert(postSpy.notCalled);
@@ -577,8 +573,8 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: {} });
     assert(deleteRequestIssued);

--- a/src/m365/aad/commands/siteclassification/siteclassification-disable.ts
+++ b/src/m365/aad/commands/siteclassification/siteclassification-disable.ts
@@ -95,14 +95,9 @@ class AadSiteClassificationDisableCommand extends GraphCommand {
       await disableSiteClassification();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to disable site classification?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to disable site classification?` });
 
-      if (result.continue) {
+      if (result) {
         await disableSiteClassification();
       }
     }

--- a/src/m365/aad/commands/user/user-license-remove.spec.ts
+++ b/src/m365/aad/commands/user/user-license-remove.spec.ts
@@ -24,7 +24,7 @@ describe(commands.USER_LICENSE_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -48,17 +48,18 @@ describe(commands.USER_LICENSE_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -112,26 +113,21 @@ describe(commands.USER_LICENSE_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified user licenses when confirm option not passed', async () => {
+  it('prompts before removing the specified user licenses when force option not passed', async () => {
     await command.action(logger, {
       options: {
         ids: validIds,
         userId: validUserId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified user licenses when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified user licenses when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -164,8 +160,8 @@ describe(commands.USER_LICENSE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/aad/commands/user/user-license-remove.ts
+++ b/src/m365/aad/commands/user/user-license-remove.ts
@@ -98,14 +98,9 @@ class AadUserLicenseRemoveCommand extends GraphCommand {
       await this.deleteUserLicenses(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the licenses for the user '${args.options.userId || args.options.userName}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the licenses for the user '${args.options.userId || args.options.userName}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deleteUserLicenses(args);
       }
     }

--- a/src/m365/aad/commands/user/user-recyclebinitem-clear.spec.ts
+++ b/src/m365/aad/commands/user/user-recyclebinitem-clear.spec.ts
@@ -16,7 +16,7 @@ import command from './user-recyclebinitem-clear.js';
 describe(commands.USER_RECYCLEBINITEM_CLEAR, () => {
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   const deletedUsersResponse = [{ id: '4c099956-ca9a-4e60-ad5f-3f8447122706' }];
   const graphGetUrl = 'https://graph.microsoft.com/v1.0/directory/deletedItems/microsoft.graph.user?$select=id';
@@ -43,11 +43,12 @@ describe(commands.USER_RECYCLEBINITEM_CLEAR, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
     (command as any).items = [];
   });
 
@@ -55,7 +56,7 @@ describe(commands.USER_RECYCLEBINITEM_CLEAR, () => {
     sinonUtil.restore([
       request.post,
       odata.getAllItems,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -75,8 +76,8 @@ describe(commands.USER_RECYCLEBINITEM_CLEAR, () => {
   it('removes a single user when prompt confirmed', async () => {
     let amountOfBatches = 0;
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
       if (url === graphGetUrl) {
@@ -124,17 +125,12 @@ describe(commands.USER_RECYCLEBINITEM_CLEAR, () => {
 
   it('prompts before removing users', async () => {
     await command.action(logger, { options: {} });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
   it('aborts removing users when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     const postStub = sinon.stub(request, 'post').callsFake(async () => {
       return;
     });

--- a/src/m365/aad/commands/user/user-recyclebinitem-clear.ts
+++ b/src/m365/aad/commands/user/user-recyclebinitem-clear.ts
@@ -90,14 +90,9 @@ class AadUserRecycleBinItemClearCommand extends GraphCommand {
       await clearRecycleBinUsers();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: 'Are you sure you want to permanently delete all deleted users?'
-      });
+      const result = await Cli.promptForConfirmation({ message: 'Are you sure you want to permanently delete all deleted users?' });
 
-      if (result.continue) {
+      if (result) {
         await clearRecycleBinUsers();
       }
     }

--- a/src/m365/aad/commands/user/user-recyclebinitem-remove.ts
+++ b/src/m365/aad/commands/user/user-recyclebinitem-remove.ts
@@ -85,14 +85,9 @@ class AadUserRecycleBinItemRemoveCommand extends GraphCommand {
       await clearRecycleBinItem();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to permanently delete the user with id ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to permanently delete the user with id ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await clearRecycleBinItem();
       }
     }

--- a/src/m365/aad/commands/user/user-remove.spec.ts
+++ b/src/m365/aad/commands/user/user-remove.spec.ts
@@ -22,7 +22,7 @@ describe(commands.USER_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -46,17 +46,18 @@ describe(commands.USER_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -101,22 +102,17 @@ describe(commands.USER_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified user when confirm option not passed', async () => {
+  it('prompts before removing the specified user when force option not passed', async () => {
     await command.action(logger, {
       options: {
         id: validId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified user when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified user when force option not passed and prompt not confirmed', async () => {
     const deleteStub = sinon.stub(request, 'delete').resolves();
 
     await command.action(logger, {
@@ -136,8 +132,8 @@ describe(commands.USER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -157,8 +153,8 @@ describe(commands.USER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/aad/commands/user/user-remove.ts
+++ b/src/m365/aad/commands/user/user-remove.ts
@@ -90,14 +90,9 @@ class AadUserRemoveCommand extends GraphCommand {
       await this.deleteUser(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove user '${args.options.id || args.options.userName}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove user '${args.options.id || args.options.userName}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deleteUser(args);
       }
     }

--- a/src/m365/app/commands/permission/permission-add.spec.ts
+++ b/src/m365/app/commands/permission/permission-add.spec.ts
@@ -49,6 +49,13 @@ describe(commands.PERMISSION_ADD, () => {
     }));
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/booking/commands/business/business-get.spec.ts
+++ b/src/m365/booking/commands/business/business-get.spec.ts
@@ -41,6 +41,13 @@ describe(commands.BUSINESS_GET, () => {
     sinon.stub(session, 'getId').returns('');
 
     auth.service.connected = true;
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -9,6 +9,7 @@ import GlobalOptions from '../../GlobalOptions.js';
 import { accessToken } from '../../utils/accessToken.js';
 import { misc } from '../../utils/misc.js';
 import commands from './commands.js';
+import { prompt } from '../../utils/prompt.js';
 
 interface CommandArgs {
   options: Options;
@@ -43,6 +44,7 @@ class LoginCommand extends Command {
 
     this.#initTelemetry();
     this.#initOptions();
+    this.#initOptionSets();
     this.#initValidators();
   }
 
@@ -55,6 +57,10 @@ class LoginCommand extends Command {
     });
   }
 
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['certificateFile', 'certificateBase64Encoded'], runsWhen: (args: CommandArgs) => args.options.authType === 'certificate' });
+  }
+
   #initOptions(): void {
     this.options.unshift(
       {
@@ -62,10 +68,13 @@ class LoginCommand extends Command {
         autocomplete: LoginCommand.allowedAuthTypes
       },
       {
-        option: '-u, --userName [userName]'
+        option: '-u, --userName [userName]',
+        requiredWhen: (args: CommandArgs) => args.options.authType === 'password'
       },
       {
-        option: '-p, --password [password]'
+        option: '-p, --password [password]',
+        requiredWhen: (args: CommandArgs) => args.options.authType === 'password',
+        whenPrompted: (optionName: string) => prompt.forMaskedInput({ message: `${optionName}: ` })
       },
       {
         option: '-c, --certificateFile [certificateFile]'
@@ -83,7 +92,8 @@ class LoginCommand extends Command {
         option: '--tenant [tenant]'
       },
       {
-        option: '-s, --secret [secret]'
+        option: '-s, --secret [secret]',
+        requiredWhen: (args: CommandArgs) => args.options.authType === 'secret'
       },
       {
         option: '--cloud [cloud]',

--- a/src/m365/commands/setup.spec.ts
+++ b/src/m365/commands/setup.spec.ts
@@ -11,6 +11,7 @@ import { sinonUtil } from '../../utils/sinonUtil.js';
 import commands from './commands.js';
 import command, { SettingNames } from './setup.js';
 import { interactivePreset, powerShellPreset, scriptingPreset } from './setupPresets.js';
+import { ConfirmationConfig, SelectionConfig } from '../../utils/prompt.js';
 
 describe(commands.SETUP, () => {
   let log: any[];
@@ -45,6 +46,8 @@ describe(commands.SETUP, () => {
   afterEach(() => {
     sinonUtil.restore([
       (command as any).configureSettings,
+      Cli.promptForConfirmation,
+      Cli.promptForSelection,
       Cli.getInstance().config.set,
       pid.isPowerShell
     ]);
@@ -67,11 +70,25 @@ describe(commands.SETUP, () => {
   });
 
   it('sets correct settings for interactive, beginner', async () => {
-    (command as any).answers = {
-      usageMode: 'Interactively',
-      experience: 'Beginner',
-      summary: true
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Interactively';
+        case 'How experienced are you in using the CLI?':
+          return 'Beginner';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return true;
+        default: //summary
+          return true;
+      }
+    });
+
     const configureSettingsStub = sinon.stub(command as any, 'configureSettings').callsFake(() => { });
 
     const expected: SettingNames = {};
@@ -85,11 +102,24 @@ describe(commands.SETUP, () => {
   });
 
   it('sets correct settings for interactive, proficient', async () => {
-    (command as any).answers = {
-      usageMode: 'Interactively',
-      experience: 'Proficient',
-      summary: true
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Interactively';
+        case 'How experienced are you in using the CLI?':
+          return 'Proficient';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return true;
+        default: //summary
+          return true;
+      }
+    });
     const configureSettingsStub = sinon.stub(command as any, 'configureSettings').callsFake(() => { });
 
     const expected: SettingNames = {};
@@ -103,12 +133,24 @@ describe(commands.SETUP, () => {
   });
 
   it('sets correct settings for scripting, non-PowerShell, beginner', async () => {
-    (command as any).answers = {
-      usageMode: 'Scripting',
-      usedInPowerShell: false,
-      experience: 'Beginner',
-      summary: true
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Scripting';
+        case 'How experienced are you in using the CLI?':
+          return 'Beginner';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return false;
+        default: //summary
+          return true;
+      }
+    });
     const configureSettingsStub = sinon.stub(command as any, 'configureSettings').callsFake(() => { });
 
     const expected: SettingNames = {};
@@ -122,12 +164,24 @@ describe(commands.SETUP, () => {
   });
 
   it('sets correct settings for scripting, PowerShell, beginner', async () => {
-    (command as any).answers = {
-      usageMode: 'Scripting',
-      usedInPowerShell: true,
-      experience: 'Beginner',
-      summary: true
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Scripting';
+        case 'How experienced are you in using the CLI?':
+          return 'Beginner';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return true;
+        default: //summary
+          return true;
+      }
+    });
     const configureSettingsStub = sinon.stub(command as any, 'configureSettings').callsFake(() => { });
 
     const expected: SettingNames = {};
@@ -142,12 +196,24 @@ describe(commands.SETUP, () => {
   });
 
   it('sets correct settings for scripting, non-PowerShell, proficient', async () => {
-    (command as any).answers = {
-      usageMode: 'Scripting',
-      usedInPowerShell: false,
-      experience: 'Proficient',
-      summary: true
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Scripting';
+        case 'How experienced are you in using the CLI?':
+          return 'Proficient';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return false;
+        default: //summary
+          return true;
+      }
+    });
     const configureSettingsStub = sinon.stub(command as any, 'configureSettings').callsFake(() => { });
 
     const expected: SettingNames = {};
@@ -161,12 +227,24 @@ describe(commands.SETUP, () => {
   });
 
   it('sets correct settings for scripting, PowerShell, proficient', async () => {
-    (command as any).answers = {
-      usageMode: 'Scripting',
-      usedInPowerShell: true,
-      experience: 'Proficient',
-      summary: true
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Scripting';
+        case 'How experienced are you in using the CLI?':
+          return 'Proficient';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return true;
+        default: //summary
+          return true;
+      }
+    });
     const configureSettingsStub = sinon.stub(command as any, 'configureSettings').callsFake(() => { });
 
     const expected: SettingNames = {};
@@ -181,12 +259,24 @@ describe(commands.SETUP, () => {
   });
 
   it(`doesn't apply settings when not confirmed`, async () => {
-    (command as any).answers = {
-      usageMode: 'Scripting',
-      usedInPowerShell: false,
-      experience: 'Beginner',
-      summary: false
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Scripting';
+        case 'How experienced are you in using the CLI?':
+          return 'Beginner';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return false;
+        default: //summary
+          return false;
+      }
+    });
     const configureSettingsStub = sinon.stub(command as any, 'configureSettings').callsFake(() => { });
 
     await command.action(logger, { options: {} });
@@ -247,11 +337,24 @@ describe(commands.SETUP, () => {
   });
 
   it('outputs settings to configure to console in debug mode', async () => {
-    (command as any).answers = {
-      usageMode: 'Interactively',
-      experience: 'Beginner',
-      summary: true
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Interactively';
+        case 'How experienced are you in using the CLI?':
+          return 'Beginner';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return false;
+        default: //summary
+          return true;
+      }
+    });
     sinon.stub(Cli.getInstance().config, 'set').callsFake(() => { });
 
     const expected: SettingNames = {};
@@ -265,11 +368,24 @@ describe(commands.SETUP, () => {
   });
 
   it('logs configured settings when used interactively', async () => {
-    (command as any).answers = {
-      usageMode: 'Interactively',
-      experience: 'Beginner',
-      summary: true
-    };
+    sinon.stub(Cli, 'promptForSelection').callsFake(async (config: SelectionConfig<unknown>): Promise<unknown> => {
+      switch (config.message) {
+        case 'How do you plan to use the CLI?':
+          return 'Interactively';
+        case 'How experienced are you in using the CLI?':
+          return 'Beginner';
+        default:
+          return '';
+      }
+    });
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig): Promise<boolean> => {
+      switch (config.message) {
+        case 'Are you going to use the CLI in PowerShell?':
+          return false;
+        default: //summary
+          return true;
+      }
+    });
     sinon.stub(Cli.getInstance().config, 'set').callsFake(() => { });
 
     const expected: SettingNames = {};

--- a/src/m365/commands/setup.ts
+++ b/src/m365/commands/setup.ts
@@ -9,7 +9,7 @@ import { pid } from '../../utils/pid.js';
 import AnonymousCommand from '../base/AnonymousCommand.js';
 import commands from './commands.js';
 import { interactivePreset, powerShellPreset, scriptingPreset } from './setupPresets.js';
-import { prompt } from '../../utils/prompt.js';
+import { ConfirmationConfig, SelectionConfig } from '../../utils/prompt.js';
 
 interface Preferences {
   experience?: string;
@@ -32,9 +32,6 @@ export type SettingNames = {
 };
 
 class SetupCommand extends AnonymousCommand {
-  // used for injecting answers from tests
-  private answers: Preferences = {};
-
   public get name(): string {
     return commands.SETUP;
   }
@@ -110,43 +107,45 @@ class SetupCommand extends AnonymousCommand {
     await logger.logToStderr(`Please, answer the following questions and we'll define a set of settings to best match how you intend to use the CLI.`);
     await logger.logToStderr('');
 
-    const preferences: Preferences = await prompt.forInput([
-      {
-        type: 'list',
-        name: 'usageMode',
-        message: 'How do you plan to use the CLI?',
-        choices: [
-          'Interactively',
-          'Scripting'
-        ]
-      },
-      {
-        type: 'confirm',
-        name: 'usedInPowerShell',
+    const preferences: Preferences = {};
+
+    const usageModeConfig: SelectionConfig<string> = {
+      message: 'How do you plan to use the CLI?',
+      choices: [
+        { name: 'Interactively', value: 'Interactively' },
+        { name: 'Scripting', value: 'Scripting' }
+      ]
+    };
+    preferences.usageMode = await Cli.promptForSelection(usageModeConfig);
+
+    if (preferences.usageMode === 'Scripting') {
+      const usedInPowerShellConfig: ConfirmationConfig = {
         message: 'Are you going to use the CLI in PowerShell?',
-        when: (answers: Preferences) => answers.usageMode === 'Scripting',
         default: pid.isPowerShell()
-      },
-      {
-        type: 'list',
-        name: 'experience',
-        message: 'How experienced are you in using the CLI?',
-        choices: [
-          'Beginner',
-          'Proficient'
-        ]
-      },
-      {
-        type: 'confirm',
-        name: 'summary',
-        // invoked by inquirer
-        /* c8 ignore next 4 */
-        message: (answers: Preferences) => {
-          settings = this.getSettings(answers);
-          return this.getSummaryMessage(settings);
-        }
+      };
+      preferences.usedInPowerShell = await Cli.promptForConfirmation(usedInPowerShellConfig);
+    }
+
+    const experienceConfig: SelectionConfig<string> = {
+      message: 'How experienced are you in using the CLI?',
+      choices: [
+        { name: 'Beginner', value: 'Beginner' },
+        { name: 'Proficient', value: 'Proficient' }
+      ]
+    };
+    preferences.experience = await Cli.promptForSelection(experienceConfig);
+
+    const summaryConfig: ConfirmationConfig = {
+      // invoked by inquirer
+      /* c8 ignore next 6 */
+      message: async (): Promise<string> => {
+        settings = this.getSettings(preferences);
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        return this.getSummaryMessage(settings);
       }
-    ], this.answers);
+    };
+    preferences.summary = await Cli.promptForConfirmation(summaryConfig);
 
     if (preferences.summary) {
       // used only for testing. Normally, we'd get the settings from the answers

--- a/src/m365/context/commands/context-remove.spec.ts
+++ b/src/m365/context/commands/context-remove.spec.ts
@@ -12,7 +12,7 @@ import command from './context-remove.js';
 describe(commands.REMOVE, () => {
   let log: any[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
@@ -31,11 +31,12 @@ describe(commands.REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
@@ -44,7 +45,7 @@ describe(commands.REMOVE, () => {
       fs.readFileSync,
       fs.writeFileSync,
       fs.unlinkSync,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -60,17 +61,12 @@ describe(commands.REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before removing the context from the .m365rc.json file when confirm option not passed', async () => {
+  it('prompts before removing the context from the .m365rc.json file when force option not passed', async () => {
     await command.action(logger, {
       options: {
         debug: false
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -90,10 +86,8 @@ describe(commands.REMOVE, () => {
     let fileContents: string | undefined;
     let filePath: string | undefined;
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(fs, 'existsSync').callsFake(_ => true);
     sinon.stub(fs, 'readFileSync').callsFake(_ => JSON.stringify({

--- a/src/m365/context/commands/context-remove.ts
+++ b/src/m365/context/commands/context-remove.ts
@@ -52,14 +52,9 @@ class ContextRemoveCommand extends AnonymousCommand {
       await this.removeContext();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the context?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the context?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeContext();
       }
     }

--- a/src/m365/context/commands/option/option-remove.spec.ts
+++ b/src/m365/context/commands/option/option-remove.spec.ts
@@ -12,7 +12,7 @@ import command from './option-remove.js';
 describe(commands.OPTION_REMOVE, () => {
   let log: any[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(telemetry, 'trackEvent').callsFake(() => { });
@@ -31,11 +31,12 @@ describe(commands.OPTION_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
@@ -43,7 +44,7 @@ describe(commands.OPTION_REMOVE, () => {
       fs.existsSync,
       fs.readFileSync,
       fs.writeFileSync,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -59,17 +60,12 @@ describe(commands.OPTION_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before removing the context option from the .m365rc.json file when confirm option not passed', async () => {
+  it('prompts before removing the context option from the .m365rc.json file when force option not passed', async () => {
     await command.action(logger, {
       options: {
         debug: false
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -100,10 +96,8 @@ describe(commands.OPTION_REMOVE, () => {
   });
 
   it(`removes a context info option from the existing .m365rc.json file`, async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(fs, 'existsSync').callsFake(_ => true);
     sinon.stub(fs, 'readFileSync').callsFake(_ => JSON.stringify({

--- a/src/m365/context/commands/option/option-remove.ts
+++ b/src/m365/context/commands/option/option-remove.ts
@@ -60,14 +60,9 @@ class ContextOptionRemoveCommand extends ContextCommand {
       await this.removeContextOption(args.options.name, logger);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the context option ${args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the context option ${args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeContextOption(args.options.name, logger);
       }
     }

--- a/src/m365/flow/commands/flow-remove.spec.ts
+++ b/src/m365/flow/commands/flow-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let loggerLogToStderrSpy: sinon.SinonSpy;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -43,17 +43,18 @@ describe(commands.REMOVE, () => {
       }
     };
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -90,26 +91,21 @@ describe(commands.REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified Microsoft Flow owned by the currently signed-in user when confirm option not passed', async () => {
+  it('prompts before removing the specified Microsoft Flow owned by the currently signed-in user when force option not passed', async () => {
     await command.action(logger, {
       options: {
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified Microsoft Flow owned by the currently signed-in user when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified Microsoft Flow owned by the currently signed-in user when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -129,8 +125,8 @@ describe(commands.REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -142,7 +138,7 @@ describe(commands.REMOVE, () => {
     assert(loggerLogToStderrSpy.called);
   });
 
-  it('prompts before removing the specified Microsoft Flow owned by another user when confirm option not passed', async () => {
+  it('prompts before removing the specified Microsoft Flow owned by another user when force option not passed', async () => {
     await command.action(logger, {
       options: {
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
@@ -150,19 +146,14 @@ describe(commands.REMOVE, () => {
         asAdmin: true
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified Microsoft Flow owned by another user when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified Microsoft Flow owned by another user when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -183,8 +174,8 @@ describe(commands.REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -264,8 +255,8 @@ describe(commands.REMOVE, () => {
       }
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:
@@ -279,8 +270,8 @@ describe(commands.REMOVE, () => {
   it('correctly handles no Microsoft Flow found when prompt confirmed', async () => {
     sinon.stub(request, 'delete').resolves({ statusCode: 204 });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:

--- a/src/m365/flow/commands/flow-remove.ts
+++ b/src/m365/flow/commands/flow-remove.ts
@@ -105,14 +105,9 @@ class FlowRemoveCommand extends AzmgmtCommand {
       await removeFlow();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the Microsoft Flow ${args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the Microsoft Flow ${args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeFlow();
       }
     }

--- a/src/m365/flow/commands/owner/owner-remove.ts
+++ b/src/m365/flow/commands/owner/owner-remove.ts
@@ -154,14 +154,9 @@ class FlowOwnerRemoveCommand extends AzmgmtCommand {
         await removeFlowOwner();
       }
       else {
-        const result = await Cli.prompt<{ continue: boolean }>({
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `Are you sure you want to remove owner '${args.options.groupId || args.options.groupName || args.options.userId || args.options.userName}' from the specified flow?`
-        });
+        const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove owner '${args.options.groupId || args.options.groupName || args.options.userId || args.options.userName}' from the specified flow?` });
 
-        if (result.continue) {
+        if (result) {
           await removeFlowOwner();
         }
       }

--- a/src/m365/flow/commands/run/run-cancel.spec.ts
+++ b/src/m365/flow/commands/run/run-cancel.spec.ts
@@ -18,7 +18,7 @@ describe(commands.RUN_CANCEL, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -43,17 +43,18 @@ describe(commands.RUN_CANCEL, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -92,7 +93,7 @@ describe(commands.RUN_CANCEL, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before cancelling the specified Microsoft FlowName when confirm option not passed', async () => {
+  it('prompts before cancelling the specified Microsoft FlowName when force option not passed', async () => {
     await command.action(logger, {
       options: {
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
@@ -101,19 +102,14 @@ describe(commands.RUN_CANCEL, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts cancelling the specified Microsoft FlowName when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts cancelling the specified Microsoft FlowName when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, {
       options: {
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
@@ -154,8 +150,8 @@ describe(commands.RUN_CANCEL, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -195,8 +191,8 @@ describe(commands.RUN_CANCEL, () => {
       }
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:
@@ -216,8 +212,8 @@ describe(commands.RUN_CANCEL, () => {
       }
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:
@@ -256,8 +252,8 @@ describe(commands.RUN_CANCEL, () => {
       }
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:

--- a/src/m365/flow/commands/run/run-cancel.ts
+++ b/src/m365/flow/commands/run/run-cancel.ts
@@ -97,14 +97,9 @@ class FlowRunCancelCommand extends AzmgmtCommand {
       await cancelFlow();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to cancel the flow run ${args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to cancel the flow run ${args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await cancelFlow();
       }
     }

--- a/src/m365/flow/commands/run/run-resubmit.spec.ts
+++ b/src/m365/flow/commands/run/run-resubmit.spec.ts
@@ -18,7 +18,7 @@ describe(commands.RUN_RESUBMIT, () => {
   let logger: Logger;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -43,18 +43,19 @@ describe(commands.RUN_RESUBMIT, () => {
       }
     };
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
       request.get,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -93,7 +94,7 @@ describe(commands.RUN_RESUBMIT, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before resubmitting the specified Microsoft Flow when confirm option not passed', async () => {
+  it('prompts before resubmitting the specified Microsoft Flow when force option not passed', async () => {
     await command.action(logger, {
       options: {
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
@@ -102,20 +103,15 @@ describe(commands.RUN_RESUBMIT, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts resubmitting the specified Microsoft Flow when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts resubmitting the specified Microsoft Flow when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
     const getSpy = sinon.spy(request, 'get');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -136,8 +132,8 @@ describe(commands.RUN_RESUBMIT, () => {
       }
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:
@@ -157,8 +153,8 @@ describe(commands.RUN_RESUBMIT, () => {
       }
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:
@@ -203,8 +199,8 @@ describe(commands.RUN_RESUBMIT, () => {
       }
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:
@@ -249,8 +245,8 @@ describe(commands.RUN_RESUBMIT, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options:

--- a/src/m365/flow/commands/run/run-resubmit.ts
+++ b/src/m365/flow/commands/run/run-resubmit.ts
@@ -105,14 +105,9 @@ class FlowRunResubmitCommand extends AzmgmtCommand {
       await resubmitFlow();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to resubmit the flow with run ${args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to resubmit the flow with run ${args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await resubmitFlow();
       }
     }

--- a/src/m365/graph/commands/schemaextension/schemaextension-remove.ts
+++ b/src/m365/graph/commands/schemaextension/schemaextension-remove.ts
@@ -76,14 +76,9 @@ class GraphSchemaExtensionRemoveCommand extends GraphCommand {
       await removeSchemaExtension();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the schema extension with ID ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the schema extension with ID ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeSchemaExtension();
       }
     }

--- a/src/m365/onenote/commands/page/page-list.spec.ts
+++ b/src/m365/onenote/commands/page/page-list.spec.ts
@@ -86,6 +86,13 @@ describe(commands.PAGE_LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/pa/commands/app/app-consent-set.ts
+++ b/src/m365/pa/commands/app/app-consent-set.ts
@@ -77,14 +77,9 @@ class PaAppConsentSetCommand extends PowerAppsCommand {
       await this.consentPaApp(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you bypass the consent for the Microsoft Power App ${args.options.name} to ${args.options.bypass}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you bypass the consent for the Microsoft Power App ${args.options.name} to ${args.options.bypass}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.consentPaApp(args);
       }
     }

--- a/src/m365/pa/commands/app/app-permission-remove.ts
+++ b/src/m365/pa/commands/app/app-permission-remove.ts
@@ -138,14 +138,9 @@ class PaAppPermissionRemoveCommand extends PowerAppsCommand {
         await this.removeAppPermission(logger, args.options);
       }
       else {
-        const result = await Cli.prompt<{ continue: boolean }>({
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `Are you sure you want to remove the permissions of '${args.options.userId || args.options.userName || args.options.groupId || args.options.groupName || (args.options.tenant && 'everyone')}' from the Power App '${args.options.appName}'?`
-        });
+        const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the permissions of '${args.options.userId || args.options.userName || args.options.groupId || args.options.groupName || (args.options.tenant && 'everyone')}' from the Power App '${args.options.appName}'?` });
 
-        if (result.continue) {
+        if (result) {
           await this.removeAppPermission(logger, args.options);
         }
       }

--- a/src/m365/pa/commands/app/app-remove.spec.ts
+++ b/src/m365/pa/commands/app/app-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.APP_REMOVE, () => {
   let logger: Logger;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -43,17 +43,18 @@ describe(commands.APP_REMOVE, () => {
       }
     };
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -88,25 +89,20 @@ describe(commands.APP_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified Microsoft Power App when confirm option not passed', async () => {
+  it('prompts before removing the specified Microsoft Power App when force option not passed', async () => {
     await command.action(logger, {
       options: {
         name: 'e0c89645-7f00-4877-a290-cbaf6e060da1'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified Microsoft Power App when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified Microsoft Power App when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -125,8 +121,8 @@ describe(commands.APP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -146,8 +142,8 @@ describe(commands.APP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -199,8 +195,8 @@ describe(commands.APP_REMOVE, () => {
   it('correctly handles no Microsoft Power App found when prompt confirmed', async () => {
     sinon.stub(request, 'delete').rejects({ response: { status: 403 } });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:
@@ -225,8 +221,8 @@ describe(commands.APP_REMOVE, () => {
   it('correctly handles Microsoft Power App found when prompt confirmed', async () => {
     sinon.stub(request, 'delete').resolves({ statusCode: 200 });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options:
@@ -273,8 +269,8 @@ describe(commands.APP_REMOVE, () => {
   it('correctly handles random api error', async () => {
     sinon.stub(request, 'delete').rejects(new Error("Something went wrong"));
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:

--- a/src/m365/pa/commands/app/app-remove.ts
+++ b/src/m365/pa/commands/app/app-remove.ts
@@ -97,14 +97,9 @@ class PaAppRemoveCommand extends PowerAppsCommand {
       await removePaApp();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the Microsoft Power App ${args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the Microsoft Power App ${args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await removePaApp();
       }
     }

--- a/src/m365/planner/commands/bucket/bucket-get.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.spec.ts
@@ -87,7 +87,6 @@ describe(commands.BUCKET_GET, () => {
     ]
   };
 
-  let cli: Cli;
   const planResponse = {
     value: [{
       id: validPlanId,
@@ -95,6 +94,7 @@ describe(commands.BUCKET_GET, () => {
     }]
   };
 
+  let cli: Cli;
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -112,6 +112,13 @@ describe(commands.BUCKET_GET, () => {
       expiresOn: new Date()
     };
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {
@@ -135,8 +142,8 @@ describe(commands.BUCKET_GET, () => {
     sinonUtil.restore([
       request.get,
       request.patch,
-      cli.getSettingWithDefaultValue,
-      Cli.handleMultipleResultsFound
+      Cli.handleMultipleResultsFound,
+      cli.getSettingWithDefaultValue
     ]);
   });
 

--- a/src/m365/planner/commands/bucket/bucket-remove.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.ts
@@ -162,14 +162,9 @@ class PlannerBucketRemoveCommand extends GraphCommand {
       await removeBucket();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the bucket ${args.options.id || args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the bucket ${args.options.id || args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeBucket();
       }
     }

--- a/src/m365/planner/commands/bucket/bucket-set.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.spec.ts
@@ -112,6 +112,13 @@ describe(commands.BUCKET_SET, () => {
       expiresOn: new Date()
     };
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/planner/commands/plan/plan-remove.ts
+++ b/src/m365/planner/commands/plan/plan-remove.ts
@@ -130,13 +130,9 @@ class PlannerPlanRemoveCommand extends GraphCommand {
       await removePlan();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the plan ${args.options.id || args.options.title}?`
-      });
-      if (result.continue) {
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the plan ${args.options.id || args.options.title}?` });
+
+      if (result) {
         await removePlan();
       }
     }

--- a/src/m365/planner/commands/roster/roster-member-remove.spec.ts
+++ b/src/m365/planner/commands/roster/roster-member-remove.spec.ts
@@ -13,6 +13,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './roster-member-remove.js';
+import { ConfirmationConfig } from '../../../../utils/prompt.js';
 
 describe(commands.ROSTER_MEMBER_REMOVE, () => {
   let commandInfo: CommandInfo;
@@ -43,7 +44,7 @@ describe(commands.ROSTER_MEMBER_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -67,18 +68,19 @@ describe(commands.ROSTER_MEMBER_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
       request.get,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -125,32 +127,27 @@ describe(commands.ROSTER_MEMBER_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified roster member when confirm option not passed', async () => {
+  it('prompts before removing the specified roster member when force option not passed', async () => {
     await command.action(logger, {
       options: {
         rosterId: validRosterId,
         userId: validUserId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('prompts before removing the last roster member when confirm option not passed', async () => {
-    let secondPromptOptions: any;
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      if (options.message === `Are you sure you want to remove member '${validUserId}'?`) {
-        return { continue: true };
+  it('prompts before removing the last roster member when force option not passed', async () => {
+    let secondPromptConfirm: boolean = false;
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(async (config: ConfirmationConfig) => {
+      if (config.message === `Are you sure you want to remove member '${validUserId}'?`) {
+        return true;
       }
       else {
-        secondPromptOptions = options;
-        return { continue: false };
+        secondPromptConfirm = true;
+        return false;
       }
     });
 
@@ -171,14 +168,14 @@ describe(commands.ROSTER_MEMBER_REMOVE, () => {
 
     let promptIssued = false;
 
-    if (secondPromptOptions && secondPromptOptions.type === 'confirm') {
+    if (secondPromptConfirm) {
       promptIssued = true;
     }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified roster member when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified roster member when force option not passed and prompt not confirmed', async () => {
     const deleteSpy = sinon.spy(request, 'delete');
 
     await command.action(logger, {
@@ -212,8 +209,8 @@ describe(commands.ROSTER_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -247,8 +244,8 @@ describe(commands.ROSTER_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/planner/commands/roster/roster-member-remove.ts
+++ b/src/m365/planner/commands/roster/roster-member-remove.ts
@@ -100,14 +100,9 @@ class PlannerRosterMemberRemoveCommand extends GraphCommand {
       await this.removeRosterMember(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove member '${args.options.userId || args.options.userName}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove member '${args.options.userId || args.options.userName}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeRosterMember(args);
       }
     }
@@ -147,14 +142,9 @@ class PlannerRosterMemberRemoveCommand extends GraphCommand {
     if (!args.options.force) {
       const rosterMembers = await odata.getAllItems(`${this.resource}/beta/planner/rosters/${args.options.rosterId}/members?$select=Id`);
       if (rosterMembers.length === 1) {
-        const result = await Cli.prompt<{ continue: boolean }>({
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `You are about to remove the last member of this Roster. When this happens, the Roster and all its contents will be deleted within 30 days. Are you sure you want to proceed?`
-        });
+        const result = await Cli.promptForConfirmation({ message: `You are about to remove the last member of this Roster. When this happens, the Roster and all its contents will be deleted within 30 days. Are you sure you want to proceed?` });
 
-        return result.continue;
+        return result;
       }
     }
 

--- a/src/m365/planner/commands/roster/roster-remove.spec.ts
+++ b/src/m365/planner/commands/roster/roster-remove.spec.ts
@@ -17,7 +17,7 @@ describe(commands.PLAN_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -44,17 +44,18 @@ describe(commands.PLAN_REMOVE, () => {
         log.push(msg);
       }
     };
-    promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -72,23 +73,18 @@ describe(commands.PLAN_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before removing the specified Roster when confirm option not passed', async () => {
+  it('prompts before removing the specified Roster when force option not passed', async () => {
     await command.action(logger, {
       options: {
         id: validRosterId
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified Roster when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified Roster when force option not passed and prompt not confirmed', async () => {
     const deleteSpy = sinon.spy(request, 'delete');
     await command.action(logger, {
       options: {
@@ -125,8 +121,8 @@ describe(commands.PLAN_REMOVE, () => {
       throw 'Invalid Request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/planner/commands/roster/roster-remove.ts
+++ b/src/m365/planner/commands/roster/roster-remove.ts
@@ -59,13 +59,9 @@ class PlannerRosterRemoveCommand extends GraphCommand {
       await this.removeRoster(args, logger);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove roster ${args.options.id}?`
-      });
-      if (result.continue) {
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove roster ${args.options.id}?` });
+
+      if (result) {
         await this.removeRoster(args, logger);
       }
     }

--- a/src/m365/planner/commands/task/task-checklistitem-remove.spec.ts
+++ b/src/m365/planner/commands/task/task-checklistitem-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   const validTaskId = '2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2';
   const validId = '71175';
 
@@ -63,19 +63,19 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
         log.push(msg);
       }
     };
-    promptOptions = undefined;
-
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: true };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(true);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.patch,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -93,11 +93,11 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before removal when confirm option not passed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+  it('prompts before removal when force option not passed', async () => {
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
 
     await command.action(logger, {
@@ -106,12 +106,6 @@ describe(commands.TASK_CHECKLISTITEM_REMOVE, () => {
         id: validId
       }
     });
-
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });

--- a/src/m365/planner/commands/task/task-checklistitem-remove.ts
+++ b/src/m365/planner/commands/task/task-checklistitem-remove.ts
@@ -59,14 +59,9 @@ class PlannerTaskChecklistItemRemoveCommand extends GraphCommand {
       await this.removeChecklistitem(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the checklist item with id ${args.options.id} from the planner task?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the checklist item with id ${args.options.id} from the planner task?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeChecklistitem(args);
       }
     }

--- a/src/m365/planner/commands/task/task-get.spec.ts
+++ b/src/m365/planner/commands/task/task-get.spec.ts
@@ -144,6 +144,13 @@ describe(commands.TASK_GET, () => {
       expiresOn: new Date()
     };
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/planner/commands/task/task-list.spec.ts
+++ b/src/m365/planner/commands/task/task-list.spec.ts
@@ -286,6 +286,13 @@ describe(commands.TASK_LIST, () => {
       expiresOn: new Date()
     };
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/planner/commands/task/task-reference-remove.ts
+++ b/src/m365/planner/commands/task/task-reference-remove.ts
@@ -83,14 +83,9 @@ class PlannerTaskReferenceRemoveCommand extends GraphCommand {
       await this.removeReference(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the reference from the Planner task?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the reference from the Planner task?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeReference(logger, args);
       }
     }

--- a/src/m365/planner/commands/task/task-remove.ts
+++ b/src/m365/planner/commands/task/task-remove.ts
@@ -158,14 +158,9 @@ class PlannerTaskRemoveCommand extends GraphCommand {
       await removeTask();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the task ${args.options.id || args.options.title}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the task ${args.options.id || args.options.title}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeTask();
       }
     }

--- a/src/m365/planner/commands/task/task-set.spec.ts
+++ b/src/m365/planner/commands/task/task-set.spec.ts
@@ -153,6 +153,13 @@ describe(commands.TASK_SET, () => {
       expiresOn: new Date()
     };
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.spec.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.spec.ts
@@ -79,6 +79,13 @@ describe(commands.AIBUILDERMODEL_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-remove.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-remove.ts
@@ -98,14 +98,9 @@ class PpAiBuilderModelRemoveCommand extends PowerPlatformCommand {
       await this.deleteAiBuilderModel(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove AI builder model '${args.options.id || args.options.name}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove AI builder model '${args.options.id || args.options.name}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deleteAiBuilderModel(args);
       }
     }

--- a/src/m365/pp/commands/card/card-clone.spec.ts
+++ b/src/m365/pp/commands/card/card-clone.spec.ts
@@ -60,7 +60,7 @@ describe(commands.CARD_CLONE, () => {
       request.get,
       request.post,
       powerPlatform.getDynamicsInstanceApiUrl,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       Cli.executeCommandWithOutput
     ]);
   });

--- a/src/m365/pp/commands/card/card-get.spec.ts
+++ b/src/m365/pp/commands/card/card-get.spec.ts
@@ -88,6 +88,13 @@ describe(commands.CARD_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/pp/commands/card/card-remove.spec.ts
+++ b/src/m365/pp/commands/card/card-remove.spec.ts
@@ -26,7 +26,7 @@ describe(commands.CARD_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
@@ -52,18 +52,19 @@ describe(commands.CARD_REMOVE, () => {
       }
     };
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
       powerPlatform.getDynamicsInstanceApiUrl,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       Cli.executeCommandWithOutput
     ]);
   });
@@ -101,7 +102,7 @@ describe(commands.CARD_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified card owned by the currently signed-in user when confirm option not passed', async () => {
+  it('prompts before removing the specified card owned by the currently signed-in user when force option not passed', async () => {
     sinon.stub(powerPlatform, 'getDynamicsInstanceApiUrl').callsFake(async () => envUrl);
 
     await command.action(logger, {
@@ -110,21 +111,14 @@ describe(commands.CARD_REMOVE, () => {
         id: validId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified card owned by the currently signed-in user when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified card owned by the currently signed-in user when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, {
       options: {
         environmentName: validEnvironment,
@@ -155,10 +149,8 @@ describe(commands.CARD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         debug: true,

--- a/src/m365/pp/commands/card/card-remove.ts
+++ b/src/m365/pp/commands/card/card-remove.ts
@@ -98,14 +98,9 @@ class PpCardRemoveCommand extends PowerPlatformCommand {
       await this.deleteCard(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove card '${args.options.id || args.options.name}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove card '${args.options.id || args.options.name}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deleteCard(args);
       }
     }

--- a/src/m365/pp/commands/chatbot/chatbot-get.spec.ts
+++ b/src/m365/pp/commands/chatbot/chatbot-get.spec.ts
@@ -90,6 +90,13 @@ describe(commands.CHATBOT_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/pp/commands/chatbot/chatbot-remove.spec.ts
+++ b/src/m365/pp/commands/chatbot/chatbot-remove.spec.ts
@@ -26,7 +26,7 @@ describe(commands.CHATBOT_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
@@ -52,18 +52,19 @@ describe(commands.CHATBOT_REMOVE, () => {
       }
     };
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
       powerPlatform.getDynamicsInstanceApiUrl,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       Cli.executeCommandWithOutput
     ]);
   });
@@ -101,23 +102,18 @@ describe(commands.CHATBOT_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified chatbot owned by the currently signed-in user when confirm option not passed', async () => {
+  it('prompts before removing the specified chatbot owned by the currently signed-in user when force option not passed', async () => {
     await command.action(logger, {
       options: {
         environmentName: validEnvironment,
         id: validId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified chatbot owned by the currently signed-in user when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified chatbot owned by the currently signed-in user when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
 
     await command.action(logger, {
@@ -150,10 +146,8 @@ describe(commands.CHATBOT_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         verbose: true,

--- a/src/m365/pp/commands/chatbot/chatbot-remove.ts
+++ b/src/m365/pp/commands/chatbot/chatbot-remove.ts
@@ -98,14 +98,9 @@ class PpChatbotRemoveCommand extends PowerPlatformCommand {
       await this.deleteChatbot(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove chatbot '${args.options.id || args.options.name}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove chatbot '${args.options.id || args.options.name}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deleteChatbot(args);
       }
     }

--- a/src/m365/pp/commands/dataverse/dataverse-table-remove.spec.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-remove.spec.ts
@@ -22,7 +22,7 @@ describe(commands.DATAVERSE_TABLE_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
@@ -47,18 +47,19 @@ describe(commands.DATAVERSE_TABLE_REMOVE, () => {
       }
     };
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
       powerPlatform.getDynamicsInstanceApiUrl,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -75,23 +76,18 @@ describe(commands.DATAVERSE_TABLE_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before removing the specified table owned by the currently signed-in user when confirm option not passed', async () => {
+  it('prompts before removing the specified table owned by the currently signed-in user when force option not passed', async () => {
     await command.action(logger, {
       options: {
         environmentName: validEnvironment,
         name: validName
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified table owned by the currently signed-in user when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified table owned by the currently signed-in user when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
 
     await command.action(logger, {
@@ -114,10 +110,8 @@ describe(commands.DATAVERSE_TABLE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         debug: true,

--- a/src/m365/pp/commands/dataverse/dataverse-table-remove.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-remove.ts
@@ -68,14 +68,9 @@ class PpDataverseTableRemoveCommand extends PowerPlatformCommand {
       await this.removeDataverseTable(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the dataverse table ${args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the dataverse table ${args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeDataverseTable(args.options);
       }
     }

--- a/src/m365/pp/commands/dataverse/dataverse-table-row-remove.ts
+++ b/src/m365/pp/commands/dataverse/dataverse-table-row-remove.ts
@@ -100,14 +100,9 @@ class PpDataverseTableRowRemoveCommand extends PowerPlatformCommand {
       await this.deleteTableRow(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove row '${args.options.id}' from table '${args.options.tableName || args.options.entitySetName}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove row '${args.options.id}' from table '${args.options.tableName || args.options.entitySetName}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deleteTableRow(logger, args);
       }
     }

--- a/src/m365/pp/commands/solution/solution-publish.spec.ts
+++ b/src/m365/pp/commands/solution/solution-publish.spec.ts
@@ -73,7 +73,7 @@ describe(commands.SOLUTION_PUBLISH, () => {
       request.post,
       request.get,
       powerPlatform.getDynamicsInstanceApiUrl,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       Cli.executeCommandWithOutput
     ]);
   });

--- a/src/m365/pp/commands/solution/solution-publisher-remove.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-remove.ts
@@ -98,14 +98,9 @@ class PpSolutionPublisherRemoveCommand extends PowerPlatformCommand {
       await this.deletePublisher(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove publisher '${args.options.id || args.options.name}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove publisher '${args.options.id || args.options.name}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deletePublisher(args);
       }
     }

--- a/src/m365/pp/commands/solution/solution-remove.ts
+++ b/src/m365/pp/commands/solution/solution-remove.ts
@@ -98,14 +98,9 @@ class PpSolutionRemoveCommand extends PowerPlatformCommand {
       await this.deleteSolution(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove solution '${args.options.id || args.options.name}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove solution '${args.options.id || args.options.name}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deleteSolution(args);
       }
     }

--- a/src/m365/purview/commands/retentionevent/retentionevent-remove.spec.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.RETENTIONEVENT_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -47,17 +47,18 @@ describe(commands.RETENTIONEVENT_REMOVE, () => {
         log.push(msg);
       }
     };
-    promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -93,23 +94,18 @@ describe(commands.RETENTIONEVENT_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified retention event when confirm option not passed', async () => {
+  it('prompts before removing the specified retention event when force option not passed', async () => {
     await command.action(logger, {
       options: {
         id: validId
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified retention event when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified retention event when force option not passed and prompt not confirmed', async () => {
     const deleteSpy = sinon.spy(request, 'delete');
     await command.action(logger, {
       options: {
@@ -128,8 +124,8 @@ describe(commands.RETENTIONEVENT_REMOVE, () => {
       throw 'Invalid Request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/purview/commands/retentionevent/retentionevent-remove.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-remove.ts
@@ -68,14 +68,9 @@ class PurviewRetentionEventRemoveCommand extends GraphCommand {
       await this.removeRetentionEvent(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the retention event ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the retention event ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeRetentionEvent(args.options);
       }
     }

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.spec.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.RETENTIONEVENTTYPE_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -47,16 +47,17 @@ describe(commands.RETENTIONEVENTTYPE_REMOVE, () => {
         log.push(msg);
       }
     };
-    promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      Cli.prompt,
+      Cli.promptForConfirmation,
       request.delete
     ]);
   });
@@ -85,19 +86,14 @@ describe(commands.RETENTIONEVENTTYPE_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified retention event type when confirm option not passed', async () => {
+  it('prompts before removing the specified retention event type when force option not passed', async () => {
     await command.action(logger, { options: { id: validId } });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified retention event type when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified retention event type when force option not passed and prompt not confirmed', async () => {
     const deleteSpy = sinon.spy(request, 'delete');
     await command.action(logger, { options: { id: validId } });
     assert(deleteSpy.notCalled);
@@ -112,8 +108,8 @@ describe(commands.RETENTIONEVENTTYPE_REMOVE, () => {
       throw 'Invalid Request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { id: validId } });
   });

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.ts
@@ -68,14 +68,9 @@ class PurviewRetentionEventTypeRemoveCommand extends GraphCommand {
       await this.removeRetentionEventType(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the retention event type with id ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the retention event type with id ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeRetentionEventType(args.options);
       }
     }

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-remove.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -47,17 +47,18 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
         log.push(msg);
       }
     };
-    promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -93,23 +94,18 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified retention label when confirm option not passed', async () => {
+  it('prompts before removing the specified retention label when force option not passed', async () => {
     await command.action(logger, {
       options: {
         id: validId
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified retention label when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified retention label when force option not passed and prompt not confirmed', async () => {
     const deleteSpy = sinon.spy(request, 'delete');
     await command.action(logger, {
       options: {
@@ -128,10 +124,8 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
       throw 'Invalid Request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
@@ -68,14 +68,9 @@ class PurviewRetentionLabelRemoveCommand extends GraphCommand {
       await this.removeRetentionLabel(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the retention label ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the retention label ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeRetentionLabel(args);
       }
     }

--- a/src/m365/search/commands/externalconnection/externalconnection-remove.ts
+++ b/src/m365/search/commands/externalconnection/externalconnection-remove.ts
@@ -88,14 +88,9 @@ class SearchExternalConnectionRemoveCommand extends GraphCommand {
       await this.removeExternalConnection(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the external connection '${args.options.id || args.options.name}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the external connection '${args.options.id || args.options.name}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeExternalConnection(args);
       }
     }

--- a/src/m365/spo/commands/app/app-deploy.spec.ts
+++ b/src/m365/spo/commands/app/app-deploy.spec.ts
@@ -54,7 +54,7 @@ describe(commands.APP_DEPLOY, () => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });

--- a/src/m365/spo/commands/app/app-remove.spec.ts
+++ b/src/m365/spo/commands/app/app-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.APP_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -44,11 +44,12 @@ describe(commands.APP_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
     sinon.stub(request, 'get').resolves({ "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" });
   });
 
@@ -56,7 +57,7 @@ describe(commands.APP_REMOVE, () => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -157,17 +158,12 @@ describe(commands.APP_REMOVE, () => {
 
   it('prompts before removing an app when confirmation argument not passed', async () => {
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', appCatalogUrl: 'https://contoso.sharepoint.com' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
   it('aborts removing app when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', appCatalogUrl: 'https://contoso.sharepoint.com' } });
     assert(requests.length === 0);
   });
@@ -193,8 +189,8 @@ describe(commands.APP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', appCatalogUrl: 'https://contoso.sharepoint.com' } });
     let correctRequestIssued = false;
     requests.forEach(r => {

--- a/src/m365/spo/commands/app/app-remove.ts
+++ b/src/m365/spo/commands/app/app-remove.ts
@@ -122,14 +122,9 @@ class SpoAppRemoveCommand extends SpoAppBaseCommand {
       await removeApp();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the app ${args.options.id} from the app catalog?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the app ${args.options.id} from the app catalog?` });
 
-      if (result.continue) {
+      if (result) {
         await removeApp();
       }
     }

--- a/src/m365/spo/commands/app/app-retract.spec.ts
+++ b/src/m365/spo/commands/app/app-retract.spec.ts
@@ -18,7 +18,7 @@ describe(commands.APP_RETRACT, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -44,11 +44,12 @@ describe(commands.APP_RETRACT, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
     sinon.stub(request, 'get').resolves({ "CorporateCatalogUrl": "https://contoso.sharepoint.com/sites/apps" });
   });
 
@@ -56,7 +57,7 @@ describe(commands.APP_RETRACT, () => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -184,20 +185,13 @@ describe(commands.APP_RETRACT, () => {
 
   it('prompts before retracting an app when confirmation argument not passed', async () => {
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', appCatalogUrl: 'https://contoso.sharepoint.com' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts retracting app when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', appCatalogUrl: 'https://contoso.sharepoint.com' } });
     assert(requests.length === 0);
   });
@@ -217,10 +211,8 @@ describe(commands.APP_RETRACT, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', appCatalogUrl: 'https://contoso.sharepoint.com' } });
     let correctRequestIssued = false;
     requests.forEach(r => {

--- a/src/m365/spo/commands/app/app-retract.ts
+++ b/src/m365/spo/commands/app/app-retract.ts
@@ -121,14 +121,9 @@ class SpoAppRetractCommand extends SpoAppBaseCommand {
       await retractApp();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to retract the app ${args.options.id} from the app catalog?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to retract the app ${args.options.id} from the app catalog?` });
 
-      if (result.continue) {
+      if (result) {
         await retractApp();
       }
     }

--- a/src/m365/spo/commands/app/app-uninstall.ts
+++ b/src/m365/spo/commands/app/app-uninstall.ts
@@ -108,14 +108,9 @@ class SpoAppUninstallCommand extends SpoCommand {
       await uninstallApp();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to uninstall the app ${args.options.id} from site ${args.options.siteUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to uninstall the app ${args.options.id} from site ${args.options.siteUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await uninstallApp();
       }
     }

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-remove.spec.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-remove.spec.ts
@@ -21,8 +21,8 @@ describe(commands.APPLICATIONCUSTOMIZER_REMOVE, () => {
   const id = '14125658-a9bc-4ddf-9c75-1b5767c9a337';
   const clientSideComponentId = '015e0fcf-fe9d-4037-95af-0a4776cdfbb4';
   const title = 'SiteGuidedTour';
-  let promptOptions: any;
   let cli: Cli;
+  let promptIssued: boolean = false;
   let log: any[];
   let logger: Logger;
   let requests: any[];
@@ -121,6 +121,13 @@ describe(commands.APPLICATIONCUSTOMIZER_REMOVE, () => {
     sinon.stub(session, 'getId').callsFake(() => '');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {
@@ -137,20 +144,23 @@ describe(commands.APPLICATIONCUSTOMIZER_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.delete,
+      cli.getSettingWithDefaultValue,
       Cli.prompt,
       Cli.handleMultipleResultsFound,
-      cli.getSettingWithDefaultValue
+      Cli.promptForConfirmation,
+      Cli.handleMultipleResultsFound
     ]);
   });
 
@@ -212,16 +222,12 @@ describe(commands.APPLICATIONCUSTOMIZER_REMOVE, () => {
 
   it('should prompt before removing application customizer when confirmation argument not passed', async () => {
     await command.action(logger, { options: { webUrl: webUrl, id: id } });
-    let promptIssued = false;
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
   it('aborts removing application customizer when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { webUrl: webUrl, id: id } });
     assert(requests.length === 0);
   });
@@ -344,8 +350,8 @@ describe(commands.APPLICATIONCUSTOMIZER_REMOVE, () => {
     });
 
     const deleteCallsSpy: sinon.SinonStub = defaultDeleteCallsStub();
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { verbose: true, id: id, webUrl: webUrl, scope: 'Web' } } as any);
     assert(deleteCallsSpy.calledOnce);

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-remove.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-remove.ts
@@ -109,14 +109,9 @@ class SpoApplicationCustomizerRemoveCommand extends SpoCommand {
         return await this.removeApplicationCustomizer(logger, args.options);
       }
 
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the application customizer '${args.options.clientSideComponentId || args.options.title || args.options.id}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the application customizer '${args.options.clientSideComponentId || args.options.title || args.options.id}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeApplicationCustomizer(logger, args.options);
       }
     }

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-set.spec.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-set.spec.ts
@@ -120,6 +120,13 @@ describe(commands.APPLICATIONCUSTOMIZER_SET, () => {
     sinon.stub(session, 'getId').callsFake(() => '');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/cdn/cdn-origin-remove.ts
+++ b/src/m365/spo/commands/cdn/cdn-origin-remove.ts
@@ -115,14 +115,9 @@ class SpoCdnOriginRemoveCommand extends SpoCommand {
       await removeCdnOrigin();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to delete the ${args.options.origin} CDN origin?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to delete the ${args.options.origin} CDN origin?` });
 
-      if (result.continue) {
+      if (result) {
         await removeCdnOrigin();
       }
     }

--- a/src/m365/spo/commands/commandset/commandset-get.spec.ts
+++ b/src/m365/spo/commands/commandset/commandset-get.spec.ts
@@ -38,6 +38,13 @@ describe(commands.COMMANDSET_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/commandset/commandset-remove.ts
+++ b/src/m365/spo/commands/commandset/commandset-remove.ts
@@ -112,14 +112,9 @@ class SpoCommandSetRemoveCommand extends SpoCommand {
       await this.deleteCommandset(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove command set '${args.options.clientSideComponentId || args.options.title || args.options.id}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove command set '${args.options.clientSideComponentId || args.options.title || args.options.id}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.deleteCommandset(args);
       }
     }

--- a/src/m365/spo/commands/contenttype/contenttype-field-remove.spec.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-field-remove.spec.ts
@@ -31,7 +31,7 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   const getStubCalls = async (opts: any) => {
     if ((opts.url as string).indexOf(`_api/site?$select=Id`) > -1) {
@@ -164,24 +164,25 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
     loggerLogSpy = sinon.spy(logger, 'log');
     (command as any).requestDigest = '';
     (command as any).webId = '';
     (command as any).siteId = '';
     (command as any).listId = '';
     (command as any).fieldLinkId = '';
-    promptOptions = undefined;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -237,11 +238,6 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
         force: false
       }
     } as any);
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -249,8 +245,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         webUrl: WEB_URL, contentTypeId: CONTENT_TYPE_ID, fieldLinkId: FIELD_LINK_ID,
@@ -263,8 +259,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -287,10 +283,6 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
         debug: true
       }
     } as any);
-    let promptIssued = false;
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
@@ -298,8 +290,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -335,19 +327,14 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
         updateChildContentTypes: true
       }
     } as any);
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
   it('removes the field link from web content type with update child content types - prompt: confirmed', async () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -362,8 +349,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -387,11 +374,6 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
         debug: true
       }
     } as any);
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
@@ -399,8 +381,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -417,8 +399,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -483,11 +465,6 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
         webUrl: WEB_URL, listTitle: LIST_TITLE, contentTypeId: LIST_CONTENT_TYPE_ID, fieldLinkId: FIELD_LINK_ID
       }
     } as any);
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -496,8 +473,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -514,8 +491,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     command.action(logger, {
       options: {
@@ -553,11 +530,6 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
         debug: true
       }
     } as any);
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -565,8 +537,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -582,8 +554,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -599,8 +571,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -615,8 +587,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     const postCallbackStub = sinon.stub(request, 'post').callsFake(postStubSuccCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     command.action(logger, {
       options: {
@@ -654,8 +626,8 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinon.stub(request, 'get').callsFake(getStubCalls);
     sinon.stub(request, 'post').callsFake(postStubFailedCalls);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options: {

--- a/src/m365/spo/commands/contenttype/contenttype-field-remove.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-field-remove.ts
@@ -202,14 +202,9 @@ class SpoContentTypeFieldRemoveCommand extends SpoCommand {
       await removeFieldLink();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the column ${args.options.fieldLinkId} from content type ${args.options.contentTypeId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the column ${args.options.fieldLinkId} from content type ${args.options.contentTypeId}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeFieldLink();
       }
     }

--- a/src/m365/spo/commands/contenttype/contenttype-remove.spec.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-remove.spec.ts
@@ -19,7 +19,7 @@ describe(commands.CONTENTTYPE_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -44,18 +44,18 @@ describe(commands.CONTENTTYPE_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -85,11 +85,6 @@ describe(commands.CONTENTTYPE_REMOVE, () => {
     await command.action(logger, {
       options: { debug: true, verbose: true, webUrl: 'https://contoso.sharepoint.com/sites/portal', id: '0x0100558D85B7216F6A489A499DB361E1AE2F', force: false }
     } as any);
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -104,8 +99,8 @@ describe(commands.CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -129,10 +124,8 @@ describe(commands.CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, {
       options: {
         debug: true,
@@ -163,11 +156,6 @@ describe(commands.CONTENTTYPE_REMOVE, () => {
     });
 
     await command.action(logger, { options: { debug: true, verbose: true, webUrl: 'https://contoso.sharepoint.com/sites/portal', name: 'TestContentType', force: false } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -190,8 +178,8 @@ describe(commands.CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, verbose: false, webUrl: 'https://contoso.sharepoint.com/sites/portal', name: 'TestContentType', force: false } });
     assert(getCallbackStub.called);
@@ -215,8 +203,8 @@ describe(commands.CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { verbose: true, webUrl: 'https://contoso.sharepoint.com/sites/portal', name: 'TestContentType', force: false } });
     assert(postCallbackStub.notCalled);

--- a/src/m365/spo/commands/contenttype/contenttype-remove.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-remove.ts
@@ -147,9 +147,9 @@ class SpoContentTypeRemoveCommand extends SpoCommand {
       await removeContentType();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({ type: 'confirm', name: 'continue', default: false, message: `Are you sure you want to remove the content type ${args.options.id || args.options.name}?` });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the content type ${args.options.id || args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeContentType();
       }
     }

--- a/src/m365/spo/commands/customaction/customaction-clear.ts
+++ b/src/m365/spo/commands/customaction/customaction-clear.ts
@@ -97,14 +97,9 @@ class SpoCustomActionClearCommand extends SpoCommand {
       await clearCustomActions();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to clear all the user custom actions with scope ${chalk.yellow(args.options.scope || 'All')}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to clear all the user custom actions with scope ${chalk.yellow(args.options.scope || 'All')}?` });
 
-      if (result.continue) {
+      if (result) {
         await clearCustomActions();
       }
     }

--- a/src/m365/spo/commands/customaction/customaction-get.spec.ts
+++ b/src/m365/spo/commands/customaction/customaction-get.spec.ts
@@ -73,6 +73,13 @@ describe(commands.CUSTOMACTION_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/customaction/customaction-remove.ts
+++ b/src/m365/spo/commands/customaction/customaction-remove.ts
@@ -124,14 +124,9 @@ class SpoCustomActionRemoveCommand extends SpoCommand {
       await removeCustomAction();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the ${args.options.id} user custom action?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the ${args.options.id} user custom action?` });
 
-      if (result.continue) {
+      if (result) {
         await removeCustomAction();
       }
     }

--- a/src/m365/spo/commands/eventreceiver/eventreceiver-get.spec.ts
+++ b/src/m365/spo/commands/eventreceiver/eventreceiver-get.spec.ts
@@ -44,6 +44,13 @@ describe(commands.EVENTRECEIVER_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/eventreceiver/eventreceiver-remove.spec.ts
+++ b/src/m365/spo/commands/eventreceiver/eventreceiver-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   const eventReceiverResponse = JSON.stringify(
     {
@@ -57,18 +57,18 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
     };
     (command as any).items = [];
 
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
 
-    promptOptions = undefined;
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       Cli.executeCommandWithOutput,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       request.delete
     ]);
   });
@@ -146,14 +146,8 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('prompts before removing the event receiver when confirm option not passed', async () => {
+  it('prompts before removing the event receiver when force option not passed', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/portal', scope: 'site', name: 'PnP Test Receiver' } });
-
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -195,8 +189,8 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
       stdout: eventReceiverResponse,
       stderr: ''
     });
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/portal', scope: 'site', name: 'PnP Test Receiver' } });
     assert(requestDeleteStub.called);
@@ -216,8 +210,8 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
       stderr: ''
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/portal', name: 'PnP Test Receiver', listUrl: '/sites/portal/Lists/rerlist' } });
     assert(requestDeleteStub.called);
@@ -237,8 +231,8 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
       stderr: ''
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/portal', name: 'PnP Test Receiver', listId: '8fccab0d-78e5-4037-a6a7-0168f9359cd4' } });
     assert(requestDeleteStub.called);
@@ -258,8 +252,8 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
       stderr: ''
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/portal', scope: 'site', id: '625b1f4c-2869-457f-8b41-bed72059bb2b' } });
     assert(requestDeleteStub.called);
@@ -279,8 +273,8 @@ describe(commands.EVENTRECEIVER_REMOVE, () => {
       stderr: ''
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/portal', listTitle: 'Documents', name: 'PnP Test Receiver' } });
     assert(requestDeleteStub.called);

--- a/src/m365/spo/commands/eventreceiver/eventreceiver-remove.ts
+++ b/src/m365/spo/commands/eventreceiver/eventreceiver-remove.ts
@@ -127,14 +127,9 @@ class SpoEventreceiverRemoveCommand extends SpoCommand {
       await this.removeEventReceiver(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove event receiver with ${args.options.id ? `id ${args.options.id}` : `name ${args.options.name}`}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove event receiver with ${args.options.id ? `id ${args.options.id}` : `name ${args.options.name}`}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeEventReceiver(args.options);
       }
     }

--- a/src/m365/spo/commands/field/field-remove.spec.ts
+++ b/src/m365/spo/commands/field/field-remove.spec.ts
@@ -20,7 +20,7 @@ describe(commands.FIELD_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -46,10 +46,12 @@ describe(commands.FIELD_REMOVE, () => {
       }
     };
 
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
 
     requests = [];
   });
@@ -58,7 +60,7 @@ describe(commands.FIELD_REMOVE, () => {
     sinonUtil.restore([
       request.post,
       request.get,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -78,48 +80,33 @@ describe(commands.FIELD_REMOVE, () => {
 
   it('prompts before removing field when confirmation argument not passed (id)', async () => {
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('prompts before removing field when confirmation argument not passed (title)', async () => {
     await command.action(logger, { options: { title: 'myfield1', webUrl: 'https://contoso.sharepoint.com' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('prompts before removing list column when confirmation argument not passed', async () => {
     await command.action(logger, { options: { title: 'myfield1', webUrl: 'https://contoso.sharepoint.com', listTitle: 'My List' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing field when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com' } });
     assert(requests.length === 0);
   });
 
   it('aborts removing field when prompt not confirmed and passing the group parameter', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { group: 'MyGroup', webUrl: 'https://contoso.sharepoint.com' } });
     assert(requests.length === 0);
@@ -140,8 +127,8 @@ describe(commands.FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await assert.rejects(command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com' } }));
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -212,8 +199,8 @@ describe(commands.FIELD_REMOVE, () => {
   });
 
   it('calls group and deletes two fields and asks for confirmation', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     const getStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/web/GetList(\'%2Fsites%2Fportal%2FLists%2FEvents\')/fields`) {

--- a/src/m365/spo/commands/field/field-remove.ts
+++ b/src/m365/spo/commands/field/field-remove.ts
@@ -206,14 +206,9 @@ class SpoFieldRemoveCommand extends SpoCommand {
     else {
       const confirmMessage: string = `Are you sure you want to remove the ${args.options.group ? 'fields' : 'field'} ${args.options.id || args.options.title || 'from group ' + args.options.group} ${messageEnd}?`;
 
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: confirmMessage
-      });
+      const result = await Cli.promptForConfirmation({ message: confirmMessage });
 
-      if (result.continue) {
+      if (result) {
         await prepareRemoval();
       }
     }

--- a/src/m365/spo/commands/file/file-checkout-undo.ts
+++ b/src/m365/spo/commands/file/file-checkout-undo.ts
@@ -123,14 +123,9 @@ class SpoFileCheckoutUndoCommand extends SpoCommand {
       await undoCheckout();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to undo the checkout for file ${args.options.fileId || args.options.fileUrl} ?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to undo the checkout for file ${args.options.fileId || args.options.fileUrl} ?` });
 
-      if (result.continue) {
+      if (result) {
         await undoCheckout();
       }
     }

--- a/src/m365/spo/commands/file/file-copy.spec.ts
+++ b/src/m365/spo/commands/file/file-copy.spec.ts
@@ -37,6 +37,13 @@ describe(commands.FILE_COPY, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/file/file-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-remove.spec.ts
@@ -21,7 +21,7 @@ describe(commands.FILE_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -47,16 +47,17 @@ describe(commands.FILE_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -90,29 +91,19 @@ describe(commands.FILE_REMOVE, () => {
 
   it('prompts before removing file when confirmation argument not passed (id)', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('prompts before removing file when confirmation argument not passed (title)', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing file when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
     assert(requests.length === 0);
@@ -133,8 +124,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
     let correctRequestIssued = false;
@@ -166,10 +157,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -200,10 +189,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -234,10 +221,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -268,10 +253,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -302,8 +285,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
@@ -335,10 +318,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -369,8 +350,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
@@ -402,8 +383,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
@@ -435,8 +416,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
@@ -468,8 +449,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
     let correctRequestIssued = false;
@@ -498,8 +479,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf', recycle: true } });
     let correctRequestIssued = false;
@@ -528,8 +509,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
     let correctRequestIssued = false;
@@ -558,8 +539,8 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf', recycle: true } });
     let correctRequestIssued = false;

--- a/src/m365/spo/commands/file/file-remove.ts
+++ b/src/m365/spo/commands/file/file-remove.ts
@@ -142,14 +142,9 @@ class SpoFileRemoveCommand extends SpoCommand {
       await removeFile();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to ${args.options.recycle ? 'recycle' : 'remove'} the file ${args.options.id || args.options.url} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.recycle ? 'recycle' : 'remove'} the file ${args.options.id || args.options.url} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeFile();
       }
     }

--- a/src/m365/spo/commands/file/file-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-remove.spec.ts
@@ -35,7 +35,7 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -60,16 +60,17 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       Cli.executeCommandWithOutput,
       cli.getSettingWithDefaultValue
     ]);
@@ -90,19 +91,14 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
 
   it('prompts before removing retentionlabel from a file when confirmation argument not passed', async () => {
     await command.action(logger, { options: { webUrl: webUrl, fileUrl: fileUrl } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing file retention label when prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -122,8 +118,8 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === spoListItemRetentionLabelRemoveCommand) {
@@ -152,8 +148,8 @@ describe(commands.FILE_RETENTIONLABEL_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === spoListItemRetentionLabelRemoveCommand) {

--- a/src/m365/spo/commands/file/file-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-remove.ts
@@ -95,14 +95,9 @@ class SpoFileRetentionLabelRemoveCommand extends SpoCommand {
       await this.removeFileRetentionLabel(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the retentionlabel from file ${args.options.fileId || args.options.fileUrl} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the retentionlabel from file ${args.options.fileId || args.options.fileUrl} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeFileRetentionLabel(logger, args);
       }
     }

--- a/src/m365/spo/commands/file/file-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-roleassignment-remove.spec.ts
@@ -29,7 +29,7 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -53,16 +53,17 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      Cli.prompt,
+      Cli.promptForConfirmation,
       Cli.executeCommandWithOutput,
       request.post
     ]);
@@ -101,7 +102,7 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing role assignment from the file when confirm option not passed', async () => {
+  it('prompts before removing role assignment from the file when force option not passed', async () => {
     await command.action(logger, {
       options: {
         webUrl: webUrl,
@@ -110,16 +111,11 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing role assignment from the file when confirm option is not passed and prompt not confirmed', async () => {
+  it('aborts removing role assignment from the file when force option is not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
 
     await command.action(logger, {
@@ -143,8 +139,8 @@ describe(commands.FILE_ROLEASSIGNMENT_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/file/file-roleassignment-remove.ts
+++ b/src/m365/spo/commands/file/file-roleassignment-remove.ts
@@ -151,14 +151,9 @@ class SpoFileRoleAssignmentRemoveCommand extends SpoCommand {
       await removeRoleAssignment();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove role assignment from file ${args.options.fileUrl || args.options.fileId} from site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove role assignment from file ${args.options.fileUrl || args.options.fileId} from site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeRoleAssignment();
       }
     }

--- a/src/m365/spo/commands/file/file-roleinheritance-break.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-break.ts
@@ -121,14 +121,9 @@ class SpoFileRoleInheritanceBreakCommand extends SpoCommand {
       await breakFileRoleInheritance();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to break the role inheritance of file ${args.options.fileUrl || args.options.fileId} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to break the role inheritance of file ${args.options.fileUrl || args.options.fileId} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await breakFileRoleInheritance();
       }
     }

--- a/src/m365/spo/commands/file/file-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-reset.spec.ts
@@ -23,7 +23,7 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -47,16 +47,17 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      Cli.prompt,
+      Cli.promptForConfirmation,
       request.post
     ]);
   });
@@ -89,7 +90,7 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before resetting role inheritance for the file when confirm option not passed', async () => {
+  it('prompts before resetting role inheritance for the file when force option not passed', async () => {
     await command.action(logger, {
       options: {
         webUrl: webUrl,
@@ -97,16 +98,11 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts resetting role inheritance for the file when confirm option is not passed and prompt not confirmed', async () => {
+  it('aborts resetting role inheritance for the file when force option is not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
 
     await command.action(logger, {
@@ -157,8 +153,8 @@ describe(commands.FILE_ROLEINHERITANCE_RESET, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/file/file-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/file/file-roleinheritance-reset.ts
@@ -114,14 +114,9 @@ class SpoFileRoleInheritanceResetCommand extends SpoCommand {
       await resetFileRoleInheritance();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to reset the role inheritance of file ${args.options.fileUrl || args.options.fileId} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to reset the role inheritance of file ${args.options.fileUrl || args.options.fileId} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await resetFileRoleInheritance();
       }
     }

--- a/src/m365/spo/commands/file/file-sharinglink-clear.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-clear.ts
@@ -129,14 +129,9 @@ class SpoFileSharingLinkClearCommand extends SpoCommand {
       await clearSharingLinks();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to clear the sharing links of file ${args.options.fileUrl || args.options.fileId}${args.options.scope ? ` with scope ${args.options.scope}` : ''}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to clear the sharing links of file ${args.options.fileUrl || args.options.fileId}${args.options.scope ? ` with scope ${args.options.scope}` : ''}?` });
 
-      if (result.continue) {
+      if (result) {
         await clearSharingLinks();
       }
     }

--- a/src/m365/spo/commands/file/file-sharinglink-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-remove.spec.ts
@@ -31,7 +31,7 @@ describe(commands.FILE_SHARINGLINK_REMOVE, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -55,18 +55,19 @@ describe(commands.FILE_SHARINGLINK_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -98,7 +99,7 @@ describe(commands.FILE_SHARINGLINK_REMOVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('prompts before removing the specified sharing link to a file when confirm option not passed', async () => {
+  it('prompts before removing the specified sharing link to a file when force option not passed', async () => {
     await command.action(logger, {
       options: {
         webUrl: webUrl,
@@ -107,19 +108,14 @@ describe(commands.FILE_SHARINGLINK_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified sharing link to a file when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified sharing link to a file when force option not passed and prompt not confirmed', async () => {
     const deleteSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -149,8 +145,8 @@ describe(commands.FILE_SHARINGLINK_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/file/file-sharinglink-remove.ts
+++ b/src/m365/spo/commands/file/file-sharinglink-remove.ts
@@ -115,14 +115,9 @@ class SpoFileSharingLinkRemoveCommand extends SpoCommand {
       await removeSharingLink();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove sharing link ${args.options.id} of file ${args.options.fileUrl || args.options.fileId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove sharing link ${args.options.id} of file ${args.options.fileUrl || args.options.fileId}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeSharingLink();
       }
     }

--- a/src/m365/spo/commands/file/file-version-clear.ts
+++ b/src/m365/spo/commands/file/file-version-clear.ts
@@ -90,14 +90,9 @@ class SpoFileVersionClearCommand extends SpoCommand {
         await this.clearVersions(args);
       }
       else {
-        const result = await Cli.prompt<{ continue: boolean }>({
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `Are you sure you want to delete all version history for file ${args.options.fileId || args.options.fileUrl}'?`
-        });
+        const result = await Cli.promptForConfirmation({ message: `Are you sure you want to delete all version history for file ${args.options.fileId || args.options.fileUrl}'?` });
 
-        if (result.continue) {
+        if (result) {
           await this.clearVersions(args);
         }
       }

--- a/src/m365/spo/commands/file/file-version-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-version-remove.spec.ts
@@ -19,7 +19,7 @@ describe(commands.FILE_VERSION_REMOVE, () => {
   let logger: Logger;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   const validWebUrl = "https://contoso.sharepoint.com";
   const validFileUrl = "/Shared Documents/Document.docx";
   const validFileId = "7a9b8bb6-d5c4-4de9-ab76-5210a7879e89";
@@ -48,17 +48,18 @@ describe(commands.FILE_VERSION_REMOVE, () => {
       }
     };
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -101,7 +102,7 @@ describe(commands.FILE_VERSION_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified version when confirm option not passed', async () => {
+  it('prompts before removing the specified version when force option not passed', async () => {
     await command.action(logger, {
       options: {
         webUrl: validWebUrl,
@@ -109,19 +110,14 @@ describe(commands.FILE_VERSION_REMOVE, () => {
         fileId: validFileId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified version when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified version when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -181,8 +177,8 @@ describe(commands.FILE_VERSION_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -203,8 +199,8 @@ describe(commands.FILE_VERSION_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/file/file-version-remove.ts
+++ b/src/m365/spo/commands/file/file-version-remove.ts
@@ -99,14 +99,9 @@ class SpoFileVersionRemoveCommand extends SpoCommand {
         await this.removeVersion(args);
       }
       else {
-        const result = await Cli.prompt<{ continue: boolean }>({
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `Are you sure you want to remove the version ${args.options.label} from file ${args.options.fileId || args.options.fileUrl}'?`
-        });
+        const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the version ${args.options.label} from file ${args.options.fileId || args.options.fileUrl}'?` });
 
-        if (result.continue) {
+        if (result) {
           await this.removeVersion(args);
         }
       }

--- a/src/m365/spo/commands/file/file-version-restore.spec.ts
+++ b/src/m365/spo/commands/file/file-version-restore.spec.ts
@@ -19,7 +19,7 @@ describe(commands.FILE_VERSION_RESTORE, () => {
   let logger: Logger;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   const validWebUrl = "https://contoso.sharepoint.com";
   const validFileUrl = "/Shared Documents/Document.docx";
   const validFileId = "7a9b8bb6-d5c4-4de9-ab76-5210a7879e89";
@@ -48,17 +48,18 @@ describe(commands.FILE_VERSION_RESTORE, () => {
       }
     };
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -101,7 +102,7 @@ describe(commands.FILE_VERSION_RESTORE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before restoring the specified version when confirm option not passed', async () => {
+  it('prompts before restoring the specified version when force option not passed', async () => {
     await command.action(logger, {
       options: {
         webUrl: validWebUrl,
@@ -109,19 +110,14 @@ describe(commands.FILE_VERSION_RESTORE, () => {
         fileId: validFileId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts restoring the specified version when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts restoring the specified version when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -181,8 +177,8 @@ describe(commands.FILE_VERSION_RESTORE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -203,10 +199,8 @@ describe(commands.FILE_VERSION_RESTORE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/file/file-version-restore.ts
+++ b/src/m365/spo/commands/file/file-version-restore.ts
@@ -99,14 +99,9 @@ class SpoFileVersionRestoreCommand extends SpoCommand {
         await this.restoreVersion(args);
       }
       else {
-        const result = await Cli.prompt<{ continue: boolean }>({
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `Are you sure you want to restore the version ${args.options.label} from file ${args.options.fileId || args.options.fileUrl}'?`
-        });
+        const result = await Cli.promptForConfirmation({ message: `Are you sure you want to restore the version ${args.options.label} from file ${args.options.fileId || args.options.fileUrl}'?` });
 
-        if (result.continue) {
+        if (result) {
           await this.restoreVersion(args);
         }
       }

--- a/src/m365/spo/commands/folder/folder-remove.spec.ts
+++ b/src/m365/spo/commands/folder/folder-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.FOLDER_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let stubPost: sinon.SinonStub;
 
   before(() => {
@@ -52,17 +52,19 @@ describe(commands.FOLDER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
     requests = [];
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -81,26 +83,20 @@ describe(commands.FOLDER_REMOVE, () => {
 
   it('prompts before removing folder when confirmation argument not passed', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '/Shared Documents' } });
-    let promptIssued = false;
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing folder when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '/Shared Documents' } });
     assert(requests.length === 0);
   });
 
   it('removes the folder when prompt confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options:
       {
@@ -128,8 +124,8 @@ describe(commands.FOLDER_REMOVE, () => {
   });
 
   it('should send params for remove request for sites/test1', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options:
@@ -146,8 +142,8 @@ describe(commands.FOLDER_REMOVE, () => {
   });
 
   it('should send params for recycle request when recycle is set to true', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options:
@@ -179,8 +175,8 @@ describe(commands.FOLDER_REMOVE, () => {
     sinonUtil.restore(request.post);
     sinon.stub(request, 'post').rejects(error);
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options:

--- a/src/m365/spo/commands/folder/folder-remove.ts
+++ b/src/m365/spo/commands/folder/folder-remove.ts
@@ -77,14 +77,9 @@ class SpoFolderRemoveCommand extends SpoCommand {
       await this.removeFolder(logger, args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to ${args.options.recycle ? "recycle" : "remove"} the folder ${args.options.url} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.recycle ? "recycle" : "remove"} the folder ${args.options.url} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeFolder(logger, args.options);
       }
     }

--- a/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
@@ -95,14 +95,9 @@ class SpoFolderRetentionLabelRemoveCommand extends SpoCommand {
       await this.removeFolderRetentionLabel(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the retentionlabel from folder ${args.options.folderId || args.options.folderUrl} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the retentionlabel from folder ${args.options.folderId || args.options.folderUrl} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeFolderRetentionLabel(logger, args);
       }
     }

--- a/src/m365/spo/commands/folder/folder-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/folder/folder-roleassignment-remove.spec.ts
@@ -22,7 +22,7 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -48,17 +48,18 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
       Cli.executeCommandWithOutput,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -289,11 +290,6 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
         groupName: 'someGroup'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
@@ -316,8 +312,8 @@ describe(commands.FOLDER_ROLEASSIGNMENT_REMOVE, () => {
       throw new CommandError('Unknown case');
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         debug: true,

--- a/src/m365/spo/commands/folder/folder-roleassignment-remove.ts
+++ b/src/m365/spo/commands/folder/folder-roleassignment-remove.ts
@@ -131,14 +131,9 @@ class SpoFolderRoleAssignmentRemoveCommand extends SpoCommand {
       await removeRoleAssignment();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove a role assignment from the folder with url '${args.options.folderUrl}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove a role assignment from the folder with url '${args.options.folderUrl}'?` });
 
-      if (result.continue) {
+      if (result) {
         await removeRoleAssignment();
       }
     }

--- a/src/m365/spo/commands/folder/folder-roleinheritance-break.spec.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-break.spec.ts
@@ -23,7 +23,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -47,16 +47,17 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      Cli.prompt,
+      Cli.promptForConfirmation,
       request.post
     ]);
   });
@@ -84,7 +85,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before breaking role inheritance for the folder when confirm option not passed', async () => {
+  it('prompts before breaking role inheritance for the folder when force option not passed', async () => {
     await command.action(logger, {
       options: {
         webUrl: webUrl,
@@ -92,16 +93,11 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts breaking role inheritance for the folder when confirm option is not passed and prompt not confirmed', async () => {
+  it('aborts breaking role inheritance for the folder when force option is not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
 
     await command.action(logger, {
@@ -144,8 +140,8 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -165,8 +161,8 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -185,8 +181,8 @@ describe(commands.FOLDER_ROLEINHERITANCE_BREAK, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/folder/folder-roleinheritance-break.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-break.ts
@@ -100,14 +100,9 @@ class SpoFolderRoleInheritanceBreakCommand extends SpoCommand {
       await breakFolderRoleInheritance();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to break the role inheritance of folder ${args.options.folderUrl} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to break the role inheritance of folder ${args.options.folderUrl} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await breakFolderRoleInheritance();
       }
     }

--- a/src/m365/spo/commands/folder/folder-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-reset.spec.ts
@@ -21,7 +21,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_RESET, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -45,16 +45,17 @@ describe(commands.FOLDER_ROLEINHERITANCE_RESET, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      Cli.prompt,
+      Cli.promptForConfirmation,
       request.post
     ]);
   });
@@ -82,7 +83,7 @@ describe(commands.FOLDER_ROLEINHERITANCE_RESET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before resetting role inheritance for the folder when confirm option not passed', async () => {
+  it('prompts before resetting role inheritance for the folder when force option not passed', async () => {
     await command.action(logger, {
       options: {
         webUrl: webUrl,
@@ -90,16 +91,11 @@ describe(commands.FOLDER_ROLEINHERITANCE_RESET, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts resetting role inheritance for the folder when confirm option is not passed and prompt not confirmed', async () => {
+  it('aborts resetting role inheritance for the folder when force option is not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
 
     await command.action(logger, {
@@ -140,10 +136,8 @@ describe(commands.FOLDER_ROLEINHERITANCE_RESET, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -162,8 +156,8 @@ describe(commands.FOLDER_ROLEINHERITANCE_RESET, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/folder/folder-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/folder/folder-roleinheritance-reset.ts
@@ -95,14 +95,9 @@ class SpoFolderRoleInheritanceResetCommand extends SpoCommand {
       await resetFolderRoleInheritance();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to reset the role inheritance of folder ${args.options.folderUrl} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to reset the role inheritance of folder ${args.options.folderUrl} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await resetFolderRoleInheritance();
       }
     }

--- a/src/m365/spo/commands/group/group-member-remove.spec.ts
+++ b/src/m365/spo/commands/group/group-member-remove.spec.ts
@@ -79,7 +79,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       Cli.executeCommandWithOutput,
       cli.getSettingWithDefaultValue
     ]);
@@ -99,8 +99,8 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
   });
 
   it('Removes Azure AD group from SharePoint group using Azure AD Group Name', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === spoGroupMemberListCommand) {
@@ -161,8 +161,8 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
   });
 
   it('Removes Azure AD group from SharePoint group using Azure AD Group ID and SharePoint Group ID', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === spoGroupMemberListCommand) {
@@ -424,7 +424,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('removes user from SharePoint group by groupId and userName with confirm option (debug)', async () => {
+  it('removes user from SharePoint group by groupId and userName with force option (debug)', async () => {
     const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       const loginName: string = `i:0#.f|membership|${userName}`;
       if (opts.url === `${webUrl}/_api/web/sitegroups/GetById('${groupId}')/users/removeByLoginName(@LoginName)?@LoginName='${formatting.encodeQueryParameter(loginName)}'`) {
@@ -448,11 +448,9 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
     assert(postStub.called);
   });
 
-  it('removes user from SharePoint group by groupId and userName when confirm option not passed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+  it('removes user from SharePoint group by groupId and userName when force option not passed', async () => {
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       const loginName: string = `i:0#.f|membership|${userName}`;
@@ -476,11 +474,9 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
     assert(postStub.called);
   });
 
-  it('removes user from SharePoint group by groupId and userId when confirm option not passed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+  it('removes user from SharePoint group by groupId and userId when force option not passed', async () => {
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `${webUrl}/_api/web/sitegroups/GetById('${groupId}')/users/removeById(${userId})`) {
@@ -503,11 +499,9 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
     assert(postStub.called);
   });
 
-  it('removes user from SharePoint group by groupId and email when confirm option not passed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+  it('removes user from SharePoint group by groupId and email when force option not passed', async () => {
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake(() => Promise.resolve({
       stdout: JSON.stringify(userInformation),
@@ -536,7 +530,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
     assert(postStub.called);
   });
 
-  it('removes user from SharePoint group by groupName and userId with confirm option', async () => {
+  it('removes user from SharePoint group by groupName and userId with force option', async () => {
     const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `${webUrl}/_api/web/sitegroups/GetByName('${formatting.encodeQueryParameter(groupName)}')/users/removeById(${userId})`) {
         return UserRemovalJSONResponse;
@@ -558,7 +552,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
     assert(postStub.called);
   });
 
-  it('removes user from SharePoint group by groupName and email with confirm option', async () => {
+  it('removes user from SharePoint group by groupName and email with force option', async () => {
     sinon.stub(Cli, 'executeCommandWithOutput').callsFake(() => Promise.resolve({
       stdout: JSON.stringify(userInformation),
       stderr: ''
@@ -588,10 +582,8 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
 
   it('aborts removing user from SharePoint group when prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/group/group-member-remove.ts
+++ b/src/m365/spo/commands/group/group-member-remove.ts
@@ -155,14 +155,9 @@ class SpoGroupMemberRemoveCommand extends SpoCommand {
       await this.removeUserfromSPGroup(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove user ${args.options.userName || args.options.userId || args.options.email || args.options.aadGroupId || args.options.aadGroupName} from the SharePoint group?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove user ${args.options.userName || args.options.userId || args.options.email || args.options.aadGroupId || args.options.aadGroupName} from the SharePoint group?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeUserfromSPGroup(logger, args);
       }
     }

--- a/src/m365/spo/commands/group/group-remove.ts
+++ b/src/m365/spo/commands/group/group-remove.ts
@@ -129,14 +129,9 @@ class SpoGroupRemoveCommand extends SpoCommand {
       await removeGroup();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the group ${args.options.id || args.options.name} from web ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the group ${args.options.id || args.options.name} from web ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeGroup();
       }
     }

--- a/src/m365/spo/commands/hidedefaultthemes/hidedefaultthemes-set.spec.ts
+++ b/src/m365/spo/commands/hidedefaultthemes/hidedefaultthemes-set.spec.ts
@@ -30,6 +30,13 @@ describe(commands.HIDEDEFAULTTHEMES_SET, () => {
     auth.service.connected = true;
     auth.service.spoUrl = 'https://contoso.sharepoint.com';
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/homesite/homesite-remove.ts
+++ b/src/m365/spo/commands/homesite/homesite-remove.ts
@@ -83,14 +83,9 @@ class SpoHomeSiteRemoveCommand extends SpoCommand {
       await removeHomeSite();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the Home Site?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the Home Site?` });
 
-      if (result.continue) {
+      if (result) {
         await removeHomeSite();
       }
     }

--- a/src/m365/spo/commands/hubsite/hubsite-connect.spec.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-connect.spec.ts
@@ -65,6 +65,13 @@ describe(commands.HUBSITE_CONNECT, () => {
 
       throw 'Invalid requet URL: ' + opts.url;
     });
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/hubsite/hubsite-disconnect.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-disconnect.ts
@@ -124,14 +124,9 @@ class SpoHubSiteDisconnectCommand extends SpoCommand {
       await disconnectHubSite();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want disconnect hub site '${args.options.id || args.options.title || args.options.url}' from its parent hub site?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want disconnect hub site '${args.options.id || args.options.title || args.options.url}' from its parent hub site?` });
 
-      if (result.continue) {
+      if (result) {
         await disconnectHubSite();
       }
     }

--- a/src/m365/spo/commands/hubsite/hubsite-get.spec.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-get.spec.ts
@@ -42,6 +42,13 @@ describe(commands.HUBSITE_GET, () => {
     auth.service.connected = true;
     auth.service.spoUrl = 'https://contoso.sharepoint.com';
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/hubsite/hubsite-rights-revoke.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-rights-revoke.ts
@@ -104,14 +104,9 @@ class SpoHubSiteRightsRevokeCommand extends SpoCommand {
       await revokeRights();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to revoke rights to join sites to the hub site ${args.options.hubSiteUrl} from the specified users?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to revoke rights to join sites to the hub site ${args.options.hubSiteUrl} from the specified users?` });
 
-      if (result.continue) {
+      if (result) {
         await revokeRights();
       }
     }

--- a/src/m365/spo/commands/hubsite/hubsite-unregister.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-unregister.ts
@@ -87,14 +87,9 @@ class SpoHubSiteUnregisterCommand extends SpoCommand {
       await unregisterHubSite();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to unregister the site collection ${args.options.url} as a hub site?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to unregister the site collection ${args.options.url} as a hub site?` });
 
-      if (result.continue) {
+      if (result) {
         await unregisterHubSite();
       }
     }

--- a/src/m365/spo/commands/knowledgehub/knowledgehub-remove.spec.ts
+++ b/src/m365/spo/commands/knowledgehub/knowledgehub-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.KNOWLEDGEHUB_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -65,15 +65,16 @@ describe(commands.KNOWLEDGEHUB_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
-    sinonUtil.restore(Cli.prompt);
+    sinonUtil.restore(Cli.promptForConfirmation);
   });
 
   after(() => {
@@ -121,26 +122,21 @@ describe(commands.KNOWLEDGEHUB_REMOVE, () => {
 
   it('removes Knowledge Hub settings from tenant when confirmation argument not passed', async () => {
     await command.action(logger, { options: { debug: true } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing Knowledge Hub settings from tenant when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { debug: true } });
     assert(requests.length === 0);
   });
 
   it('removes removing Knowledge Hub settings from tenant when prompt confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true } });
   });

--- a/src/m365/spo/commands/knowledgehub/knowledgehub-remove.ts
+++ b/src/m365/spo/commands/knowledgehub/knowledgehub-remove.ts
@@ -87,14 +87,9 @@ class SpoKnowledgehubRemoveCommand extends SpoCommand {
       await removeKnowledgehub();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove Knowledge Hub Site from your tenant?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove Knowledge Hub Site from your tenant?` });
 
-      if (result.continue) {
+      if (result) {
         await removeKnowledgehub();
       }
     }

--- a/src/m365/spo/commands/list/list-contenttype-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-contenttype-remove.spec.ts
@@ -25,7 +25,7 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -51,16 +51,17 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -86,11 +87,6 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
         id: contentTypeId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -103,18 +99,13 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
         id: contentTypeId
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing content type from list when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, {
       options: {
         listId: listId,
@@ -137,8 +128,8 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -165,10 +156,8 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -195,8 +184,8 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -223,8 +212,8 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -250,10 +239,8 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -279,8 +266,8 @@ describe(commands.LIST_CONTENTTYPE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/list/list-contenttype-remove.ts
+++ b/src/m365/spo/commands/list/list-contenttype-remove.ts
@@ -143,14 +143,9 @@ class SpoListContentTypeRemoveCommand extends SpoCommand {
       await removeContentTypeFromList();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the content type ${args.options.id} from the list ${args.options.listId ? args.options.listId : args.options.listTitle ? args.options.listTitle : args.options.listUrl} in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the content type ${args.options.id} from the list ${args.options.listId ? args.options.listId : args.options.listTitle ? args.options.listTitle : args.options.listUrl} in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeContentTypeFromList();
       }
     }

--- a/src/m365/spo/commands/list/list-remove.ts
+++ b/src/m365/spo/commands/list/list-remove.ts
@@ -123,14 +123,9 @@ class SpoListRemoveCommand extends SpoCommand {
       await removeList();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the list ${args.options.id || args.options.title} from site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the list ${args.options.id || args.options.title} from site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeList();
       }
     }

--- a/src/m365/spo/commands/list/list-retentionlabel-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-remove.spec.ts
@@ -19,7 +19,6 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
   const listResponse = {
     "RootFolder": {
       "ServerRelativeUrl": "/sites/team1/Shared Documents"
@@ -34,6 +33,13 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {
@@ -49,17 +55,13 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
-    });
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -77,55 +79,48 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before removing the retentionlabel on the specified list when confirm option not passed (listTitle)', async () => {
+  it('prompts before removing the retentionlabel on the specified list when force option not passed (listTitle)', async () => {
+    const confirmationStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
+
     await command.action(logger, {
       options: {
         webUrl: 'https://contoso.sharepoint.com/sites/team1',
         listTitle: 'MyLibrary'
       }
     });
-    let promptIssued = false;
 
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-
-    assert(promptIssued);
+    assert(confirmationStub.calledOnce);
   });
 
-  it('prompts before removing the retentionlabel on the specified list when confirm option not passed (listId)', async () => {
+  it('prompts before removing the retentionlabel on the specified list when force option not passed (listId)', async () => {
+    const confirmationStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
+
     await command.action(logger, {
       options: {
         webUrl: 'https://contoso.sharepoint.com/sites/team1',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF'
       }
     });
-    let promptIssued = false;
 
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-
-    assert(promptIssued);
+    assert(confirmationStub.calledOnce);
   });
 
-  it('prompts before removing the retentionlabel on the specified list when confirm option not passed (listUrl)', async () => {
+  it('prompts before removing the retentionlabel on the specified list when force option not passed (listUrl)', async () => {
+    const confirmationStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
+
     await command.action(logger, {
       options: {
         webUrl: 'https://contoso.sharepoint.com/sites/team1',
         listUrl: '/sites/team1/MyLibrary'
       }
     });
-    let promptIssued = false;
 
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-
-    assert(promptIssued);
+    assert(confirmationStub.calledOnce);
   });
 
   it('aborts removing list retentionlabel when prompt not confirmed', async () => {
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
+
     const getSpy = sinon.spy(request, 'get');
     await command.action(logger, {
       options: {
@@ -282,10 +277,8 @@ describe(commands.LIST_RETENTIONLABEL_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.doesNotReject(command.action(logger, {
       options: {

--- a/src/m365/spo/commands/list/list-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-remove.ts
@@ -91,14 +91,9 @@ class SpoListRetentionLabelRemoveCommand extends SpoCommand {
       await this.removeListRetentionLabel(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the retention label from list '${args.options.listId || args.options.listTitle || args.options.listUrl}'?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the retention label from list '${args.options.listId || args.options.listTitle || args.options.listUrl}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeListRetentionLabel(logger, args);
       }
     }

--- a/src/m365/spo/commands/list/list-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-roleassignment-remove.spec.ts
@@ -20,7 +20,7 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -29,6 +29,13 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {
@@ -45,17 +52,19 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
       Cli.executeCommandWithOutput,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -302,11 +311,6 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -321,11 +325,6 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -349,8 +348,8 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
       throw new CommandError('Unknown case');
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/list/list-roleassignment-remove.ts
+++ b/src/m365/spo/commands/list/list-roleassignment-remove.ts
@@ -155,14 +155,9 @@ class SpoListRoleAssignmentRemoveCommand extends SpoCommand {
       await removeRoleAssignment();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove role assignment from list ${args.options.listId || args.options.listTitle} from site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove role assignment from list ${args.options.listId || args.options.listTitle} from site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeRoleAssignment();
       }
     }

--- a/src/m365/spo/commands/list/list-roleinheritance-break.spec.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-break.spec.ts
@@ -19,7 +19,7 @@ describe(commands.LIST_ROLEINHERITANCE_BREAK, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -44,16 +44,17 @@ describe(commands.LIST_ROLEINHERITANCE_BREAK, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -272,8 +273,8 @@ describe(commands.LIST_ROLEINHERITANCE_BREAK, () => {
   });
 
   it('aborts breaking role inheritance when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     const postSpy = sinon.spy(request, 'post');
     await command.action(logger, {
@@ -294,11 +295,6 @@ describe(commands.LIST_ROLEINHERITANCE_BREAK, () => {
         listTitle: 'test'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
@@ -310,11 +306,6 @@ describe(commands.LIST_ROLEINHERITANCE_BREAK, () => {
         listId: '202b8199-b9de-43fd-9737-7f213f51c991'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
@@ -327,8 +318,8 @@ describe(commands.LIST_ROLEINHERITANCE_BREAK, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/list/list-roleinheritance-break.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-break.ts
@@ -140,14 +140,9 @@ class SpoListRoleInheritanceBreakCommand extends SpoCommand {
       await breakListRoleInheritance();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to break the role inheritance of ${args.options.listId ?? args.options.listTitle}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to break the role inheritance of ${args.options.listId ?? args.options.listTitle}?` });
 
-      if (result.continue) {
+      if (result) {
         await breakListRoleInheritance();
       }
     }

--- a/src/m365/spo/commands/list/list-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/list/list-roleinheritance-reset.ts
@@ -130,14 +130,9 @@ class SpoListRoleInheritanceResetCommand extends SpoCommand {
       await resetListRoleInheritance();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to reset the role inheritance of ${args.options.listId ?? args.options.listTitle}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to reset the role inheritance of ${args.options.listId ?? args.options.listTitle}?` });
 
-      if (result.continue) {
+      if (result) {
         await resetListRoleInheritance();
       }
     }

--- a/src/m365/spo/commands/list/list-sensitivitylabel-ensure.spec.ts
+++ b/src/m365/spo/commands/list/list-sensitivitylabel-ensure.spec.ts
@@ -49,6 +49,13 @@ describe(commands.LIST_SENSITIVITYLABEL_ENSURE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/list/list-view-field-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-view-field-remove.spec.ts
@@ -18,7 +18,7 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   const stubAllGetRequests: any = () => {
     return sinon.stub(request, 'get').callsFake(async (opts) => {
@@ -103,17 +103,19 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -168,20 +170,13 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
 
   it('prompts before removing field from list view when confirmation argument not passed (list title, view id, field title)', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', viewId: 'cc27a922-8224-4296-90a5-ebbc54da2e81', title: 'Created By' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing field by title from list view when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', viewId: 'cc27a922-8224-4296-90a5-ebbc54da2e81', title: 'Created By' } });
     assert(requests.length === 0);
   });
@@ -203,10 +198,8 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', viewId: 'cc27a922-8224-4296-90a5-ebbc54da2e81', title: 'Created By' } });
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -265,8 +258,8 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listId: '0cd891ef-afce-4e55-b836-fce03286cccf', viewTitle: 'MyView', title: 'Created By' } });
     let correctRequestIssued = false;
@@ -297,8 +290,8 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listId: '0cd891ef-afce-4e55-b836-fce03286cccf', viewId: 'cc27a922-8224-4296-90a5-ebbc54da2e81', title: 'Created By' } });
     let correctRequestIssued = false;
@@ -329,8 +322,8 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { verbose: true, webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', viewId: 'cc27a922-8224-4296-90a5-ebbc54da2e81', id: '330f29c5-5c4c-465f-9f4b-7903020ae1ce' } });
     let correctRequestIssued = false;
@@ -361,8 +354,8 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', viewTitle: 'MyView', id: '330f29c5-5c4c-465f-9f4b-7903020ae1ce' } });
     let correctRequestIssued = false;
@@ -393,8 +386,8 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listId: '0cd891ef-afce-4e55-b836-fce03286cccf', viewTitle: 'MyView', id: '330f29c5-5c4c-465f-9f4b-7903020ae1ce' } });
     let correctRequestIssued = false;
@@ -425,8 +418,8 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listId: '0cd891ef-afce-4e55-b836-fce03286cccf', viewId: 'cc27a922-8224-4296-90a5-ebbc54da2e81', id: '330f29c5-5c4c-465f-9f4b-7903020ae1ce' } });
     let correctRequestIssued = false;
@@ -457,8 +450,8 @@ describe(commands.LIST_VIEW_FIELD_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listUrl: '/sites/ninja/Shared Documents', viewId: 'cc27a922-8224-4296-90a5-ebbc54da2e81', id: '330f29c5-5c4c-465f-9f4b-7903020ae1ce' } });
     let correctRequestIssued = false;

--- a/src/m365/spo/commands/list/list-view-field-remove.ts
+++ b/src/m365/spo/commands/list/list-view-field-remove.ts
@@ -175,14 +175,9 @@ class SpoListViewFieldRemoveCommand extends SpoCommand {
       await removeFieldFromView();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the field ${args.options.id || args.options.title} from the view ${args.options.viewId || args.options.viewTitle} from list ${args.options.listId || args.options.listTitle} in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the field ${args.options.id || args.options.title} from the view ${args.options.viewId || args.options.viewTitle} from list ${args.options.listId || args.options.listTitle} in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeFieldFromView();
       }
     }

--- a/src/m365/spo/commands/list/list-view-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-view-remove.spec.ts
@@ -26,7 +26,6 @@ describe(commands.LIST_VIEW_REMOVE, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -50,16 +49,13 @@ describe(commands.LIST_VIEW_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
-    });
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -96,7 +92,10 @@ describe(commands.LIST_VIEW_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified view from list by id and listTitle when confirm option not passed', async () => {
+  it('prompts before removing the specified view from list by id and listTitle when force option not passed', async () => {
+    sinonUtil.restore(Cli.promptForConfirmation);
+    const confirmationStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
+
     await command.action(logger, {
       options: {
         webUrl: webUrl,
@@ -105,16 +104,13 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-
-    assert(promptIssued);
+    assert(confirmationStub.calledOnce);
   });
 
-  it('prompts before removing the specified view from list by title and listId when confirm option not passed', async () => {
+  it('prompts before removing the specified view from list by title and listId when force option not passed', async () => {
+    sinonUtil.restore(Cli.promptForConfirmation);
+    const confirmationStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
+
     await command.action(logger, {
       options: {
         webUrl: webUrl,
@@ -123,16 +119,13 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-
-    assert(promptIssued);
+    assert(confirmationStub.calledOnce);
   });
 
-  it('prompts before removing the specified view from list by title and listUrl when confirm option not passed', async () => {
+  it('prompts before removing the specified view from list by title and listUrl when force option not passed', async () => {
+    sinonUtil.restore(Cli.promptForConfirmation);
+    const confirmationStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
+
     await command.action(logger, {
       options: {
         webUrl: webUrl,
@@ -141,13 +134,7 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-
-    assert(promptIssued);
+    assert(confirmationStub.calledOnce);
   });
 
   it('aborts removing view from list when prompt not confirmed', async () => {
@@ -174,10 +161,8 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -198,8 +183,8 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -221,8 +206,8 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -244,8 +229,8 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -266,8 +251,8 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -289,8 +274,8 @@ describe(commands.LIST_VIEW_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/list/list-view-remove.ts
+++ b/src/m365/spo/commands/list/list-view-remove.ts
@@ -156,14 +156,9 @@ class SpoListViewRemoveCommand extends SpoCommand {
       await removeViewFromList();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the view ${args.options.id || args.options.title} from the list ${args.options.listId || args.options.listTitle || args.options.listUrl} in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the view ${args.options.id || args.options.title} from the list ${args.options.listId || args.options.listTitle || args.options.listUrl} in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeViewFromList();
       }
     }

--- a/src/m365/spo/commands/list/list-webhook-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-webhook-remove.spec.ts
@@ -21,7 +21,7 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -47,16 +47,17 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -76,42 +77,25 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
 
   it('prompts before removing webhook from list when confirmation argument not passed (list title)', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('prompts before removing webhook from list when confirmation argument not passed (list url)', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listUrl: '/sites/ninja/Documents', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('prompts before removing list when confirmation argument not passed (list id)', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listId: '0cd891ef-afce-4e55-b836-fce03286cccf', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing list when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
     assert(requests.length === 0);
   });
@@ -131,8 +115,8 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
     let correctRequestIssued = false;
@@ -161,8 +145,8 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listTitle: 'Documents', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
     let correctRequestIssued = false;
@@ -191,8 +175,8 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listId: 'dfddade1-4729-428d-881e-7fedf3cae50d', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
     let correctRequestIssued = false;
@@ -221,8 +205,8 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/ninja', listId: 'dfddade1-4729-428d-881e-7fedf3cae50d', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
     let correctRequestIssued = false;
@@ -305,8 +289,8 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/ninja', listUrl: '/sites/ninja/lists/Documents', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
     let correctRequestIssued = false;
@@ -335,8 +319,8 @@ describe(commands.LIST_WEBHOOK_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, webUrl: 'https://contoso.sharepoint.com/sites/ninja', listUrl: '/sites/ninja/lists/Documents', id: 'cc27a922-8224-4296-90a5-ebbc54da2e81' } });
     let correctRequestIssued = false;

--- a/src/m365/spo/commands/list/list-webhook-remove.ts
+++ b/src/m365/spo/commands/list/list-webhook-remove.ts
@@ -143,14 +143,9 @@ class SpoListWebhookRemoveCommand extends SpoCommand {
       await removeWebhook();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove webhook ${args.options.id} from list ${args.options.listTitle || args.options.listId || args.options.listUrl} located at site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove webhook ${args.options.id} from list ${args.options.listTitle || args.options.listId || args.options.listUrl} located at site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeWebhook();
       }
     }

--- a/src/m365/spo/commands/listitem/listitem-remove.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-remove.spec.ts
@@ -26,7 +26,7 @@ describe(commands.LISTITEM_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -52,16 +52,17 @@ describe(commands.LISTITEM_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -81,31 +82,19 @@ describe(commands.LISTITEM_REMOVE, () => {
 
   it('prompts before removing list item when confirmation argument not passed (id)', async () => {
     await command.action(logger, { options: { id: 1, webUrl: 'https://contoso.sharepoint.com', listTitle: 'Documents' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('prompts before removing list item when confirmation argument not passed (title)', async () => {
     await command.action(logger, { options: { listTitle: 'My list', webUrl: 'https://contoso.sharepoint.com', id: 1 } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts removing list item when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { listTitle: 'My list', webUrl: 'https://contoso.sharepoint.com', id: 1 } });
     assert(requests.length === 0);
   });
@@ -125,10 +114,8 @@ describe(commands.LISTITEM_REMOVE, () => {
       return Promise.reject('Invalid request');
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { listId: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', id: 1 } });
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -154,10 +141,8 @@ describe(commands.LISTITEM_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { verbose: true, listUrl: listUrl, webUrl: webUrl, id: 1 } });
     let correctRequestIssued = false;
     requests.forEach(r => {
@@ -186,10 +171,8 @@ describe(commands.LISTITEM_REMOVE, () => {
       return Promise.reject('Invalid request');
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { listId: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', id: 1, recycle: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {

--- a/src/m365/spo/commands/listitem/listitem-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-remove.ts
@@ -154,14 +154,9 @@ class SpoListItemRemoveCommand extends SpoCommand {
       await removeListItem();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to ${args.options.recycle ? "recycle" : "remove"} the list item ${args.options.id} from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.recycle ? "recycle" : "remove"} the list item ${args.options.id} from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeListItem();
       }
     }

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-remove.ts
@@ -105,14 +105,9 @@ class SpoListItemRetentionLabelRemoveCommand extends SpoCommand {
       await this.removeListItemRetentionLabel(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the retentionlabel from list item ${args.options.listItemId} from list '${args.options.listId || args.options.listTitle || args.options.listUrl}' located in site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the retentionlabel from list item ${args.options.listItemId} from list '${args.options.listId || args.options.listTitle || args.options.listUrl}' located in site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeListItemRetentionLabel(logger, args);
       }
     }

--- a/src/m365/spo/commands/listitem/listitem-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleassignment-remove.spec.ts
@@ -20,7 +20,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -45,17 +45,19 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
       Cli.executeCommandWithOutput,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -321,11 +323,6 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_REMOVE, () => {
         groupName: 'someGroup'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
@@ -339,11 +336,6 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_REMOVE, () => {
         groupName: 'someGroup'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -367,10 +359,8 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_REMOVE, () => {
       throw new CommandError('Unknown case');
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         debug: true,

--- a/src/m365/spo/commands/listitem/listitem-roleassignment-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleassignment-remove.ts
@@ -128,14 +128,9 @@ class SpoListItemRoleAssignmentRemoveCommand extends SpoCommand {
       await this.removeRoleAssignment(logger, args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove role assignment from listitem ${args.options.listItemId} from list ${args.options.listId || args.options.listTitle} from site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove role assignment from listitem ${args.options.listItemId} from list ${args.options.listId || args.options.listTitle} from site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeRoleAssignment(logger, args.options);
       }
     }

--- a/src/m365/spo/commands/listitem/listitem-roleinheritance-break.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleinheritance-break.ts
@@ -112,14 +112,9 @@ class SpoListItemRoleInheritanceBreakCommand extends SpoCommand {
       await this.breakListItemRoleInheritance(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to break the role inheritance of ${args.options.listItemId} in list ${args.options.listId ?? args.options.listTitle}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to break the role inheritance of ${args.options.listItemId} in list ${args.options.listId ?? args.options.listTitle}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.breakListItemRoleInheritance(args.options);
       }
     }

--- a/src/m365/spo/commands/listitem/listitem-roleinheritance-reset.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleinheritance-reset.spec.ts
@@ -19,7 +19,7 @@ describe(commands.LISTITEM_ROLEINHERITANCE_RESET, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -43,16 +43,18 @@ describe(commands.LISTITEM_ROLEINHERITANCE_RESET, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -222,10 +224,8 @@ describe(commands.LISTITEM_ROLEINHERITANCE_RESET, () => {
 
   it('aborts resetting role inheritance when prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, {
       options: {
         debug: true,
@@ -247,11 +247,6 @@ describe(commands.LISTITEM_ROLEINHERITANCE_RESET, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -266,11 +261,6 @@ describe(commands.LISTITEM_ROLEINHERITANCE_RESET, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -284,10 +274,8 @@ describe(commands.LISTITEM_ROLEINHERITANCE_RESET, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         debug: true,

--- a/src/m365/spo/commands/listitem/listitem-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleinheritance-reset.ts
@@ -107,14 +107,9 @@ class SpoListItemRoleInheritanceResetCommand extends SpoCommand {
       await this.resetListItemRoleInheritance(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to reset the role inheritance of ${args.options.listItemId} in list ${args.options.listId ?? args.options.listTitle}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to reset the role inheritance of ${args.options.listItemId} in list ${args.options.listId ?? args.options.listTitle}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.resetListItemRoleInheritance(args.options);
       }
     }

--- a/src/m365/spo/commands/navigation/navigation-node-remove.spec.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-remove.spec.ts
@@ -20,7 +20,7 @@ describe(commands.NAVIGATION_NODE_REMOVE, () => {
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
   let loggerLogToStderrSpy: sinon.SinonSpy;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -52,18 +52,19 @@ describe(commands.NAVIGATION_NODE_REMOVE, () => {
     };
     loggerLogSpy = sinon.spy(logger, 'log');
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -108,11 +109,6 @@ describe(commands.NAVIGATION_NODE_REMOVE, () => {
 
   it('prompts before removing navigation node when confirmation argument not passed', async () => {
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/team-a', location: 'TopNavigationBar', id: '2003' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -121,10 +117,8 @@ describe(commands.NAVIGATION_NODE_REMOVE, () => {
     sinon.stub(request, 'delete').callsFake(() => {
       throw 'Invalid request';
     });
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/team-a', location: 'TopNavigationBar', id: '2003' } });
   });
 
@@ -137,10 +131,8 @@ describe(commands.NAVIGATION_NODE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/team-a', location: 'TopNavigationBar', id: '2003' } });
     assert(loggerLogSpy.notCalled);
   });

--- a/src/m365/spo/commands/navigation/navigation-node-remove.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-remove.ts
@@ -90,14 +90,9 @@ class SpoNavigationNodeRemoveCommand extends SpoCommand {
       await this.removeNode(logger, args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the node ${args.options.id} from the navigation?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the node ${args.options.id} from the navigation?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeNode(logger, args.options);
       }
     }

--- a/src/m365/spo/commands/orgassetslibrary/orgassetslibrary-remove.spec.ts
+++ b/src/m365/spo/commands/orgassetslibrary/orgassetslibrary-remove.spec.ts
@@ -17,7 +17,7 @@ import command from './orgassetslibrary-remove.js';
 describe(commands.ORGASSETSLIBRARY_REMOVE, () => {
   let log: any[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -47,17 +47,18 @@ describe(commands.ORGASSETSLIBRARY_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -75,24 +76,17 @@ describe(commands.ORGASSETSLIBRARY_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('prompts before removing the Org Assets Library when confirm option is not passed', async () => {
+  it('prompts before removing the Org Assets Library when force option is not passed', async () => {
     await command.action(logger, { options: { debug: true } } as any);
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
-  it('aborts removing the Org Assets Library when confirm option is not passed and prompt not confirmed', async () => {
+  it('aborts removing the Org Assets Library when force option is not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: {} });
     assert(postSpy.notCalled);
@@ -120,10 +114,8 @@ describe(commands.ORGASSETSLIBRARY_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { libraryUrl: '/sites/branding/assets' } });
     assert(orgAssetLibRemoveCallIssued);
   });
@@ -176,10 +168,8 @@ describe(commands.ORGASSETSLIBRARY_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { libraryUrl: '/sites/branding/assets', output: 'json' } });
     assert(orgAssetLibRemoveCallIssued);
   });

--- a/src/m365/spo/commands/orgassetslibrary/orgassetslibrary-remove.ts
+++ b/src/m365/spo/commands/orgassetslibrary/orgassetslibrary-remove.ts
@@ -47,14 +47,9 @@ class SpoOrgAssetsLibraryRemoveCommand extends SpoCommand {
       await this.removeLibrary(logger, args.options.libraryUrl);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the library ${args.options.libraryUrl} as a central location for organization assets?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the library ${args.options.libraryUrl} as a central location for organization assets?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeLibrary(logger, args.options.libraryUrl);
       }
     }

--- a/src/m365/spo/commands/orgnewssite/orgnewssite-remove.ts
+++ b/src/m365/spo/commands/orgnewssite/orgnewssite-remove.ts
@@ -65,14 +65,9 @@ class SpoOrgNewsSiteRemoveCommand extends SpoCommand {
       await this.removeOrgNewsSite(logger, args.options.url);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove ${args.options.url} from the list of organizational news sites?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove ${args.options.url} from the list of organizational news sites?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeOrgNewsSite(logger, args.options.url);
       }
     }

--- a/src/m365/spo/commands/page/page-remove.spec.ts
+++ b/src/m365/spo/commands/page/page-remove.spec.ts
@@ -20,7 +20,7 @@ describe(commands.PAGE_REMOVE, () => {
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
   let loggerLogToStderrSpy: sinon.SinonSpy;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   const fakeRestCalls: (pageName?: string) => sinon.SinonStub = (pageName: string = 'page.aspx') => {
     return sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -63,16 +63,18 @@ describe(commands.PAGE_REMOVE, () => {
     };
     loggerLogSpy = sinon.spy(logger, 'log');
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -139,11 +141,8 @@ describe(commands.PAGE_REMOVE, () => {
 
   it('removes a modern page with confirm prompt', async () => {
     fakeRestCalls();
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: true };
-    });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger,
       {
         options: {
@@ -156,11 +155,8 @@ describe(commands.PAGE_REMOVE, () => {
 
   it('removes a modern page (debug) with confirm prompt', async () => {
     fakeRestCalls();
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: true };
-    });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger,
       {
         options: {
@@ -182,21 +178,14 @@ describe(commands.PAGE_REMOVE, () => {
           webUrl: 'https://contoso.sharepoint.com/sites/team-a'
         }
       });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('should abort page removal when prompt not confirmed', async () => {
     const postCallSpy = fakeRestCalls();
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger,
       {
         options: {
@@ -210,10 +199,8 @@ describe(commands.PAGE_REMOVE, () => {
 
   it('automatically appends the .aspx extension', async () => {
     fakeRestCalls();
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger,
       {
         options: {
@@ -230,10 +217,8 @@ describe(commands.PAGE_REMOVE, () => {
       throw { error: { 'odata.error': { message: { value: 'An error has occurred' } } } };
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await assert.rejects(command.action(logger,
       {
         options: {

--- a/src/m365/spo/commands/page/page-remove.ts
+++ b/src/m365/spo/commands/page/page-remove.ts
@@ -59,15 +59,9 @@ class SpoPageRemoveCommand extends SpoCommand {
       await this.removePage(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>(
-        {
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `Are you sure you want to remove the page '${args.options.name}'?`
-        });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the page '${args.options.name}'?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removePage(logger, args);
       }
     }

--- a/src/m365/spo/commands/propertybag/propertybag-remove.spec.ts
+++ b/src/m365/spo/commands/propertybag/propertybag-remove.spec.ts
@@ -22,7 +22,7 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   const stubAllPostRequests = (
     requestObjectIdentityResp: any = null,
     folderObjectIdentityResp: any = null,
@@ -121,11 +121,11 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+    promptIssued = false;
   });
 
   afterEach(() => {
@@ -133,7 +133,7 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
       request.post,
       (command as any).removePropertyWithIdentityResp,
       (command as any).removeProperty,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -173,11 +173,6 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
         key: 'key1'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -185,10 +180,8 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
   it('should abort property remove when prompt not confirmed', async () => {
     const postCallsSpy: sinon.SinonStub = stubAllPostRequests();
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, {
       options: {
         webUrl: 'https://contoso.sharepoint.com',
@@ -202,10 +195,8 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
     const postCallsSpy: sinon.SinonStub = stubAllPostRequests();
     const removePropertySpy = sinon.spy((command as any), 'removeProperty');
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         webUrl: 'https://contoso.sharepoint.com',

--- a/src/m365/spo/commands/propertybag/propertybag-remove.ts
+++ b/src/m365/spo/commands/propertybag/propertybag-remove.ts
@@ -74,14 +74,9 @@ class SpoPropertyBagRemoveCommand extends SpoPropertyBagBaseCommand {
       await this.removeProperty(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the ${args.options.key} property?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the ${args.options.key} property?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeProperty(args);
       }
     }

--- a/src/m365/spo/commands/roledefinition/roledefinition-remove.ts
+++ b/src/m365/spo/commands/roledefinition/roledefinition-remove.ts
@@ -73,14 +73,9 @@ class SpoRoleDefinitionRemoveCommand extends SpoCommand {
       await this.removeRoleDefinition(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the role definition with id ${args.options.id} from site ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the role definition with id ${args.options.id} from site ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeRoleDefinition(logger, args);
       }
     }

--- a/src/m365/spo/commands/serviceprincipal/serviceprincipal-set.spec.ts
+++ b/src/m365/spo/commands/serviceprincipal/serviceprincipal-set.spec.ts
@@ -20,7 +20,7 @@ describe(commands.SERVICEPRINCIPAL_SET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
@@ -52,17 +52,18 @@ describe(commands.SERVICEPRINCIPAL_SET, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -189,32 +190,20 @@ describe(commands.SERVICEPRINCIPAL_SET, () => {
 
   it('prompts before enabling service principal when confirmation argument not passed', async () => {
     await command.action(logger, { options: { enabled: true } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('prompts before disabling service principal when confirmation argument not passed', async () => {
     await command.action(logger, { options: { enabled: false } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
   it('aborts enabling service principal when prompt not confirmed', async () => {
     const requestPostSpy = sinon.spy(request, 'post');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, { options: { enabled: true } });
     assert(requestPostSpy.notCalled);
   });
@@ -232,10 +221,8 @@ describe(commands.SERVICEPRINCIPAL_SET, () => {
       }
     ]));
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { enabled: true } });
     assert(loggerLogSpy.calledWith({
       AccountEnabled: true,

--- a/src/m365/spo/commands/serviceprincipal/serviceprincipal-set.ts
+++ b/src/m365/spo/commands/serviceprincipal/serviceprincipal-set.ts
@@ -66,14 +66,9 @@ class SpoServicePrincipalSetCommand extends SpoCommand {
       await this.toggleServicePrincipal(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to ${args.options.enabled ? 'enable' : 'disable'} the service principal?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.enabled ? 'enable' : 'disable'} the service principal?` });
 
-      if (result.continue) {
+      if (result) {
         await this.toggleServicePrincipal(logger, args);
       }
     }

--- a/src/m365/spo/commands/site/site-apppermission-remove.spec.ts
+++ b/src/m365/spo/commands/site/site-apppermission-remove.spec.ts
@@ -19,7 +19,7 @@ describe(commands.SITE_APPPERMISSION_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   let deleteRequestStub: sinon.SinonStub;
 
@@ -83,12 +83,12 @@ describe(commands.SITE_APPPERMISSION_REMOVE, () => {
       }
     };
 
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
 
-    promptOptions = undefined;
+    promptIssued = false;
 
     deleteRequestStub = sinon.stub(request, 'delete').callsFake(async (opts) => {
       if ((opts.url as string).indexOf('/permissions/') > -1) {
@@ -103,7 +103,7 @@ describe(commands.SITE_APPPERMISSION_REMOVE, () => {
       request.get,
       request.delete,
       global.setTimeout,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -252,27 +252,20 @@ describe(commands.SITE_APPPERMISSION_REMOVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('prompts before removing the site apppermission when confirm option not passed', async () => {
+  it('prompts before removing the site apppermission when force option not passed', async () => {
     await command.action(logger, {
       options: {
         siteUrl: 'https://contoso.sharepoint.com/sites/sitecollection-name',
         appDisplayName: 'Foo'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
   it('aborts removing the site apppermission when prompt not confirmed', async () => {
-    sinonUtil.restore(Cli.prompt);
+    sinonUtil.restore(Cli.promptForConfirmation);
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
       options: {
@@ -284,11 +277,9 @@ describe(commands.SITE_APPPERMISSION_REMOVE, () => {
   });
 
   it('removes site apppermission when prompt confirmed (debug)', async () => {
-    sinonUtil.restore(Cli.prompt);
+    sinonUtil.restore(Cli.promptForConfirmation);
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     const getRequestStub = sinon.stub(request, 'get');
     getRequestStub.onCall(0)
@@ -318,11 +309,9 @@ describe(commands.SITE_APPPERMISSION_REMOVE, () => {
   });
 
   it('removes site apppermission with specified appId', async () => {
-    sinonUtil.restore(Cli.prompt);
+    sinonUtil.restore(Cli.promptForConfirmation);
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     const getRequestStub = sinon.stub(request, 'get');
     getRequestStub.onCall(0)
@@ -352,11 +341,9 @@ describe(commands.SITE_APPPERMISSION_REMOVE, () => {
   });
 
   it('removes site apppermission with specified appDisplayName', async () => {
-    sinonUtil.restore(Cli.prompt);
+    sinonUtil.restore(Cli.promptForConfirmation);
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     const getRequestStub = sinon.stub(request, 'get');
     getRequestStub.onCall(0)

--- a/src/m365/spo/commands/site/site-apppermission-remove.ts
+++ b/src/m365/spo/commands/site/site-apppermission-remove.ts
@@ -144,14 +144,9 @@ class SpoSiteAppPermissionRemoveCommand extends GraphCommand {
       await this.removeSiteAppPermission(logger, args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the specified application permission from site ${args.options.siteUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the specified application permission from site ${args.options.siteUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeSiteAppPermission(logger, args.options);
       }
     }

--- a/src/m365/spo/commands/site/site-commsite-enable.spec.ts
+++ b/src/m365/spo/commands/site/site-commsite-enable.spec.ts
@@ -28,6 +28,13 @@ describe(commands.SITE_COMMSITE_ENABLE, () => {
     sinon.stub(session, 'getId').resolves();
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/site/site-hubsite-disconnect.ts
+++ b/src/m365/spo/commands/site/site-hubsite-disconnect.ts
@@ -63,14 +63,9 @@ class SpoSiteHubSiteDisconnectCommand extends SpoCommand {
       await this.disconnectHubSite(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to disconnect the site collection ${args.options.siteUrl} from its hub site?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to disconnect the site collection ${args.options.siteUrl} from its hub site?` });
 
-      if (result.continue) {
+      if (result) {
         await this.disconnectHubSite(logger, args);
       }
     }

--- a/src/m365/spo/commands/site/site-recyclebinitem-clear.ts
+++ b/src/m365/spo/commands/site/site-recyclebinitem-clear.ts
@@ -74,14 +74,9 @@ class SpoSiteRecycleBinItemClearCommand extends SpoCommand {
       await this.clearRecycleBin(args, logger);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to clear the recycle bin of site ${args.options.siteUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to clear the recycle bin of site ${args.options.siteUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.clearRecycleBin(args, logger);
       }
     }

--- a/src/m365/spo/commands/site/site-recyclebinitem-move.ts
+++ b/src/m365/spo/commands/site/site-recyclebinitem-move.ts
@@ -90,14 +90,9 @@ class SpoSiteRecycleBinItemMoveCommand extends SpoCommand {
       await this.moveRecycleBinItem(args, logger);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: 'Are you sure you want to move these items to the second-stage recycle bin?'
-      });
+      const result = await Cli.promptForConfirmation({ message: 'Are you sure you want to move these items to the second-stage recycle bin?' });
 
-      if (result.continue) {
+      if (result) {
         await this.moveRecycleBinItem(args, logger);
       }
     }

--- a/src/m365/spo/commands/site/site-recyclebinitem-remove.spec.ts
+++ b/src/m365/spo/commands/site/site-recyclebinitem-remove.spec.ts
@@ -17,7 +17,7 @@ describe(commands.SITE_RECYCLEBINITEM_REMOVE, () => {
 
   let log: any[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -42,17 +42,18 @@ describe(commands.SITE_RECYCLEBINITEM_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -84,23 +85,18 @@ describe(commands.SITE_RECYCLEBINITEM_REMOVE, () => {
     assert(actual);
   });
 
-  it('prompts before removing the items from the recycle bin when confirm option not passed', async () => {
+  it('prompts before removing the items from the recycle bin when force option not passed', async () => {
     await command.action(logger, {
       options: {
         siteUrl: 'https://contoso.sharepoint.com',
         ids: '85528dee-00d5-4c38-a6ba-e2abace32f63,aecb840f-20e9-4ff8-accf-5df8eaad31a1'
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the items from the recycle bin when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the items from the recycle bin when force option not passed and prompt not confirmed', async () => {
     const postStub = sinon.stub(request, 'post').resolves();
     await command.action(logger, {
       options: {
@@ -112,7 +108,7 @@ describe(commands.SITE_RECYCLEBINITEM_REMOVE, () => {
     assert(postStub.notCalled);
   });
 
-  it('removes items from the recycle bin with ids and confirm option', async () => {
+  it('removes items from the recycle bin with ids and force option', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `https://contoso.sharepoint.com/_api/site/RecycleBin/DeleteByIds`) {
         return {
@@ -144,10 +140,8 @@ describe(commands.SITE_RECYCLEBINITEM_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/site/site-recyclebinitem-remove.ts
+++ b/src/m365/spo/commands/site/site-recyclebinitem-remove.ts
@@ -77,14 +77,9 @@ class SpoSiteRecycleBinItemRemoveCommand extends SpoCommand {
       await this.removeRecycleBinItem(args, logger);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to permanently delete ${args.options.ids.split(',').length} item(s) from the site recycle bin?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to permanently delete ${args.options.ids.split(',').length} item(s) from the site recycle bin?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeRecycleBinItem(args, logger);
       }
     }

--- a/src/m365/spo/commands/site/site-remove.spec.ts
+++ b/src/m365/spo/commands/site/site-remove.spec.ts
@@ -52,9 +52,7 @@ describe(commands.SITE_REMOVE, () => {
     loggerLogSpy = sinon.spy(logger, 'log');
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
   });
 
   afterEach(() => {
@@ -65,7 +63,7 @@ describe(commands.SITE_REMOVE, () => {
       request.delete,
       global.setTimeout,
       spo.ensureFormDigest,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -142,10 +140,8 @@ describe(commands.SITE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { url: 'https://contoso.sharepoint.com/sites/demosite', debug: true, verbose: true } });
     assert(loggerLogToStderrSpy.called);
   });
@@ -982,10 +978,8 @@ describe(commands.SITE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { url: 'https://contoso.sharepoint.com/sites/demositeGrouped', debug: true, verbose: true, skipRecycleBin: true } });
   });
@@ -1080,10 +1074,8 @@ describe(commands.SITE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     sinon.stub(global, 'setTimeout').callsFake((fn) => {
       fn();

--- a/src/m365/spo/commands/site/site-remove.ts
+++ b/src/m365/spo/commands/site/site-remove.ts
@@ -85,14 +85,9 @@ class SpoSiteRemoveCommand extends SpoCommand {
       await this.removeSite(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the site ${args.options.url}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the site ${args.options.url}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeSite(logger, args);
       }
     }

--- a/src/m365/spo/commands/sitedesign/sitedesign-remove.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-remove.ts
@@ -69,14 +69,9 @@ class SpoSiteDesignRemoveCommand extends SpoCommand {
       await this.removeSiteDesign(logger, args.options.id);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the site design ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the site design ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeSiteDesign(logger, args.options.id);
       }
     }

--- a/src/m365/spo/commands/sitedesign/sitedesign-rights-revoke.spec.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-rights-revoke.spec.ts
@@ -19,7 +19,7 @@ describe(commands.SITEDESIGN_RIGHTS_REVOKE, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -51,17 +51,18 @@ describe(commands.SITEDESIGN_RIGHTS_REVOKE, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -79,7 +80,7 @@ describe(commands.SITEDESIGN_RIGHTS_REVOKE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('revokes access to the specified site design from the specified principal without prompting for confirmation when confirm option specified', async () => {
+  it('revokes access to the specified site design from the specified principal without prompting for confirmation when force option specified', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.RevokeSiteDesignRights`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
@@ -155,13 +156,8 @@ describe(commands.SITEDESIGN_RIGHTS_REVOKE, () => {
     assert(loggerLogSpy.notCalled);
   });
 
-  it('prompts before revoking access to the specified site design when confirm option not passed', async () => {
+  it('prompts before revoking access to the specified site design when force option not passed', async () => {
     await command.action(logger, { options: { siteDesignId: 'b2307a39-e878-458b-bc90-03bc578531d6', principals: 'PattiF' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -174,10 +170,8 @@ describe(commands.SITEDESIGN_RIGHTS_REVOKE, () => {
 
   it('revokes site design access when prompt confirmed', async () => {
     const postStub = sinon.stub(request, 'post').resolves();
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { siteDesignId: 'b2307a39-e878-458b-bc90-03bc578531d6', principals: 'PattiF' } });
     assert(postStub.called);

--- a/src/m365/spo/commands/sitedesign/sitedesign-rights-revoke.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-rights-revoke.ts
@@ -98,14 +98,9 @@ class SpoSiteDesignRightsRevokeCommand extends SpoCommand {
       await revokePermissions();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to revoke access to site design ${args.options.siteDesignId} from the specified users?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to revoke access to site design ${args.options.siteDesignId} from the specified users?` });
 
-      if (result.continue) {
+      if (result) {
         await revokePermissions();
       }
     }

--- a/src/m365/spo/commands/sitedesign/sitedesign-task-remove.spec.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-task-remove.spec.ts
@@ -19,7 +19,6 @@ describe(commands.SITEDESIGN_TASK_REMOVE, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -51,16 +50,13 @@ describe(commands.SITEDESIGN_TASK_REMOVE, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
-    });
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -77,7 +73,7 @@ describe(commands.SITEDESIGN_TASK_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('removes the specified site design task without prompting for confirmation when confirm option specified', async () => {
+  it('removes the specified site design task without prompting for confirmation when force option specified', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.RemoveSiteDesignTask`) > -1 &&
         JSON.stringify(opts.data) === JSON.stringify({
@@ -95,15 +91,13 @@ describe(commands.SITEDESIGN_TASK_REMOVE, () => {
     assert(loggerLogSpy.notCalled);
   });
 
-  it('prompts before removing the specified site design task when confirm option not passed', async () => {
+  it('prompts before removing the specified site design task when force option not passed', async () => {
+    sinonUtil.restore(Cli.promptForConfirmation);
+    const confirmationStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
+
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6' } });
-    let promptIssued = false;
 
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-
-    assert(promptIssued);
+    assert(confirmationStub.calledOnce);
   });
 
   it('aborts removing site design task when prompt not confirmed', async () => {
@@ -116,10 +110,8 @@ describe(commands.SITEDESIGN_TASK_REMOVE, () => {
   it('removes the site design task when prompt confirmed', async () => {
     const postStub = sinon.stub(request, 'post').resolves();
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6' } });
     assert(postStub.called);
   });

--- a/src/m365/spo/commands/sitedesign/sitedesign-task-remove.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-task-remove.ts
@@ -69,14 +69,9 @@ class SpoSiteDesignTaskRemoveCommand extends SpoCommand {
       await this.removeSiteDesignTask(logger, args.options.id);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the site design task ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the site design task ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeSiteDesignTask(logger, args.options.id);
       }
     }

--- a/src/m365/spo/commands/sitescript/sitescript-remove.ts
+++ b/src/m365/spo/commands/sitescript/sitescript-remove.ts
@@ -69,14 +69,9 @@ class SpoSiteScriptRemoveCommand extends SpoCommand {
       await this.removeSiteScript(logger, args.options.id);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the site script ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the site script ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeSiteScript(logger, args.options.id);
       }
     }

--- a/src/m365/spo/commands/storageentity/storageentity-remove.spec.ts
+++ b/src/m365/spo/commands/storageentity/storageentity-remove.spec.ts
@@ -20,7 +20,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   let cli: Cli;
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -53,16 +53,17 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -98,11 +99,6 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   it('prompts before removing tenant property when confirmation argument not passed', async () => {
 
     await command.action(logger, { options: { debug: true, key: 'existingproperty', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
@@ -121,10 +117,8 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, key: 'existingproperty', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } });
     assert.strictEqual(postStub.lastCall.args[0].url, 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery');
@@ -147,10 +141,8 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, { options: { debug: true, key: 'nonexistentproperty', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } } as any), new CommandError('File Not Found.'));
     assert.strictEqual(postStub.lastCall.args[0].url, 'https://contoso-admin.sharepoint.com/_vti_bin/client.svc/ProcessQuery');
@@ -224,10 +216,8 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
     sinonUtil.restore(spo.getRequestDigest);
     sinon.stub(spo, 'getRequestDigest').rejects(new Error('getRequestDigest error'));
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, { options: { debug: true, key: 'nonexistentproperty', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } } as any), new CommandError('getRequestDigest error'));
   });

--- a/src/m365/spo/commands/storageentity/storageentity-remove.ts
+++ b/src/m365/spo/commands/storageentity/storageentity-remove.ts
@@ -69,14 +69,9 @@ class SpoStorageEntityRemoveCommand extends SpoCommand {
       await this.removeTenantProperty(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to delete the ${args.options.key} tenant property?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to delete the ${args.options.key} tenant property?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeTenantProperty(logger, args);
       }
     }

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-remove.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-remove.ts
@@ -98,14 +98,9 @@ class SpoTenantApplicationCustomizerRemoveCommand extends SpoCommand {
         return await this.removeTenantApplicationCustomizer(logger, args);
       }
 
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the tenant applicationcustomizer ${args.options.id || args.options.title || args.options.clientSideComponentId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the tenant applicationcustomizer ${args.options.id || args.options.title || args.options.clientSideComponentId}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeTenantApplicationCustomizer(logger, args);
       }
     }

--- a/src/m365/spo/commands/tenant/tenant-commandset-get.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-get.spec.ts
@@ -63,6 +63,13 @@ describe(commands.TENANT_COMMANDSET_GET, () => {
     auth.service.connected = true;
     auth.service.spoUrl = spoUrl;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/spo/commands/tenant/tenant-commandset-remove.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-remove.spec.ts
@@ -52,7 +52,7 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     cli = Cli.getInstance();
@@ -63,6 +63,13 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
     auth.service.connected = true;
     auth.service.spoUrl = spoUrl;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {
@@ -78,20 +85,22 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.post,
-      Cli.prompt,
-      Cli.handleMultipleResultsFound,
-      cli.getSettingWithDefaultValue
+      cli.getSettingWithDefaultValue,
+      Cli.promptForConfirmation,
+      Cli.handleMultipleResultsFound
     ]);
   });
 
@@ -223,27 +232,20 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('prompts before removing the specified tenant command set when confirm option not passed', async () => {
+  it('prompts before removing the specified tenant command set when force option not passed', async () => {
     await command.action(logger, {
       options: {
         id: id
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified tenant command set when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified tenant command set when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'post');
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, {
       options: {
         id: id
@@ -311,10 +313,8 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -346,10 +346,8 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -381,10 +379,8 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -416,10 +412,8 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -529,10 +523,8 @@ describe(commands.TENANT_COMMANDSET_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/tenant/tenant-commandset-remove.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-remove.ts
@@ -98,14 +98,9 @@ class SpoTenantCommandSetRemoveCommand extends SpoCommand {
         return await this.removeTenantCommandSet(logger, args);
       }
 
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the tenant commandset ${args.options.id || args.options.title || args.options.clientSideComponentId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the tenant commandset ${args.options.id || args.options.title || args.options.clientSideComponentId}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeTenantCommandSet(logger, args);
       }
     }

--- a/src/m365/spo/commands/tenant/tenant-recyclebinitem-remove.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-recyclebinitem-remove.spec.ts
@@ -49,16 +49,14 @@ describe(commands.TENANT_RECYCLEBINITEM_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
       global.setTimeout,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -112,10 +110,8 @@ describe(commands.TENANT_RECYCLEBINITEM_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, { options: { siteUrl: 'https://contoso.sharepoint.com/sites/hr' } });
     sinonUtil.restore([
       request.post

--- a/src/m365/spo/commands/tenant/tenant-recyclebinitem-remove.ts
+++ b/src/m365/spo/commands/tenant/tenant-recyclebinitem-remove.ts
@@ -72,14 +72,9 @@ class SpoTenantRecycleBinItemRemoveCommand extends SpoCommand {
       await this.removeDeletedSite(logger, args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the deleted site collection ${args.options.siteUrl} from tenant recycle bin?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the deleted site collection ${args.options.siteUrl} from tenant recycle bin?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeDeletedSite(logger, args);
       }
     }

--- a/src/m365/spo/commands/theme/theme-remove.spec.ts
+++ b/src/m365/spo/commands/theme/theme-remove.spec.ts
@@ -15,7 +15,7 @@ import command from './theme-remove.js';
 describe(commands.THEME_REMOVE, () => {
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let loggerLogSpy: sinon.SinonSpy;
 
   before(() => {
@@ -41,17 +41,18 @@ describe(commands.THEME_REMOVE, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -71,11 +72,6 @@ describe(commands.THEME_REMOVE, () => {
 
   it('should prompt before removing theme when confirmation argument not passed', async () => {
     await command.action(logger, { options: { name: 'Contoso' } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -134,10 +130,8 @@ describe(commands.THEME_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -160,10 +154,8 @@ describe(commands.THEME_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, {
       options: {

--- a/src/m365/spo/commands/theme/theme-remove.ts
+++ b/src/m365/spo/commands/theme/theme-remove.ts
@@ -55,14 +55,9 @@ class SpoThemeRemoveCommand extends SpoCommand {
       await this.removeTheme(logger, args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the theme`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the theme` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeTheme(logger, args.options);
       }
     }

--- a/src/m365/spo/commands/user/user-remove.spec.ts
+++ b/src/m365/spo/commands/user/user-remove.spec.ts
@@ -19,7 +19,7 @@ describe(commands.USER_REMOVE, () => {
   let log: any[];
   let requests: any[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -46,17 +46,17 @@ describe(commands.USER_REMOVE, () => {
       }
     };
     requests = [];
-    promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -129,11 +129,6 @@ describe(commands.USER_REMOVE, () => {
         id: 10
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -146,11 +141,6 @@ describe(commands.USER_REMOVE, () => {
         loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
       }
     });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -216,10 +206,8 @@ describe(commands.USER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         webUrl: "https://contoso.sharepoint.com/subsite",
@@ -245,10 +233,8 @@ describe(commands.USER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         webUrl: "https://contoso.sharepoint.com/subsite",

--- a/src/m365/spo/commands/user/user-remove.ts
+++ b/src/m365/spo/commands/user/user-remove.ts
@@ -80,14 +80,9 @@ class SpoUserRemoveCommand extends SpoCommand {
       await this.removeUser(logger, args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove specified user from the site ${args.options.webUrl}`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove specified user from the site ${args.options.webUrl}` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeUser(logger, args.options);
       }
     }

--- a/src/m365/spo/commands/web/web-remove.ts
+++ b/src/m365/spo/commands/web/web-remove.ts
@@ -62,14 +62,9 @@ class SpoWebRemoveCommand extends SpoCommand {
       await this.removeWeb(logger, args.options.url);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the subsite ${args.options.url}`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the subsite ${args.options.url}` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeWeb(logger, args.options.url);
       }
     }

--- a/src/m365/spo/commands/web/web-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/web/web-roleassignment-remove.spec.ts
@@ -20,7 +20,7 @@ describe(commands.WEB_ROLEASSIGNMENT_REMOVE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
   let requests: any[];
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -45,17 +45,19 @@ describe(commands.WEB_ROLEASSIGNMENT_REMOVE, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.post,
       Cli.executeCommandWithOutput,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -245,11 +247,6 @@ describe(commands.WEB_ROLEASSIGNMENT_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
@@ -272,10 +269,8 @@ describe(commands.WEB_ROLEASSIGNMENT_REMOVE, () => {
       throw new CommandError('Unknown case');
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/spo/commands/web/web-roleassignment-remove.ts
+++ b/src/m365/spo/commands/web/web-roleassignment-remove.ts
@@ -98,14 +98,9 @@ class SpoWebRoleAssignmentRemoveCommand extends SpoCommand {
       await this.removeRoleAssignment(logger, args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove role assignment from web ${args.options.webUrl}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove role assignment from web ${args.options.webUrl}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeRoleAssignment(logger, args.options);
       }
     }

--- a/src/m365/spo/commands/web/web-roleinheritance-break.ts
+++ b/src/m365/spo/commands/web/web-roleinheritance-break.ts
@@ -78,14 +78,9 @@ class SpoWebRoleInheritanceBreakCommand extends SpoCommand {
       await this.breakRoleInheritance(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to break the role inheritance of subsite ${args.options.webUrl}`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to break the role inheritance of subsite ${args.options.webUrl}` });
 
-      if (result.continue) {
+      if (result) {
         await this.breakRoleInheritance(args.options);
       }
     }

--- a/src/m365/spo/commands/web/web-roleinheritance-reset.ts
+++ b/src/m365/spo/commands/web/web-roleinheritance-reset.ts
@@ -68,14 +68,9 @@ class SpoWebRoleInheritanceResetCommand extends SpoCommand {
       await this.resetWebRoleInheritance(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to reset the role inheritance of ${args.options.webUrl}`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to reset the role inheritance of ${args.options.webUrl}` });
 
-      if (result.continue) {
+      if (result) {
         await this.resetWebRoleInheritance(args.options);
       }
     }

--- a/src/m365/teams/commands/app/app-remove.spec.ts
+++ b/src/m365/teams/commands/app/app-remove.spec.ts
@@ -52,9 +52,9 @@ describe(commands.APP_REMOVE, () => {
     sinonUtil.restore([
       request.get,
       request.delete,
-      Cli.prompt,
+      cli.getSettingWithDefaultValue,
       Cli.handleMultipleResultsFound,
-      cli.getSettingWithDefaultValue
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -147,14 +147,14 @@ describe(commands.APP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, filePath: 'teamsapp.zip', id: `e3e29acb-8c79-412b-b746-e6c39ff4cd22` } });
     assert(removeTeamsAppCalled);
   });
 
   it('aborts removing Teams app when prompt not confirmed', async () => {
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     command.action(logger, { options: { id: `e3e29acb-8c79-412b-b746-e6c39ff4cd22` } });
     assert(requests.length === 0);
@@ -186,9 +186,10 @@ describe(commands.APP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { debug: true, name: 'TeamsApp' } });
+    await assert.doesNotReject(command.action(logger, { options: { debug: true, name: 'TeamsApp' } }));
     assert(removeTeamsAppCalled);
   });
 
@@ -216,10 +217,11 @@ describe(commands.APP_REMOVE, () => {
       throw 'Invalid request';
     });
 
+    sinonUtil.restore(Cli.promptForConfirmation);
     sinon.stub(Cli, 'handleMultipleResultsFound').resolves({ id: 'e3e29acb-8c79-412b-b746-e6c39ff4cd22' });
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { debug: true, name: 'TeamsApp' } });
+    await assert.doesNotReject(command.action(logger, { options: { debug: true, name: 'TeamsApp' } }));
     assert(removeTeamsAppCalled);
   });
 

--- a/src/m365/teams/commands/app/app-remove.ts
+++ b/src/m365/teams/commands/app/app-remove.ts
@@ -102,14 +102,9 @@ class TeamsAppRemoveCommand extends GraphCommand {
       await removeApp();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the Teams app ${args.options.id || args.options.name} from the app catalog?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the Teams app ${args.options.id || args.options.name} from the app catalog?` });
 
-      if (result.continue) {
+      if (result) {
         await removeApp();
       }
     }

--- a/src/m365/teams/commands/app/app-uninstall.spec.ts
+++ b/src/m365/teams/commands/app/app-uninstall.spec.ts
@@ -48,7 +48,7 @@ describe(commands.APP_UNINSTALL, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -104,7 +104,7 @@ describe(commands.APP_UNINSTALL, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     await command.action(logger, {
       options: {
         teamId: 'c527a470-a882-481c-981c-ee6efaba85c7',
@@ -115,7 +115,7 @@ describe(commands.APP_UNINSTALL, () => {
   });
 
   it('aborts uninstalling an app from a Microsoft Teams team when prompt not confirmed', async () => {
-    sinon.stub(Cli, 'prompt').resolves({ continue: false });
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
     command.action(logger, {
       options: {
         teamId: 'c527a470-a882-481c-981c-ee6efaba85c7',

--- a/src/m365/teams/commands/app/app-uninstall.ts
+++ b/src/m365/teams/commands/app/app-uninstall.ts
@@ -92,14 +92,9 @@ class TeamsAppUninstallCommand extends GraphCommand {
       await uninstallApp();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to uninstall the app with id ${args.options.id} from the Microsoft Teams team ${args.options.teamId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to uninstall the app with id ${args.options.id} from the Microsoft Teams team ${args.options.teamId}?` });
 
-      if (result.continue) {
+      if (result) {
         await uninstallApp();
       }
     }

--- a/src/m365/teams/commands/cache/cache-remove.ts
+++ b/src/m365/teams/commands/cache/cache-remove.ts
@@ -80,14 +80,9 @@ class TeamsCacheRemoveCommand extends AnonymousCommand {
         await logger.logToStderr('- Stop the Microsoft Teams client.');
         await logger.logToStderr('- Clear the Microsoft Teams cached files.');
 
-        const result = await Cli.prompt<{ continue: boolean }>({
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: `Are you sure you want to clear your Microsoft Teams cache?`
-        });
+        const result = await Cli.promptForConfirmation({ message: `Are you sure you want to clear your Microsoft Teams cache?` });
 
-        if (result.continue) {
+        if (result) {
           await this.clearTeamsCache(logger);
         }
       }

--- a/src/m365/teams/commands/channel/channel-member-add.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.spec.ts
@@ -193,6 +193,13 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
     commandInfo = Cli.getCommandInfo(command);
+    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
+      if (settingName === 'prompt') {
+        return false;
+      }
+
+      return defaultValue;
+    });
   });
 
   beforeEach(() => {

--- a/src/m365/teams/commands/channel/channel-member-remove.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.ts
@@ -146,14 +146,9 @@ class TeamsChannelMemberRemoveCommand extends GraphCommand {
       const userName = args.options.userName || args.options.userId || args.options.id;
       const teamName = args.options.teamName || args.options.teamId;
       const channelName = args.options.channelName || args.options.channelId;
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the member ${userName} from the channel ${channelName} in team ${teamName}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the member ${userName} from the channel ${channelName} in team ${teamName}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeMember();
       }
     }

--- a/src/m365/teams/commands/channel/channel-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-remove.spec.ts
@@ -22,7 +22,7 @@ describe(commands.CHANNEL_REMOVE, () => {
 
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -47,18 +47,19 @@ describe(commands.CHANNEL_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -134,7 +135,7 @@ describe(commands.CHANNEL_REMOVE, () => {
     }), new CommandError(errorMessage));
   });
 
-  it('prompts before removing the specified channel when confirm option not passed (debug)', async () => {
+  it('prompts before removing the specified channel when force option not passed (debug)', async () => {
     await command.action(logger, {
       options: {
         debug: true,
@@ -143,16 +144,11 @@ describe(commands.CHANNEL_REMOVE, () => {
       }
     });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified channel when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified channel when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
 
     await command.action(logger, {
@@ -194,7 +190,7 @@ describe(commands.CHANNEL_REMOVE, () => {
     }), new CommandError(errorMessage));
   });
 
-  it('removes specified channel when id is passed with confirm option', async () => {
+  it('removes specified channel when id is passed with force option', async () => {
     sinon.stub(request, 'delete').returns(Promise.resolve());
 
     await command.action(logger, {
@@ -215,10 +211,8 @@ describe(commands.CHANNEL_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -253,8 +247,8 @@ describe(commands.CHANNEL_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
@@ -293,8 +287,8 @@ describe(commands.CHANNEL_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/teams/commands/channel/channel-remove.ts
+++ b/src/m365/teams/commands/channel/channel-remove.ts
@@ -130,14 +130,9 @@ class TeamsChannelRemoveCommand extends GraphCommand {
     }
     else {
       const channel = args.options.name ? args.options.name : args.options.id;
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the channel ${channel} from team ${args.options.teamId || args.options.teamName}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the channel ${channel} from team ${args.options.teamId || args.options.teamName}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeChannel();
       }
     }

--- a/src/m365/teams/commands/chat/chat-member-remove.spec.ts
+++ b/src/m365/teams/commands/chat/chat-member-remove.spec.ts
@@ -43,7 +43,7 @@ describe(commands.CHAT_MEMBER_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -67,18 +67,19 @@ describe(commands.CHAT_MEMBER_REMOVE, () => {
         log.push(msg);
       }
     };
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
-    promptOptions = undefined;
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       odata.getAllItems,
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -145,8 +146,8 @@ describe(commands.CHAT_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { chatId: chatId, userName: userPrincipalName, verbose: true } });
     assert(deleteStub.called);
@@ -178,19 +179,14 @@ describe(commands.CHAT_MEMBER_REMOVE, () => {
       new CommandError(`Member with userId '${userId}' could not be found in the chat.`));
   });
 
-  it('prompts before removing the specified message when confirm option not passed', async () => {
+  it('prompts before removing the specified message when force option not passed', async () => {
     await command.action(logger, { options: { chatId: chatId, id: chatMemberId } });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
 
-  it('aborts removing the specified chat member when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified chat member when force option not passed and prompt not confirmed', async () => {
     const deleteStub = sinon.stub(request, 'delete').resolves();
 
     await command.action(logger, { options: { chatId: chatId, userId: userId } });

--- a/src/m365/teams/commands/chat/chat-member-remove.ts
+++ b/src/m365/teams/commands/chat/chat-member-remove.ts
@@ -118,14 +118,9 @@ class TeamsChatMemberRemoveCommand extends GraphCommand {
       await removeUserFromChat();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove member ${args.options.id || args.options.userId || args.options.userName} from chat with id ${args.options.chatId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove member ${args.options.id || args.options.userId || args.options.userName} from chat with id ${args.options.chatId}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeUserFromChat();
       }
     }

--- a/src/m365/teams/commands/tab/tab-remove.ts
+++ b/src/m365/teams/commands/tab/tab-remove.ts
@@ -101,14 +101,9 @@ class TeamsTabRemoveCommand extends GraphCommand {
       await removeTab();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the tab with id ${args.options.id} from channel ${args.options.channelId} in team ${args.options.teamId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the tab with id ${args.options.id} from channel ${args.options.channelId} in team ${args.options.teamId}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeTab();
       }
     }

--- a/src/m365/teams/commands/team/team-remove.spec.ts
+++ b/src/m365/teams/commands/team/team-remove.spec.ts
@@ -16,7 +16,7 @@ import command from './team-remove.js';
 describe(commands.TEAM_REMOVE, () => {
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -42,18 +42,19 @@ describe(commands.TEAM_REMOVE, () => {
       }
     };
 
-    promptOptions = undefined;
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.get,
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -113,33 +114,23 @@ describe(commands.TEAM_REMOVE, () => {
     } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
   });
 
-  it('prompts before removing the specified team by id when confirm option not passed', async () => {
+  it('prompts before removing the specified team by id when force option not passed', async () => {
     await command.action(logger, { options: { id: "00000000-0000-0000-0000-000000000000" } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
-  it('prompts before removing the specified team by name when confirm option not passed (debug)', async () => {
+  it('prompts before removing the specified team by name when force option not passed (debug)', async () => {
     await command.action(logger, { options: { debug: true, name: "Finance" } });
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
     assert(promptIssued);
   });
 
-  it('aborts removing the specified team when confirm option not passed and prompt not confirmed', async () => {
+  it('aborts removing the specified team when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
     await command.action(logger, { options: { id: "00000000-0000-0000-0000-000000000000" } });
     assert(postSpy.notCalled);
   });
 
-  it('aborts removing the specified team when confirm option not passed and prompt not confirmed (debug)', async () => {
+  it('aborts removing the specified team when force option not passed and prompt not confirmed (debug)', async () => {
     const postSpy = sinon.spy(request, 'delete');
     await command.action(logger, { options: { debug: true, id: "00000000-0000-0000-0000-000000000000" } });
     assert(postSpy.notCalled);
@@ -157,8 +148,8 @@ describe(commands.TEAM_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, id: "00000000-0000-0000-0000-000000000000" } });
     assert(teamsDeleteCallIssued);
@@ -220,8 +211,8 @@ describe(commands.TEAM_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, { options: { id: '8231f9f2-701f-4c6e-93ce-ecb563e3c1ee' } } as any), new CommandError('No team found with Group Id 8231f9f2-701f-4c6e-93ce-ecb563e3c1ee'));
   });

--- a/src/m365/teams/commands/team/team-remove.ts
+++ b/src/m365/teams/commands/team/team-remove.ts
@@ -115,14 +115,9 @@ class TeamsTeamRemoveCommand extends GraphCommand {
       await removeTeam();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the team ${args.options.id ? args.options.id : args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the team ${args.options.id ? args.options.id : args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeTeam();
       }
     }

--- a/src/m365/teams/commands/user/user-app-remove.spec.ts
+++ b/src/m365/teams/commands/user/user-app-remove.spec.ts
@@ -16,7 +16,7 @@ import command from './user-app-remove.js';
 describe(commands.USER_APP_REMOVE, () => {
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -42,16 +42,18 @@ describe(commands.USER_APP_REMOVE, () => {
       }
     };
     (command as any).items = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -95,10 +97,7 @@ describe(commands.USER_APP_REMOVE, () => {
         id: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY='
       }
     } as any);
-    let promptIssued = false;
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
+
     assert(promptIssued);
   });
 
@@ -140,8 +139,8 @@ describe(commands.USER_APP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').resolves({ continue: true });
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {

--- a/src/m365/teams/commands/user/user-app-remove.ts
+++ b/src/m365/teams/commands/user/user-app-remove.ts
@@ -91,14 +91,9 @@ class TeamsUserAppRemoveCommand extends GraphCommand {
       await removeApp();
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the app with id ${args.options.id} for user ${args.options.userId}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the app with id ${args.options.id} for user ${args.options.userId}?` });
 
-      if (result.continue) {
+      if (result) {
         await removeApp();
       }
     }

--- a/src/m365/todo/commands/list/list-remove.spec.ts
+++ b/src/m365/todo/commands/list/list-remove.spec.ts
@@ -18,7 +18,6 @@ describe(commands.LIST_REMOVE, () => {
   let cli: Cli;
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
   let commandInfo: CommandInfo;
 
   before(() => {
@@ -28,10 +27,7 @@ describe(commands.LIST_REMOVE, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.service.connected = true;
-    sinon.stub(Cli, 'prompt').callsFake(async (options) => {
-      promptOptions = options;
-      return { continue: true };
-    });
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
     commandInfo = Cli.getCommandInfo(command);
   });
 
@@ -108,7 +104,7 @@ describe(commands.LIST_REMOVE, () => {
     assert.strictEqual(log.length, 0);
   });
 
-  it('removes a To Do task list by name when confirm option is passed', async () => {
+  it('removes a To Do task list by name when force option is passed', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/me/todo/lists?$filter=displayName eq 'FooList'`) {
         return {
@@ -223,7 +219,7 @@ describe(commands.LIST_REMOVE, () => {
     await assert.rejects(command.action(logger, { options: { name: "FooList" } } as any), new CommandError('An error has occurred'));
   });
 
-  it('prompts before removing the list when confirm option not passed', async () => {
+  it('prompts before removing the list when force option not passed', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/me/todo/lists?$filter=displayName eq 'FooList'`) {
         return {
@@ -251,22 +247,15 @@ describe(commands.LIST_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    const confirmationStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         name: "FooList"
       }
     } as any);
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
-    assert(promptIssued);
+    assert(confirmationStub.calledOnce);
   });
 
   it('fails validation if both name and id are not set', async () => {

--- a/src/m365/todo/commands/list/list-remove.ts
+++ b/src/m365/todo/commands/list/list-remove.ts
@@ -65,14 +65,9 @@ class TodoListRemoveCommand extends GraphCommand {
       await this.removeList(args);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the task list ${args.options.id || args.options.name}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the task list ${args.options.id || args.options.name}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeList(args);
       }
     }

--- a/src/m365/todo/commands/task/task-remove.ts
+++ b/src/m365/todo/commands/task/task-remove.ts
@@ -69,14 +69,9 @@ class TodoTaskRemoveCommand extends GraphCommand {
       await this.removeToDoTask(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the task ${args.options.id} from list ${args.options.listId || args.options.listName}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the task ${args.options.id} from list ${args.options.listId || args.options.listName}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeToDoTask(args.options);
       }
     }

--- a/src/m365/yammer/commands/group/group-user-add.spec.ts
+++ b/src/m365/yammer/commands/group/group-user-add.spec.ts
@@ -45,7 +45,7 @@ describe(commands.GROUP_USER_ADD, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -97,9 +97,7 @@ describe(commands.GROUP_USER_ADD, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, groupId: 1231231 } });
 

--- a/src/m365/yammer/commands/group/group-user-remove.spec.ts
+++ b/src/m365/yammer/commands/group/group-user-remove.spec.ts
@@ -47,7 +47,7 @@ describe(commands.GROUP_USER_REMOVE, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -73,9 +73,7 @@ describe(commands.GROUP_USER_REMOVE, () => {
       };
     });
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('An error has occurred.'));
   });
@@ -103,9 +101,7 @@ describe(commands.GROUP_USER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, groupId: 1231231 } });
 
@@ -133,9 +129,7 @@ describe(commands.GROUP_USER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, groupId: 1231231, id: 989998789 } });
 
@@ -143,9 +137,7 @@ describe(commands.GROUP_USER_REMOVE, () => {
   });
 
   it('prompts before removal when confirmation argument not passed', async () => {
-    const promptStub: sinon.SinonStub = sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    const promptStub: sinon.SinonStub = sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { groupId: 1231231, id: 989998789 } });
 
@@ -153,9 +145,7 @@ describe(commands.GROUP_USER_REMOVE, () => {
   });
 
   it('aborts execution when prompt not confirmed', async () => {
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { groupId: 1231231, id: 989998789 } });
 

--- a/src/m365/yammer/commands/group/group-user-remove.ts
+++ b/src/m365/yammer/commands/group/group-user-remove.ts
@@ -81,14 +81,9 @@ class YammerGroupUserRemoveCommand extends YammerCommand {
         messagePrompt = `Are you sure you want to remove the user ${args.options.id} from the group ${args.options.groupId}?`;
       }
 
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: messagePrompt
-      });
+      const result = await Cli.promptForConfirmation({ message: messagePrompt });
 
-      if (result.continue) {
+      if (result) {
         await this.executeRemoveAction(args.options);
       }
     }

--- a/src/m365/yammer/commands/message/message-like-set.spec.ts
+++ b/src/m365/yammer/commands/message/message-like-set.spec.ts
@@ -16,7 +16,7 @@ import command from './message-like-set.js';
 describe(commands.MESSAGE_LIKE_SET, () => {
   let log: string[];
   let logger: Logger;
-  let promptOptions: any;
+  let promptIssued: boolean = false;
   let requests: any[];
   let commandInfo: CommandInfo;
 
@@ -43,17 +43,19 @@ describe(commands.MESSAGE_LIKE_SET, () => {
       }
     };
     requests = [];
-    sinon.stub(Cli, 'prompt').callsFake(async (options: any) => {
-      promptOptions = options;
-      return { continue: false };
+    sinon.stub(Cli, 'promptForConfirmation').callsFake(() => {
+      promptIssued = true;
+      return Promise.resolve(false);
     });
+
+    promptIssued = false;
   });
 
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
       request.post,
-      Cli.prompt
+      Cli.promptForConfirmation
     ]);
   });
 
@@ -103,11 +105,6 @@ describe(commands.MESSAGE_LIKE_SET, () => {
   it('prompts when confirmation argument not passed', async () => {
     await command.action(logger, { options: { messageId: 1231231, enable: false } });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -163,11 +160,6 @@ describe(commands.MESSAGE_LIKE_SET, () => {
   it('prompts when disliking and confirmation parameter is denied', async () => {
     await command.action(logger, { options: { messageId: 1231231, enable: false, force: false } });
 
-    let promptIssued = false;
-
-    if (promptOptions && promptOptions.type === 'confirm') {
-      promptIssued = true;
-    }
 
     assert(promptIssued);
   });
@@ -180,20 +172,16 @@ describe(commands.MESSAGE_LIKE_SET, () => {
       throw 'Invalid request';
     });
 
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, messageId: 1231231, enable: false } });
     assert(requestDeleteStub.called);
   });
 
   it('Aborts execution when enabled set to false and confirmation is not given', async () => {
-    sinonUtil.restore(Cli.prompt);
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinonUtil.restore(Cli.promptForConfirmation);
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { messageId: 1231231, enable: false } });
     assert(requests.length === 0);

--- a/src/m365/yammer/commands/message/message-like-set.ts
+++ b/src/m365/yammer/commands/message/message-like-set.ts
@@ -79,16 +79,11 @@ class YammerMessageLikeSetCommand extends YammerCommand {
         await this.executeLikeAction(args.options);
       }
       else {
-        const messagePrompt = `Are you sure you want to unlike message ${args.options.messageId}?`;
+        const message = `Are you sure you want to unlike message ${args.options.messageId}?`;
 
-        const result = await Cli.prompt<{ continue: boolean }>({
-          type: 'confirm',
-          name: 'continue',
-          default: false,
-          message: messagePrompt
-        });
+        const result = await Cli.promptForConfirmation({ message });
 
-        if (result.continue) {
+        if (result) {
           await this.executeLikeAction(args.options);
         }
       }

--- a/src/m365/yammer/commands/message/message-remove.spec.ts
+++ b/src/m365/yammer/commands/message/message-remove.spec.ts
@@ -49,7 +49,7 @@ describe(commands.MESSAGE_REMOVE, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.delete,
-      Cli.prompt,
+      Cli.promptForConfirmation,
       cli.getSettingWithDefaultValue
     ]);
   });
@@ -104,9 +104,7 @@ describe(commands.MESSAGE_REMOVE, () => {
       }
       throw 'Invalid request';
     });
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: true }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, { options: { debug: true, id: 10123190123123, force: false } });
     assert.strictEqual(requestDeleteStub.lastCall.args[0].url, 'https://www.yammer.com/api/v1/messages/10123190123123.json');
@@ -120,9 +118,7 @@ describe(commands.MESSAGE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(Cli, 'prompt').callsFake(async () => (
-      { continue: false }
-    ));
+    sinon.stub(Cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, { options: { debug: true, id: 10123190123123, force: false } });
     assert(requestDeleteStub.notCalled);

--- a/src/m365/yammer/commands/message/message-remove.ts
+++ b/src/m365/yammer/commands/message/message-remove.ts
@@ -67,14 +67,9 @@ class YammerMessageRemoveCommand extends YammerCommand {
       await this.removeMessage(args.options);
     }
     else {
-      const result = await Cli.prompt<{ continue: boolean }>({
-        type: 'confirm',
-        name: 'continue',
-        default: false,
-        message: `Are you sure you want to remove the Yammer message ${args.options.id}?`
-      });
+      const result = await Cli.promptForConfirmation({ message: `Are you sure you want to remove the Yammer message ${args.options.id}?` });
 
-      if (result.continue) {
+      if (result) {
         await this.removeMessage(args.options);
       }
     }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -5,6 +5,7 @@ import { Cli } from '../cli/Cli.js';
 let inquirerInput: typeof import('@inquirer/input') | undefined;
 let inquirerConfirm: typeof import('@inquirer/confirm') | undefined;
 let inquirerSelect: typeof import('@inquirer/select') | undefined;
+let inquirerPassword: typeof import('@inquirer/password') | undefined;
 
 export interface Choice<T> {
   name: string;
@@ -18,6 +19,13 @@ export interface InputConfig {
   transformer?: ((value: string, { isFinal }: {
     isFinal: boolean;
   }) => string) | undefined;
+  validate?: ((value: string) => string | boolean | Promise<string | boolean>) | undefined;
+}
+
+export interface PasswordConfig {
+  message: string | Promise<string> | (() => Promise<string>);
+  default?: string | undefined;
+  mask?: boolean | string;
   validate?: ((value: string) => string | boolean | Promise<string | boolean>) | undefined;
 }
 
@@ -68,5 +76,21 @@ export const prompt = {
     const errorOutput: string = cli.getSettingWithDefaultValue(settingsNames.errorOutput, 'stderr');
 
     return inquirerSelect.default(config, { output: errorOutput === 'stderr' ? process.stderr : process.stdout });
+  },
+
+  /* c8 ignore next 10 */
+  async forMaskedInput(config: PasswordConfig): Promise<string> {
+    if (!inquirerPassword) {
+      inquirerPassword = await import('@inquirer/password');
+    }
+
+    if (!config.mask) {
+      config.mask = '*';
+    }
+
+    const cli = Cli.getInstance();
+    const errorOutput: string = cli.getSettingWithDefaultValue(settingsNames.errorOutput, 'stderr');
+
+    return inquirerPassword.default(config, { output: errorOutput === 'stderr' ? process.stderr : process.stdout });
   }
 };

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,19 +1,72 @@
-import { Cli } from '../cli/Cli.js';
+import { Separator } from '@inquirer/core';
 import { settingsNames } from '../settingsNames.js';
+import { Cli } from '../cli/Cli.js';
 
-let inquirer: typeof import('inquirer') | undefined;
+let inquirerInput: typeof import('@inquirer/input') | undefined;
+let inquirerConfirm: typeof import('@inquirer/confirm') | undefined;
+let inquirerSelect: typeof import('@inquirer/select') | undefined;
+
+export interface Choice<T> {
+  name: string;
+  value: T;
+  description?: string;
+}
+
+export interface InputConfig {
+  message: string | Promise<string> | (() => Promise<string>);
+  default?: string | undefined;
+  transformer?: ((value: string, { isFinal }: {
+    isFinal: boolean;
+  }) => string) | undefined;
+  validate?: ((value: string) => string | boolean | Promise<string | boolean>) | undefined;
+}
+
+export interface ConfirmationConfig {
+  message: string | Promise<string> | (() => Promise<string>);
+  default?: boolean | undefined;
+  transformer?: ((value: boolean) => string) | undefined;
+}
+
+export interface SelectionConfig<Value> {
+  message: string | Promise<string> | (() => Promise<string>);
+  choices: readonly (Separator | Choice<Value>)[];
+  pageSize?: number | undefined;
+}
 
 export const prompt = {
   /* c8 ignore next 10 */
-  async forInput<T>(config: any, answers?: any): Promise<T> {
-    if (!inquirer) {
-      inquirer = await import('inquirer');
+  async forInput(config: InputConfig): Promise<string> {
+    if (!inquirerInput) {
+      inquirerInput = await import('@inquirer/input');
     }
 
     const cli = Cli.getInstance();
     const errorOutput: string = cli.getSettingWithDefaultValue(settingsNames.errorOutput, 'stderr');
-    const prompt = inquirer.createPromptModule({ output: errorOutput === 'stderr' ? process.stderr : process.stdout });
 
-    return await prompt(config, answers) as any;
+    return inquirerInput.default(config, { output: errorOutput === 'stderr' ? process.stderr : process.stdout });
+  },
+
+  /* c8 ignore next 10 */
+  async forConfirmation(config: ConfirmationConfig): Promise<boolean> {
+    if (!inquirerConfirm) {
+      inquirerConfirm = await import('@inquirer/confirm');
+    }
+
+    const cli = Cli.getInstance();
+    const errorOutput: string = cli.getSettingWithDefaultValue(settingsNames.errorOutput, 'stderr');
+
+    return inquirerConfirm.default(config, { output: errorOutput === 'stderr' ? process.stderr : process.stdout });
+  },
+
+  /* c8 ignore next 10 */
+  async forSelection<T>(config: SelectionConfig<T>): Promise<T> {
+    if (!inquirerSelect) {
+      inquirerSelect = await import('@inquirer/select');
+    }
+
+    const cli = Cli.getInstance();
+    const errorOutput: string = cli.getSettingWithDefaultValue(settingsNames.errorOutput, 'stderr');
+
+    return inquirerSelect.default(config, { output: errorOutput === 'stderr' ? process.stderr : process.stdout });
   }
 };


### PR DESCRIPTION
Closes  #5560 and #5636
Adds requiredWhen and whenPrompted functionality.

This is a POC PR that focusses on solving two issues:

- Custom option-based prompts
- Optional required fields

Try it out by running the following:

```sh
m365 login --authType password
```

> Don't forget to run `npm install` first

Example Picture
![image](https://github.com/pnp/cli-microsoft365/assets/5267487/40b4e3b5-5acb-4257-9c3a-88de25fa83cd)

❗ This PR is stacked on top of my inquirer update-branch. I'll move it as soon as @Adam-it has merged that PR. 
❗So if you check out the code you only need to pick the last commit!
