### PR TITLE
Extends 'teams user app remove' command with support for name option. Closes #5447

### DIFF
--- a/docs/docs/cmd/teams/user/user-app-remove.mdx
+++ b/docs/docs/cmd/teams/user/user-app-remove.mdx
@@ -13,8 +13,11 @@ m365 teams user app remove [options]
 ## Options
 
 ```md definition-list
-`--id <id>`
-: The unique id of the app instance installed for the user.
+`--id [id]`
+: The unique id of the app instance installed for the user. Specify either `id` or `name`.
+
+`--name [name]`
+: Name of the app instance installed for the user. Specify either `id` or `name`.
 
 `--userId [userId]`
 : The ID of the user to uninstall the app for. Specify `userId` or `userName` but not both.
@@ -35,16 +38,22 @@ Do not use the ID from the manifest of the zip app package or the id from the Mi
 
 ## Examples
 
-Uninstall an app for the specified user.
+Uninstall an app by id for the specified user.
 
 ```sh
 m365 teams user app remove --id YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY= --userId 2609af39-7775-4f94-a3dc-0dd67657e900
 ```
 
-Uninstall an app for the specified user using its UPN.
+Uninstall an app by id for the specified user using its UPN.
 
 ```sh
 m365 teams user app remove --id YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY= --userName admin@contoso.com
+```
+
+Uninstall an app by name for the specified user.
+
+```sh
+m365 teams user app remove --name HelloWorld --userId 2609af39-7775-4f94-a3dc-0dd67657e900
 ```
 
 ## Response

--- a/src/m365/teams/commands/user/user-app-remove.ts
+++ b/src/m365/teams/commands/user/user-app-remove.ts
@@ -12,7 +12,8 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  id: string;
+  id?: string;
+  name?: string;
   userId?: string;
   userName?: string;
   force?: boolean;
@@ -39,6 +40,8 @@ class TeamsUserAppRemoveCommand extends GraphCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
+        id: typeof args.options.id !== 'undefined',
+        name: typeof args.options.name !== 'undefined',
         userId: typeof args.options.userId !== 'undefined',
         userName: typeof args.options.userName !== 'undefined',
         force: (!!args.options.force).toString()
@@ -49,7 +52,10 @@ class TeamsUserAppRemoveCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '--id <id>'
+        option: '--id [id]'
+      },
+      {
+        option: '--name [name]'
       },
       {
         option: '--userId [userId]'
@@ -80,17 +86,23 @@ class TeamsUserAppRemoveCommand extends GraphCommand {
   }
 
   #initOptionSets(): void {
+    this.optionSets.push({ options: ['id', 'name'] });
     this.optionSets.push({ options: ['userId', 'userName'] });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     const removeApp = async (): Promise<void> => {
+      const appId: string = await this.getAppId(args);
       // validation ensures that here we have either userId or userName
       const userId: string = (args.options.userId ?? args.options.userName) as string;
       const endpoint: string = `${this.resource}/v1.0`;
 
+      if (this.verbose) {
+        await logger.logToStderr(`Removing app with ID ${args.options.id} for user ${args.options.userId}`);
+      }
+
       const requestOptions: CliRequestOptions = {
-        url: `${endpoint}/users/${formatting.encodeQueryParameter(userId)}/teamwork/installedApps/${args.options.id}`,
+        url: `${endpoint}/users/${formatting.encodeQueryParameter(userId)}/teamwork/installedApps/${appId}`,
         headers: {
           'accept': 'application/json;odata.metadata=none'
         },
@@ -115,6 +127,34 @@ class TeamsUserAppRemoveCommand extends GraphCommand {
         await removeApp();
       }
     }
+  }
+
+  private async getAppId(args: CommandArgs): Promise<string> {
+    if (args.options.id) {
+      return args.options.id;
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${this.resource}/v1.0/users/${args.options.userId}/teamwork/installedApps?$expand=teamsAppDefinition&$filter=teamsAppDefinition/displayName eq '${formatting.encodeQueryParameter(args.options.name as string)}'`,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      responseType: 'json'
+    };
+
+    const response = await request.get<{ value: { id: string; }[] }>(requestOptions);
+
+    if (response.value.length === 1) {
+      return response.value[0].id;
+    }
+
+    if (response.value.length === 0) {
+      throw `The specified Teams app does not exist`;
+    }
+
+    const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', response.value);
+    const result: { id: string } = (await Cli.handleMultipleResultsFound(`Multiple Teams apps with name '${args.options.name}' found.`, resultAsKeyValuePair)) as { id: string };
+    return result.id;
   }
 }
 


### PR DESCRIPTION
Extends `teams user app remove` command with support for specifying the name option. Closes #5447