### PR TITLE
Fixes missing columns in CSV output. Closes #5684

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -608,7 +608,11 @@ export default abstract class Command {
     if (logStatement && logStatement.length > 0 && !options.query) {
       logStatement.map(l => {
         for (const x of Object.keys(l)) {
-          if (typeof l[x] === 'object') {
+          // Remove object-properties from the output
+          // Excludes null from the check, because null is an object in JavaScript.  
+          //  Properties with null values are not removed from the output, 
+          //  as this can cause missing columns
+          if (typeof l[x] === 'object' && l[x] !== null) {
             delete l[x];
           }
         }

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -620,7 +620,7 @@ export class Cli {
       return logStatement.join(os.EOL);
     }
 
-    // if output type has been set to 'text' or 'csv', process the retrieved
+    // if output type has been set to 'text', process the retrieved
     // data so that returned objects contain only default properties specified
     // on the current command. If there is no current command or the
     // command doesn't specify default properties, return original data


### PR DESCRIPTION
Closes #5684

Fixes missing columns in CSV output. 

Also updated a comment where 'csv' was incorrectly mentioned. (`shouldTrimOutput` no longer returns true for `csv`)