### PR TITLE
Added missing force option to docs for 'flow run cancel'

### DIFF
--- a/docs/docs/cmd/flow/run/run-cancel.mdx
+++ b/docs/docs/cmd/flow/run/run-cancel.mdx
@@ -21,6 +21,9 @@ m365 flow run cancel [options]
 
 `-e, --environmentName <environmentName>`
 : The name of the environment where the flow is located
+
+`-f, --force`
+: Don't prompt for confirmation
 ```
 
 <Global />


### PR DESCRIPTION
Noticed that the force option was missing for `m365 flow run cancel`