### PR TITLE
Removes outputFile param for reports. Closes #5681

### DIFF
--- a/docs/docs/cmd/onedrive/report/report-activityfilecounts.mdx
+++ b/docs/docs/cmd/onedrive/report/report-activityfilecounts.mdx
@@ -17,9 +17,6 @@ m365 onedrive report activityfilecounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/onedrive/report/report-activityusercounts.mdx
+++ b/docs/docs/cmd/onedrive/report/report-activityusercounts.mdx
@@ -17,9 +17,6 @@ m365 onedrive report activityusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/onedrive/report/report-activityuserdetail.mdx
+++ b/docs/docs/cmd/onedrive/report/report-activityuserdetail.mdx
@@ -20,9 +20,6 @@ m365 onedrive report activityuserdetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is YYYY-MM-DD. Specify the date or period, but not both`
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/onedrive/report/report-usageaccountcounts.mdx
+++ b/docs/docs/cmd/onedrive/report/report-usageaccountcounts.mdx
@@ -17,9 +17,6 @@ m365 onedrive report usageaccountcounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/onedrive/report/report-usageaccountdetail.mdx
+++ b/docs/docs/cmd/onedrive/report/report-usageaccountdetail.mdx
@@ -20,9 +20,6 @@ m365 onedrive report usageaccountdetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is YYYY-MM-DD. Specify the date or period, but not both`
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/onedrive/report/report-usagefilecounts.mdx
+++ b/docs/docs/cmd/onedrive/report/report-usagefilecounts.mdx
@@ -17,9 +17,6 @@ m365 onedrive report usagefilecounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/onedrive/report/report-usagestorage.mdx
+++ b/docs/docs/cmd/onedrive/report/report-usagestorage.mdx
@@ -17,9 +17,6 @@ m365 onedrive report usagestorage [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailactivitycounts.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailactivitycounts.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailactivitycounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailactivityusercounts.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailactivityusercounts.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailactivityusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailactivityuserdetail.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailactivityuserdetail.mdx
@@ -20,9 +20,6 @@ m365 outlook report mailactivityuserdetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is YYYY-MM-DD. Specify the date or period, but not both
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailappusageappsusercounts.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailappusageappsusercounts.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailappusageappsusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailappusageusercounts.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailappusageusercounts.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailappusageusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailappusageuserdetail.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailappusageuserdetail.mdx
@@ -20,9 +20,6 @@ m365 outlook report mailappusageuserdetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is YYYY-MM-DD. Specify the date or period, but not both
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailappusageversionsusercounts.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailappusageversionsusercounts.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailappusageversionsusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailboxusagedetail.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailboxusagedetail.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailboxusagedetail [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailboxusagemailboxcount.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailboxusagemailboxcount.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailboxusagemailboxcount [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailboxusagequotastatusmailboxcounts.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailboxusagequotastatusmailboxcounts.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailboxusagequotastatusmailboxcounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/outlook/report/report-mailboxusagestorage.mdx
+++ b/docs/docs/cmd/outlook/report/report-mailboxusagestorage.mdx
@@ -17,9 +17,6 @@ m365 outlook report mailboxusagestorage [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/skype/report/report-activitycounts.mdx
+++ b/docs/docs/cmd/skype/report/report-activitycounts.mdx
@@ -17,8 +17,6 @@ m365 skype report activitycounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/skype/report/report-activityusercounts.mdx
+++ b/docs/docs/cmd/skype/report/report-activityusercounts.mdx
@@ -17,9 +17,6 @@ m365 skype report activityusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/skype/report/report-activityuserdetail.mdx
+++ b/docs/docs/cmd/skype/report/report-activityuserdetail.mdx
@@ -20,9 +20,6 @@ m365 skype report activityuserdetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is YYYY-MM-DD. Specify the date or period, but not both
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-activityfilecounts.mdx
+++ b/docs/docs/cmd/spo/report/report-activityfilecounts.mdx
@@ -17,9 +17,6 @@ m365 spo report activityfilecounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-activitypages.mdx
+++ b/docs/docs/cmd/spo/report/report-activitypages.mdx
@@ -17,9 +17,6 @@ m365 spo report activitypages [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-activityusercounts.mdx
+++ b/docs/docs/cmd/spo/report/report-activityusercounts.mdx
@@ -17,9 +17,6 @@ m365 spo report activityusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-activityuserdetail.mdx
+++ b/docs/docs/cmd/spo/report/report-activityuserdetail.mdx
@@ -20,9 +20,6 @@ m365 spo report activityuserdetail [options]
 
 `-p, --period [period]`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`. Specify either `date` or `period`, but not both.
-
-`--outputFile [outputFile]`
-: Path to the file where the Microsoft Teams device usage by user report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-siteusagedetail.mdx
+++ b/docs/docs/cmd/spo/report/report-siteusagedetail.mdx
@@ -20,9 +20,6 @@ m365 spo report siteusagedetail [options]
 
 `-p, --period [period]`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`. Specify either `date` or `period`, but not both.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-siteusagefilecounts.mdx
+++ b/docs/docs/cmd/spo/report/report-siteusagefilecounts.mdx
@@ -17,9 +17,6 @@ m365 spo report siteusagefilecounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-siteusagepages.mdx
+++ b/docs/docs/cmd/spo/report/report-siteusagepages.mdx
@@ -17,9 +17,6 @@ m365 spo report siteusagepages [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-siteusagesitecounts.mdx
+++ b/docs/docs/cmd/spo/report/report-siteusagesitecounts.mdx
@@ -17,9 +17,6 @@ m365 spo report siteusagesitecounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/report/report-siteusagestorage.mdx
+++ b/docs/docs/cmd/spo/report/report-siteusagestorage.mdx
@@ -17,9 +17,6 @@ m365 spo report siteusagestorage [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/teams/report/report-deviceusagedistributionusercounts.mdx
+++ b/docs/docs/cmd/teams/report/report-deviceusagedistributionusercounts.mdx
@@ -17,9 +17,6 @@ m365 teams report deviceusagedistributionusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the Microsoft Teams unique users by device type report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/teams/report/report-deviceusageusercounts.mdx
+++ b/docs/docs/cmd/teams/report/report-deviceusageusercounts.mdx
@@ -17,9 +17,6 @@ m365 teams report deviceusageusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the Microsoft Teams daily unique users by device type report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/teams/report/report-deviceusageuserdetail.mdx
+++ b/docs/docs/cmd/teams/report/report-deviceusageuserdetail.mdx
@@ -20,9 +20,6 @@ m365 teams report deviceusageuserdetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is `YYYY-MM-DD`.
-
-`--outputFile [outputFile]`
-: Path to the file where the Microsoft Teams device usage by user report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/teams/report/report-useractivitycounts.mdx
+++ b/docs/docs/cmd/teams/report/report-useractivitycounts.mdx
@@ -17,9 +17,6 @@ m365 teams report useractivitycounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the Microsoft Teams activities by activity type report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/teams/report/report-useractivityusercounts.mdx
+++ b/docs/docs/cmd/teams/report/report-useractivityusercounts.mdx
@@ -17,9 +17,6 @@ m365 teams report useractivityusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the Microsoft Teams users by activity type report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/teams/report/report-useractivityuserdetail.mdx
+++ b/docs/docs/cmd/teams/report/report-useractivityuserdetail.mdx
@@ -20,9 +20,6 @@ m365 teams report useractivityuserdetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is `YYYY-MM-DD`. Specify the `date` or `period`, but not both.
-
-`--outputFile [outputFile]`
-: Path to the file where the Microsoft Teams user activity by user report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/tenant/report/report-activeusercounts.mdx
+++ b/docs/docs/cmd/tenant/report/report-activeusercounts.mdx
@@ -17,9 +17,6 @@ m365 tenant report activeusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the Microsoft Teams daily unique users by device type report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/tenant/report/report-activeuserdetail.mdx
+++ b/docs/docs/cmd/tenant/report/report-activeuserdetail.mdx
@@ -20,9 +20,6 @@ m365 tenant report activeuserdetail [options]
 
 `-p, --period [period]`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/tenant/report/report-servicesusercounts.mdx
+++ b/docs/docs/cmd/tenant/report/report-servicesusercounts.mdx
@@ -17,9 +17,6 @@ m365 tenant report servicesusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in.
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-activitycounts.mdx
+++ b/docs/docs/cmd/yammer/report/report-activitycounts.mdx
@@ -17,9 +17,6 @@ m365 yammer report activitycounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-activityusercounts.mdx
+++ b/docs/docs/cmd/yammer/report/report-activityusercounts.mdx
@@ -17,9 +17,6 @@ m365 yammer report activityusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-activityuserdetail.mdx
+++ b/docs/docs/cmd/yammer/report/report-activityuserdetail.mdx
@@ -20,9 +20,6 @@ m365 yammer report activityuserdetail [options]
 
 `-p, --period [period]`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-deviceusagedistributionusercounts.mdx
+++ b/docs/docs/cmd/yammer/report/report-deviceusagedistributionusercounts.mdx
@@ -17,9 +17,6 @@ m365 yammer report deviceusagedistributionusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-deviceusageusercounts.mdx
+++ b/docs/docs/cmd/yammer/report/report-deviceusageusercounts.mdx
@@ -17,9 +17,6 @@ m365 yammer report deviceusageusercounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-deviceusageuserdetail.mdx
+++ b/docs/docs/cmd/yammer/report/report-deviceusageuserdetail.mdx
@@ -20,9 +20,6 @@ m365 yammer report deviceusageuserdetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is `YYYY-MM-DD`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-groupsactivitycounts.mdx
+++ b/docs/docs/cmd/yammer/report/report-groupsactivitycounts.mdx
@@ -17,9 +17,6 @@ m365 yammer report groupsactivitycounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-groupsactivitydetail.mdx
+++ b/docs/docs/cmd/yammer/report/report-groupsactivitydetail.mdx
@@ -20,9 +20,6 @@ m365 yammer report groupsactivitydetail [options]
 
 `-d, --date [date]`
 : The date for which you would like to view the users who performed any activity. Supported date format is `YYYY-MM-DD`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />

--- a/docs/docs/cmd/yammer/report/report-groupsactivitygroupcounts.mdx
+++ b/docs/docs/cmd/yammer/report/report-groupsactivitygroupcounts.mdx
@@ -17,9 +17,6 @@ m365 yammer report groupsactivitygroupcounts [options]
 ```md definition-list
 `-p, --period <period>`
 : The length of time over which the report is aggregated. Supported values `D7`, `D30`, `D90`, `D180`.
-
-`--outputFile [outputFile]`
-: Path to the file where the report should be stored in
 ```
 
 <Global />


### PR DESCRIPTION
 ### Removes outputFile parameter for reports. Closes #5681

Closes #5681

Update in the documentation.

All the reports are based on `src/m365/base/DateAndPeriodBasedReport.ts` or `src/m365/base/PeriodBasedReport.ts`. The original base files contained an `--outputFile` parameter that was removed without updating the documentation. This change makes the required modification in the documentation, eliminating the parameter from the docs.
