### PR TITLE
Removes obsolete tracking exceptions

### DIFF
--- a/src/appInsights.ts
+++ b/src/appInsights.ts
@@ -27,6 +27,7 @@ appInsightsClient.commonProperties = {
 };
 
 appInsightsClient.context.tags['ai.cloud.roleInstance'] = crypto.createHash('sha256').update(appInsightsClient.context.tags['ai.cloud.roleInstance']).digest('hex');
-appInsightsClient.context.tags['ai.cloud.role'];
+delete appInsightsClient.context.tags['ai.cloud.role'];
+delete appInsightsClient.context.tags['ai.cloud.roleName'];
 
 export default appInsightsClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { Cli } from './cli/Cli.js';
-import { telemetry } from './telemetry.js';
 import { app } from './utils/app.js';
 
 // required to make console.log() in combination with piped output synchronous
@@ -18,11 +17,4 @@ if (!process.env.CLIMICROSOFT365_NOUPDATE) {
   });
 }
 
-try {
-  const cli: Cli = Cli.getInstance();
-  cli.execute(process.argv.slice(2));
-}
-catch (e: any) {
-  telemetry.trackException(e);
-  process.exit(1);
-}
+Cli.getInstance().execute(process.argv.slice(2));

--- a/src/telemetry.spec.ts
+++ b/src/telemetry.spec.ts
@@ -65,30 +65,6 @@ describe('Telemetry', () => {
     assert(spawnStub.called);
   });
 
-  it(`doesn't log an exception when disableTelemetry is set`, () => {
-    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.disableTelemetry) {
-        return true;
-      }
-
-      return defaultValue;
-    });
-    telemetry.trackException('Error!');
-    assert(spawnStub.notCalled);
-  });
-
-  it('logs an exception when disableTelemetry is not set', () => {
-    sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.disableTelemetry) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-    telemetry.trackException('Error!');
-    assert(spawnStub.called);
-  });
-
   it(`logs an empty string for shell if it couldn't resolve shell process name`, () => {
     sinon.stub(Cli.getInstance(), 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.disableTelemetry) {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -35,15 +35,5 @@ export const telemetry = {
       commandName,
       properties
     });
-  },
-
-  trackException: (exception: any): void => {
-    if (Cli.getInstance().getSettingWithDefaultValue<boolean>(settingsNames.disableTelemetry, false)) {
-      return;
-    }
-
-    trackTelemetry({
-      exception
-    });
   }
 };


### PR DESCRIPTION
Removes obsolete tracking exceptions. This code was not being used, because error are handled earlier in the process.