### PR TITLE
Extends 'teams user app add' command with support for specifying UPN of the user. Closes #5702

### DIFF
--- a/docs/docs/cmd/teams/user/user-app-add.mdx
+++ b/docs/docs/cmd/teams/user/user-app-add.mdx
@@ -16,8 +16,11 @@ m365 teams user app add [options]
 `--id <id>`
 : The ID of the app to install.
 
-`--userId <userId>`
-: The ID of the user to install the app for.
+`--userId [userId]`
+: The ID of the user to install the app for. Specify either `userId` or `userName` but not both.
+
+`--userName [userName]`
+: The UPN of the user to install the app for. Specify either `userId` or `userName` but not both.
 ```
 
 <Global />
@@ -28,10 +31,16 @@ The `id` has to be the ID of the app from the Microsoft Teams App Catalog. Do no
 
 ## Examples
 
-Install an app from the catalog for the specified user.
+Install an app from the catalog for the specified user by id.
 
 ```sh
 m365 teams user app add --id 4440558e-8c73-4597-abc7-3644a64c4bce --userId 2609af39-7775-4f94-a3dc-0dd67657e900
+```
+
+Install an app from the catalog for the specified user by name.
+
+```sh
+m365 teams user app add --id 4440558e-8c73-4597-abc7-3644a64c4bce --userName admin@contoso.com
 ```
 
 ## Response

--- a/docs/docs/cmd/teams/user/user-app-remove.mdx
+++ b/docs/docs/cmd/teams/user/user-app-remove.mdx
@@ -14,16 +14,16 @@ m365 teams user app remove [options]
 
 ```md definition-list
 `--id [id]`
-: The unique id of the app instance installed for the user. Specify either `id` or `name`.
+: The unique id of the app instance installed for the user. Specify either `id` or `name` but not both.
 
 `--name [name]`
-: Name of the app instance installed for the user. Specify either `id` or `name`.
+: Name of the app instance installed for the user. Specify either `id` or `name` but not both.
 
 `--userId [userId]`
-: The ID of the user to uninstall the app for. Specify `userId` or `userName` but not both.
+: The ID of the user to uninstall the app for. Specify either `userId` or `userName` but not both.
 
 `--userName [userName]`
-: The UPN of the user to uninstall the app for. Specify `userId` or `userName` but not both.
+: The UPN of the user to uninstall the app for. Specify either `userId` or `userName` but not both.
 
 `-f, --force`
 : Confirm removal of app for user.


### PR DESCRIPTION
Extends `teams user app add` command with support for specifying name of the user as an option. Closes #5702