### PR TITLE
Enhances `m365 flow run get` with the ability to retrieve the action details. Closes #1828

### DIFF
--- a/docs/docs/cmd/flow/run/run-get.mdx
+++ b/docs/docs/cmd/flow/run/run-get.mdx
@@ -25,7 +25,14 @@ m365 flow run get [options]
 : The name of the environment where the flow is located
 
 `--includeTriggerInformation`
+: (deprecated. Use option `withTrigger` instead) If specified, include information about the trigger details
+
+`--withTrigger`
 : If specified, include information about the trigger details
+
+`--withActions [withActions]`
+: If specified, include information about all actions when no action names are specified, or provide a specified list of actions separated by commas to include only the relevant action details
+
 ```
 
 <Global />
@@ -44,7 +51,7 @@ If the Microsoft Flow with the name you specified doesn't exist, you will get th
 
 If the run with the name you specified doesn't exist, you will get the `The provided workflow run name is not valid.` error.
 
-If the option `includeTriggerInformation` is specified, but the trigger does not contain an outputsLink such as for example with a `Recurrence` trigger, this option will be ignored.
+If the option `withTrigger` is specified, but the trigger does not contain an outputsLink such as for example with a `Recurrence` trigger, this option will be ignored.
 
 ## Examples
 
@@ -57,7 +64,19 @@ m365 flow run get --environmentName Default-d87a7535-dd31-4437-bfe1-95340acd55c5
 Get information about the given run of the specified Power Automate flow including trigger information
 
 ```sh
-m365 flow run get --environmentName Default-d87a7535-dd31-4437-bfe1-95340acd55c5 --flowName 5923cb07-ce1a-4a5c-ab81-257ce820109a --name 08586653536760200319026785874CU62 --includeTriggerInformation
+m365 flow run get --environmentName Default-d87a7535-dd31-4437-bfe1-95340acd55c5 --flowName 5923cb07-ce1a-4a5c-ab81-257ce820109a --name 08586653536760200319026785874CU62 --withTrigger
+```
+
+Get information about the given run of the specified Power Automate flow including details about all associated actions.
+
+```sh
+m365 flow run get --environmentName Default-d87a7535-dd31-4437-bfe1-95340acd55c5 --flowName 5923cb07-ce1a-4a5c-ab81-257ce820109a --name 08586653536760200319026785874CU62 --withActions
+```
+
+Get information about the given run of the specified Power Automate flow including exclusively the details of 'Action_Internal_Name1' and 'Action_Internal_Name2' actions
+
+```sh
+m365 flow run get --environmentName Default-d87a7535-dd31-4437-bfe1-95340acd55c5 --flowName 5923cb07-ce1a-4a5c-ab81-257ce820109a --name 08586653536760200319026785874CU62 --withActions "Action_Internal_Name1,Action_Internal_Name2"
 ```
 
 ## Response
@@ -157,9 +176,9 @@ m365 flow run get --environmentName Default-d87a7535-dd31-4437-bfe1-95340acd55c5
   </TabItem>
 </Tabs>
 
-### `includeTriggerInformation` response
+### `withTrigger` response
 
-When using the option `includeTriggerInformation`, the response for the json-output will differ.
+When using the option `withTrigger`, the response for the json-output will differ.
 
 <Tabs>
   <TabItem value="JSON">
@@ -233,3 +252,147 @@ When using the option `includeTriggerInformation`, the response for the json-out
   </TabItem>
 </Tabs>
 
+### `withActions` response
+
+When using the option `withActions`, the response for the json-output will differ.
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ```json
+  {
+    "name": "08585236861638480597867166179CU104",
+    "id": "/providers/Microsoft.ProcessSimple/environments/Default-e1dd4023-a656-480a-8a0e-c1b1eec51e1d/flows/24335774-daf6-4183-acb7-f5155c2cd2fe/runs/08585236861638480597867166179CU104",
+    "type": "Microsoft.ProcessSimple/environments/flows/runs",
+    "properties": {
+      "actions":{
+        "Compose": {
+          "input": "Test",
+          "inputsLink": {
+            "uri": "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionInputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionInputs%2Fread&sv=1.0&sig=wYD6bMHjdoOawYAMTHqpmyILowLKRCkFEfsNxi1NFzw",
+            "contentVersion": "test==",
+            "contentSize": 6,
+            "contentHash": {
+              "algorithm": "md5",
+              "value": "test=="
+            }
+          },
+          "output": "Test",
+          "outputsLink": {
+            "uri": "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionOutputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionOutputs%2Fread&sv=1.0&sig=KoI4_RAEVNFUgymktOFxvfb5mCoIKR2WCYGwexjD7kY",
+            "contentVersion": "test==",
+            "contentSize": 6,
+            "contentHash": {
+              "algorithm": "md5",
+              "value": "test=="
+            }
+          },
+          "startTime": "2023-11-17T21:06:14.466889Z",
+          "endTime": "2023-11-17T21:06:14.4676104Z",
+          "correlation": {
+            "actionTrackingId": "dabed750-0ec4-4c34-98f5-cc3695e0811e",
+            "clientTrackingId": "08585013686846794051719443325CU251",
+            "clientKeywords": [
+              "resubmitFlow"
+            ]
+          },
+          "status": "Succeeded",
+          "code": "OK"
+        }
+      },
+      "startTime": "2023-03-04T09:05:21.8066368Z",
+      "endTime": "2023-03-04T09:05:22.5880202Z",
+      "status": "Succeeded",
+      "correlation": {
+        "clientTrackingId": "08585236861638480598867166179CU131"
+      },
+      "trigger": {
+        "name": "When_an_email_is_flagged_(V4)",
+        "inputsLink": {
+          "uri": "https://prod-130.westeurope.logic.azure.com:443/workflows/3ebadb794f6641e0b7f4fda131cdfb0b/runs/08585236861638480597867166179CU104/contents/TriggerInputs?api-version=2016-06-01&se=2023-03-04T14%3A00%3A00.0000000Z&sp=%2Fruns%2F08585236861638480597867166179CU104%2Fcontents%2FTriggerInputs%2Fread&sv=1.0&sig=",
+          "contentVersion": "2v/VLXFrKV6JvwSdcN7aHg==",
+          "contentSize": 343,
+          "contentHash": {
+            "algorithm": "md5",
+            "value": "2v/VLXFrKV6JvwSdcN7aHg=="
+          }
+        },
+        "outputsLink": {
+          "uri": "https://prod-130.westeurope.logic.azure.com:443/workflows/3ebadb794f6641e0b7f4fda131cdfb0b/runs/08585236861638480597867166179CU104/contents/TriggerOutputs?api-version=2016-06-01&se=2023-03-04T14%3A00%3A00.0000000Z&sp=%2Fruns%2F08585236861638480597867166179CU104%2Fcontents%2FTriggerOutputs%2Fread&sv=1.0&sig=",
+          "contentVersion": "AHZEeWNlQ0bLe48yDmpzrQ==",
+          "contentSize": 3478,
+          "contentHash": {
+            "algorithm": "md5",
+            "value": "AHZEeWNlQ0bLe48yDmpzrQ=="
+          }
+        },
+        "startTime": "2023-03-04T09:05:21.6192576Z",
+        "endTime": "2023-03-04T09:05:21.7442626Z",
+        "scheduledTime": "2023-03-04T09:05:21.573561Z",
+        "originHistoryName": "08585236861638480598867166179CU131",
+        "correlation": {
+          "clientTrackingId": "08585236861638480598867166179CU131"
+        },
+        "code": "OK",
+        "status": "Succeeded"
+      }
+    },
+    "startTime": "2023-03-04T09:05:21.8066368Z",
+    "endTime": "2023-03-04T09:05:22.5880202Z",
+    "status": "Succeeded",
+    "triggerName": "When_an_email_is_flagged_(V4)",
+    "triggerInformation": {
+      "from": "john@contoso.com",
+      "toRecipients": "doe@contoso.com",
+      "subject": "Dummy email",
+      "body": "<html><head>\r\\\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></head><body><p>This is dummy content</p></body></html>",
+      "importance": "normal",
+      "bodyPreview": "This is dummy content",
+      "hasAttachments": false,
+      "id": "AAMkADgzN2Q1NThiLTI0NjYtNGIxYS05MDdjLTg1OWQxNzgwZGM2ZgBGAAAAAAC6jQfUzacTSIHqMw2yacnUBwBiOC8xvYmdT6G2E_hLMK5kAAAAAAEMAABiOC8xvYmdT6G2E_hLMK5kAALUqy81AAA=",
+      "internetMessageId": "<DB7PR03MB5018879914324FC65695809FE1AD9@DB7PR03MB5018.eurprd03.prod.outlook.com>",
+      "conversationId": "AAQkADgzN2Q1NThiLTI0NjYtNGIxYS05MDdjLTg1OWQxNzgwZGM2ZgAQAMqP9zsK8a1CnIYEgHclLTk=",
+      "receivedDateTime": "2023-03-01T15:06:57+00:00",
+      "isRead": false,
+      "attachments": [],
+      "isHtml": true
+    },
+    "actions": {
+      "Compose": {
+        "input": "Test",
+        "inputsLink": {
+          "uri": "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionInputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionInputs%2Fread&sv=1.0&sig=wYD6bMHjdoOawYAMTHqpmyILowLKRCkFEfsNxi1NFzw",
+          "contentVersion": "test==",
+          "contentSize": 6,
+          "contentHash": {
+            "algorithm": "md5",
+            "value": "test=="
+          }
+        },
+        "output": "Test",
+        "outputsLink": {
+          "uri": "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionOutputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionOutputs%2Fread&sv=1.0&sig=KoI4_RAEVNFUgymktOFxvfb5mCoIKR2WCYGwexjD7kY",
+          "contentVersion": "test==",
+          "contentSize": 6,
+          "contentHash": {
+            "algorithm": "md5",
+            "value": "test=="
+          }
+        },
+        "startTime": "2023-11-17T21:06:14.466889Z",
+        "endTime": "2023-11-17T21:06:14.4676104Z",
+        "correlation": {
+          "actionTrackingId": "dabed750-0ec4-4c34-98f5-cc3695e0811e",
+          "clientTrackingId": "08585013686846794051719443325CU251",
+          "clientKeywords": [
+            "resubmitFlow"
+          ]
+        },
+        "status": "Succeeded",
+        "code": "OK"
+      }
+    }
+  }
+  ```
+  </TabItem>
+</Tabs>

--- a/src/m365/flow/commands/run/run-get.spec.ts
+++ b/src/m365/flow/commands/run/run-get.spec.ts
@@ -26,6 +26,190 @@ describe(commands.RUN_GET, () => {
   const flowResponseFormatted = { 'name': runName, 'id': '/providers/Microsoft.ProcessSimple/environments/Default-48595cc3-adce-4267-8e99-0c838923dbb9/flows/edf73e7e-9928-4cb9-8eb2-fc263f375ada/runs/08586652586741142222645090602CU35', 'type': 'Microsoft.ProcessSimple/environments/flows/runs', 'properties': { 'startTime': '2018-09-07T19:23:31.3640166Z', 'endTime': '2018-09-07T19:33:31.3640166Z', 'status': 'Running', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'trigger': { 'name': 'manual', 'inputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerInputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerInputs%2Fread&sv=1.0&sig=yjCLU5P9pqCoDPHmRFq-oLKGhcFNnGUXH6ojpQz9z6Q', 'contentVersion': '1UI/8pYQdWDVSsijF+0l2Q==', 'contentSize': 58, 'contentHash': { 'algorithm': 'md5', 'value': '1UI/8pYQdWDVSsijF+0l2Q==' } }, 'outputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerOutputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerOutputs%2Fread&sv=1.0&sig=SLd0zBScyF6F6eMTBIROalK32e2t0od2SDETe9X9SMM', 'contentVersion': 'YgV2ecynizFKxzT8yiNtpA==', 'contentSize': 4244, 'contentHash': { 'algorithm': 'md5', 'value': 'YgV2ecynizFKxzT8yiNtpA==' } }, 'startTime': '2018-09-07T19:23:31.3482269Z', 'endTime': '2018-09-07T19:23:31.3482269Z', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'status': 'Succeeded' } }, startTime: '2018-09-07T19:23:31.3640166Z', endTime: '2018-09-07T19:33:31.3640166Z', status: 'Running', triggerName: 'manual' };
   const flowResponseFormattedNoEndTime = { 'name': runName, 'id': '/providers/Microsoft.ProcessSimple/environments/Default-48595cc3-adce-4267-8e99-0c838923dbb9/flows/edf73e7e-9928-4cb9-8eb2-fc263f375ada/runs/08586652586741142222645090602CU35', 'type': 'Microsoft.ProcessSimple/environments/flows/runs', 'properties': { 'startTime': '2018-09-07T19:23:31.3640166Z', 'endTime': '', 'status': 'Running', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'trigger': { 'name': 'manual', 'inputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerInputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerInputs%2Fread&sv=1.0&sig=yjCLU5P9pqCoDPHmRFq-oLKGhcFNnGUXH6ojpQz9z6Q', 'contentVersion': '1UI/8pYQdWDVSsijF+0l2Q==', 'contentSize': 58, 'contentHash': { 'algorithm': 'md5', 'value': '1UI/8pYQdWDVSsijF+0l2Q==' } }, 'outputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerOutputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerOutputs%2Fread&sv=1.0&sig=SLd0zBScyF6F6eMTBIROalK32e2t0od2SDETe9X9SMM', 'contentVersion': 'YgV2ecynizFKxzT8yiNtpA==', 'contentSize': 4244, 'contentHash': { 'algorithm': 'md5', 'value': 'YgV2ecynizFKxzT8yiNtpA==' } }, 'startTime': '2018-09-07T19:23:31.3482269Z', 'endTime': '', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'status': 'Succeeded' } }, startTime: '2018-09-07T19:23:31.3640166Z', endTime: '', status: 'Running', triggerName: 'manual' };
   const flowResponseFormattedIncludingInformation = { 'name': runName, 'id': '/providers/Microsoft.ProcessSimple/environments/Default-48595cc3-adce-4267-8e99-0c838923dbb9/flows/edf73e7e-9928-4cb9-8eb2-fc263f375ada/runs/08586652586741142222645090602CU35', 'type': 'Microsoft.ProcessSimple/environments/flows/runs', 'properties': { 'startTime': '2018-09-07T19:23:31.3640166Z', 'endTime': '2018-09-07T19:33:31.3640166Z', 'status': 'Running', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'trigger': { 'name': 'manual', 'inputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerInputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerInputs%2Fread&sv=1.0&sig=yjCLU5P9pqCoDPHmRFq-oLKGhcFNnGUXH6ojpQz9z6Q', 'contentVersion': '1UI/8pYQdWDVSsijF+0l2Q==', 'contentSize': 58, 'contentHash': { 'algorithm': 'md5', 'value': '1UI/8pYQdWDVSsijF+0l2Q==' } }, 'outputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerOutputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerOutputs%2Fread&sv=1.0&sig=SLd0zBScyF6F6eMTBIROalK32e2t0od2SDETe9X9SMM', 'contentVersion': 'YgV2ecynizFKxzT8yiNtpA==', 'contentSize': 4244, 'contentHash': { 'algorithm': 'md5', 'value': 'YgV2ecynizFKxzT8yiNtpA==' } }, 'startTime': '2018-09-07T19:23:31.3482269Z', 'endTime': '2018-09-07T19:23:31.3482269Z', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'status': 'Succeeded' } }, startTime: '2018-09-07T19:23:31.3640166Z', endTime: '2018-09-07T19:33:31.3640166Z', status: 'Running', triggerName: 'manual', triggerInformation: triggerInformationResponse.body };
+
+  const basicActionsInformation = {
+    'Compose': {
+      'inputsLink': {
+        'uri': "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionInputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionInputs%2Fread&sv=1.0&sig=wYD6bMHjdoOawYAMTHqpmyILowLKRCkFEfsNxi1NFzw",
+        'contentVersion': "test==",
+        'contentSize': 6,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'outputsLink': {
+        'uri': "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionOutputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionOutputs%2Fread&sv=1.0&sig=KoI4_RAEVNFUgymktOFxvfb5mCoIKR2WCYGwexjD7kY",
+        'contentVersion': "test==",
+        'contentSize': 6,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'startTime': "2023-11-17T21:06:14.466889Z",
+      'endTime': "2023-11-17T21:06:14.4676104Z",
+      'correlation': {
+        'actionTrackingId': "dabed750-0ec4-4c34-98f5-cc3695e0811e",
+        'clientTrackingId': "08585013686846794051719443325CU251",
+        'clientKeywords': [
+          "resubmitFlow"
+        ]
+      },
+      'status': "Succeeded",
+      'code': "OK"
+    },
+    'Get_items': {
+      'inputsLink': {
+        'uri': "https://prod-01.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Get_items/contents/ActionInputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FGet_items%2Fcontents%2FActionInputs%2Fread&sv=1.0&",
+        'contentVersion': "test==",
+        'contentSize': 356,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'outputsLink': {
+        'uri': "https://prod-01.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Get_items/contents/ActionOutputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FGet_items%2Fcontents%2FActionOutputs%2Fread&sv=1.0&",
+        'contentVersion': "test==",
+        'contentSize': 125480,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'startTime': "2023-11-17T21:06:14.4688325Z",
+      'endTime': "2023-11-17T21:06:14.7534248Z",
+      'correlation': {
+        'actionTrackingId': "af8e70eb-274e-425f-83de-651211e7f6b8",
+        'clientTrackingId': "08585013686846794051719443325CU251",
+        'clientKeywords': [
+          "resubmitFlow"
+        ]
+      },
+      'status': "Succeeded",
+      'code': "OK"
+    }
+  };
+
+  const actionInputStringExample = 'Test';
+  const actionInputComplexExample = {
+    'host': { 'apiId': "subscriptions/12345678901-1234-1234-1234-12345678901/providers/Microsoft.Web/locations/westeurope/runtimes/europe-001/apis/sharepointonline", 'connectionReferenceName': "shared_sharepointonline", 'operationId': "GetItems" }, 'parameters': { 'dataset': "https://contoso.sharepoint.com/sites/Example", 'table': "a38bbda1-15c8-4479-b9af-4f6e8fe8d26c" }
+  };
+
+  const actionOutputStringExample = 'Test';
+  const actionOutputComplexExample = { 'value': [{ '@odata.etag': '"1"', '@odata.type': '#Microsoft.Azure.Connectors.SharePoint.SPListExpandedReference', 'Id': 1, 'Title': 'Test', 'Value': 'Test' }] };
+
+  const actionsWithInputOutputInformation = {
+    'Compose': {
+      'inputsLink': {
+        'uri': "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionInputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionInputs%2Fread&sv=1.0&sig=wYD6bMHjdoOawYAMTHqpmyILowLKRCkFEfsNxi1NFzw",
+        'contentVersion': "test==",
+        'contentSize': 6,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'outputsLink': {
+        'uri': "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionOutputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionOutputs%2Fread&sv=1.0&sig=KoI4_RAEVNFUgymktOFxvfb5mCoIKR2WCYGwexjD7kY",
+        'contentVersion': "test==",
+        'contentSize': 6,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'startTime': "2023-11-17T21:06:14.466889Z",
+      'endTime': "2023-11-17T21:06:14.4676104Z",
+      'correlation': {
+        'actionTrackingId': "dabed750-0ec4-4c34-98f5-cc3695e0811e",
+        'clientTrackingId': "08585013686846794051719443325CU251",
+        'clientKeywords': [
+          "resubmitFlow"
+        ]
+      },
+      'status': "Succeeded",
+      'code': "OK",
+      'input': actionInputStringExample,
+      'output': actionOutputStringExample
+    },
+    'Get_items': {
+      'inputsLink': {
+        'uri': "https://prod-01.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Get_items/contents/ActionInputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FGet_items%2Fcontents%2FActionInputs%2Fread&sv=1.0&",
+        'contentVersion': "test==",
+        'contentSize': 356,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'outputsLink': {
+        'uri': "https://prod-01.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Get_items/contents/ActionOutputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FGet_items%2Fcontents%2FActionOutputs%2Fread&sv=1.0&",
+        'contentVersion': "test==",
+        'contentSize': 125480,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'startTime': "2023-11-17T21:06:14.4688325Z",
+      'endTime': "2023-11-17T21:06:14.7534248Z",
+      'correlation': {
+        'actionTrackingId': "af8e70eb-274e-425f-83de-651211e7f6b8",
+        'clientTrackingId': "08585013686846794051719443325CU251",
+        'clientKeywords': [
+          "resubmitFlow"
+        ]
+      },
+      'status': "Succeeded",
+      'code': "OK",
+      'input': actionInputComplexExample,
+      'output': actionOutputComplexExample
+    }
+  };
+
+  const actionsWithInputOutputInformationOfSelectedAction = {
+    'Compose': {
+      'inputsLink': {
+        'uri': "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionInputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionInputs%2Fread&sv=1.0&sig=wYD6bMHjdoOawYAMTHqpmyILowLKRCkFEfsNxi1NFzw",
+        'contentVersion': "test==",
+        'contentSize': 6,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'outputsLink': {
+        'uri': "https://prod-255.westeurope.logic.azure.com:443/workflows/88b5146587d144ea85efb15683c4e58f/runs/08586652586741142222645090602CU35/actions/Compose/contents/ActionOutputs?api-version=2016-06-01&se=2023-12-14T19%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Factions%2FCompose%2Fcontents%2FActionOutputs%2Fread&sv=1.0&sig=KoI4_RAEVNFUgymktOFxvfb5mCoIKR2WCYGwexjD7kY",
+        'contentVersion': "test==",
+        'contentSize': 6,
+        'contentHash': {
+          'algorithm': "md5",
+          'value': "test=="
+        }
+      },
+      'startTime': "2023-11-17T21:06:14.466889Z",
+      'endTime': "2023-11-17T21:06:14.4676104Z",
+      'correlation': {
+        'actionTrackingId': "dabed750-0ec4-4c34-98f5-cc3695e0811e",
+        'clientTrackingId': "08585013686846794051719443325CU251",
+        'clientKeywords': [
+          "resubmitFlow"
+        ]
+      },
+      'status': "Succeeded",
+      'code': "OK",
+      'input': actionInputStringExample,
+      'output': actionOutputStringExample
+    }
+  };
+
+  const flowResponseFormattedIncludingActionsBasicInformation = { 'name': runName, 'id': '/providers/Microsoft.ProcessSimple/environments/Default-48595cc3-adce-4267-8e99-0c838923dbb9/flows/edf73e7e-9928-4cb9-8eb2-fc263f375ada/runs/08586652586741142222645090602CU35', 'type': 'Microsoft.ProcessSimple/environments/flows/runs', 'properties': { actions: basicActionsInformation, 'startTime': '2018-09-07T19:23:31.3640166Z', 'endTime': '2018-09-07T19:33:31.3640166Z', 'status': 'Running', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'trigger': { 'name': 'manual', 'inputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerInputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerInputs%2Fread&sv=1.0&sig=yjCLU5P9pqCoDPHmRFq-oLKGhcFNnGUXH6ojpQz9z6Q', 'contentVersion': '1UI/8pYQdWDVSsijF+0l2Q==', 'contentSize': 58, 'contentHash': { 'algorithm': 'md5', 'value': '1UI/8pYQdWDVSsijF+0l2Q==' } }, 'outputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerOutputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerOutputs%2Fread&sv=1.0&sig=SLd0zBScyF6F6eMTBIROalK32e2t0od2SDETe9X9SMM', 'contentVersion': 'YgV2ecynizFKxzT8yiNtpA==', 'contentSize': 4244, 'contentHash': { 'algorithm': 'md5', 'value': 'YgV2ecynizFKxzT8yiNtpA==' } }, 'startTime': '2018-09-07T19:23:31.3482269Z', 'endTime': '2018-09-07T19:23:31.3482269Z', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'status': 'Succeeded' } }, startTime: '2018-09-07T19:23:31.3640166Z', endTime: '2018-09-07T19:33:31.3640166Z', status: 'Running', triggerName: 'manual' };
+
+  const commandResultIncluddingAllActions = { 'name': runName, 'id': '/providers/Microsoft.ProcessSimple/environments/Default-48595cc3-adce-4267-8e99-0c838923dbb9/flows/edf73e7e-9928-4cb9-8eb2-fc263f375ada/runs/08586652586741142222645090602CU35', 'type': 'Microsoft.ProcessSimple/environments/flows/runs', 'properties': { actions: basicActionsInformation, 'startTime': '2018-09-07T19:23:31.3640166Z', 'endTime': '2018-09-07T19:33:31.3640166Z', 'status': 'Running', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'trigger': { 'name': 'manual', 'inputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerInputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerInputs%2Fread&sv=1.0&sig=yjCLU5P9pqCoDPHmRFq-oLKGhcFNnGUXH6ojpQz9z6Q', 'contentVersion': '1UI/8pYQdWDVSsijF+0l2Q==', 'contentSize': 58, 'contentHash': { 'algorithm': 'md5', 'value': '1UI/8pYQdWDVSsijF+0l2Q==' } }, 'outputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerOutputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerOutputs%2Fread&sv=1.0&sig=SLd0zBScyF6F6eMTBIROalK32e2t0od2SDETe9X9SMM', 'contentVersion': 'YgV2ecynizFKxzT8yiNtpA==', 'contentSize': 4244, 'contentHash': { 'algorithm': 'md5', 'value': 'YgV2ecynizFKxzT8yiNtpA==' } }, 'startTime': '2018-09-07T19:23:31.3482269Z', 'endTime': '2018-09-07T19:23:31.3482269Z', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'status': 'Succeeded' } }, startTime: '2018-09-07T19:23:31.3640166Z', endTime: '2018-09-07T19:33:31.3640166Z', status: 'Running', triggerName: 'manual', actions: actionsWithInputOutputInformation };
+
+  const commandResultIncludingSelectedAction = { 'name': runName, 'id': '/providers/Microsoft.ProcessSimple/environments/Default-48595cc3-adce-4267-8e99-0c838923dbb9/flows/edf73e7e-9928-4cb9-8eb2-fc263f375ada/runs/08586652586741142222645090602CU35', 'type': 'Microsoft.ProcessSimple/environments/flows/runs', 'properties': { actions: basicActionsInformation, 'startTime': '2018-09-07T19:23:31.3640166Z', 'endTime': '2018-09-07T19:33:31.3640166Z', 'status': 'Running', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'trigger': { 'name': 'manual', 'inputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerInputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerInputs%2Fread&sv=1.0&sig=yjCLU5P9pqCoDPHmRFq-oLKGhcFNnGUXH6ojpQz9z6Q', 'contentVersion': '1UI/8pYQdWDVSsijF+0l2Q==', 'contentSize': 58, 'contentHash': { 'algorithm': 'md5', 'value': '1UI/8pYQdWDVSsijF+0l2Q==' } }, 'outputsLink': { 'uri': 'https://prod-09.westeurope.logic.azure.com:443/workflows/8c76aebc46484a29889c426f55a52f55/runs/08586652586741142222645090602CU35/contents/TriggerOutputs?api-version=2016-06-01&se=2018-09-07T23%3A00%3A00.0000000Z&sp=%2Fruns%2F08586652586741142222645090602CU35%2Fcontents%2FTriggerOutputs%2Fread&sv=1.0&sig=SLd0zBScyF6F6eMTBIROalK32e2t0od2SDETe9X9SMM', 'contentVersion': 'YgV2ecynizFKxzT8yiNtpA==', 'contentSize': 4244, 'contentHash': { 'algorithm': 'md5', 'value': 'YgV2ecynizFKxzT8yiNtpA==' } }, 'startTime': '2018-09-07T19:23:31.3482269Z', 'endTime': '2018-09-07T19:23:31.3482269Z', 'correlation': { 'clientTrackingId': '08586652586741142222645090602CU35', 'clientKeywords': ['testFlow'] }, 'status': 'Succeeded' } }, startTime: '2018-09-07T19:23:31.3640166Z', endTime: '2018-09-07T19:33:31.3640166Z', status: 'Running', triggerName: 'manual', actions: actionsWithInputOutputInformationOfSelectedAction };
   //#endregion
 
   let log: string[];
@@ -103,7 +287,7 @@ describe(commands.RUN_GET, () => {
     assert(loggerLogSpy.calledWith(flowResponseFormattedNoEndTime));
   });
 
-  it('retrieves information about the specified run including trigger information', async () => {
+  it('retrieves information about the specified run including trigger information using includeTriggerInformation parameter', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentName}/flows/${flowName}/runs/${runName}?api-version=2016-11-01`) {
         return flowResponse;
@@ -120,6 +304,107 @@ describe(commands.RUN_GET, () => {
     assert(loggerLogSpy.calledWith(flowResponseFormattedIncludingInformation));
   });
 
+  it('retrieves information about the specified run including trigger information using withTrigger parameter', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentName}/flows/${flowName}/runs/${runName}?api-version=2016-11-01`) {
+        return flowResponse;
+      }
+
+      if (opts.url === flowResponse.properties.trigger.outputsLink.uri) {
+        return triggerInformationResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, withTrigger: true, verbose: true } });
+    assert(loggerLogSpy.calledWith(flowResponseFormattedIncludingInformation));
+  });
+
+  it('retrieves information about the specified run including all actions details information using withActions parameter', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentName}/flows/${flowName}/runs/${runName}?$expand=properties%2Factions&api-version=2016-11-01`) {
+        return flowResponseFormattedIncludingActionsBasicInformation;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Compose.inputsLink.uri) {
+        return actionInputStringExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Compose.outputsLink.uri) {
+        return actionOutputStringExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Get_items.inputsLink.uri) {
+        return actionInputComplexExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Get_items.outputsLink.uri) {
+        return actionOutputComplexExample;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, withActions: true, verbose: true } });
+    assert(loggerLogSpy.calledWith(commandResultIncluddingAllActions));
+  });
+
+  it('retrieves information about the specified run including details information of selected actions', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentName}/flows/${flowName}/runs/${runName}?$expand=properties%2Factions&api-version=2016-11-01`) {
+        return flowResponseFormattedIncludingActionsBasicInformation;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Compose.inputsLink.uri) {
+        return actionInputStringExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Compose.outputsLink.uri) {
+        return actionOutputStringExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Get_items.inputsLink.uri) {
+        return actionInputComplexExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Get_items.outputsLink.uri) {
+        return actionOutputComplexExample;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, withActions: "Compose", verbose: true } });
+    assert(loggerLogSpy.calledWith(commandResultIncludingSelectedAction));
+  });
+
+  it('retrieves information of actions without details even when name of the selected action is incorrect', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentName}/flows/${flowName}/runs/${runName}?$expand=properties%2Factions&api-version=2016-11-01`) {
+        return flowResponseFormattedIncludingActionsBasicInformation;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Compose.inputsLink.uri) {
+        return actionInputStringExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Compose.outputsLink.uri) {
+        return actionOutputStringExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Get_items.inputsLink.uri) {
+        return actionInputComplexExample;
+      }
+
+      if (opts.url === flowResponseFormattedIncludingActionsBasicInformation.properties.actions.Get_items.outputsLink.uri) {
+        return actionOutputComplexExample;
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, withActions: "Wrong,Wrong2", verbose: true } });
+    assert(loggerLogSpy.calledWith(flowResponseFormattedIncludingActionsBasicInformation));
+  });
+
   it('correctly handles Flow not found', async () => {
     sinon.stub(request, 'get').rejects({
       'error': {
@@ -134,6 +419,11 @@ describe(commands.RUN_GET, () => {
 
   it('fails validation if the flowName is not valid GUID', async () => {
     const actual = await command.validate({ options: { environmentName: environmentName, flowName: 'invalid', name: runName } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the withActions parameter is not valid boolean or string', async () => {
+    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, name: runName, withActions: -1 } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 

--- a/src/m365/flow/commands/run/run-get.ts
+++ b/src/m365/flow/commands/run/run-get.ts
@@ -15,6 +15,60 @@ interface Options extends GlobalOptions {
   flowName: string;
   name: string;
   includeTriggerInformation?: boolean
+  withTrigger?: boolean;
+  withActions?: string | boolean;
+}
+
+interface FlowLink {
+  uri: string;
+}
+
+interface Trigger {
+  endTime: string
+  name: string;
+  originHistoryName: string;
+  isAborted: boolean;
+  inputsLink: FlowLink;
+  outputsLink: FlowLink;
+  sourceHistoryName: string
+  startTime: string
+  status: string
+}
+
+interface Action {
+  [actionKey: string]: {
+    code: string;
+    endTime: string;
+    startTime: string;
+    status: string;
+    inputsLink?: FlowLink;
+    outputsLink?: FlowLink;
+    input?: any;
+    output?: any;
+  }
+}
+
+interface Run {
+  id: string;
+  name: string;
+  properties: {
+    startTime: string,
+    endTime: string,
+    status: string,
+    code: string,
+    trigger: Trigger,
+    actions?: Action
+  },
+  type: string;
+}
+
+interface RunResult extends Run {
+  endTime?: string
+  startTime?: string;
+  status?: string;
+  triggerName?: string;
+  triggerInformation?: any;
+  actions?: Action;
 }
 
 class FlowRunGetCommand extends PowerAutomateCommand {
@@ -51,6 +105,12 @@ class FlowRunGetCommand extends PowerAutomateCommand {
       },
       {
         option: '--includeTriggerInformation'
+      },
+      {
+        option: '--withTrigger'
+      },
+      {
+        option: '--withActions [withActions]'
       }
     );
   }
@@ -62,6 +122,10 @@ class FlowRunGetCommand extends PowerAutomateCommand {
           return `${args.options.flowName} is not a valid GUID`;
         }
 
+        if (args.options.withActions && (typeof args.options.withActions !== 'string' && typeof args.options.withActions !== 'boolean')) {
+          return 'the withActions parameter must be a string or boolean';
+        }
+
         return true;
       }
     );
@@ -70,7 +134,9 @@ class FlowRunGetCommand extends PowerAutomateCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        includeTriggerInformation: !!args.options.includeTriggerInformation
+        includeTriggerInformation: !!args.options.includeTriggerInformation,
+        withTrigger: !!args.options.withTrigger,
+        withActions: typeof args.options.withActions !== 'undefined'
       });
     });
   }
@@ -80,8 +146,13 @@ class FlowRunGetCommand extends PowerAutomateCommand {
       await logger.logToStderr(`Retrieving information about run ${args.options.name} of Microsoft Flow ${args.options.flowName}...`);
     }
 
+    if (args.options.includeTriggerInformation) {
+      await this.warn(logger, `Parameter 'includeTriggerInformation' is deprecated. Please use 'withTrigger instead`);
+    }
+
+    const actionsParameter = args.options.withActions ? '$expand=properties%2Factions&' : '';
     const requestOptions: CliRequestOptions = {
-      url: `${this.resource}/providers/Microsoft.ProcessSimple/environments/${formatting.encodeQueryParameter(args.options.environmentName)}/flows/${formatting.encodeQueryParameter(args.options.flowName)}/runs/${formatting.encodeQueryParameter(args.options.name)}?api-version=2016-11-01`,
+      url: `${this.resource}/providers/Microsoft.ProcessSimple/environments/${formatting.encodeQueryParameter(args.options.environmentName)}/flows/${formatting.encodeQueryParameter(args.options.flowName)}/runs/${formatting.encodeQueryParameter(args.options.name)}?${actionsParameter}api-version=2016-11-01`,
       headers: {
         accept: 'application/json'
       },
@@ -89,24 +160,18 @@ class FlowRunGetCommand extends PowerAutomateCommand {
     };
 
     try {
-      const res = await request.get<any>(requestOptions);
-
+      const res: RunResult = await request.get<Run>(requestOptions);
       res.startTime = res.properties.startTime;
       res.endTime = res.properties.endTime || '';
       res.status = res.properties.status;
       res.triggerName = res.properties.trigger.name;
 
-      if (args.options.includeTriggerInformation && res.properties.trigger.outputsLink) {
-        const triggerInformationOptions: CliRequestOptions = {
-          url: res.properties.trigger.outputsLink.uri,
-          headers: {
-            accept: 'application/json',
-            'x-anonymous': true
-          },
-          responseType: 'json'
-        };
-        const triggerInformationResponse = await request.get<any>(triggerInformationOptions);
-        res.triggerInformation = triggerInformationResponse.body;
+      if ((args.options.includeTriggerInformation || args.options.withTrigger) && res.properties.trigger.outputsLink) {
+        res.triggerInformation = await this.getTriggerInformation(res);
+      }
+
+      if (!!args.options.withActions) {
+        res.actions = await this.getActionsInformation(res, args.options.withActions);
       }
 
       await logger.log(res);
@@ -114,6 +179,42 @@ class FlowRunGetCommand extends PowerAutomateCommand {
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
+  }
+
+  private async getTriggerInformation(res: RunResult): Promise<any> {
+    return await this.requestAdditionalInformation(res.properties.trigger.outputsLink.uri);
+  }
+
+  private async getActionsInformation(res: RunResult, withActions: boolean | string): Promise<any> {
+    const chosenActions = typeof withActions === 'string' ? withActions.split(',') : null;
+    const actionsResult: any = {};
+
+    for (const action in res.properties.actions) {
+      if (!res.properties.actions[action] || (chosenActions && chosenActions.indexOf(action) === -1)) { continue; }
+
+      actionsResult[action] = res.properties.actions[action];
+      if (!!res.properties.actions[action].inputsLink?.uri) {
+        actionsResult[action].input = await this.requestAdditionalInformation(res.properties.actions[action].inputsLink?.uri);
+      }
+
+      if (!!res.properties.actions[action].outputsLink?.uri) {
+        actionsResult[action].output = await this.requestAdditionalInformation(res.properties.actions[action].outputsLink?.uri);
+      }
+    }
+    return actionsResult;
+  }
+
+  private async requestAdditionalInformation(requestUri: string | undefined): Promise<any> {
+    const additionalInformationOptions: CliRequestOptions = {
+      url: requestUri,
+      headers: {
+        accept: 'application/json',
+        'x-anonymous': true
+      },
+      responseType: 'json'
+    };
+    const additionalInformationResponse = await request.get<any | string>(additionalInformationOptions);
+    return additionalInformationResponse.body ? additionalInformationResponse.body : additionalInformationResponse;
   }
 }
 


### PR DESCRIPTION
Enhances `m365 flow run get` with the ability to retrieve the action details. Closes #1828

Hi, I have submitted this PR, but I would like to confirm some points:
- Is the deprecation message in line 150 of run-get.ts ok?
- I have introduced some interfaces instead of using 'any.' Should I extract them into a separate file?
- I am not sure how to describe the deprecated parameter in the run-get.mdx file. I understand that both parameters 'includeTriggerInformation' and 'withTrigger' should coexist.
- 'withActions' parameter can be a boolean (to include all actions) or a string with desired actions separated by a comma.
- the output of actions is similar to what is provided by the Flow API. Please let me know if this is acceptable

I noticed that there were some changes in the flows commands made by @martinlingstuyl in #5721. Once his code is merged, I can retest my changes included in this PR.
