### PR TITLE
Removes trailing slash config

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -15,7 +15,6 @@ const config: Config = {
   favicon: 'img/favicon.ico',
   organizationName: 'pnp',
   projectName: 'cli-microsoft365',
-  trailingSlash: false,
 
   i18n: {
     defaultLocale: 'en',


### PR DESCRIPTION
Context: https://github.com/pnp/cli-microsoft365/pull/5537#issuecomment-1752150250

TL;DR: A few months ago, the docs build pipeline weirdly failed because of something weird. We got it fixed by using this config setting. However it's recommended for GitHub pages to not turn this setting off, it was the only way to get the build pipeline working again. 

Since we now moved to Docusaurus v3, I tried the build again without this setting, and it seems to work. Since it's recommended to disable the config for GH pages, let's remove it again.