### PR TITLE
Extends 'pa app get' command with support to throw error when app not found. Closes #5728

### DIFF
--- a/src/m365/pa/commands/app/app-get.spec.ts
+++ b/src/m365/pa/commands/app/app-get.spec.ts
@@ -20,7 +20,6 @@ describe(commands.APP_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -45,7 +44,6 @@ describe(commands.APP_GET, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
   });
 
   afterEach(() => {
@@ -1941,8 +1939,12 @@ describe(commands.APP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, displayName: 'NoAppFound' } });
-    assert(loggerLogToStderrSpy.calledWith(`No app found with displayName 'NoAppFound'`));
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: true,
+        displayName: 'NoAppFound'
+      }
+    } as any), new CommandError(`No app found with displayName 'NoAppFound'`));
   });
 
   it('correctly handles no apps found using displayName (debug)', async () => {
@@ -1953,8 +1955,12 @@ describe(commands.APP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, displayName: 'Playwright' } });
-    assert(loggerLogToStderrSpy.calledWith(`No apps found`));
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: true,
+        displayName: 'Playwright'
+      }
+    } as any), new CommandError(`No apps found`));
   });
 
   it('correctly handles API OData error', async () => {

--- a/src/m365/pa/commands/app/app-get.ts
+++ b/src/m365/pa/commands/app/app-get.ts
@@ -106,19 +106,16 @@ class PaAppGetCommand extends PowerAppsCommand {
           const app = allApps.find((a: any) => {
             return a.properties.displayName.toLowerCase() === `${args.options.displayName}`.toLowerCase();
           });
+
           if (!!app) {
             await logger.log(this.setProperties(app));
           }
           else {
-            if (this.verbose) {
-              await logger.logToStderr(`No app found with displayName '${args.options.displayName}'`);
-            }
+            throw `No app found with displayName '${args.options.displayName}'`;
           }
         }
         else {
-          if (this.verbose) {
-            await logger.logToStderr('No apps found');
-          }
+          throw 'No apps found';
         }
       }
     }


### PR DESCRIPTION
Extends `pa app get` command with support to throw error when app not found. Closes #5728