### PR TITLE
Add support for redirect URLs. Closes #5738

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import type { Options as ClientRedirectsOptions } from '@docusaurus/plugin-client-redirects';
 import LightCodeTheme from './src/config/lightCodeTheme';
 import DarkCodeTheme from './src/config/darkCodeTheme';
 import definitionList from './src/remark/definitionLists';
@@ -43,6 +44,18 @@ const config: Config = {
       {
         excludeAliases: ['console']
       }
+    ],
+    [
+      'client-redirects',
+      {
+        createRedirects(routePath) {
+          if (routePath.includes('/entra')) {
+            return [routePath.replace('/entra', '/aad')];
+          }
+
+          return [];
+        }
+      } satisfies ClientRedirectsOptions
     ]
   ],
 
@@ -69,9 +82,6 @@ const config: Config = {
     ]
   ],
 
-  markdown: {
-    mermaid: true,
-  },
   themes: ['@docusaurus/theme-mermaid'],
 
   themeConfig:

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.0.0",
+        "@docusaurus/plugin-client-redirects": "^3.0.0",
         "@docusaurus/preset-classic": "^3.0.0",
         "@docusaurus/theme-mermaid": "^3.0.0",
         "@docusaurus/types": "^3.0.0",
@@ -2356,6 +2357,29 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.0.1.tgz",
+      "integrity": "sha512-CoZapnHbV3j5jsHCa/zmKaa8+H+oagHBgg91dN5I8/3kFit/xtZPfRaznvDX49cHg2nSoV74B3VMAT+bvCmzFQ==",
+      "dependencies": {
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,9 +16,10 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.0.0",
+    "@docusaurus/plugin-client-redirects": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",
-    "@docusaurus/types": "^3.0.0",
     "@docusaurus/theme-mermaid": "^3.0.0",
+    "@docusaurus/types": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "@mendable/search": "^0.0.183",
     "clsx": "^2.0.0",


### PR DESCRIPTION
Closes #5738

Just a heads up, testing this PR locally can be a bit of a hassle. If you want to see the redirect page in action, follow these steps:

1. Make a new folder called `entra` inside `docs\docs\cmd`.
2. Inside that folder, create another one named `test`.
3. Drop a file named `test.mdx` in there with something simple like "Hello World."
4. Run `npm run build` or `yarn build` to build the docs.
5. Fire up the build with `npm run serve` or `yarn serve`.
6. Open your browser and go to `http://localhost:3000/cli-microsoft365/cmd/aad/test` to see it automatically redirect to `http://localhost:3000/cli-microsoft365/cmd/entra/test`.