### PR TITLE
Fix typo in `v6-upgrade-guidance`.

### DIFF
--- a/docs/docs/v6-upgrade-guidance.mdx
+++ b/docs/docs/v6-upgrade-guidance.mdx
@@ -201,7 +201,7 @@ Update your scripts to use the new `member` noun instead of `user`. If you are u
 
 ## Removed short notation for option asAdmin in pp commands
 
-We've decided to remove all short notations for option `--asAdmin` in pp commands. In previous versions, many commands had the notation `-a, --asAdmin`. This has been changed to `--adAdmin`, we removed the short notation to align it with our naming convention.
+We've decided to remove all short notations for option `--asAdmin` in pp commands. In previous versions, many commands had the notation `-a, --asAdmin`. This has been changed to `--asAdmin`, we removed the short notation to align it with our naming convention.
 
 Affected commands:
 


### PR DESCRIPTION
Noticed a little typo in `v6-upgrade-guidance.mdx`. `--adAdmin` should be `--asAdmin`