### PR TITLE
Fixes 'spo group member add', 'spo group member remove', and 'spo user ensure' commands to update options. Closes #5745

### DIFF
--- a/docs/docs/cmd/spo/group/group-member-add.mdx
+++ b/docs/docs/cmd/spo/group/group-member-add.mdx
@@ -33,18 +33,24 @@ m365 spo group member add [options]
 `--userIds [userIds]`
 : The user Id of the user to add as a member. (Id of the site user, for example: 14) If multiple users need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds` or `aadGroupNames`.
 
+`--entraGroupIds [entraGroupIds]`
+: The object Id of the Entra group to add as a member. If multiple groups need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames`.
+
 `--aadGroupIds [aadGroupIds]`
-: The object Id of the Azure AD group to add as a member. If multiple groups need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds` or `aadGroupNames`.
+: (deprecated. Use `entraGroupIds` instead) The object Id of the Azure AD group to add as a member. If multiple groups need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames`.
+
+`--entraGroupNames [entraGroupNames]`
+: The name of the Entra group to add as a member. If multiple groups need to be added, they have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames`.
 
 `--aadGroupNames [aadGroupNames]`
-: The name of the Azure AD group to add as a member. If multiple groups need to be added, they have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds` or `aadGroupNames`.
+: (deprecated. Use `entraGroupNames` instead) The name of the Azure AD group to add as a member. If multiple groups need to be added, they have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames`.
 ```
 
 <Global />
 
 ## Remarks
 
-For the `userIds`, `userNames`, `emails`, `aadGroupIds` or `aadGroupNames` options you can specify multiple values by separating them with a comma. If one of the specified entries is not valid, the command will fail with an error message showing the list of invalid values.
+For the `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames` options you can specify multiple values by separating them with a comma. If one of the specified entries is not valid, the command will fail with an error message showing the list of invalid values.
 
 ## Examples
 
@@ -84,11 +90,29 @@ Add multiple users with the userIds parameter to a SharePoint group with the gro
 m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --userIds "5,12"
 ```
 
-Add multiple users with the aadGroupNames parameter to a SharePoint group with the groupId parameter 
+Add multiple users with the aadGroupIds parameter to a SharePoint group with the groupId parameter.
   
- ```sh 
- m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --aadGroupNames "Azure group one, Azure group two" 
- ``` 
+```sh 
+m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --aadGroupIds "f2fb2f10-cfd2-4054-8ffd-64533657a5ab,3e86049e-89e6-4c27-bccb-d7549f0bbd06"
+```
+
+Add multiple users with the entraGroupIds parameter to a SharePoint group with the groupId parameter.
+  
+```sh 
+m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --entraGroupIds "f2fb2f10-cfd2-4054-8ffd-64533657a5ab,3e86049e-89e6-4c27-bccb-d7549f0bbd06"
+```
+
+Add multiple users with the entraGroupNames parameter to a SharePoint group with the groupId parameter.
+  
+```sh 
+m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --entraGroupNames "Azure group one, Azure group two" 
+```
+
+Add multiple users with the aadGroupNames parameter to a SharePoint group with the groupId parameter.
+  
+```sh 
+m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --aadGroupNames "Azure group one, Azure group two" 
+```
 
 ## Response
 

--- a/docs/docs/cmd/spo/group/group-member-add.mdx
+++ b/docs/docs/cmd/spo/group/group-member-add.mdx
@@ -90,12 +90,6 @@ Add multiple users with the userIds parameter to a SharePoint group with the gro
 m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --userIds "5,12"
 ```
 
-Add multiple users with the aadGroupIds parameter to a SharePoint group with the groupId parameter.
-  
-```sh 
-m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --aadGroupIds "f2fb2f10-cfd2-4054-8ffd-64533657a5ab,3e86049e-89e6-4c27-bccb-d7549f0bbd06"
-```
-
 Add multiple users with the entraGroupIds parameter to a SharePoint group with the groupId parameter.
   
 ```sh 
@@ -106,12 +100,6 @@ Add multiple users with the entraGroupNames parameter to a SharePoint group with
   
 ```sh 
 m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --entraGroupNames "Azure group one, Azure group two" 
-```
-
-Add multiple users with the aadGroupNames parameter to a SharePoint group with the groupId parameter.
-  
-```sh 
-m365 spo group member add --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --aadGroupNames "Azure group one, Azure group two" 
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/group/group-member-remove.mdx
+++ b/docs/docs/cmd/spo/group/group-member-remove.mdx
@@ -72,22 +72,10 @@ Remove an Entra group from a SharePoint group based on the Entra group name on a
 m365 spo group member remove --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --entraGroupName "Azure AD Security Group"
 ```
 
-Remove an Azure AD group from a SharePoint group based on the Azure AD group name on a given web.
-
-```sh
-m365 spo group member remove --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --aadGroupName "Azure AD Security Group"
-```
-
 Remove an Entra group from a SharePoint group based on the Entra group ID on a given web.
 
 ```sh
 m365 spo group member remove --webUrl https://contoso.sharepoint.com/sites/SiteA --groupName "Site A Visitors" --entraGroupId "5786b8e8-c495-4734-b345-756733960730"
-```
-
-Remove an Azure AD group from a SharePoint group based on the Azure AD group ID on a given web.
-
-```sh
-m365 spo group member remove --webUrl https://contoso.sharepoint.com/sites/SiteA --groupName "Site A Visitors" --aadGroupId "5786b8e8-c495-4734-b345-756733960730"
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/group/group-member-remove.mdx
+++ b/docs/docs/cmd/spo/group/group-member-remove.mdx
@@ -31,11 +31,17 @@ m365 spo group member remove [options]
 `--userId [userId]`
 : The user Id (Id of the site user, eg. 14) of the user to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId` or `aadGroupName`.
 
+`--entraGroupId [entraGroupId]`
+: The object Id of the Entra group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId`, `entraGroupId`, `aadGroupName`, or `entraGroupName`.
+
 `--aadGroupId [aadGroupId]`
-: The object Id of the Azure AD group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId` or `aadGroupName`.
+: (deprecated. Use `entraGroupId` instead) The object Id of the Azure AD group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId`, `entraGroupId`, `aadGroupName`, or `entraGroupName`.
+
+`--entraGroupName [entraGroupName]`
+: The name of the Entra group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId`, `entraGroupId`, `aadGroupName`, or `entraGroupName`.
 
 `--aadGroupName [aadGroupName]`
-: The name of the Azure AD group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId` or `aadGroupName`.
+: (deprecated. Use `entraGroupName` instead) The name of the Azure AD group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId`, `entraGroupId`, `aadGroupName`, or `entraGroupName`.
 ```
 
 <Global />
@@ -60,10 +66,22 @@ Remove a user from a SharePoint group by email.
 m365 spo group member remove --webUrl https://contoso.sharepoint.com/sites/SiteA --groupName "Site A Visitors" --userId 14
 ```
 
+Remove an Entra group from a SharePoint group based on the Entra group name on a given web.
+
+```sh
+m365 spo group member remove --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --entraGroupName "Azure AD Security Group"
+```
+
 Remove an Azure AD group from a SharePoint group based on the Azure AD group name on a given web.
 
 ```sh
 m365 spo group member remove --webUrl https://contoso.sharepoint.com/sites/SiteA --groupId 5 --aadGroupName "Azure AD Security Group"
+```
+
+Remove an Entra group from a SharePoint group based on the Entra group ID on a given web.
+
+```sh
+m365 spo group member remove --webUrl https://contoso.sharepoint.com/sites/SiteA --groupName "Site A Visitors" --entraGroupId "5786b8e8-c495-4734-b345-756733960730"
 ```
 
 Remove an Azure AD group from a SharePoint group based on the Azure AD group ID on a given web.

--- a/docs/docs/cmd/spo/user/user-ensure.mdx
+++ b/docs/docs/cmd/spo/user/user-ensure.mdx
@@ -32,19 +32,13 @@ m365 spo user ensure [options]
 
 ## Examples
 
-Ensures a user by its Entra Id
+Ensures a user by its Entra Id.
 
 ```sh
 m365 spo user ensure --webUrl https://contoso.sharepoint.com/sites/project --entraId e254750a-eaa4-44f6-9517-b74f65cdb747
 ```
 
-Ensures a user by its Azure AD Id
-
-```sh
-m365 spo user ensure --webUrl https://contoso.sharepoint.com/sites/project --aadId e254750a-eaa4-44f6-9517-b74f65cdb747
-```
-
-Ensures a user by its user principal name
+Ensures a user by its user principal name.
 
 ```sh
 m365 spo user ensure --webUrl https://contoso.sharepoint.com/sites/project --userName john@contoso.com

--- a/docs/docs/cmd/spo/user/user-ensure.mdx
+++ b/docs/docs/cmd/spo/user/user-ensure.mdx
@@ -18,16 +18,25 @@ m365 spo user ensure [options]
 `-u, --webUrl <webUrl>`
 : Absolute URL of the site.
 
+`--entraId [--entraId]`
+: Id of the user in Entra. Specify either `aadId`, `entraId`, or `userName`.
+
 `--aadId [--aadId]`
-: Id of the user in Azure AD. Specify either `aadId` or `userName` but not both.
+: (deprecated. Use `entraId` instead) Id of the user in Azure AD. Specify either `aadId`, `entraId`, or `userName`.
 
 `--userName [userName]`
-: User's UPN (user principal name, e.g. john@contoso.com). Specify either `aadId` or `userName` but not both.
+: User's UPN (user principal name, e.g. john@contoso.com). Specify either `aadId`, `entraId`, or `userName`.
 ```
 
 <Global />
 
 ## Examples
+
+Ensures a user by its Entra Id
+
+```sh
+m365 spo user ensure --webUrl https://contoso.sharepoint.com/sites/project --entraId e254750a-eaa4-44f6-9517-b74f65cdb747
+```
 
 Ensures a user by its Azure AD Id
 

--- a/src/m365/spo/commands/user/user-ensure.ts
+++ b/src/m365/spo/commands/user/user-ensure.ts
@@ -12,6 +12,7 @@ interface CommandArgs {
 
 interface Options extends GlobalOptions {
   webUrl: string;
+  entraId?: string;
   aadId?: string;
   userName?: string;
 }
@@ -37,6 +38,7 @@ class SpoUserEnsureCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
+        entraId: typeof args.options.entraId !== 'undefined',
         aadId: typeof args.options.aadId !== 'undefined',
         userName: typeof args.options.userName !== 'undefined'
       });
@@ -47,6 +49,9 @@ class SpoUserEnsureCommand extends SpoCommand {
     this.options.unshift(
       {
         option: '-u, --webUrl <webUrl>'
+      },
+      {
+        option: '--entraId [entraId]'
       },
       {
         option: '--aadId [aadId]'
@@ -65,6 +70,10 @@ class SpoUserEnsureCommand extends SpoCommand {
           return isValidSharePointUrl;
         }
 
+        if (args.options.entraId && !validation.isValidGuid(args.options.entraId)) {
+          return `${args.options.entraId} is not a valid GUID.`;
+        }
+
         if (args.options.aadId && !validation.isValidGuid(args.options.aadId)) {
           return `${args.options.aadId} is not a valid GUID.`;
         }
@@ -79,17 +88,23 @@ class SpoUserEnsureCommand extends SpoCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push({ options: ['aadId', 'userName'] });
+    this.optionSets.push({ options: ['entraId', 'aadId', 'userName'] });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (args.options.aadId) {
+      args.options.entraId = args.options.aadId;
+
+      this.warn(logger, `Option 'aadId' is deprecated. Please use 'entraId' instead`);
+    }
+
     if (this.verbose) {
-      await logger.logToStderr(`Ensuring user ${args.options.aadId || args.options.userName} at site ${args.options.webUrl}`);
+      await logger.logToStderr(`Ensuring user ${args.options.entraId || args.options.userName} at site ${args.options.webUrl}`);
     }
 
     try {
       const requestBody = {
-        logonName: args.options.userName || await this.getUpnByUserId(args.options.aadId!, logger)
+        logonName: args.options.userName || await this.getUpnByUserId(args.options.entraId!, logger)
       };
 
       const requestOptions: CliRequestOptions = {
@@ -109,12 +124,12 @@ class SpoUserEnsureCommand extends SpoCommand {
     }
   }
 
-  private async getUpnByUserId(aadId: string, logger: Logger): Promise<string> {
+  private async getUpnByUserId(entraId: string, logger: Logger): Promise<string> {
     if (this.verbose) {
-      await logger.logToStderr(`Retrieving user principal name for user with id ${aadId}`);
+      await logger.logToStderr(`Retrieving user principal name for user with id ${entraId}`);
     }
 
-    return await aadUser.getUpnByUserId(aadId);
+    return await aadUser.getUpnByUserId(entraId);
   }
 }
 


### PR DESCRIPTION
Fixes `spo group member add`, `spo group member remove`, and `spo user ensure` commands to update options that have an aad prefix. Closes #5745