### PR TITLE
Updates Docker images to use Node@20

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:alpine-3.17
+FROM waldekm/powershell:alpine-3.18
 
 LABEL name="CLI for Microsoft 365 Development" \
   description="Development container for contributing to CLI for Microsoft 365" \
@@ -22,7 +22,7 @@ RUN apk add --no-cache \
   shadow \
   zsh \
   jq \
-  nodejs \
+  nodejs-current \
   npm
 
 RUN useradd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:alpine-3.17
+FROM waldekm/powershell:alpine-3.18
 
 ARG CLI_VERSION=latest
 
@@ -21,7 +21,7 @@ RUN apk add --no-cache \
   bash \
   shadow \
   bash-completion \
-  nodejs \
+  nodejs-current \
   npm \
   python3 \
   py3-pip


### PR DESCRIPTION
Updates Docker images to use Node@20
Until there's an official PowerShell image on alpine 3.18, which is required to install Node@20, switches to use a custom image, based off of the official PowerShell image.