### PR TITLE
Adds command `purview threatassessment add`

### DIFF
--- a/docs/docs/cmd/purview/threatassessment/threatassessment-add.mdx
+++ b/docs/docs/cmd/purview/threatassessment/threatassessment-add.mdx
@@ -1,0 +1,128 @@
+import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# purview threatassessment add
+
+Create a threat assessment
+
+## Usage
+
+```sh
+m365 purview threatassessment add [options]
+```
+
+## Options
+
+```md definition-list
+`-t, --type <type>`
+: The type of threat assessment to retrieve. Supports `file` and `url`.
+
+`-e, --expectedAssessment <expectedAssessment>`
+: The expected assessment from submitter. Possible values are: `block` and `unblock`.
+
+`-c, --category <category>`
+: The threat category. Possible values are: `spam`, `phishing`, `malware`.
+
+`-p, --path [path]`
+: Local path to the file to upload. Can only be used for threat assessment with type `file`.
+
+`-u, --url [url]`
+: The URL string. Can only be used for threat assessment with type `url`.
+```
+
+<Global />
+
+## Remarks
+
+!!! attention
+    This command currently only supports delegated permissions.
+
+## Examples
+
+Create a file threat assessment
+
+```sh
+m365 purview threatassessment add --type file --expectedAssessment block --category malware --fileName 'test.txt' --path 'C:\Path\To\File.txt'
+```
+
+Create a url threat assessment
+
+```sh
+m365 purview threatassessment add --type url --expectedAssessment block --category phishing --url 'http://contoso.com'
+```
+
+## Response
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ```json
+    {
+      "id": "b0e69f1c-adda-4df2-2906-08dc2caa6b3f",
+      "createdDateTime": "2024-02-13T15:42:43.5131654Z",
+      "contentType": "file",
+      "expectedAssessment": "block",
+      "category": "malware",
+      "status": "pending",
+      "requestSource": "administrator",
+      "fileName": "test.txt",
+      "contentData": "dGVzdC50eHQ=",
+      "createdBy": {
+        "user": {
+          "id": "fe36f75e-c103-410b-a18a-2bf6df06ac3a",
+          "displayName": "John Doe"
+        }
+      }
+    }
+  ```
+
+  </TabItem>
+  <TabItem value="Text">
+
+  ```text
+  category          : malware
+  contentData       : dGVzdC50eHQ=
+  contentType       : file
+  createdBy         : {"user":{"id":"fe36f75e-c103-410b-a18a-2bf6df06ac3a","displayName":"John Doe"}}
+  createdDateTime   : 2024-02-13T16:15:00.4125206Z
+  expectedAssessment: block
+  fileName          : test.txt
+  id                : be1223c4-4e92-4a4c-8c16-08dc2caeedba
+  requestSource     : administrator
+  status            : pending
+  ```
+
+  </TabItem>
+  <TabItem value="CSV">
+
+  ```csv
+  id,createdDateTime,contentType,expectedAssessment,category,status,requestSource,fileName,contentData
+  d31eb5f5-ecd5-4a8e-fb2a-08dc2caf00a8,2024-02-13T16:15:32.1741098Z,file,block,malware,pending,administrator,test.txt,dGVzdC50eHQ=
+  ```
+
+  </TabItem>
+  <TabItem value="Markdown">
+
+  ```md
+  # purview threatassessment add --type "file" --expectedAssessment "block" --category "malware" --path "C:\temp\test.txt"
+
+  Date: 13/02/2024
+
+  ## e3524baf-6ea6-4fab-68af-08dc2caf0ae3
+
+  Property | Value
+  ---------|-------
+  id | e3524baf-6ea6-4fab-68af-08dc2caf0ae3
+  createdDateTime | 2024-02-13T16:15:49.3342383Z
+  contentType | file
+  expectedAssessment | block
+  category | malware
+  status | pending
+  requestSource | administrator
+  fileName | test.txt
+  contentData | dGVzdC50eHQ=
+  ```
+
+  </TabItem>
+</Tabs>

--- a/docs/src/config/sidebars.ts
+++ b/docs/src/config/sidebars.ts
@@ -1817,6 +1817,11 @@ const sidebars: SidebarsConfig = {
           threatassessment: [
             {
               type: 'doc',
+              label: 'threatassessment add',
+              id: 'cmd/purview/threatassessment/threatassessment-add'
+            },
+            {
+              type: 'doc',
               label: 'threatassessment get',
               id: 'cmd/purview/threatassessment/threatassessment-get'
             }

--- a/src/m365/purview/commands.ts
+++ b/src/m365/purview/commands.ts
@@ -19,5 +19,6 @@ export default {
   SENSITIVITYLABEL_GET: `${prefix} sensitivitylabel get`,
   SENSITIVITYLABEL_LIST: `${prefix} sensitivitylabel list`,
   SENSITIVITYLABEL_POLICYSETTINGS_LIST: `${prefix} sensitivitylabel policysettings list`,
+  THREATASSESSMENT_ADD: `${prefix} threatassessment add`,
   THREATASSESSMENT_GET: `${prefix} threatassessment get`
 };

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.spec.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.spec.ts
@@ -16,7 +16,6 @@ import commands from '../../commands.js';
 import command from './threatassessment-add.js';
 
 describe(commands.THREATASSESSMENT_ADD, () => {
-
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.spec.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.spec.ts
@@ -27,8 +27,8 @@ describe(commands.THREATASSESSMENT_ADD, () => {
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
-    auth.service.connected = true;
-    auth.service.accessTokens[(command as any).resource] = {
+    auth.connection.active = true;
+    auth.connection.accessTokens[(command as any).resource] = {
       accessToken: 'abc',
       expiresOn: new Date()
     };
@@ -66,8 +66,8 @@ describe(commands.THREATASSESSMENT_ADD, () => {
 
   after(() => {
     sinon.restore();
-    auth.service.connected = false;
-    auth.service.accessTokens = {};
+    auth.connection.active = false;
+    auth.connection.accessTokens = {};
   });
 
   it('has correct name', () => {

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.spec.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.spec.ts
@@ -1,0 +1,181 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import { telemetry } from '../../../../telemetry.js';
+import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
+import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
+import request from '../../../../request.js';
+import { pid } from '../../../../utils/pid.js';
+import { sinonUtil } from '../../../../utils/sinonUtil.js';
+import { session } from '../../../../utils/session.js';
+import { accessToken } from '../../../../utils/accessToken.js';
+import fs from 'fs';
+import commands from '../../commands.js';
+import command from './threatassessment-add.js';
+
+describe(commands.THREATASSESSMENT_ADD, () => {
+
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
+    auth.service.connected = true;
+    auth.service.accessTokens[(command as any).resource] = {
+      accessToken: 'abc',
+      expiresOn: new Date()
+    };
+    commandInfo = cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: async (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: async (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: async (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+    (command as any).items = [];
+    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
+    sinon.stub(fs, 'existsSync').returns(true);
+    sinon.stub(fs, 'readFileSync').returns('VGhpcyBpcyBhIHRlc3QgZmlsZQ==');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      accessToken.isAppOnlyAccessToken,
+      fs.existsSync,
+      fs.readFileSync,
+      request.post
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+    auth.service.connected = false;
+    auth.service.accessTokens = {};
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name.startsWith(commands.THREATASSESSMENT_ADD), true);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('creates a file assessment request', async () => {
+    const fileThreatAssessmentRequest = {
+      '@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#informationProtection/threatAssessmentRequests/$entity',
+      '@odata.type': '#microsoft.graph.fileAssessmentRequest',
+      'id': '18406a56-7209-4720-a250-08d772fccdaa',
+      'createdDateTime': '2019-11-27T05:44:00.4051536Z',
+      'contentType': 'file',
+      'expectedAssessment': 'block',
+      'category': 'malware',
+      'status': 'completed',
+      'requestSource': 'administrator',
+      'fileName': 'illegalfile.txt',
+      'contentData': '',
+      'createdBy': {
+        'user': {
+          'id': 'c52ce8db-3e4b-4181-93c4-7d6b6bffaf60',
+          'displayName': 'John Doe'
+        }
+      }
+    };
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/informationProtection/threatAssessmentRequests`) {
+        return fileThreatAssessmentRequest;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { type: 'file', expectedAssessment: 'block', category: 'malware', path: 'C:\\Temp\\DummyFile.txt', verbose: true } });
+    assert.strictEqual(postStub.lastCall.args[0].data['@odata.type'], '#microsoft.graph.fileAssessmentRequest');
+    assert(loggerLogSpy.calledWith(fileThreatAssessmentRequest));
+  });
+
+  it('creates an url assessment request', async () => {
+    const urlThreatAssessmentRequest = {
+      '@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#informationProtection/threatAssessmentRequests/$entity',
+      '@odata.type': '#microsoft.graph.urlAssessmentRequest',
+      'id': '8d87d2b2-ca4d-422c-f8df-08d774a5c9ac',
+      'createdDateTime': '2019-11-29T08:26:09.8196703Z',
+      'contentType': 'url',
+      'expectedAssessment': 'block',
+      'category': 'phishing',
+      'status': 'pending',
+      'requestSource': 'administrator',
+      'url': 'http://test.com',
+      'createdBy': {
+        'user': {
+          'id': 'c52ce8db-3e4b-4181-93c4-7d6b6bffaf60',
+          'displayName': 'John Doe'
+        }
+      }
+    };
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/informationProtection/threatAssessmentRequests`) {
+        return urlThreatAssessmentRequest;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { type: 'url', expectedAssessment: 'block', category: 'phishing', url: 'https://phisingurl.be', verbose: true } });
+    assert.strictEqual(postStub.lastCall.args[0].data['@odata.type'], '#microsoft.graph.urlAssessmentRequest');
+    assert(loggerLogSpy.calledWith(urlThreatAssessmentRequest));
+  });
+
+  it('passes validation if all options are passed propertly', async () => {
+    const actual = await command.validate({ options: { type: 'url', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if type is not a valid type', async () => {
+    const actual = await command.validate({ options: { type: 'invalid', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if expectedAssessment is not a valid expectedAssessment', async () => {
+    const actual = await command.validate({ options: { type: 'url', expectedAssessment: 'invalid', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if category is not a valid category', async () => {
+    const actual = await command.validate({ options: { type: 'url', expectedAssessment: 'block', category: 'invalid', url: 'https://pnp.github.io/cli-microsoft365/' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if path is specified and file does not exist', async () => {
+    sinonUtil.restore(fs.existsSync);
+    sinon.stub(fs, 'existsSync').returns(false);
+    const actual = await command.validate({ options: { type: 'file', expectedAssessment: 'block', category: 'malware', path: 'C:\\Path\\That\\Does\\Not\\Exist' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('throws an error when we execute the command using application permissions', async () => {
+    sinonUtil.restore(accessToken.isAppOnlyAccessToken);
+    sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
+    await assert.rejects(command.action(logger, { options: { type: 'url', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' } }),
+      new CommandError('This command currently does not support app only permissions.'));
+  });
+});

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.ts
@@ -1,0 +1,166 @@
+import { Logger } from '../../../../cli/Logger.js';
+import GlobalOptions from '../../../../GlobalOptions.js';
+import request, { CliRequestOptions } from '../../../../request.js';
+import { accessToken } from '../../../../utils/accessToken.js';
+import GraphCommand from '../../../base/GraphCommand.js';
+import commands from '../../commands.js';
+import auth from '../../../../Auth.js';
+import fs from 'fs';
+import path from 'path';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  type: string;
+  expectedAssessment: string;
+  category: string;
+  recipientEmail?: string;
+  path?: string;
+  url?: string;
+  messageUri?: string;
+}
+
+class PurviewThreatAssessmentAddCommand extends GraphCommand {
+  private readonly allowedTypes = ['file', 'url'];
+  private readonly allowedExpectedAssessments = ['block', 'unblock'];
+  private readonly allowedCategories = ['spam', 'phishing', 'malware'];
+
+  public get name(): string {
+    return commands.THREATASSESSMENT_ADD;
+  }
+
+  public get description(): string {
+    return 'Create a threat assessment';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initOptionSets();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        path: typeof args.options.path !== 'undefined',
+        url: typeof args.options.url !== 'undefined'
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-t, --type <type>',
+        autocomplete: this.allowedTypes
+      },
+      {
+        option: '-e, --expectedAssessment <expectedAssessment>',
+        autocomplete: this.allowedExpectedAssessments
+      },
+      {
+        option: '-c, --category <category>',
+        autocomplete: this.allowedCategories
+      },
+      {
+        option: '-p, --path [path]'
+      },
+      {
+        option: '-u, --url [url]'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        if (!this.allowedTypes.some(type => type === args.options.type)) {
+          return `${args.options.type} is not an allowed type. Allowed types are ${this.allowedTypes.join('|')}`;
+        }
+
+        if (!this.allowedExpectedAssessments.some(expectedAssessment => expectedAssessment === args.options.expectedAssessment)) {
+          return `${args.options.expectedAssessment} is not an allowed expected assessment. Allowed expected assessments are ${this.allowedExpectedAssessments.join('|')}`;
+        }
+
+        if (!this.allowedCategories.some(category => category === args.options.category)) {
+          return `${args.options.category} is not an allowed category. Allowed categories are ${this.allowedCategories.join('|')}`;
+        }
+
+        if (args.options.path && !fs.existsSync(args.options.path)) {
+          return `File '${args.options.path}' not found. Please provide a valid path to the file.`;
+        }
+
+        return true;
+      }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push(
+      {
+        options: ['path'],
+        runsWhen: (args) => {
+          return args.options.type === 'file';
+        }
+      },
+      {
+        options: ['url'],
+        runsWhen: (args) => {
+          return args.options.type === 'url';
+        }
+      }
+    );
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+
+      if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
+        throw 'This command currently does not support app only permissions.';
+      }
+
+      if (this.verbose) {
+        await logger.logToStderr(`Adding threat assessment of type ${args.options.type} with expected assessment ${args.options.expectedAssessment} and category ${args.options.category}`);
+      }
+
+      const requestBody: any = {
+        expectedAssessment: args.options.expectedAssessment,
+        category: args.options.category,
+        url: args.options.url,
+        contentData: args.options.path && fs.readFileSync(args.options.path).toString('base64'),
+        fileName: args.options.path && path.basename(args.options.path)
+      };
+
+      switch (args.options.type) {
+        case 'file':
+          requestBody['@odata.type'] = '#microsoft.graph.fileAssessmentRequest';
+          break;
+        case 'url':
+          requestBody['@odata.type'] = '#microsoft.graph.urlAssessmentRequest';
+          break;
+      }
+
+      const requestOptions: CliRequestOptions = {
+        url: `${this.resource}/v1.0/informationProtection/threatAssessmentRequests`,
+        headers: {
+          accept: 'application/json;odata.metadata=none'
+        },
+        data: requestBody,
+        responseType: 'json'
+      };
+
+      const response = await request.post(requestOptions);
+      await logger.log(response);
+    }
+    catch (err: any) {
+      this.handleRejectedODataPromise(err);
+    }
+  }
+}
+
+export default new PurviewThreatAssessmentAddCommand();

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.ts
@@ -120,7 +120,7 @@ class PurviewThreatAssessmentAddCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
 
-      if (accessToken.isAppOnlyAccessToken(auth.service.accessTokens[this.resource].accessToken)) {
+      if (accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[this.resource].accessToken)) {
         throw 'This command currently does not support app only permissions.';
       }
 


### PR DESCRIPTION
Closes #4428 

@martinlingstuyl as discussed, I've created a PR for the threatassessment add command, obviously only using the two endpoints that are working (url and file).