### PR TITLE
Adds more validation output with invalid arrays.

### DIFF
--- a/src/m365/entra/commands/group/group-add.ts
+++ b/src/m365/entra/commands/group/group-add.ts
@@ -101,32 +101,30 @@ class EntraGroupAddCommand extends GraphCommand {
         }
 
         if (args.options.ownerIds) {
-          const ids = args.options.ownerIds.split(',').map(i => i.trim());
-          if (!validation.isValidGuidArray(ids)) {
-            const invalidGuid = ids.find(id => !validation.isValidGuid(id));
-            return `'${invalidGuid}' is not a valid GUID for option 'ownerIds'.`;
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.ownerIds);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'ownerIds': ${isValidGUIDArrayResult}.`;
           }
         }
 
         if (args.options.ownerUserNames) {
-          const isValidUserPrincipalNameArray = validation.isValidUserPrincipalNameArray(args.options.ownerUserNames.split(',').map(u => u.trim()));
-          if (isValidUserPrincipalNameArray !== true) {
-            return `User principal name '${isValidUserPrincipalNameArray}' is invalid for option 'ownerUserNames'.`;
+          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.ownerUserNames);
+          if (isValidUPNArrayResult !== true) {
+            return `The following user principal names are invalid for the option 'ownerUserNames': ${isValidUPNArrayResult}.`;
           }
         }
 
         if (args.options.memberIds) {
-          const ids = args.options.memberIds.split(',').map(i => i.trim());
-          if (!validation.isValidGuidArray(ids)) {
-            const invalidGuid = ids.find(id => !validation.isValidGuid(id));
-            return `'${invalidGuid}' is not a valid GUID for option 'memberIds'.`;
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.memberIds);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'memberIds': ${isValidGUIDArrayResult}.`;
           }
         }
 
         if (args.options.memberUserNames) {
-          const isValidUserPrincipalNameArray = validation.isValidUserPrincipalNameArray(args.options.memberUserNames.split(',').map(u => u.trim()));
-          if (isValidUserPrincipalNameArray !== true) {
-            return `User principal name '${isValidUserPrincipalNameArray}' is invalid for option 'memberUserNames'.`;
+          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.memberUserNames);
+          if (isValidUPNArrayResult !== true) {
+            return `The following user principal names are invalid for the option 'memberUserNames': ${isValidUPNArrayResult}.`;
           }
         }
 

--- a/src/m365/entra/commands/group/group-user-add.ts
+++ b/src/m365/entra/commands/group/group-user-add.ts
@@ -80,17 +80,16 @@ class EntraGroupUserAddCommand extends GraphCommand {
         }
 
         if (args.options.ids) {
-          const ids = args.options.ids.split(',').map(i => i.trim());
-          if (!validation.isValidGuidArray(ids)) {
-            const invalidGuid = ids.find(id => !validation.isValidGuid(id));
-            return `'${invalidGuid}' is not a valid GUID for option 'ids'.`;
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.ids);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'ids': ${isValidGUIDArrayResult}.`;
           }
         }
 
         if (args.options.userNames) {
-          const isValidUserPrincipalNameArray = validation.isValidUserPrincipalNameArray(args.options.userNames.split(',').map(u => u.trim()));
-          if (isValidUserPrincipalNameArray !== true) {
-            return `User principal name '${isValidUserPrincipalNameArray}' is invalid for option 'userNames'.`;
+          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.userNames);
+          if (isValidUPNArrayResult !== true) {
+            return `The following user principal names are invalid for the option 'userNames': ${isValidUPNArrayResult}.`;
           }
         }
 

--- a/src/m365/planner/commands/plan/plan-add.spec.ts
+++ b/src/m365/planner/commands/plan/plan-add.spec.ts
@@ -201,6 +201,18 @@ describe(commands.PLAN_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if shareWithUserNames contains invalid user principal name', async () => {
+    const shareWithUserNames = ['john.doe@contoso.com', 'foo'];
+    const actual = await command.validate({
+      options: {
+        title: validTitle,
+        ownerGroupId: validOwnerGroupId,
+        shareWithUserNames: shareWithUserNames.join(',')
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('fails validation when both shareWithUserIds and shareWithUserNames are specified', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/planner/commands/plan/plan-add.ts
+++ b/src/m365/planner/commands/plan/plan-add.ts
@@ -90,8 +90,18 @@ class PlannerPlanAddCommand extends GraphCommand {
           return 'Specify either shareWithUserIds or shareWithUserNames but not both';
         }
 
-        if (args.options.shareWithUserIds && !validation.isValidGuidArray(args.options.shareWithUserIds.split(','))) {
-          return 'shareWithUserIds contains invalid GUID';
+        if (args.options.shareWithUserIds) {
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.shareWithUserIds);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'shareWithUserIds': ${isValidGUIDArrayResult}.`;
+          }
+        }
+
+        if (args.options.shareWithUserNames) {
+          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.shareWithUserNames);
+          if (isValidUPNArrayResult !== true) {
+            return `The following user principal names are invalid for the option 'shareWithUserNames': ${isValidUPNArrayResult}.`;
+          }
         }
 
         return true;

--- a/src/m365/planner/commands/plan/plan-set.spec.ts
+++ b/src/m365/planner/commands/plan/plan-set.spec.ts
@@ -189,6 +189,18 @@ describe(commands.PLAN_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if shareWithUserNames contains invalid user principal name', async () => {
+    const shareWithUserNames = ['john.doe@contoso.com', 'foo'];
+    const actual = await command.validate({
+      options: {
+        title: title,
+        ownerGroupId: ownerGroupId,
+        shareWithUserNames: shareWithUserNames.join(',')
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('fails validation if neither the ownerGroupId nor ownerGroupName are provided when using title.', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {

--- a/src/m365/planner/commands/plan/plan-set.ts
+++ b/src/m365/planner/commands/plan/plan-set.ts
@@ -104,8 +104,18 @@ class PlannerPlanSetCommand extends GraphCommand {
           return 'Specify either shareWithUserIds or shareWithUserNames but not both';
         }
 
-        if (args.options.shareWithUserIds && !validation.isValidGuidArray(args.options.shareWithUserIds.split(','))) {
-          return 'shareWithUserIds contains invalid GUID';
+        if (args.options.shareWithUserIds) {
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.shareWithUserIds);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'shareWithUserIds': ${isValidGUIDArrayResult}.`;
+          }
+        }
+
+        if (args.options.shareWithUserNames) {
+          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.shareWithUserNames);
+          if (isValidUPNArrayResult !== true) {
+            return `The following user principal names are invalid for the option 'shareWithUserNames': ${isValidUPNArrayResult}.`;
+          }
         }
 
         const allowedCategories: string[] = [

--- a/src/m365/planner/commands/task/task-add.spec.ts
+++ b/src/m365/planner/commands/task/task-add.spec.ts
@@ -453,6 +453,19 @@ describe(commands.TASK_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if assignedToUserNames contains invalid user principal name', async () => {
+    const assignedToUserNames = ['john.doe@contoso.com', 'foo'];
+    const actual = await command.validate({
+      options: {
+        title: 'My Planner Task',
+        planId: '8QZEH7b3wkS_bGQobscsM5gADCBb',
+        bucketId: 'IK8tuFTwQEa5vTonM7ZMRZgAKdno',
+        assignedToUserNames: assignedToUserNames.join(',')
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('fails validation when both assignedToUserIds and assignedToUserNames are specified', async () => {
     const actual = await command.validate({
       options: {

--- a/src/m365/planner/commands/task/task-add.ts
+++ b/src/m365/planner/commands/task/task-add.ts
@@ -139,12 +139,22 @@ class PlannerTaskAddCommand extends GraphCommand {
           return `percentComplete should be between 0 and 100`;
         }
 
-        if (args.options.assignedToUserIds && !validation.isValidGuidArray(args.options.assignedToUserIds.split(','))) {
-          return 'assignedToUserIds contains invalid GUID';
+        if (args.options.assignedToUserIds) {
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.assignedToUserIds);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'assignedToUserIds': ${isValidGUIDArrayResult}.`;
+          }
         }
 
         if (args.options.assignedToUserIds && args.options.assignedToUserNames) {
           return 'Specify either assignedToUserIds or assignedToUserNames but not both';
+        }
+
+        if (args.options.assignedToUserNames) {
+          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.assignedToUserNames);
+          if (isValidUPNArrayResult !== true) {
+            return `The following user principal names are invalid for the option 'assignedToUserNames': ${isValidUPNArrayResult}.`;
+          }
         }
 
         if (args.options.appliedCategories && args.options.appliedCategories.split(',').filter(category => this.allowedAppliedCategories.indexOf(category.toLocaleLowerCase()) < 0).length !== 0) {

--- a/src/m365/planner/commands/task/task-set.spec.ts
+++ b/src/m365/planner/commands/task/task-set.spec.ts
@@ -362,6 +362,17 @@ describe(commands.TASK_SET, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if assignedToUserNames contains invalid user principal name', async () => {
+    const assignedToUserNames = ['john.doe@contoso.com', 'foo'];
+    const actual = await command.validate({
+      options: {
+        id: 'Z-RLQGfppU6H3663DBzfs5gAMD3o',
+        assignedToUserNames: assignedToUserNames.join(',')
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('fails validation when both assignedToUserIds and assignedToUserNames are specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {

--- a/src/m365/planner/commands/task/task-set.ts
+++ b/src/m365/planner/commands/task/task-set.ts
@@ -133,8 +133,18 @@ class PlannerTaskSetCommand extends GraphCommand {
           return `percentComplete should be between 0 and 100`;
         }
 
-        if (args.options.assignedToUserIds && !validation.isValidGuidArray(args.options.assignedToUserIds.split(','))) {
-          return 'assignedToUserIds contains invalid GUID';
+        if (args.options.assignedToUserIds) {
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.assignedToUserIds);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'assignedToUserIds': ${isValidGUIDArrayResult}.`;
+          }
+        }
+
+        if (args.options.assignedToUserNames) {
+          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.assignedToUserNames);
+          if (isValidUPNArrayResult !== true) {
+            return `The following user principal names are invalid for the option 'assignedToUserNames': ${isValidUPNArrayResult}.`;
+          }
         }
 
         if (args.options.appliedCategories && args.options.appliedCategories.split(',').filter(category => this.allowedAppliedCategories.indexOf(category.toLocaleLowerCase()) < 0).length !== 0) {

--- a/src/m365/spo/commands/navigation/navigation-node-add.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-add.ts
@@ -109,8 +109,9 @@ class SpoNavigationNodeAddCommand extends SpoCommand {
             return 'The maximum amount of audienceIds per navigation node exceeded. The maximum amount of auciendeIds is 10.';
           }
 
-          if (!validation.isValidGuidArray(audienceIdsSplitted)) {
-            return 'The option audienceIds contains one or more invalid GUIDs';
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.audienceIds);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'audienceIds': ${isValidGUIDArrayResult}.`;
           }
         }
 

--- a/src/m365/spo/commands/navigation/navigation-node-set.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-set.ts
@@ -99,8 +99,9 @@ class SpoNavigationNodeSetCommand extends SpoCommand {
             return 'The maximum amount of audienceIds per navigation node exceeded. The maximum amount of audienceIds is 10.';
           }
 
-          if (!validation.isValidGuidArray(audienceIdsSplitted)) {
-            return `The option audienceIds contains one or more invalid GUIDs`;
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.audienceIds);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'audienceIds': ${isValidGUIDArrayResult}.`;
           }
         }
 

--- a/src/m365/spo/commands/site/site-recyclebinitem-move.ts
+++ b/src/m365/spo/commands/site/site-recyclebinitem-move.ts
@@ -76,8 +76,11 @@ class SpoSiteRecycleBinItemMoveCommand extends SpoCommand {
           return isValidSharePointUrl;
         }
 
-        if (args.options.ids && !validation.isValidGuidArray(args.options.ids.split(','))) {
-          return 'The option ids contains one or more invalid GUIDs';
+        if (args.options.ids) {
+          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.ids);
+          if (isValidGUIDArrayResult !== true) {
+            return `The following GUIDs are invalid for the option 'ids': ${isValidGUIDArrayResult}.`;
+          }
         }
 
         return true;

--- a/src/m365/spo/commands/site/site-recyclebinitem-remove.ts
+++ b/src/m365/spo/commands/site/site-recyclebinitem-remove.ts
@@ -63,8 +63,9 @@ class SpoSiteRecycleBinItemRemoveCommand extends SpoCommand {
           return isValidSharePointUrl;
         }
 
-        if (!validation.isValidGuidArray(args.options.ids.split(','))) {
-          return 'The option ids contains one or more invalid GUIDs.';
+        const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.ids);
+        if (isValidGUIDArrayResult !== true) {
+          return `The following GUIDs are invalid for the option 'ids': ${isValidGUIDArrayResult}.`;
         }
 
         return true;

--- a/src/m365/teams/commands/meeting/meeting-add.ts
+++ b/src/m365/teams/commands/meeting/meeting-add.ts
@@ -99,10 +99,9 @@ class TeamsMeetingAddCommand extends GraphCommand {
         }
 
         if (args.options.participantUserNames) {
-          const participants = args.options.participantUserNames.trim().toLowerCase().split(',').filter(e => e && e !== '');
-
-          if (!participants || participants.length === 0 || participants.some(e => !validation.isValidUserPrincipalName(e))) {
-            return `'${args.options.participantUserNames}' contains one or more invalid UPN.`;
+          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.participantUserNames);
+          if (isValidUPNArrayResult !== true) {
+            return `The following user principal names are invalid for the option 'participantUserNames': ${isValidUPNArrayResult}.`;
           }
         }
 

--- a/src/utils/validation.spec.ts
+++ b/src/utils/validation.spec.ts
@@ -106,6 +106,16 @@ describe('validation/validation', () => {
     assert.strictEqual(result, true);
   });
 
+  it('isValidGuidArray returns true if guids are valid', () => {
+    const result = validation.isValidGuidArray('16c578ea-5785-492e-ac22-cad3cd9ca1fa,16cd5c6b-e9e9-4364-b71e-1a1664f81b98,7c9a1059-a725-424c-9dd0-788e66a5338e,02e83c70-f05f-4e63-b9af-73a8e44fdb32,5a53c7d7-2a26-4645-a938-b3e4d08b4a18');
+    assert.strictEqual(result, true);
+  });
+
+  it('isValidGuidArray returns guids that are not valid', () => {
+    const result = validation.isValidGuidArray('000,16c578ea-5785-492e-ac22-cad3cd9ca1fz,16cd5c6b-e9e9-4364-b71e-1a1664f81b98,7c9a1059-a725-424c-9dd0-788e66a5338e,02e83c70-f05f-4e63-b9af-73a8e44fdb32,5a53c7d7-2a26-4645-a938-b3e4d08b4a18');
+    assert.strictEqual(result, "000, 16c578ea-5785-492e-ac22-cad3cd9ca1fz");
+  });
+
   it('isValidGuid returns true if valid guid', () => {
     const result = validation.isValidGuid('b2307a39-e878-458b-bc90-03bc578531d6');
     assert.strictEqual(result, true);
@@ -131,29 +141,28 @@ describe('validation/validation', () => {
     assert.strictEqual(result, true);
   });
 
-
   it('isValidGuid returns true with @meId (case sensitive)', () => {
     const result = validation.isValidGuid('@meId ');
     assert.strictEqual(result, true);
   });
 
   it('isValidUserPrincipalNameArray returns true if valid username array', () => {
-    const result = validation.isValidUserPrincipalNameArray(['john.doe@contoso.com', 'adele@contoso.onmicrosoft.com']);
+    const result = validation.isValidUserPrincipalNameArray('john.doe@contoso.com,adele@contoso.onmicrosoft.com');
     assert.strictEqual(result, true);
   });
 
   it('isValidUserPrincipalNameArray returns falsy value of invalid username array', () => {
-    const result = validation.isValidUserPrincipalNameArray(['john.doe@contoso.com', 'foo']);
+    const result = validation.isValidUserPrincipalNameArray('john.doe@contoso.com,foo');
     assert.strictEqual(result, 'foo');
   });
 
   it('isValidUserPrincipalNameArray returns true with @meusername token', () => {
-    const result = validation.isValidUserPrincipalNameArray(['john.doe@contoso.com', '@meusername']);
+    const result = validation.isValidUserPrincipalNameArray('john.doe@contoso.com,@meusername');
     assert.strictEqual(result, true);
   });
 
   it('isValidUserPrincipalNameArray returns true with @meusername token and spaces', () => {
-    const result = validation.isValidUserPrincipalNameArray(['john.doe@contoso.com', '@meusername ']);
+    const result = validation.isValidUserPrincipalNameArray('john.doe@contoso.com,@meusername ');
     assert.strictEqual(result, true);
   });
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,8 +1,11 @@
 import { FormDigestInfo } from "./spo.js";
 
 export const validation = {
-  isValidGuidArray(guids: string[]): boolean {
-    return guids.every(guid => this.isValidGuid(guid));
+  isValidGuidArray(guidsString: string): boolean | string {
+    const guids = guidsString.split(',').map(guid => guid.trim());
+    const invalidGuids = guids.filter(guid => !this.isValidGuid(guid));
+
+    return invalidGuids.length > 0 ? invalidGuids.join(', ') : true;
   },
 
   isValidGuid(guid?: string): boolean {
@@ -31,9 +34,11 @@ export const validation = {
     return guidRegEx.test(guid);
   },
 
-  isValidUserPrincipalNameArray(upns: string[]): boolean | string {
-    const invalidGuid = upns.find(upn => !this.isValidUserPrincipalName(upn));
-    return invalidGuid || true;
+  isValidUserPrincipalNameArray(upnsString: string): boolean | string {
+    const upns = upnsString.split(',').map(upn => upn.trim());
+    const invalidUPNs = upns.filter(upn => !this.isValidUserPrincipalName(upn));
+
+    return invalidUPNs.length > 0 ? invalidUPNs.join(', ') : true;
   },
 
   isValidUserPrincipalName(upn: string): boolean {


### PR DESCRIPTION
Closes #5834

Also includes:

- For `isValidGuidArray`, returns all faulty values and modified the error output.
- For `isValidUserPrincipalNameArray`, returns all faulty values and modified the error output.
- For `isValidUserPrincipalNameArray`, applied this validation logic to `planner plan add`, `planner plan set`, `planner task add`, `planner task set`, and `teams meeting add`.