### PR TITLE
Fixes login response output

### DIFF
--- a/docs/docs/cmd/login.mdx
+++ b/docs/docs/cmd/login.mdx
@@ -201,6 +201,7 @@ m365 login --authType secret --secret topSeCr3t@007
   Upon successful login:
   ```json
   {
+    "connectionName": "dd8b99a7-77c6-4238-a609-396d27844921",
     "connectedAs": "john.doe@contoso.onmicrosoft.com",
     "authType": "DeviceCode",
     "appId": "31359c7f-bd7e-475c-86db-fdb8c937548e",
@@ -217,11 +218,12 @@ m365 login --authType secret --secret topSeCr3t@007
   ```
   Upon successful login:
   ```text
-  appId      : 31359c7f-bd7e-475c-86db-fdb8c937548e
-  appTenant  : common
-  authType   : DeviceCode
-  connectedAs: john.doe@contoso.onmicrosoft.com,
-  cloudType  : Public
+  appId         : 31359c7f-bd7e-475c-86db-fdb8c937548e
+  appTenant     : common
+  authType      : DeviceCode
+  cloudType     : Public
+  connectedAs   : john.doe@contoso.onmicrosoft.com
+  connectionName: dd8b99a7-77c6-4238-a609-396d27844921
   ```
 
   </TabItem>
@@ -232,8 +234,8 @@ m365 login --authType secret --secret topSeCr3t@007
   ```
   Upon successful login:
   ```csv
-  connectedAs,authType,appId,appTenant,cloudType
-  john.doe@contoso.onmicrosoft.com,DeviceCode,31359c7f-bd7e-475c-86db-fdb8c937548e,common,Public
+  connectionName,connectedAs,authType,appId,appTenant,cloudType
+  dd8b99a7-77c6-4238-a609-396d27844921,john.doe@contoso.onmicrosoft.com,DeviceCode,31359c7f-bd7e-475c-86db-fdb8c937548e,common,Public
   ```
 
   </TabItem>
@@ -244,14 +246,13 @@ m365 login --authType secret --secret topSeCr3t@007
   ```
   Upon successful login:
   ```md
-  # status
+  # login
 
   Date: 7/2/2023
 
-
-
   Property | Value
   ---------|-------
+  connectionName | dd8b99a7-77c6-4238-a609-396d27844921
   connectedAs | john.doe@contoso.onmicrosoft.com
   authType | DeviceCode
   appId | 31359c7f-bd7e-475c-86db-fdb8c937548e
@@ -261,4 +262,3 @@ m365 login --authType secret --secret topSeCr3t@007
 
   </TabItem>
 </Tabs>
-


### PR DESCRIPTION
I noticed that the login response output wasn't up to date yet with our incredible new "connections" feature. This PR includes `connectionName` to the different responses.