### PR TITLE
Adds a new command: 'spo site admin list'. Closes #5882

### DIFF
--- a/docs/docs/cmd/spo/site/site-admin-list.mdx
+++ b/docs/docs/cmd/spo/site/site-admin-list.mdx
@@ -1,0 +1,115 @@
+import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# spo site admin list
+
+Lists all administrators of a specific SharePoint site
+
+## Usage
+
+```sh
+m365 spo site admin list [options]
+```
+
+## Options
+
+```md definition-list
+`-u, --siteUrl <siteUrl>`
+: The URL of the SharePoint site
+
+`--asAdmin`
+: List admins as admin for sites you don't have permission to
+```
+
+<Global />
+
+## Remarks
+
+:::info
+
+To use this command with the `--asAdmin` mode, you must have permission to access the tenant admin site.
+
+Without this parameter, you must have site collection admin permissions for the requested site.
+
+In `--asAdmin` mode, the Id, PrincipalType, and PrincipalTypeString properties are not exported.
+
+:::
+
+## Examples
+
+Lists all admins of a SharePoint site
+
+```sh
+m365 spo site admin list --siteUrl https://contoso.sharepoint.com
+```
+
+Lists all admins of a SharePoint site as admin
+
+```sh
+m365 spo site admin list --siteUrl https://contoso.sharepoint.com --asAdmin
+```
+
+## Response
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ```json
+  [
+    {
+      "Id": 6,
+      "LoginName": "i:0#.f|membership|user@contoso.com",
+      "Title": "User Example",
+      "PrincipalType": 1,
+      "PrincipalTypeString": "User",
+      "Email": "user@contoso.com",
+      "IsPrimaryAdmin": true
+    }
+  ]
+  ```
+
+  </TabItem>
+  <TabItem value="Text">
+
+  ```text
+  Email               : user@contoso.com
+  Id                  : 6
+  LoginName           : i:0#.f|membership|user@contoso.com
+  PrincipalType       : 1
+  PrincipalTypeString : User
+  Title               : User Example
+  IsPrimaryAdmin      : true
+  ```
+
+  </TabItem>
+  <TabItem value="CSV">
+
+  ```csv
+  Id,LoginName,Title,PrincipalType,PrincipalTypeString,Email,IsPrimaryAdmin
+  6,i:0#.f|membership|user@contoso.com,User Example,1,User,user@contoso.com,1
+  ```
+
+  </TabItem>
+  <TabItem value="Markdown">
+
+  ```md
+  # spo site admin list --siteUrl "https://contoso.sharepoint.com/sites/Test"
+
+  Date: 20/03/2024
+
+  ## User
+
+  Property | Value
+  ---------|-------
+  Id | 6
+  LoginName | i:0#.f\|membership\|user@contoso.com
+  Title | User Example
+  PrincipalType | 1
+  PrincipalTypeString | User
+  Email | user@contoso.com
+  IsPrimaryAdmin | true
+  ```
+
+  </TabItem>
+</Tabs>

--- a/docs/src/config/sidebars.ts
+++ b/docs/src/config/sidebars.ts
@@ -3288,6 +3288,11 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
+              label: 'site admin list',
+              id: 'cmd/spo/site/site-admin-list'
+            },
+            {
+              type: 'doc',
               label: 'site ensure',
               id: 'cmd/spo/site/site-ensure'
             },

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -240,6 +240,7 @@ export default {
   SERVICEPRINCIPAL_SET: `${prefix} serviceprincipal set`,
   SET: `${prefix} set`,
   SITE_ADD: `${prefix} site add`,
+  SITE_ADMIN_LIST: `${prefix} site admin list`,
   SITE_APPCATALOG_ADD: `${prefix} site appcatalog add`,
   SITE_APPCATALOG_LIST: `${prefix} site appcatalog list`,
   SITE_APPCATALOG_REMOVE: `${prefix} site appcatalog remove`,

--- a/src/m365/spo/commands/site/SiteProperties.ts
+++ b/src/m365/spo/commands/site/SiteProperties.ts
@@ -2,4 +2,5 @@ export interface SiteProperties {
   Status: string;
   Title: string;
   Url: string;
+  SiteId: string;
 }

--- a/src/m365/spo/commands/site/site-admin-list.spec.ts
+++ b/src/m365/spo/commands/site/site-admin-list.spec.ts
@@ -1,0 +1,453 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
+import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
+import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
+import { pid } from '../../../../utils/pid.js';
+import { session } from '../../../../utils/session.js';
+import { sinonUtil } from '../../../../utils/sinonUtil.js';
+import { spo } from '../../../../utils/spo.js';
+import commands from '../../commands.js';
+import command from './site-admin-list.js';
+import { settingsNames } from '../../../../settingsNames.js';
+
+describe(commands.SITE_ADMIN_LIST, () => {
+  let log: any[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+  let loggerLogToStderrSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+
+  const primaryAdminLoginName = 'user1loginName';
+  const listOfAdminsResultRegularMode = [
+    {
+      Id: 1,
+      LoginName: 'user1loginName',
+      Title: 'user1DisplayName',
+      PrincipalType: 1,
+      PrincipalTypeString: 'User',
+      IsPrimaryAdmin: true,
+      Email: 'user1Email@email.com'
+    },
+    {
+      Id: 2,
+      LoginName: 'user2loginName',
+      Title: 'user2DisplayName',
+      PrincipalType: 1,
+      PrincipalTypeString: 'User',
+      IsPrimaryAdmin: false,
+      Email: 'user2Email@email.com'
+    }
+  ];
+
+  const listOfAdminsResultAsAdmin = [
+    {
+      Id: null,
+      LoginName: 'user1loginName',
+      Title: 'user1DisplayName',
+      PrincipalType: null,
+      PrincipalTypeString: null,
+      IsPrimaryAdmin: true,
+      Email: 'user1Email@email.com'
+    },
+    {
+      Id: null,
+      LoginName: 'user2loginName',
+      Title: 'user2DisplayName',
+      PrincipalType: null,
+      PrincipalTypeString: null,
+      IsPrimaryAdmin: false,
+      Email: 'user2Email@email.com'
+    }
+  ];
+
+  const listOfAdminsFromSiteSource = [
+    {
+      Email: 'user1Email@email.com',
+      Id: 1,
+      IsSiteAdmin: true,
+      LoginName: 'user1loginName',
+      PrincipalType: 1,
+      Title: 'user1DisplayName'
+    },
+    {
+      Email: 'user2Email@email.com',
+      Id: 2,
+      IsSiteAdmin: true,
+      LoginName: 'user2loginName',
+      PrincipalType: 1,
+      Title: 'user2DisplayName'
+    }
+  ];
+
+  const listOfAdminsFromAdminSource = [
+    {
+      email: 'user1Email@email.com',
+      loginName: 'user1loginName',
+      name: 'user1DisplayName',
+      userPrincipalName: 'user1loginName'
+    },
+    {
+      email: 'user2Email@email.com',
+      loginName: 'user2loginName',
+      name: 'user2DisplayName',
+      userPrincipalName: 'user2loginName'
+    }
+  ];
+  const rootUrl = 'https://contoso.sharepoint.com';
+  const siteUrl = 'https://contoso.sharepoint.com/sites/site';
+  const adminUrl = 'https://contoso-admin.sharepoint.com';
+  const siteId = '00000000-0000-0000-0000-000000000000';
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
+    sinon.stub(spo, 'getRequestDigest').resolves({
+      FormDigestValue: 'abc',
+      FormDigestTimeoutSeconds: 1800,
+      FormDigestExpiresAt: new Date(),
+      WebFullUrl: 'https://contoso.sharepoint.com'
+    });
+    auth.connection.active = true;
+    auth.connection.spoUrl = 'https://contoso.sharepoint.com';
+    commandInfo = cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: async (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: async (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: async (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      request.post,
+      cli.getSettingWithDefaultValue
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+    auth.connection.active = false;
+    auth.connection.spoUrl = undefined;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.SITE_ADMIN_LIST);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('gets site collection admins in regular mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/web/siteusers?$filter=IsSiteAdmin eq true`) {
+        return { value: listOfAdminsFromSiteSource };
+      }
+
+      if (opts.url === `${siteUrl}/_api/site/owner`) {
+        return { LoginName: primaryAdminLoginName };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl } });
+    assert(loggerLogSpy.calledOnceWithExactly(listOfAdminsResultRegularMode));
+  });
+
+  it('gets site collection admins in admin mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')?$select=OwnerLoginName`) {
+        return JSON.stringify({ OwnerLoginName: primaryAdminLoginName });
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, asAdmin: true } });
+    assert(loggerLogSpy.calledOnceWithExactly(listOfAdminsResultAsAdmin));
+  });
+
+  it('correctly handles empty list of site collection admins from API in regular mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/web/siteusers?$filter=IsSiteAdmin eq true`) {
+        return { value: [] };
+      }
+
+      if (opts.url === `${siteUrl}/_api/site/owner`) {
+        return null;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl } });
+    assert(loggerLogSpy.calledOnceWithExactly([]));
+  });
+
+  it('correctly handles errors from API in regular mode', async () => {
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
+
+    await assert.rejects(command.action(logger, { options: { siteUrl: siteUrl } }), new CommandError('An error has occurred'));
+  });
+
+  it('correctly handles empty list of site collection admins from API in admin mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')?$select=OwnerLoginName`) {
+        return JSON.stringify({ OwnerLoginName: '' });
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: []
+        });
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, asAdmin: true } });
+    assert(loggerLogSpy.calledOnceWithExactly([]));
+  });
+
+  it('handles error when primary admin API returns error in regular mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/web/siteusers?$filter=IsSiteAdmin eq true`) {
+        return { value: listOfAdminsFromSiteSource };
+      }
+
+      if (opts.url === `${siteUrl}/_api/site/owner`) {
+        throw "Invalid request";
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await assert.rejects(command.action(logger, { options: { siteUrl: siteUrl } }), new CommandError('Invalid request'));
+  });
+
+  it('handles error when primary admin API returns error in admin mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')?$select=OwnerLoginName`) {
+        throw "Invalid request";
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await assert.rejects(command.action(logger, { options: { siteUrl: siteUrl, asAdmin: true } }), new CommandError('Invalid request'));
+  });
+
+  it('handles error when returned siteId is incorrect in admin mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')?$select=OwnerLoginName`) {
+        throw "Invalid request";
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: 'Incorrect ID' };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await assert.rejects(command.action(logger, { options: { siteUrl: siteUrl, asAdmin: true } }), new CommandError(`Site with URL ${siteUrl} not found`));
+  });
+
+  it('passes validation when only correct siteUrl option specified', async () => {
+    const actual = await command.validate({
+      options: {
+        siteUrl: 'https://contoso.sharepoint.com/sites/site'
+      }
+    }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation when correct siteUrl and correct asAdmin options specified', async () => {
+    const actual = await command.validate({
+      options: {
+        siteUrl: 'https://contoso.sharepoint.com/sites/site',
+        asAdmin: true
+      }
+    }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation when the url option not specified', async () => {
+    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
+      if (settingName === settingsNames.prompt) {
+        return false;
+      }
+      return defaultValue;
+    });
+
+    const actual = await command.validate({
+      options: {}
+    }, commandInfo);
+    assert.notDeepEqual(actual, true);
+  });
+
+  it('fails validation when the url option is not a valid SharePoint site URL', async () => {
+    const actual = await command.validate({
+      options: {
+        siteUrl: 'foo'
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('get additional log when verbose parameter is set in regular mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/web/siteusers?$filter=IsSiteAdmin eq true`) {
+        return { value: listOfAdminsFromSiteSource };
+      }
+
+      if (opts.url === `${siteUrl}/_api/site/owner`) {
+        return { LoginName: primaryAdminLoginName };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, verbose: true } });
+    assert(loggerLogToStderrSpy.firstCall.firstArg === 'Retrieving site administrators...');
+  });
+
+  it('get additional log when verbose parameter is set in admin mode', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')?$select=OwnerLoginName`) {
+        return JSON.stringify({ OwnerLoginName: primaryAdminLoginName });
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, asAdmin: true, verbose: true } });
+    assert(loggerLogToStderrSpy.firstCall.firstArg === 'Retrieving site administrators as an administrator...');
+  });
+});

--- a/src/m365/spo/commands/site/site-admin-list.ts
+++ b/src/m365/spo/commands/site/site-admin-list.ts
@@ -1,0 +1,213 @@
+import { Logger } from '../../../../cli/Logger.js';
+import GlobalOptions from '../../../../GlobalOptions.js';
+import request, { CliRequestOptions } from '../../../../request.js';
+import { spo } from '../../../../utils/spo.js';
+import { validation } from '../../../../utils/validation.js';
+import SpoCommand from '../../../base/SpoCommand.js';
+import commands from '../../commands.js';
+import { ListPrincipalType } from '../list/ListPrincipalType.js';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface AdminUserResult {
+  email: string;
+  loginName: string;
+  name: string;
+  userPrincipalName: string;
+}
+
+interface AdminResult {
+  value: AdminUserResult[];
+}
+
+interface SiteUserResult {
+  Email: string;
+  Id: number;
+  IsSiteAdmin: boolean;
+  LoginName: string;
+  PrincipalType: number;
+  Title: string;
+}
+
+interface SiteResult {
+  value: SiteUserResult[];
+}
+
+interface CommandResultItem {
+  Id: number | null;
+  Email: string;
+  IsPrimaryAdmin: boolean;
+  LoginName: string;
+  Title: string;
+  PrincipalType: number | null;
+  PrincipalTypeString: string | null;
+}
+
+interface Options extends GlobalOptions {
+  siteUrl: string;
+  asAdmin?: boolean;
+}
+
+class SpoSiteAdminListCommand extends SpoCommand {
+  public get name(): string {
+    return commands.SITE_ADMIN_LIST;
+  }
+
+  public get description(): string {
+    return 'Lists all administrators of a specific SharePoint site';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initTypes();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        siteUrl: typeof args.options.siteUrl !== 'undefined',
+        asAdmin: !!args.options.asAdmin
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --siteUrl <siteUrl>'
+      },
+      {
+        option: '--asAdmin'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => validation.isValidSharePointUrl(args.options.siteUrl)
+    );
+  }
+
+  #initTypes(): void {
+    this.types.string.push('siteUrl');
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      if (args.options.asAdmin) {
+        await this.callActionAsAdmin(logger, args);
+        return;
+      }
+
+      await this.callAction(logger, args);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+
+  private async callActionAsAdmin(logger: Logger, args: CommandArgs): Promise<void> {
+    if (this.verbose) {
+      await logger.logToStderr('Retrieving site administrators as an administrator...');
+    }
+
+    const adminUrl: string = await spo.getSpoAdminUrl(logger, this.debug);
+    const siteId = await this.getSiteId(args.options.siteUrl, logger);
+    const requestOptions: CliRequestOptions = {
+      url: `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`,
+      headers: {
+        accept: 'application/json;odata=nometadata',
+        'content-type': 'application/json;charset=utf-8'
+      }
+    };
+
+    const response: string = await request.post<string>(requestOptions);
+    const responseContent: AdminResult = JSON.parse(response);
+    const primaryAdminLoginName = await this.getPrimaryAdminLoginNameFromAdmin(adminUrl, siteId);
+
+    const mappedResult = responseContent.value.map((u: AdminUserResult): CommandResultItem => ({
+      Id: null,
+      Email: u.email,
+      LoginName: u.loginName,
+      Title: u.name,
+      PrincipalType: null,
+      PrincipalTypeString: null,
+      IsPrimaryAdmin: u.loginName === primaryAdminLoginName
+    }));
+    await logger.log(mappedResult);
+  }
+
+  private async getSiteId(siteUrl: string, logger: Logger): Promise<string> {
+    const siteGraphId = await spo.getSiteId(siteUrl, logger, this.verbose);
+    const match = siteGraphId.match(/,([a-f0-9\-]{36}),/i);
+    if (!match) {
+      throw `Site with URL ${siteUrl} not found`;
+    }
+
+    return match[1];
+  }
+
+  private async getPrimaryAdminLoginNameFromAdmin(adminUrl: string, siteId: string): Promise<string> {
+    const requestOptions: CliRequestOptions = {
+      url: `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')?$select=OwnerLoginName`,
+      headers: {
+        accept: 'application/json;odata=nometadata',
+        'content-type': 'application/json;charset=utf-8'
+      }
+    };
+
+    const response: string = await request.get<string>(requestOptions);
+    const responseContent = JSON.parse(response);
+    return responseContent.OwnerLoginName;
+  }
+
+  private async callAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (this.verbose) {
+      await logger.logToStderr('Retrieving site administrators...');
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${args.options.siteUrl}/_api/web/siteusers?$filter=IsSiteAdmin eq true`,
+      method: 'GET',
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const responseContent: SiteResult = await request.get<SiteResult>(requestOptions);
+    const primaryOwnerLogin = await this.getPrimaryOwnerLoginFromSite(args.options.siteUrl);
+    const mappedResult = responseContent.value.map((u: SiteUserResult): CommandResultItem => ({
+      Id: u.Id,
+      LoginName: u.LoginName,
+      Title: u.Title,
+      PrincipalType: u.PrincipalType,
+      PrincipalTypeString: ListPrincipalType[u.PrincipalType],
+      Email: u.Email,
+      IsPrimaryAdmin: u.LoginName === primaryOwnerLogin
+    }));
+    await logger.log(mappedResult);
+  }
+
+  private async getPrimaryOwnerLoginFromSite(siteUrl: string): Promise<string | null> {
+    const requestOptions: CliRequestOptions = {
+      url: `${siteUrl}/_api/site/owner`,
+      method: 'GET',
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const responseContent = await request.get<{ LoginName: string }>(requestOptions);
+    return responseContent?.LoginName ?? null;
+  }
+}
+
+export default new SpoSiteAdminListCommand();


### PR DESCRIPTION
### Adds a new command: 'm365 spo site admin list'.

Closes #5882

Hello, could you please review the pull request below? It contains a new command for retrieving a list of administrators for SharePoint sites.

I still have some concerns, so please confirm the following:

- Is the function to obtain the SiteId based on the SiteUrl suitable for users who are only SharePoint admins? (Similar to what is used in `spo site list`)
- Is the endpoint `_api/sites/owner` the correct one to retrieve the primary admin of the site in regular cases (not '--asAdmin')?
- Is it acceptable to not provide information about PrincipalType and Id in the '--asAdmin' case, since it is not provided by the `/_api/SPO.Tenant/GetSiteAdministrators endpoint`?

I believe I've made all the necessary changes. If everything looks good, this command could be a base for other tasks mentioned. #5874