### PR TITLE
Removes trailing slashes from 'spo get'

### DIFF
--- a/src/m365/spo/commands/spo-set.spec.ts
+++ b/src/m365/spo/commands/spo-set.spec.ts
@@ -73,6 +73,11 @@ describe(commands.SET, () => {
     assert.strictEqual(auth.connection.spoUrl, 'https://contoso.sharepoint.com');
   });
 
+  it('trims trailing slashes from the URL', async () => {
+    await command.action(logger, { options: { url: 'https://contoso.sharepoint.com/' } });
+    assert.strictEqual(auth.connection.spoUrl, 'https://contoso.sharepoint.com');
+  });
+
   it('throws error when trying to set SPO URL when not logged in to M365', async () => {
     auth.connection.active = false;
 
@@ -86,17 +91,6 @@ describe(commands.SET, () => {
     sinon.stub(auth, 'storeConnectionInfo').rejects(new Error('An error has occurred while setting the password'));
 
     await assert.rejects(command.action(logger, { options: { url: 'https://contoso.sharepoint.com' } } as any), new CommandError('An error has occurred while setting the password'));
-  });
-
-  it('supports specifying url', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--url') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
   });
 
   it('fails validation if url is not a valid SharePoint URL', async () => {

--- a/src/m365/spo/commands/spo-set.ts
+++ b/src/m365/spo/commands/spo-set.ts
@@ -1,6 +1,7 @@
 import auth from '../../../Auth.js';
 import { Logger } from '../../../cli/Logger.js';
 import GlobalOptions from '../../../GlobalOptions.js';
+import { urlUtil } from '../../../utils/urlUtil.js';
 import { validation } from '../../../utils/validation.js';
 import SpoCommand from '../../base/SpoCommand.js';
 import commands from '../commands.js';
@@ -27,6 +28,7 @@ class SpoSetCommand extends SpoCommand {
 
     this.#initOptions();
     this.#initValidators();
+    this.#initTypes();
   }
 
   #initOptions(): void {
@@ -43,8 +45,12 @@ class SpoSetCommand extends SpoCommand {
     );
   }
 
+  #initTypes(): void {
+    this.types.string.push('url');
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    auth.connection.spoUrl = args.options.url;
+    auth.connection.spoUrl = urlUtil.removeTrailingSlashes(args.options.url);
 
     try {
       await auth.storeConnectionInfo();


### PR DESCRIPTION
While using the CLI, I used `spo set` command. I just copied the tenant URL from my browser and noticed it has a trailing slash. While the API requests are still working, it doesn't look nice in the debug logs.
I also enforced that the URL parameter is a string.

![image](https://github.com/pnp/cli-microsoft365/assets/11723921/24c011ae-9498-4ec9-b8df-997d6415ae43)
