### PR TITLE
Fix ACS Sample script

### DIFF
--- a/docs/docs/sample-scripts/spo/sp-add-ins-and-azure-acs-retirement-report/index.mdx
+++ b/docs/docs/sample-scripts/spo/sp-add-ins-and-azure-acs-retirement-report/index.mdx
@@ -129,7 +129,7 @@ function GetRetirementStatus {
           AppName              = $EntraApp.displayName
           AppId                = $EntraApp.appId
           ServicePrincipalType = $EntraApp.servicePrincipalType
-          Created              = $EntraApp.createdDateTime.ToLongDateString()
+          Created              = $EntraApp.createdDateTime?.ToLongDateString()
         }
       }
       return $ResultList


### PR DESCRIPTION
Closes #5936 

The issue was that the createdDateTime of the ACS apps sometimes could be null, resulting in the error.