### PR TITLE
Adds command `teams user app upgrade`

### DIFF
--- a/docs/docs/cmd/teams/user/user-app-upgrade.mdx
+++ b/docs/docs/cmd/teams/user/user-app-upgrade.mdx
@@ -1,0 +1,59 @@
+import Global from '/docs/cmd/_global.mdx';
+
+# teams user app upgrade
+
+Upgrade an app in the personal scope of the specified user
+
+## Usage
+
+```sh
+m365 teams user app upgrade [options]
+```
+
+## Options
+
+```md definition-list
+`--id [id]`
+: The unique id of the app instance installed for the user. Specify either `id` or `name`.
+
+`--name [name]`
+: Name of the app instance installed for the user. Specify either `id` or `name`.
+
+`--userId [userId]`
+: The ID of the user to upgrade the app for. Specify either `userId` or `userName` but not both.
+
+`--userName [userName]`
+: The UPN of the user to upgrade the app for. Specify either `userId` or `userName` but not both.
+```
+
+<Global />
+
+## Examples
+
+Upgrade an app by name for the specified user using its UPN.
+
+```sh
+m365 teams user app upgrade --name HelloWorld --userName admin@contoso.com
+```
+
+Upgrade an app by name for the specified user using its id.
+
+```sh
+m365 teams user app upgrade --name HelloWorld --userId 2609af39-7775-4f94-a3dc-0dd67657e900
+```
+
+Upgrade an app by id for the specified user using its UPN.
+
+```sh
+m365 teams user app upgrade --id YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY= --userName admin@contoso.com
+```
+
+Upgrade an app by id for the specified user using its id.
+
+```sh
+m365 teams user app upgrade --id YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY= --userId 2609af39-7775-4f94-a3dc-0dd67657e900
+```
+
+## Response
+
+The command won't return a response on success.

--- a/docs/src/config/sidebars.ts
+++ b/docs/src/config/sidebars.ts
@@ -4153,6 +4153,11 @@ const sidebars: SidebarsConfig = {
               type: 'doc',
               label: 'user app remove',
               id: 'cmd/teams/user/user-app-remove'
+            },
+            {
+              type: 'doc',
+              label: 'user app upgrade',
+              id: 'cmd/teams/user/user-app-upgrade'
             }
           ]
         }

--- a/src/m365/teams/commands.ts
+++ b/src/m365/teams/commands.ts
@@ -68,5 +68,6 @@ export default {
   USER_SET: `${prefix} user set`,
   USER_APP_ADD: `${prefix} user app add`,
   USER_APP_LIST: `${prefix} user app list`,
-  USER_APP_REMOVE: `${prefix} user app remove`
+  USER_APP_REMOVE: `${prefix} user app remove`,
+  USER_APP_UPGRADE: `${prefix} user app upgrade`
 };

--- a/src/m365/teams/commands/user/user-app-upgrade.spec.ts
+++ b/src/m365/teams/commands/user/user-app-upgrade.spec.ts
@@ -1,0 +1,178 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
+import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
+import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
+import { pid } from '../../../../utils/pid.js';
+import { session } from '../../../../utils/session.js';
+import { sinonUtil } from '../../../../utils/sinonUtil.js';
+import commands from '../../commands.js';
+import command from './user-app-upgrade.js';
+import { odata } from '../../../../utils/odata.js';
+import { formatting } from '../../../../utils/formatting.js';
+
+describe(commands.USER_APP_UPGRADE, () => {
+  let log: string[];
+  let logger: Logger;
+  let commandInfo: CommandInfo;
+
+  const userId = '520883a5-a09f-4ff4-bfbc-4ae8b57b1e39';
+  const userName = 'adelev@contoso.com';
+  const installedAppId = 'ODMyM2Y3ZmUtZThhNC00NmM0LWI1ZWEtZjQ4NjQ4ODdkMTYwIyNlZmZlMTNlZi0wMGUyLTRkNTUtYTIwNy1mMmQ5ZDFkZDcyNjM=';
+  const installedAppName = 'Custom App Name';
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
+    auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: async (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: async (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: async (msg: string) => {
+        log.push(msg);
+      }
+    };
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      odata.getAllItems,
+      request.post,
+      cli.handleMultipleResultsFound
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+    auth.connection.active = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.USER_APP_UPGRADE);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if the userId is not a valid guid.', async () => {
+    const actual = await command.validate({ options: { userId: 'invalid', id: installedAppId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if the userName is not a valid UPN.', async () => {
+    const actual = await command.validate({ options: { userName: 'invalid', id: installedAppId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the userName is a valid userName', async () => {
+    const actual = await command.validate({ options: { id: installedAppId, userName: userName } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation when the userId is a valid GUID', async () => {
+    const actual = await command.validate({ options: { id: installedAppId, userId: userId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('upgrades application retrieved by name and handles multiple values found', async () => {
+    const userInstalledAppsResponse = [{ id: installedAppId }, { id: 'installedTeamsAppId' }];
+
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userId)}/teamwork/installedApps?$expand=teamsAppDefinition&$filter=teamsAppDefinition/displayName eq '${formatting.encodeQueryParameter(installedAppName)}'&$select=id`) {
+        return userInstalledAppsResponse;
+      }
+      throw 'Invalid request';
+    });
+
+    sinon.stub(cli, 'handleMultipleResultsFound').resolves(userInstalledAppsResponse[0]);
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userId)}/teamwork/installedApps/${installedAppId}/upgrade`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { verbose: true, userId: userId, name: installedAppName } });
+    assert(postStub.calledOnce);
+  });
+
+  it('upgrades application retrieved by name when only single application is found', async () => {
+    const userInstalledAppsResponse = [{ id: installedAppId }];
+
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userId)}/teamwork/installedApps?$expand=teamsAppDefinition&$filter=teamsAppDefinition/displayName eq '${formatting.encodeQueryParameter(installedAppName)}'&$select=id`) {
+        return userInstalledAppsResponse;
+      }
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userId)}/teamwork/installedApps/${installedAppId}/upgrade`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { verbose: true, userId: userId, name: installedAppName } });
+    assert(postStub.calledOnce);
+  });
+
+
+  it('correctly handles error when app specified by name is not found', async () => {
+    sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
+      if (url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userName)}/teamwork/installedApps?$expand=teamsAppDefinition&$filter=teamsAppDefinition/displayName eq '${formatting.encodeQueryParameter(installedAppName)}'&$select=id`) {
+        return [];
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { userName: userName, name: installedAppName, verbose: true } } as any),
+      new CommandError(`The specified Teams app ${installedAppName} does not exist or is not installed for the user`));
+  });
+
+  it('correctly handles error when trying to upgrade permanent app', async () => {
+    const error = {
+      error: {
+        code: 'Forbidden',
+        message: 'User operation (Upgrade) is not allowed on a permanent app (appId: effe13ef-00e2-4d55-a207-f2d9d1dd7263)',
+        innerError: {
+          code: 'AccessDenied',
+          message: 'User operation (Upgrade) is not allowed on a permanent app (appId: effe13ef-00e2-4d55-a207-f2d9d1dd7263)',
+          details: [],
+          date: '2024-04-01T18:56:18',
+          'request-id': 'edb30b06-1995-46d5-826b-2c9e2e376990',
+          'client-request-id': 'edb30b06-1995-46d5-826b-2c9e2e376990'
+        }
+      }
+    };
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${formatting.encodeQueryParameter(userName)}/teamwork/installedApps/${installedAppId}/upgrade`) {
+        throw error;
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { userName: userName, id: installedAppId, verbose: true } } as any),
+      new CommandError(error.error.message));
+  });
+});

--- a/src/m365/teams/commands/user/user-app-upgrade.ts
+++ b/src/m365/teams/commands/user/user-app-upgrade.ts
@@ -3,6 +3,7 @@ import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { odata } from '../../../../utils/odata.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
@@ -18,13 +19,13 @@ interface Options extends GlobalOptions {
   userName?: string;
 }
 
-class TeamsUserAppAddCommand extends GraphCommand {
+class TeamsUserAppUpgradeCommand extends GraphCommand {
   public get name(): string {
-    return commands.USER_APP_ADD;
+    return commands.USER_APP_UPGRADE;
   }
 
   public get description(): string {
-    return 'Install an app in the personal scope of the specified user';
+    return 'Upgrade an app in the personal scope of the specified user';
   }
 
   constructor() {
@@ -67,10 +68,6 @@ class TeamsUserAppAddCommand extends GraphCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
-          return `${args.options.id} is not a valid GUID`;
-        }
-
         if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
           return `${args.options.userId} is not a valid GUID`;
         }
@@ -85,29 +82,27 @@ class TeamsUserAppAddCommand extends GraphCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push({ options: ['id', 'name'] });
-    this.optionSets.push({ options: ['userId', 'userName'] });
+    this.optionSets.push(
+      {
+        options: ['id', 'name']
+      },
+      {
+        options: ['userId', 'userName']
+      }
+    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const appId: string = await this.getAppId(args);
-      const userId: string = (args.options.userId ?? args.options.userName) as string;
-      const endpoint: string = `${this.resource}/v1.0`;
-
       if (this.verbose) {
-        await logger.logToStderr(`Adding app with ID ${appId} for user ${args.options.userId}`);
+        await logger.logToStderr(`Upgrading app ${args.options.id || args.options.name} for user ${args.options.userId || args.options.userName}`);
       }
 
+      const installedAppId: string = await this.getInstalledAppId(args.options, logger);
       const requestOptions: CliRequestOptions = {
-        url: `${endpoint}/users/${formatting.encodeQueryParameter(userId)}/teamwork/installedApps`,
+        url: `${this.resource}/v1.0/users/${formatting.encodeQueryParameter(args.options.userId || args.options.userName!)}/teamwork/installedApps/${installedAppId}/upgrade`,
         headers: {
-          'content-type': 'application/json;odata=nometadata',
           'accept': 'application/json;odata.metadata=none'
-        },
-        responseType: 'json',
-        data: {
-          'teamsApp@odata.bind': `${endpoint}/appCatalogs/teamsApps/${appId}`
         }
       };
 
@@ -118,33 +113,29 @@ class TeamsUserAppAddCommand extends GraphCommand {
     }
   }
 
-  private async getAppId(args: CommandArgs): Promise<string> {
-    if (args.options.id) {
-      return args.options.id;
+  private async getInstalledAppId(options: Options, logger: Logger): Promise<string> {
+    if (this.verbose) {
+      await logger.logToStderr(`Retrieving app ID`);
     }
 
-    const requestOptions: CliRequestOptions = {
-      url: `${this.resource}/v1.0/appCatalogs/teamsApps?$filter=displayName eq '${formatting.encodeQueryParameter(args.options.name as string)}'`,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
-
-    const response = await request.get<{ value: { id: string; }[] }>(requestOptions);
-
-    if (response.value.length === 1) {
-      return response.value[0].id;
+    if (options.id) {
+      return options.id;
     }
 
-    if (response.value.length === 0) {
-      throw `The specified Teams app does not exist`;
+    const installedApps = await odata.getAllItems<{ id: string }>(`${this.resource}/v1.0/users/${formatting.encodeQueryParameter(options.userId || options.userName!)}/teamwork/installedApps?$expand=teamsAppDefinition&$filter=teamsAppDefinition/displayName eq '${formatting.encodeQueryParameter(options.name!)}'&$select=id`);
+
+    if (installedApps.length === 1) {
+      return installedApps[0].id;
     }
 
-    const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', response.value);
-    const result: { id: string } = (await cli.handleMultipleResultsFound(`Multiple Teams apps with name '${args.options.name}' found.`, resultAsKeyValuePair)) as { id: string };
+    if (installedApps.length === 0) {
+      throw `The specified Teams app ${options.name!} does not exist or is not installed for the user`;
+    }
+
+    const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', installedApps);
+    const result: { id: string } = (await cli.handleMultipleResultsFound(`Multiple installed Teams apps with name '${options.name}' found.`, resultAsKeyValuePair)) as { id: string };
     return result.id;
   }
 }
 
-export default new TeamsUserAppAddCommand();
+export default new TeamsUserAppUpgradeCommand();


### PR DESCRIPTION
Closes #5705 

When looking at `teams user app add` for inspiration, I noticed that the try catch was not around the full command and the verbose log had `removing` in it while it is an add command. I have added that in this PR, but if wanted, I can raise a separate issue for this and include it in that.