### PR TITLE
Fixes 'spo site apppermission remove' output

### DIFF
--- a/docs/docs/cmd/spo/site/site-apppermission-add.mdx
+++ b/docs/docs/cmd/spo/site/site-apppermission-add.mdx
@@ -32,7 +32,7 @@ m365 spo site apppermission add [options]
 
 ## Remarks
 
-To set permissions, specify at minimum either `appId` or `addDisplayName`. For best performance specify both values to avoid extra lookup.
+To set permissions, specify at minimum either `appId` or `appDisplayName`. For best performance specify both values to avoid extra lookup.
 
 ## Example
 


### PR DESCRIPTION
A few months ago, we accidentally introduced an output for `spo site apppermission remove`.

![image](https://github.com/pnp/cli-microsoft365/assets/11723921/7c029981-455c-4ea1-a08d-abbb46bad6ae)
