### PR TITLE
Adds support for node@22

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -56,6 +56,9 @@ jobs:
           - os: ubuntu-latest
             nodeRun: 18
             nodeBuild: 20
+          - os: ubuntu-latest
+            nodeRun: 22
+            nodeBuild: 20
 
     steps:
       - name: Configure pagefile

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -58,6 +58,9 @@ jobs:
           - os: ubuntu-latest
             nodeRun: 18
             nodeBuild: 20
+          - os: ubuntu-latest
+            nodeRun: 22
+            nodeBuild: 20
 
     steps:
       - name: Configure pagefile

--- a/src/m365/entra/commands/m365group/m365group-add.spec.ts
+++ b/src/m365/entra/commands/m365group/m365group-add.spec.ts
@@ -40,6 +40,34 @@ describe(commands.M365GROUP_ADD, () => {
     visibility: 'Public'
   };
 
+  const fsStats: fs.Stats = {
+    isDirectory: () => false,
+    isFile: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isSymbolicLink: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    dev: 0,
+    ino: 0,
+    mode: 0,
+    nlink: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    size: 0,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    atime: new Date(),
+    mtime: new Date(),
+    ctime: new Date(),
+    birthtime: new Date()
+  };
+
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -696,8 +724,7 @@ describe(commands.M365GROUP_ADD, () => {
   });
 
   it('fails validation if logoPath points to a folder', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').callsFake(() => true);
+    const stats = { ...fsStats, isDirectory: () => true };
     sinon.stub(fs, 'existsSync').callsFake(() => true);
     sinon.stub(fs, 'lstatSync').callsFake(() => stats);
     const actual = await command.validate({ options: { displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', logoPath: 'folder' } }, commandInfo);
@@ -721,10 +748,8 @@ describe(commands.M365GROUP_ADD, () => {
   });
 
   it('passes validation if logoPath points to an existing file', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').callsFake(() => false);
     sinon.stub(fs, 'existsSync').callsFake(() => true);
-    sinon.stub(fs, 'lstatSync').callsFake(() => stats);
+    sinon.stub(fs, 'lstatSync').callsFake(() => fsStats);
     const actual = await command.validate({ options: { displayName: 'My group', description: 'My awesome group', mailNickname: 'my_group', logoPath: 'folder' } }, commandInfo);
     sinonUtil.restore([
       fs.existsSync,

--- a/src/m365/entra/commands/m365group/m365group-set.spec.ts
+++ b/src/m365/entra/commands/m365group/m365group-set.spec.ts
@@ -18,6 +18,34 @@ import { entraGroup } from '../../../../utils/entraGroup.js';
 import aadCommands from '../../aadCommands.js';
 
 describe(commands.M365GROUP_SET, () => {
+  const fsStats: fs.Stats = {
+    isDirectory: () => false,
+    isFile: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isSymbolicLink: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    dev: 0,
+    ino: 0,
+    mode: 0,
+    nlink: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    size: 0,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    atime: new Date(),
+    mtime: new Date(),
+    ctime: new Date(),
+    birthtime: new Date()
+  };
+
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -475,8 +503,7 @@ describe(commands.M365GROUP_SET, () => {
   });
 
   it('fails validation if logoPath points to a folder', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(true);
+    const stats = { ...fsStats, isDirectory: () => true };
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'lstatSync').returns(stats);
     const actual = await command.validate({ options: { id: '28beab62-7540-4db1-a23f-29a6018a3848', logoPath: 'folder' } }, commandInfo);
@@ -488,10 +515,8 @@ describe(commands.M365GROUP_SET, () => {
   });
 
   it('passes validation if logoPath points to an existing file', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
     const actual = await command.validate({ options: { id: '28beab62-7540-4db1-a23f-29a6018a3848', logoPath: 'folder' } }, commandInfo);
     sinonUtil.restore([
       fs.existsSync,

--- a/src/m365/spo/commands/app/app-add.spec.ts
+++ b/src/m365/spo/commands/app/app-add.spec.ts
@@ -16,6 +16,34 @@ import command from './app-add.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.APP_ADD, () => {
+  const fsStats: fs.Stats = {
+    isDirectory: () => false,
+    isFile: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isSymbolicLink: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    dev: 0,
+    ino: 0,
+    mode: 0,
+    nlink: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    size: 0,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    atime: new Date(),
+    mtime: new Date(),
+    ctime: new Date(),
+    birthtime: new Date()
+  };
+
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -441,10 +469,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('passes validation on valid \'tenant\' scope', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { appCatalogScope: 'tenant', filePath: 'abc' } }, commandInfo);
     sinonUtil.restore([
@@ -455,10 +481,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('passes validation on valid \'Tenant\' scope', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { appCatalogScope: 'Tenant', filePath: 'abc' } }, commandInfo);
     sinonUtil.restore([
@@ -469,10 +493,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('passes validation on valid \'SiteCollection\' scope', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { appCatalogScope: 'SiteCollection', appCatalogUrl: 'https://contoso.sharepoint.com', filePath: 'abc' } }, commandInfo);
     sinonUtil.restore([
@@ -602,8 +624,7 @@ describe(commands.APP_ADD, () => {
   });
 
   it('fails validation if file path points to a directory', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(true);
+    const stats = { ...fsStats, isDirectory: () => true };
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'lstatSync').returns(stats);
     const actual = await command.validate({ options: { filePath: 'abc' } }, commandInfo);
@@ -615,10 +636,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('fails validation when invalid scope is specified', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { filePath: 'abc', appCatalogScope: 'foo' } }, commandInfo);
 
@@ -630,10 +649,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('passes validation when path points to a valid file', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { filePath: 'abc' } }, commandInfo);
 
@@ -645,10 +662,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('passes validation when no scope is specified', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { filePath: 'abc' } }, commandInfo);
 
@@ -660,10 +675,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('passes validation when the scope is specified with \'tenant\'', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { filePath: 'abc', appCatalogScope: 'tenant' } }, commandInfo);
 
@@ -676,10 +689,8 @@ describe(commands.APP_ADD, () => {
 
 
   it('should fail when \'sitecollection\' scope, but no appCatalogUrl specified', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { filePath: 'abc', appCatalogScope: 'sitecollection' } }, commandInfo);
 
@@ -691,10 +702,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('should not fail when \'tenant\' scope, but also appCatalogUrl specified', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { filePath: 'abc', appCatalogScope: 'tenant', appCatalogUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
 
@@ -706,10 +715,8 @@ describe(commands.APP_ADD, () => {
   });
 
   it('should fail when \'sitecollection\' scope, but bad appCatalogUrl format specified', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({ options: { filePath: 'abc', appCatalogScope: 'sitecollection', appCatalogUrl: 'contoso.sharepoint.com' } }, commandInfo);
 

--- a/src/m365/spo/commands/page/page-clientsidewebpart-add.ts
+++ b/src/m365/spo/commands/page/page-clientsidewebpart-add.ts
@@ -1,4 +1,3 @@
-import { isNumber } from 'util';
 import { v4 } from 'uuid';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
@@ -127,11 +126,11 @@ class SpoPageClientSideWebPartAddCommand extends SpoCommand {
           }
         }
 
-        if (args.options.section && (!isNumber(args.options.section) || args.options.section < 1)) {
+        if (args.options.section && (!Number.isInteger(args.options.section) || args.options.section < 1)) {
           return 'The value of parameter section must be 1 or higher';
         }
 
-        if (args.options.column && (!isNumber(args.options.column) || args.options.column < 1)) {
+        if (args.options.column && (!Number.isInteger(args.options.column) || args.options.column < 1)) {
           return 'The value of parameter column must be 1 or higher';
         }
 

--- a/src/m365/spo/commands/page/page-text-add.ts
+++ b/src/m365/spo/commands/page/page-text-add.ts
@@ -1,4 +1,3 @@
-import { isNumber } from 'util';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request from '../../../../request.js';
@@ -79,11 +78,11 @@ class SpoPageTextAddCommand extends SpoCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (args.options.section && (!isNumber(args.options.section) || args.options.section < 1)) {
+        if (args.options.section && (!Number.isInteger(args.options.section) || args.options.section < 1)) {
           return 'The value of parameter section must be 1 or higher';
         }
 
-        if (args.options.column && (!isNumber(args.options.column) || args.options.column < 1)) {
+        if (args.options.column && (!Number.isInteger(args.options.column) || args.options.column < 1)) {
           return 'The value of parameter column must be 1 or higher';
         }
 

--- a/src/m365/spo/commands/spo-search.ts
+++ b/src/m365/spo/commands/spo-search.ts
@@ -1,4 +1,3 @@
-import { isNumber } from 'util';
 import { cli } from '../../../cli/cli.js';
 import { Logger } from '../../../cli/Logger.js';
 import GlobalOptions from '../../../GlobalOptions.js';
@@ -181,11 +180,11 @@ class SpoSearchCommand extends SpoCommand {
           return `sortlist parameter value '${args.options.sortList}' does not match the required pattern (=comma-separated list of '<property>:(ascending|descending)'-pattern)`;
         }
 
-        if (args.options.rowLimit && !isNumber(args.options.rowLimit)) {
+        if (args.options.rowLimit && !Number.isInteger(args.options.rowLimit)) {
           return `${args.options.rowLimit} is not a valid number`;
         }
 
-        if (args.options.startRow && !isNumber(args.options.startRow)) {
+        if (args.options.startRow && !Number.isInteger(args.options.startRow)) {
           return `${args.options.startRow} is not a valid number`;
         }
 
@@ -193,7 +192,7 @@ class SpoSearchCommand extends SpoCommand {
           return 'You cannot specify startRow when allResults is set';
         }
 
-        if (args.options.culture && !isNumber(args.options.culture)) {
+        if (args.options.culture && !Number.isInteger(args.options.culture)) {
           return `${args.options.culture} is not a valid number`;
         }
 

--- a/src/m365/teams/commands/app/app-publish.spec.ts
+++ b/src/m365/teams/commands/app/app-publish.spec.ts
@@ -26,6 +26,34 @@ describe(commands.APP_PUBLISH, () => {
     distributionMethod: "organization"
   };
 
+  const fsStats: fs.Stats = {
+    isDirectory: () => false,
+    isFile: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isSymbolicLink: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    dev: 0,
+    ino: 0,
+    mode: 0,
+    nlink: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    size: 0,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    atime: new Date(),
+    mtime: new Date(),
+    ctime: new Date(),
+    birthtime: new Date()
+  };
+
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').returns();
@@ -82,8 +110,7 @@ describe(commands.APP_PUBLISH, () => {
   });
 
   it('fails validation if the filePath points to a directory', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(true);
+    const stats = { ...fsStats, isDirectory: () => true };
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'lstatSync').returns(stats);
 
@@ -97,10 +124,8 @@ describe(commands.APP_PUBLISH, () => {
   });
 
   it('validates for a correct input.', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({
       options: {

--- a/src/m365/teams/commands/app/app-update.spec.ts
+++ b/src/m365/teams/commands/app/app-update.spec.ts
@@ -20,6 +20,34 @@ describe(commands.APP_UPDATE, () => {
   let logger: Logger;
   let commandInfo: CommandInfo;
 
+  const fsStats: fs.Stats = {
+    isDirectory: () => false,
+    isFile: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isSymbolicLink: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    dev: 0,
+    ino: 0,
+    mode: 0,
+    nlink: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    size: 0,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    atime: new Date(),
+    mtime: new Date(),
+    ctime: new Date(),
+    birthtime: new Date()
+  };
+
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').returns();
@@ -124,8 +152,7 @@ describe(commands.APP_UPDATE, () => {
   });
 
   it('fails validation if the filePath points to a directory', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(true);
+    const stats = { ...fsStats, isDirectory: () => true };
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'lstatSync').returns(stats);
 
@@ -139,10 +166,8 @@ describe(commands.APP_UPDATE, () => {
   });
 
   it('validates for a correct input.', async () => {
-    const stats: fs.Stats = new fs.Stats();
-    sinon.stub(stats, 'isDirectory').returns(false);
     sinon.stub(fs, 'existsSync').returns(true);
-    sinon.stub(fs, 'lstatSync').returns(stats);
+    sinon.stub(fs, 'lstatSync').returns(fsStats);
 
     const actual = await command.validate({
       options: {


### PR DESCRIPTION
Closes #6003

---

Node 22 comes with following deprecated APIs:

- DeprecationWarning: The `util.isNumber` API is deprecated. Please use `typeof arg === "number"` instead.
- DeprecationWarning: fs.Stats constructor is deprecated.