### PR TITLE
Enhances `entra user list` properties

### DIFF
--- a/docs/docs/cmd/entra/user/user-list.mdx
+++ b/docs/docs/cmd/entra/user/user-list.mdx
@@ -32,7 +32,7 @@ m365 aad user list [options]
 
 ## Remarks
 
-Using the `--properties` option, you can specify a comma-separated list of user properties to retrieve from the Microsoft Graph. If you don't specify any properties, the command will retrieve user's display name, account name, id, and mail.
+Using the `--properties` option, you can specify a comma-separated list of user properties to retrieve from the Microsoft Graph. If you don't specify any properties, the command will retrieve all the properties returned by Graph of the users.
 
 When the `properties` option includes values with a `/`, for example: `manager/displayName`, an additional `$expand` query parameter will be included on `manager`.
 
@@ -86,10 +86,19 @@ m365 entra user list --properties "displayName,mail,manager/*"
   ```json
   [
     {
-      "id": "1f5595b2-aa07-445d-9801-a45ea18160b2",
+      "businessPhones": [
+        "+32 456 789 123"
+      ],
       "displayName": "John Doe",
+      "givenName": "John",
+      "jobTitle": "Sales Manager",
       "mail": "John@contoso.onmicrosoft.com",
-      "userPrincipalName": "John@contoso.onmicrosoft.com"
+      "mobilePhone": "+32 456 789 123",
+      "officeLocation": "Antwerp",
+      "preferredLanguage": "nl-BE",
+      "surname": "Doe",
+      "userPrincipalName": "John@contoso.onmicrosoft.com",
+      "id": "ef0d4f29-e359-4443-a15d-bc3dccc8143f"
     }
   ]
   ```
@@ -98,17 +107,17 @@ m365 entra user list --properties "displayName,mail,manager/*"
   <TabItem value="Text">
 
   ```text
-  id                                    displayName         mail                                 userPrincipalName
-  ------------------------------------  ------------------  -----------------------------------  ------------------------------------------
-  1f5595b2-aa07-445d-9801-a45ea18160b2  John Doe            John@contoso.onmicrosoft.com         John@contoso.onmicrosoft.com
+  businessPhones   displayName  givenName  jobTitle       mail                          mobilePhone      officeLocation  preferredLanguage  surname  userPrincipalName             id
+  ---------------  -----------  ---------  -------------  ----------------------------  ---------------  --------------  -----------------  -------  ----------------------------  ------------------------------------
+  +32 456 789 123  John Doe     John       Sales Manager  John@contoso.onmicrosoft.com  +32 456 789 123  Antwerp         nl-BE              Doe      John@contoso.onmicrosoft.com  ef0d4f29-e359-4443-a15d-bc3dccc8143f
   ```
 
   </TabItem>
   <TabItem value="CSV">
 
   ```csv
-  id,displayName,mail,userPrincipalName
-  1f5595b2-aa07-445d-9801-a45ea18160b2,John Doe,John@contoso.onmicrosoft.com,John@contoso.onmicrosoft.com
+  displayName,givenName,jobTitle,mail,mobilePhone,officeLocation,preferredLanguage,surname,userPrincipalName,id
+  John Doe,John,Sales Manager,John@contoso.onmicrosoft.com,+32 456 789 123,Antwerp,nl-BE,Doe,John@contoso.onmicrosoft.com,ef0d4f29-e359-4443-a15d-bc3dccc8143f
   ```
 
   </TabItem>
@@ -123,10 +132,16 @@ m365 entra user list --properties "displayName,mail,manager/*"
 
   Property | Value
   ---------|-------
-  id | 1f5595b2-aa07-445d-9801-a45ea18160b2
   displayName | John Doe
+  givenName | John
+  jobTitle | Sales Manager
   mail | John@contoso.onmicrosoft.com
+  mobilePhone | +32 456 789 123
+  officeLocation | Antwerp
+  preferredLanguage | nl-BE
+  surname | Doe
   userPrincipalName | John@contoso.onmicrosoft.com  
+  id | 1f5595b2-aa07-445d-9801-a45ea18160b2
   ```
 
   </TabItem>

--- a/src/m365/entra/commands/user/user-list.spec.ts
+++ b/src/m365/entra/commands/user/user-list.spec.ts
@@ -1,8 +1,10 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
-import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
+import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { formatting } from '../../../../utils/formatting.js';
@@ -14,6 +16,7 @@ import command from './user-list.js';
 import aadCommands from '../../aadCommands.js';
 
 describe(commands.USER_LIST, () => {
+  let commandInfo: CommandInfo;
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -24,6 +27,7 @@ describe(commands.USER_LIST, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
@@ -71,9 +75,19 @@ describe(commands.USER_LIST, () => {
     assert.deepStrictEqual(alias, [aadCommands.USER_LIST]);
   });
 
+  it('fails validation if mentioned type is not a valid user type.', async () => {
+    const actual = await command.validate({ options: { type: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if mentioned type is a valid user type.', async () => {
+    const actual = await command.validate({ options: { type: 'Member' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
   it('lists users in the tenant with the default properties (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*`) {
         return {
           "value": [
             { "id": "1f5595b2-aa07-445d-9801-a45ea18160b2", "displayName": "Aarif Sherzai", "mail": "AarifS@contoso.onmicrosoft.com", "userPrincipalName": "AarifS@contoso.onmicrosoft.com" },
@@ -94,7 +108,7 @@ describe(commands.USER_LIST, () => {
 
   it('retrieves only the specified user properties', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=displayName,mail&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=displayName,mail`) {
         return {
           "value": [
             { "displayName": "Aarif Sherzai", "mail": "AarifS@contoso.onmicrosoft.com" }, { "displayName": "Achim Maier", "mail": "AchimM@contoso.onmicrosoft.com" }
@@ -113,7 +127,7 @@ describe(commands.USER_LIST, () => {
 
   it('retrieves properties for all users with properties option includes values with a slash', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=displayName&$expand=manager($select=displayName),manager($select=department)&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=displayName&$expand=manager($select=displayName),manager($select=department)`) {
         return {
           "value": [
             { "displayName": "Aarif Sherzai", "manager": { "displayName": "Jon Doe", "department": "IT" } }, { "displayName": "Achim Maier", "manager": { "displayName": "Jon Doe", "department": "IT" } }
@@ -132,7 +146,7 @@ describe(commands.USER_LIST, () => {
 
   it('filters users by one property', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$filter=startsWith(surname, 'M')&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*&$filter=startsWith(surname, 'M')`) {
         return {
           "value": [
             { "id": "1f5595b2-aa07-445d-9801-a45ea18160b2", "displayName": "Achim Maier", "mail": "AchimM@contoso.onmicrosoft.com", "userPrincipalName": "AchimM@contoso.onmicrosoft.com" }, { "id": "0fe76bf5-222b-48f8-a5c1-a3a03b96d472", "displayName": "Karl Matteson", "mail": "KarlM@contoso.onmicrosoft.com", "userPrincipalName": "KarlM@contoso.onmicrosoft.com" }
@@ -151,7 +165,7 @@ describe(commands.USER_LIST, () => {
 
   it('filters users by multiple properties', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$filter=startsWith(surname, 'M') and startsWith(givenName, 'A')&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*&$filter=startsWith(surname, 'M') and startsWith(givenName, 'A')`) {
         return {
           "value": [
             { "id": "1f5595b2-aa07-445d-9801-a45ea18160b2", "displayName": "Achim Maier", "mail": "AchimM@contoso.onmicrosoft.com", "userPrincipalName": "AchimM@contoso.onmicrosoft.com" }, { "id": "7f50c7d9-916b-4da9-949e-09a431de2646", "displayName": "Anne Matthews", "mail": "AnneM@contoso.onmicrosoft.com", "userPrincipalName": "AnneM@contoso.onmicrosoft.com" }
@@ -170,7 +184,7 @@ describe(commands.USER_LIST, () => {
 
   it('lists users in the tenant with the guest type and surname', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$filter=startsWith(surname, 'S') and userType eq 'Guest'&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*&$filter=startsWith(surname, 'S') and userType eq 'Guest'`) {
         return {
           "value": [
             { "id": "7dc52cef-c513-4a53-bd43-93e9f6727911", "displayName": "Aarif Sherzai", "mail": "AarifS@fabrikam.onmicrosoft.com", "userPrincipalName": "AarifS_fabrikam.onmicrosoft.com#EXT#@contoso.onmicrosoft.com" }
@@ -189,7 +203,7 @@ describe(commands.USER_LIST, () => {
 
   it('lists users in the tenant with only guest type', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$filter=userType eq 'Guest'&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*&$filter=userType eq 'Guest'`) {
         return {
           "value": [
             { "id": "7dc52cef-c513-4a53-bd43-93e9f6727911", "displayName": "Aarif Sherzai", "mail": "AarifS@fabrikam.onmicrosoft.com", "userPrincipalName": "AarifS_fabrikam.onmicrosoft.com#EXT#@contoso.onmicrosoft.com" }
@@ -205,11 +219,11 @@ describe(commands.USER_LIST, () => {
       { "id": "7dc52cef-c513-4a53-bd43-93e9f6727911", "displayName": "Aarif Sherzai", "mail": "AarifS@fabrikam.onmicrosoft.com", "userPrincipalName": "AarifS_fabrikam.onmicrosoft.com#EXT#@contoso.onmicrosoft.com" }
     ]));
   });
-  
+
   it('escapes special characters in filters', async () => {
     const displayName = 'O\'Brien';
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$filter=startsWith(displayName, '${formatting.encodeQueryParameter(displayName)}')&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*&$filter=startsWith(displayName, '${formatting.encodeQueryParameter(displayName)}')`) {
         return {
           "value": []
         };
@@ -224,7 +238,7 @@ describe(commands.USER_LIST, () => {
 
   it('ignores global options in filters', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$filter=startsWith(surname, 'M') and startsWith(givenName, 'A')&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*&$filter=startsWith(surname, 'M') and startsWith(givenName, 'A')`) {
         return {
           "value": [
             { "id": "1f5595b2-aa07-445d-9801-a45ea18160b2", "displayName": "Achim Maier", "mail": "AchimM@contoso.onmicrosoft.com", "userPrincipalName": "AchimM@contoso.onmicrosoft.com" }, { "id": "7f50c7d9-916b-4da9-949e-09a431de2646", "displayName": "Anne Matthews", "mail": "AnneM@contoso.onmicrosoft.com", "userPrincipalName": "AnneM@contoso.onmicrosoft.com" }
@@ -250,16 +264,16 @@ describe(commands.USER_LIST, () => {
 
   it('handles error when retrieving second page of users', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$top=100`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*`) {
         return {
-          "@odata.nextLink": "https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$top=100&$top=100&$skiptoken=X%2744537074090001000000000000000014000000C233BFA08475B84E8BF8C40335F8944D01000000000000000000000000000017312E322E3834302E3131333535362E312E342E32333331020000000000017D06501DC4C194438D57CFE494F81C1E%27",
+          "@odata.nextLink": "https://graph.microsoft.com/v1.0/users?$select=*&$skiptoken=X%2744537074090001000000000000000014000000C233BFA08475B84E8BF8C40335F8944D01000000000000000000000000000017312E322E3834302E3131333535362E312E342E32333331020000000000017D06501DC4C194438D57CFE494F81C1E%27",
           "value": [
             { "id": "1f5595b2-aa07-445d-9801-a45ea18160b2", "displayName": "Achim Maier", "mail": "AchimM@contoso.onmicrosoft.com", "userPrincipalName": "AchimM@contoso.onmicrosoft.com" }, { "id": "7f50c7d9-916b-4da9-949e-09a431de2646", "displayName": "Anne Matthews", "mail": "AnneM@contoso.onmicrosoft.com", "userPrincipalName": "AnneM@contoso.onmicrosoft.com" }
           ]
         };
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName&$top=100&$top=100&$skiptoken=X%2744537074090001000000000000000014000000C233BFA08475B84E8BF8C40335F8944D01000000000000000000000000000017312E322E3834302E3131333535362E312E342E32333331020000000000017D06501DC4C194438D57CFE494F81C1E%27`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users?$select=*&$skiptoken=X%2744537074090001000000000000000014000000C233BFA08475B84E8BF8C40335F8944D01000000000000000000000000000017312E322E3834302E3131333535362E312E342E32333331020000000000017D06501DC4C194438D57CFE494F81C1E%27`) {
         throw 'An error has occurred';
       }
 


### PR DESCRIPTION
Closes #4667 

I have also noticed that we added the option `type` with an autocomplete in a previous PR, but we didn't validate the options being passed, resulting in the command throwing an error when we used a user type other than `member` or `guest`. 