### PR TITLE
Adds Eslint rule to handle promises. Closes #6005

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -143,7 +143,8 @@ module.exports = {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2015,
-    "sourceType": "module"
+    "sourceType": "module",
+    "project": "./tsconfig.json"
   },
   "plugins": [
     "@typescript-eslint",
@@ -154,6 +155,7 @@ module.exports = {
     "**/package-generate/assets/**",
     "**/test-projects/**",
     "clientsidepages.ts",
+    "*.d.ts",
     "*.js",
     "*.cjs"
   ],
@@ -235,7 +237,8 @@ module.exports = {
       }
     ],
     "@typescript-eslint/explicit-function-return-type": ["error", { "allowExpressions": true }],
-    "mocha/no-identical-title": "error"
+    "mocha/no-identical-title": "error",
+    "@typescript-eslint/no-floating-promises": "error"
   },
   "overrides": [
     {

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -1908,7 +1908,8 @@ describe('Auth', () => {
         catch (e) {
           done(e);
         }
-      });
+      })
+      .catch(done);
   });
 
   it('handles error when restoring authentication', (done) => {

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -468,7 +468,7 @@ export class Auth {
     }
 
     if (cli.getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false)) {
-      browserUtil.open(response.verificationUri);
+      await browserUtil.open(response.verificationUri);
     }
 
     if (cli.getSettingWithDefaultValue<boolean>(settingsNames.copyDeviceCodeToClipboard, false)) {

--- a/src/AuthServer.ts
+++ b/src/AuthServer.ts
@@ -37,23 +37,23 @@ export class AuthServer {
     this.httpServer = http.createServer(this.httpRequest).listen(0, this.httpListener);
   };
 
-  private httpListener = (): void => {
+  private httpListener = async (): Promise<void> => {
     const requestState = Math.random().toString(16).substr(2, 20);
     const address = this.httpServer.address() as AddressInfo;
     this.generatedServerUrl = `http://localhost:${address.port}`;
     const url = `${Auth.getEndpointForResource('https://login.microsoftonline.com', this.connection.cloudType)}/${this.connection.tenant}/oauth2/authorize?response_type=code&client_id=${this.connection.appId}&redirect_uri=${this.generatedServerUrl}&state=${requestState}&resource=${this.resource}&prompt=select_account`;
     if (this.debug) {
-      this.logger.logToStderr('Redirect URL:');
-      this.logger.logToStderr(url);
-      this.logger.logToStderr('');
+      await this.logger.logToStderr('Redirect URL:');
+      await this.logger.logToStderr(url);
+      await this.logger.logToStderr('');
     }
     this.openUrl(url);
   };
 
   private openUrl(url: string): void {
     browserUtil.open(url)
-      .then(_ => {
-        this.logger.logToStderr("To sign in, use the web browser that just has been opened. Please sign-in there.");
+      .then(async _ => {
+        await this.logger.logToStderr("To sign in, use the web browser that just has been opened. Please sign-in there.");
       })
       .catch(_ => {
         const errorResponse: InteractiveAuthorizationErrorResponse = {
@@ -66,11 +66,11 @@ export class AuthServer {
       });
   }
 
-  private httpRequest = (request: IncomingMessage, response: ServerResponse): void => {
+  private httpRequest = async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
     if (this.debug) {
-      this.logger.logToStderr('Response:');
-      this.logger.logToStderr(request.url);
-      this.logger.logToStderr('');
+      await this.logger.logToStderr('Response:');
+      await this.logger.logToStderr(request.url);
+      await this.logger.logToStderr('');
     }
 
     // url.parse is deprecated but we can't move to URL, because it doesn't

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -165,7 +165,7 @@ export default abstract class Command {
 
       if (!prompted) {
         prompted = true;
-        cli.error('🌶️  Provide values for the following parameters:');
+        await cli.error('🌶️  Provide values for the following parameters:');
       }
 
       const answer = optionInfo.autocomplete !== undefined
@@ -176,10 +176,10 @@ export default abstract class Command {
     }
 
     if (prompted) {
-      cli.error('');
+      await cli.error('');
     }
 
-    this.processOptions(args.options);
+    await this.processOptions(args.options);
 
     return true;
   }
@@ -220,22 +220,22 @@ export default abstract class Command {
   }
 
   private async promptForOptionSetNameAndValue(args: CommandArgs, optionSet: OptionSet): Promise<void> {
-    cli.error(`🌶️  Please specify one of the following options:`);
+    await cli.error(`🌶️  Please specify one of the following options:`);
 
     const selectedOptionName = await prompt.forSelection<string>({ message: `Option to use:`, choices: optionSet.options.map((choice: any) => { return { name: choice, value: choice }; }) });
     const optionValue = await prompt.forInput({ message: `${selectedOptionName}:` });
 
     args.options[selectedOptionName] = optionValue;
-    cli.error('');
+    await cli.error('');
   }
 
   private async promptForSpecificOption(args: CommandArgs, commonOptions: string[]): Promise<void> {
-    cli.error(`🌶️  Multiple options for an option set specified. Please specify the correct option that you wish to use.`);
+    await cli.error(`🌶️  Multiple options for an option set specified. Please specify the correct option that you wish to use.`);
 
     const selectedOptionName = await prompt.forSelection({ message: `Option to use:`, choices: commonOptions.map((choice: any) => { return { name: choice, value: choice }; }) });
 
     commonOptions.filter(y => y !== selectedOptionName).map(optionName => args.options[optionName] = undefined);
-    cli.error('');
+    await cli.error('');
   }
 
   private async validateOutput(args: CommandArgs): Promise<string | boolean> {
@@ -284,7 +284,7 @@ export default abstract class Command {
       throw new CommandError(error);
     }
 
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
 
     if (!auth.connection.active) {
       throw new CommandError('Log in to Microsoft 365 first');
@@ -433,14 +433,14 @@ export default abstract class Command {
     this.handleError(rawResponse);
   }
 
-  protected initAction(args: CommandArgs, logger: Logger): void {
+  protected async initAction(args: CommandArgs, logger: Logger): Promise<void> {
     this.debug = args.options.debug || process.env.CLIMICROSOFT365_DEBUG === '1';
     this.verbose = this.debug || args.options.verbose || process.env.CLIMICROSOFT365_VERBOSE === '1';
     request.debug = this.debug;
     request.logger = logger;
 
     if (this.debug && auth.connection.identityName !== undefined) {
-      logger.logToStderr(`Executing command as '${auth.connection.identityName}', appId: ${auth.connection.appId}, tenantId: ${auth.connection.identityTenantId}`);
+      await logger.logToStderr(`Executing command as '${auth.connection.identityName}', appId: ${auth.connection.appId}, tenantId: ${auth.connection.identityTenantId}`);
     }
 
     telemetry.trackEvent(this.getUsedCommandName(), this.getTelemetryProperties(args));

--- a/src/chili/chili.spec.ts
+++ b/src/chili/chili.spec.ts
@@ -516,15 +516,16 @@ describe('chili', () => {
     sinon.stub(request, 'post').callsFake(async options => {
       switch (options.url) {
         case 'https://api.mendable.ai/v1/newConversation':
-          return Promise.reject('An error has occurred');
+          throw new Error('An error has occurred');
       }
       throw `Invalid request: ${options.url}`;
     });
+
     sinon.stub(prompt, 'forSelection').resolves({});
-    assert.rejects(chili.startConversation(['Hello']), 'An error has occurred');
+    await assert.rejects(chili.startConversation(['Hello']), new Error('An error has occurred'));
   });
 
-  it('throw exception when calling Mendable API to search in CLI docs failed', () => {
+  it('throw exception when calling Mendable API to search in CLI docs failed', async () => {
     sinon.stub(request, 'post').callsFake(async options => {
       switch (options.url) {
         case 'https://api.mendable.ai/v1/newConversation':
@@ -533,12 +534,12 @@ describe('chili', () => {
             conversation_id: 1
           };
         case 'https://api.mendable.ai/v1/mendableChat':
-          throw 'An error has occurred';
+          throw new Error('An error has occurred');
       }
       throw `Invalid request: ${options.url}`;
     });
     sinon.stub(prompt, 'forSelection').resolves({});
-    assert.rejects(chili.startConversation(['Hello']), 'An error has occurred');
+    await assert.rejects(chili.startConversation(['Hello']), new Error('An error has occurred'));
   });
 
   it('shows help when requested using --help', async () => {

--- a/src/chili/index.ts
+++ b/src/chili/index.ts
@@ -3,7 +3,7 @@
 import { chili } from './chili.js';
 
 try {
-  (async () => await chili.startConversation(process.argv.slice(2)))();
+  await (async () => await chili.startConversation(process.argv.slice(2)))();
 }
 catch (err) {
   console.error(`🛑 An error has occurred while searching documentation: ${err}`);

--- a/src/cli/cli.spec.ts
+++ b/src/cli/cli.spec.ts
@@ -1126,7 +1126,7 @@ describe('cli', () => {
   it('correctly handles error when executing command (execute)', async () => {
     sinon.stub(cli, 'executeCommand').throws('Error');
     cli.commandToExecute = cli.commands.find(c => c.name === 'cli completion clink update');
-    assert.rejects(cli.execute(['cli', 'completion', 'clink', 'update']), new Error('Error'));
+    await assert.rejects(cli.execute(['cli', 'completion', 'clink', 'update']), 'Error');
   });
 
   it('correctly handles error when executing command with output', async () => {
@@ -1142,7 +1142,7 @@ describe('cli', () => {
   });
 
   it(`loads all commands, when the matched file doesn't contain command`, async () => {
-    sinon.stub(cli, 'loadCommandFromFile').returns(cli.loadCommandFromFile as any).wrappedMethod.apply(cli, [path.join(rootFolder, 'CommandInfo.js')]);
+    await sinon.stub(cli, 'loadCommandFromFile').returns(cli.loadCommandFromFile as any).wrappedMethod.apply(cli, [path.join(rootFolder, 'CommandInfo.js')]);
     await cli.loadCommandFromArgs(['status']);
 
     assert.strictEqual(cli.commandToExecute, undefined);
@@ -1529,25 +1529,25 @@ describe('cli', () => {
         { "name": "Olympia", "state": "WA" }
       ]
     };
-    assert.rejects(async () => {
+    await assert.rejects(async () => {
       await cli.formatOutput(mockCommand, o, {
         query: `contains(abc)`,
         output: 'json'
       });
-    }, chalk.red('Error: JMESPath query error. ArgumentError: contains() takes 2 arguments but received 1. See https://jmespath.org/specification.html for more information'));
+    }, 'Error: JMESPath query error. Argumenterror: contains() takes 2 arguments but received 1. See https://jmespath.org/specification.html for more information');
   });
 
   it(`prints commands grouped per service when no command specified`, async () => {
-    cli.loadCommandFromArgs(['status']);
-    cli.loadCommandFromArgs(['spo', 'site', 'list']);
+    await cli.loadCommandFromArgs(['status']);
+    await cli.loadCommandFromArgs(['spo', 'site', 'list']);
     cli.printAvailableCommands();
 
     assert(cliLogStub.calledWith('  cli *  8 commands'));
   });
 
   it(`prints commands from the specified group`, async () => {
-    cli.loadCommandFromArgs(['status']);
-    cli.loadCommandFromArgs(['spo', 'site', 'list']);
+    await cli.loadCommandFromArgs(['status']);
+    await cli.loadCommandFromArgs(['spo', 'site', 'list']);
     cli.optionsFromArgs = {
       options: {
         _: ['cli']
@@ -1558,9 +1558,9 @@ describe('cli', () => {
     assert(cliLogStub.calledWith('  cli mock *        5 commands'));
   });
 
-  it(`prints commands from the root group when the specified string doesn't match any group`, () => {
-    cli.loadCommandFromArgs(['status']);
-    cli.loadCommandFromArgs(['spo', 'site', 'list']);
+  it(`prints commands from the root group when the specified string doesn't match any group`, async () => {
+    await cli.loadCommandFromArgs(['status']);
+    await cli.loadCommandFromArgs(['spo', 'site', 'list']);
     cli.optionsFromArgs = {
       options: {
         _: ['foo']

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -178,24 +178,24 @@ async function execute(rawArgs: string[]): Promise<void> {
     await cli.executeCommand(cli.commandToExecute.command, cli.optionsFromArgs);
     const endTotal = process.hrtime.bigint();
     timings.total.push(Number(endTotal - start));
-    printTimings(rawArgs);
+    await printTimings(rawArgs);
     process.exit(0);
   }
   catch (err) {
     const endTotal = process.hrtime.bigint();
     timings.total.push(Number(endTotal - start));
-    printTimings(rawArgs);
+    await printTimings(rawArgs);
     await cli.closeWithError(err, cli.optionsFromArgs);
     /* c8 ignore next */
   }
 }
 
-function printTimings(rawArgs: string[]): void {
+async function printTimings(rawArgs: string[]): Promise<void> {
   if (rawArgs.some(arg => arg === '--debug')) {
-    cli.error('');
-    cli.error('Timings:');
-    Object.getOwnPropertyNames(timings).forEach(key => {
-      cli.error(`${key}: ${(timings as any)[key].reduce((a: number, b: number) => a + b, 0) / 1e6}ms`);
+    await cli.error('');
+    await cli.error('Timings:');
+    Object.getOwnPropertyNames(timings).forEach(async key => {
+      await cli.error(`${key}: ${(timings as any)[key].reduce((a: number, b: number) => a + b, 0) / 1e6}ms`);
     });
   }
 }
@@ -215,7 +215,7 @@ async function executeCommand(command: Command, args: { options: minimist.Parsed
     },
     logToStderr: async (message: any): Promise<void> => {
       if (args.options.output !== 'none') {
-        cli.error(message);
+        await cli.error(message);
       }
     }
   };
@@ -962,7 +962,7 @@ async function promptForSelection<T>(config: SelectionConfig<T>): Promise<T> {
   }
 
   const answer = await prompt.forSelection<T>(config);
-  cli.error('');
+  await cli.error('');
 
   // Restart the spinner if it was running before the prompt
   /* c8 ignore next 3 */
@@ -982,7 +982,7 @@ async function promptForConfirmation(config: ConfirmationConfig): Promise<boolea
   }
 
   const answer = await prompt.forConfirmation(config);
-  cli.error('');
+  await cli.error('');
 
   // Restart the spinner if it was running before the prompt
   /* c8 ignore next 3 */
@@ -999,7 +999,7 @@ async function handleMultipleResultsFound<T>(message: string, values: { [key: st
     throw new Error(`${message} Found: ${Object.keys(values).join(', ')}.`);
   }
 
-  cli.error(`🌶️  ${message} `);
+  await cli.error(`🌶️  ${message} `);
   const choices = Object.keys(values).map((choice: any) => { return { name: choice, value: choice }; });
   const response = await cli.promptForSelection<string>({ message: `Please choose one:`, choices });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { cli } from './cli/cli.js';
 import { app } from './utils/app.js';
 
-(async () => {
+await (async () => {
   // required to make console.log() in combination with piped output synchronous
   // on Windows/in PowerShell so that the output is not trimmed by calling
   // process.exit() after executing the command, while the output is still

--- a/src/m365/base/AnonymousCommand.ts
+++ b/src/m365/base/AnonymousCommand.ts
@@ -3,7 +3,7 @@ import Command, { CommandArgs } from '../../Command.js';
 
 export default abstract class AnonymousCommand extends Command {
   public async action(logger: Logger, args: CommandArgs): Promise<void> {
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger, args);
   }
 }

--- a/src/m365/base/DelegatedGraphCommand.spec.ts
+++ b/src/m365/base/DelegatedGraphCommand.spec.ts
@@ -34,20 +34,23 @@ describe('DelegatedGraphCommand', () => {
     };
   });
 
+  beforeEach(() => {
+    auth.connection.active = true;
+  });
+
   after(() => {
     sinon.restore();
     auth.connection.active = false;
     auth.connection.accessTokens = {};
   });
 
-  it(`doesn't throw error when not connected`, () => {
+  it(`doesn't throw error when not connected`, async () => {
     auth.connection.active = false;
-    (cmd as any).initAction({ options: {} }, {});
-    auth.connection.active = true;
+    await (cmd as any).initAction({ options: {} }, {});
   });
 
-  it('throws error when using application-only permissions', () => {
+  it('throws error when using application-only permissions', async () => {
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
   });
 });

--- a/src/m365/base/DelegatedGraphCommand.ts
+++ b/src/m365/base/DelegatedGraphCommand.ts
@@ -8,8 +8,8 @@ import GraphCommand from './GraphCommand.js';
  * This command class is for delegated-only Graph commands.  
  */
 export default abstract class DelegatedGraphCommand extends GraphCommand {
-  protected initAction(args: CommandArgs, logger: Logger): void {
-    super.initAction(args, logger);
+  protected async initAction(args: CommandArgs, logger: Logger): Promise<void> {
+    await super.initAction(args, logger);
 
     if (!auth.connection.active) {
       // we fail no login in the base command command class

--- a/src/m365/base/PowerAppsCommand.spec.ts
+++ b/src/m365/base/PowerAppsCommand.spec.ts
@@ -37,6 +37,10 @@ describe('PowerAppsCommand', () => {
     };
   });
 
+  beforeEach(() => {
+    auth.connection.active = true;
+  });
+
   after(() => {
     sinon.restore();
     auth.connection.active = false;
@@ -48,34 +52,33 @@ describe('PowerAppsCommand', () => {
     assert.strictEqual((command as any).resource, 'https://api.powerapps.com');
   });
 
-  it(`doesn't throw error when not connected`, () => {
-    try {
-      auth.connection.active = false;
-      (cmd as any).initAction({ options: {} }, {});
-    }
-    finally {
-      auth.connection.active = true;
-    }
+  it(`doesn't throw error when not connected`, async () => {
+    auth.connection.active = false;
+    await (cmd as any).initAction({ options: {} }, {});
   });
 
-  it('throws error when connected to USGov cloud', () => {
+  it('throws error when connected to USGov cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGov;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to USGovHigh cloud', () => {
+  it('throws error when connected to USGovHigh cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGovHigh;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to USGovDoD cloud', () => {
+  it('throws error when connected to USGovDoD cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGovDoD;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to China cloud', () => {
+  it('throws error when connected to China cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.China;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
   it(`doesn't throw error when connected to public cloud`, () => {
@@ -83,10 +86,10 @@ describe('PowerAppsCommand', () => {
     assert.doesNotThrow(() => (cmd as any).initAction({ options: {} }, {}));
   });
 
-  it('throws error when using application-only permissions', () => {
+  it('throws error when using application-only permissions', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
     auth.connection.cloudType = CloudType.Public;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
   });
 });

--- a/src/m365/base/PowerAppsCommand.ts
+++ b/src/m365/base/PowerAppsCommand.ts
@@ -8,8 +8,8 @@ export default abstract class PowerAppsCommand extends Command {
     return 'https://api.powerapps.com';
   }
 
-  protected initAction(args: CommandArgs, logger: Logger): void {
-    super.initAction(args, logger);
+  protected async initAction(args: CommandArgs, logger: Logger): Promise<void> {
+    await super.initAction(args, logger);
 
     if (!auth.connection.active) {
       // we fail no login in the base command command class

--- a/src/m365/base/PowerAutomateCommand.spec.ts
+++ b/src/m365/base/PowerAutomateCommand.spec.ts
@@ -37,6 +37,10 @@ describe('PowerAutomateCommand', () => {
     };
   });
 
+  beforeEach(() => {
+    auth.connection.active = true;
+  });
+
   after(() => {
     sinon.restore();
     auth.connection.active = false;
@@ -48,34 +52,33 @@ describe('PowerAutomateCommand', () => {
     assert.strictEqual((command as any).resource, 'https://api.flow.microsoft.com');
   });
 
-  it(`doesn't throw error when not connected`, () => {
-    try {
-      auth.connection.active = false;
-      (cmd as any).initAction({ options: {} }, {});
-    }
-    finally {
-      auth.connection.active = true;
-    }
+  it(`doesn't throw error when not connected`, async () => {
+    auth.connection.active = false;
+    await (cmd as any).initAction({ options: {} }, {});
   });
 
-  it('throws error when connected to USGov cloud', () => {
+  it('throws error when connected to USGov cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGov;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to USGovHigh cloud', () => {
+  it('throws error when connected to USGovHigh cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGovHigh;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to USGovDoD cloud', () => {
+  it('throws error when connected to USGovDoD cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGovDoD;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to China cloud', () => {
+  it('throws error when connected to China cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.China;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
   it(`doesn't throw error when connected to public cloud`, () => {
@@ -83,10 +86,10 @@ describe('PowerAutomateCommand', () => {
     assert.doesNotThrow(() => (cmd as any).initAction({ options: {} }, {}));
   });
 
-  it('throws error when using application-only permissions', () => {
+  it('throws error when using application-only permissions', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
     auth.connection.cloudType = CloudType.Public;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
   });
 });

--- a/src/m365/base/PowerAutomateCommand.ts
+++ b/src/m365/base/PowerAutomateCommand.ts
@@ -8,8 +8,8 @@ export default abstract class PowerAutomateCommand extends Command {
     return 'https://api.flow.microsoft.com';
   }
 
-  protected initAction(args: CommandArgs, logger: Logger): void {
-    super.initAction(args, logger);
+  protected async initAction(args: CommandArgs, logger: Logger): Promise<void> {
+    await super.initAction(args, logger);
 
     if (!auth.connection.active) {
       // we fail no login in the base command command class

--- a/src/m365/base/PowerBICommand.spec.ts
+++ b/src/m365/base/PowerBICommand.spec.ts
@@ -105,11 +105,11 @@ describe('PowerBICommand', () => {
     assert.strictEqual((command as any).resource, 'https://api.powerbi.com');
   });
 
-  it('throws error when using application-only permissions', () => {
+  it('throws error when using application-only permissions', async () => {
     const cmd = new MockCommand();
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
     auth.connection.active = true;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
   });
 });

--- a/src/m365/base/PowerBICommand.ts
+++ b/src/m365/base/PowerBICommand.ts
@@ -8,8 +8,8 @@ export default abstract class PowerBICommand extends Command {
     return 'https://api.powerbi.com';
   }
 
-  protected initAction(args: CommandArgs, logger: Logger): void {
-    super.initAction(args, logger);
+  protected async initAction(args: CommandArgs, logger: Logger): Promise<void> {
+    await super.initAction(args, logger);
 
     if (!auth.connection.active) {
       // we fail no login in the base command command class

--- a/src/m365/base/PowerPlatformCommand.spec.ts
+++ b/src/m365/base/PowerPlatformCommand.spec.ts
@@ -37,6 +37,10 @@ describe('PowerPlatformCommand', () => {
     };
   });
 
+  beforeEach(() => {
+    auth.connection.active = true;
+  });
+
   after(() => {
     sinon.restore();
     auth.connection.active = false;
@@ -48,34 +52,33 @@ describe('PowerPlatformCommand', () => {
     assert.strictEqual((command as any).resource, 'https://api.bap.microsoft.com');
   });
 
-  it(`doesn't throw error when not connected`, () => {
-    try {
-      auth.connection.active = false;
-      (cmd as any).initAction({ options: {} }, {});
-    }
-    finally {
-      auth.connection.active = true;
-    }
+  it(`doesn't throw error when not connected`, async () => {
+    auth.connection.active = false;
+    await (cmd as any).initAction({ options: {} }, {});
   });
 
-  it('throws error when connected to USGov cloud', () => {
+  it('throws error when connected to USGov cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGov;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to USGovHigh cloud', () => {
+  it('throws error when connected to USGovHigh cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGovHigh;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to USGovDoD cloud', () => {
+  it('throws error when connected to USGovDoD cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.USGovDoD;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
-  it('throws error when connected to China cloud', () => {
+  it('throws error when connected to China cloud', async () => {
+    auth.connection.active = true;
     auth.connection.cloudType = CloudType.China;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), cloudError);
   });
 
   it(`doesn't throw error when connected to public cloud`, () => {
@@ -83,10 +86,10 @@ describe('PowerPlatformCommand', () => {
     assert.doesNotThrow(() => (cmd as any).initAction({ options: {} }, {}));
   });
 
-  it('throws error when using application-only permissions', () => {
+  it('throws error when using application-only permissions', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
     auth.connection.cloudType = CloudType.Public;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
   });
 });

--- a/src/m365/base/PowerPlatformCommand.ts
+++ b/src/m365/base/PowerPlatformCommand.ts
@@ -9,8 +9,8 @@ export default abstract class PowerPlatformCommand extends Command {
     return 'https://api.bap.microsoft.com';
   }
 
-  protected initAction(args: CommandArgs, logger: Logger): void {
-    super.initAction(args, logger);
+  protected async initAction(args: CommandArgs, logger: Logger): Promise<void> {
+    await super.initAction(args, logger);
 
     if (!auth.connection.active) {
       // we fail no login in the base command command class

--- a/src/m365/base/VivaEngageCommand.spec.ts
+++ b/src/m365/base/VivaEngageCommand.spec.ts
@@ -139,11 +139,11 @@ describe('VivaEngageCommand', () => {
       new CommandError(error as any));
   });
 
-  it('throws error when using application-only permissions', () => {
+  it('throws error when using application-only permissions', async () => {
     const cmd = new MockCommand();
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
     auth.connection.active = true;
-    assert.throws(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
+    await assert.rejects(() => (cmd as any).initAction({ options: {} }, {}), new CommandError('This command does not support application-only permissions.'));
   });
 });

--- a/src/m365/base/VivaEngageCommand.ts
+++ b/src/m365/base/VivaEngageCommand.ts
@@ -8,8 +8,8 @@ export default abstract class VivaEngageCommand extends Command {
     return 'https://www.yammer.com/api';
   }
 
-  protected initAction(args: CommandArgs, logger: Logger): void {
-    super.initAction(args, logger);
+  protected async initAction(args: CommandArgs, logger: Logger): Promise<void> {
+    await super.initAction(args, logger);
 
     if (!auth.connection.active) {
       // we fail no login in the base command command class

--- a/src/m365/cli/commands/cli-consent.ts
+++ b/src/m365/cli/commands/cli-consent.ts
@@ -72,7 +72,7 @@ class CliConsentCommand extends AnonymousCommand {
   }
 
   public async action(logger: Logger, args: CommandArgs): Promise<void> {
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger, args);
   }
 }

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -235,7 +235,7 @@ class LoginCommand extends Command {
       throw new CommandError(error);
     }
 
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger, args);
   }
 }

--- a/src/m365/commands/logout.ts
+++ b/src/m365/commands/logout.ts
@@ -40,7 +40,7 @@ class LogoutCommand extends Command {
       throw new CommandError(error);
     }
 
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger);
   }
 }

--- a/src/m365/commands/status.ts
+++ b/src/m365/commands/status.ts
@@ -59,7 +59,7 @@ class StatusCommand extends Command {
       throw new CommandError(error);
     }
 
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger);
   }
 }

--- a/src/m365/connection/commands/connection-list.ts
+++ b/src/m365/connection/commands/connection-list.ts
@@ -52,7 +52,7 @@ class ConnectionListCommand extends Command {
       throw new CommandError(error);
     }
 
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger);
   }
 }

--- a/src/m365/connection/commands/connection-remove.ts
+++ b/src/m365/connection/commands/connection-remove.ts
@@ -81,7 +81,7 @@ class ConnectionRemoveCommand extends Command {
       throw new CommandError(error);
     }
 
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger, args);
   }
 }

--- a/src/m365/connection/commands/connection-set.ts
+++ b/src/m365/connection/commands/connection-set.ts
@@ -70,7 +70,7 @@ class ConnectionSetCommand extends Command {
       throw new CommandError(error);
     }
 
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger, args);
   }
 }

--- a/src/m365/connection/commands/connection-use.ts
+++ b/src/m365/connection/commands/connection-use.ts
@@ -61,7 +61,7 @@ class ConnectionUseCommand extends Command {
       throw new CommandError(error);
     }
 
-    this.initAction(args, logger);
+    await this.initAction(args, logger);
     await this.commandAction(logger, args);
   }
 }

--- a/src/m365/entra/commands/app/app-role-remove.spec.ts
+++ b/src/m365/entra/commands/app/app-role-remove.spec.ts
@@ -2006,7 +2006,7 @@ describe(commands.APP_ROLE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    command.action(logger, { options: { debug: true, appName: 'App-Name', claim: 'Product.Read' } });
+    await command.action(logger, { options: { debug: true, appName: 'App-Name', claim: 'Product.Read' } });
     assert(patchStub.notCalled);
   });
 

--- a/src/m365/entra/commands/approleassignment/approleassignment-add.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-add.spec.ts
@@ -153,14 +153,14 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
     getRequestStub();
     postRequestStub();
 
-    command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'exchange', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'exchange', scopes: 'Sites.Read.All' } });
   });
 
   it('handles appId for the resource option value', async () => {
     getRequestStub();
     postRequestStub();
 
-    command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'fff194f1-7dce-4428-8301-1badb5518201', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'fff194f1-7dce-4428-8301-1badb5518201', scopes: 'Sites.Read.All' } });
   });
 
   it('rejects if app roles are not found for the specified resource option value', async () => {

--- a/src/m365/entra/commands/m365group/m365group-add.ts
+++ b/src/m365/entra/commands/m365group/m365group-add.ts
@@ -289,6 +289,7 @@ class EntraM365GroupAddCommand extends GraphCommand {
     let promises: Promise<{ value: User[] }>[] = [];
     let userIds: string[] = [];
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     promises = userArr.map(user => {
       const requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/users?$filter=userPrincipalName eq '${formatting.encodeQueryParameter(user)}'&$select=id,userPrincipalName`,

--- a/src/m365/entra/commands/m365group/m365group-user-list.ts
+++ b/src/m365/entra/commands/m365group/m365group-user-list.ts
@@ -111,7 +111,7 @@ class EntraM365GroupUserListCommand extends GraphCommand {
 
     try {
       if (args.options.role === 'Guest') {
-        this.warn(logger, `Value 'Guest' for the option role is deprecated. Use --filter "userType eq 'Guest'" instead.`);
+        await this.warn(logger, `Value 'Guest' for the option role is deprecated. Use --filter "userType eq 'Guest'" instead.`);
       }
 
       const groupId = await this.getGroupId(args.options, logger);

--- a/src/m365/external/commands/connection/connection-doctor.ts
+++ b/src/m365/external/commands/connection/connection-doctor.ts
@@ -203,7 +203,7 @@ class ExternalConnectionDoctorCommand extends GraphCommand {
 
     for (const check of checks) {
       if (this.debug) {
-        logger.logToStderr(`Running check ${check.id}...`);
+        await logger.logToStderr(`Running check ${check.id}...`);
       }
 
       // don't show spinner if running tests

--- a/src/m365/external/commands/connection/connection-schema-add.ts
+++ b/src/m365/external/commands/connection/connection-schema-add.ts
@@ -117,7 +117,7 @@ class ExternalConnectionSchemaAddCommand extends GraphCommand {
       const res = await request.patch<AxiosResponse>(requestOptions);
 
       const location: string = res.headers.location;
-      logger.log(location);
+      await logger.log(location);
 
       if (!args.options.wait) {
         return;
@@ -126,14 +126,14 @@ class ExternalConnectionSchemaAddCommand extends GraphCommand {
       let status: NullableOption<ExternalConnectors.ConnectionOperationStatus> | undefined;
       do {
         if (this.verbose) {
-          logger.logToStderr(`Waiting 60 seconds...`);
+          await logger.logToStderr(`Waiting 60 seconds...`);
         }
 
         // waiting 60s before polling as recommended by Microsoft
         await new Promise(resolve => setTimeout(resolve, 60000));
 
         if (this.debug) {
-          logger.logToStderr(`Checking schema operation status...`);
+          await logger.logToStderr(`Checking schema operation status...`);
         }
 
         const operation = await request.get<ExternalConnectors.ConnectionOperation>({
@@ -146,7 +146,7 @@ class ExternalConnectionSchemaAddCommand extends GraphCommand {
         status = operation.status;
 
         if (this.verbose) {
-          logger.logToStderr(`Schema operation status: ${status}`);
+          await logger.logToStderr(`Schema operation status: ${status}`);
         }
 
         if (status === 'failed') {

--- a/src/m365/file/commands/file-copy.ts
+++ b/src/m365/file/commands/file-copy.ts
@@ -81,7 +81,7 @@ class FileCopyCommand extends GraphCommand {
       const destinationPath: string = this.getAbsoluteUrl(webUrl, targetUrl);
 
       if (this.verbose) {
-        logger.logToStderr(`Copying file '${sourcePath}' to '${destinationPath}'...`);
+        await logger.logToStderr(`Copying file '${sourcePath}' to '${destinationPath}'...`);
       }
 
       const copyUrl: string = await this.getCopyUrl(args.options, sourcePath, logger);
@@ -145,7 +145,7 @@ class FileCopyCommand extends GraphCommand {
 
   private async getDocumentLibrary(siteId: string, folderUrl: URL, folderUrlFromUser: string, logger: Logger): Promise<Drive> {
     if (this.verbose) {
-      logger.logToStderr(`Getting document library...`);
+      await logger.logToStderr(`Getting document library...`);
     }
 
     const requestOptions: CliRequestOptions = {
@@ -178,7 +178,7 @@ class FileCopyCommand extends GraphCommand {
 
   private async getStartingFolderId(documentLibrary: Drive, folderUrl: URL, logger: Logger): Promise<string> {
     if (this.verbose) {
-      logger.logToStderr(`Getting starting folder id...`);
+      await logger.logToStderr(`Getting starting folder id...`);
     }
 
     const documentLibraryRelativeFolderUrl: string = folderUrl.href.replace(new RegExp(`${documentLibrary.webUrl}`, 'i'), '').replace(/\/+$/, '');

--- a/src/m365/flow/commands/flow-list.spec.ts
+++ b/src/m365/flow/commands/flow-list.spec.ts
@@ -1519,12 +1519,16 @@ describe(commands.LIST, () => {
 
   it('retrieves flows including flows from solutions', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentId}/flows?api-version=2016-11-01&include=includeSolutionCloudFlows') {
+      if (opts.url === `https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentId}/flows?api-version=2016-11-01&include=includeSolutionCloudFlows`) {
         return {
           value: [
             {
               name: "1c6ee23a-a835-44bc-a4f5-462b658efc13",
-              id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13"
+              id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13",
+              properties: {
+                "apiId": "/providers/Microsoft.PowerApps/apis/shared_logicflows",
+                "displayName": "Get a daily digest of the top CNN news"
+              }
             }
           ]
         };
@@ -1533,27 +1537,40 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', includeSolutions: true } } as any);
+    await command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', includeSolutions: true } } as any);
+
     loggerLogSpy.calledWith([
       {
         name: "1c6ee23a-a835-44bc-a4f5-462b658efc13",
-        id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13"
+        id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13",
+        properties: {
+          "apiId": "/providers/Microsoft.PowerApps/apis/shared_logicflows",
+          "displayName": "Get a daily digest of the top CNN news"
+        }
       }
     ]);
   });
 
   it('retrieves flows and removes duplicates', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentId}/flows?api-version=2016-11-01') {
+      if (opts.url === `https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/${environmentId}/flows?api-version=2016-11-01`) {
         return {
           value: [
             {
               name: "1c6ee23a-a835-44bc-a4f5-462b658efc13",
-              id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13"
+              id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13",
+              properties: {
+                "apiId": "/providers/Microsoft.PowerApps/apis/shared_logicflows",
+                "displayName": "Get a daily digest of the top CNN news"
+              }
             },
             {
               name: "1c6ee23a-a835-44bc-a4f5-462b658efc13",
-              id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13"
+              id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13",
+              properties: {
+                "apiId": "/providers/Microsoft.PowerApps/apis/shared_logicflows",
+                "displayName": "Get a daily digest of the top CNN news"
+              }
             }
           ]
         };
@@ -1562,11 +1579,15 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } } as any);
+    await command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } } as any);
     loggerLogSpy.calledWith([
       {
         name: "1c6ee23a-a835-44bc-a4f5-462b658efc13",
-        id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13"
+        id: "/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/1c6ee23a-a835-44bc-a4f5-462b658efc13",
+        properties: {
+          "apiId": "/providers/Microsoft.PowerApps/apis/shared_logicflows",
+          "displayName": "Get a daily digest of the top CNN news"
+        }
       }
     ]);
   });

--- a/src/m365/pa/commands/app/app-export.ts
+++ b/src/m365/pa/commands/app/app-export.ts
@@ -215,7 +215,7 @@ class PaAppExportCommand extends PowerPlatformCommand {
         link = response.properties.packageLink.value;
       }
       else {
-        setTimeout(this.pollingInterval);
+        await setTimeout(this.pollingInterval);
       }
 
       if (this.verbose) {

--- a/src/m365/pa/commands/app/app-owner-set.ts
+++ b/src/m365/pa/commands/app/app-owner-set.ts
@@ -98,7 +98,7 @@ class PaAppOwnerSetCommand extends PowerAppsCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (this.verbose) {
-      logger.logToStderr(`Setting new owner ${args.options.userId || args.options.userName} for Power Apps app ${args.options.appName}...`);
+      await logger.logToStderr(`Setting new owner ${args.options.userId || args.options.userName} for Power Apps app ${args.options.appName}...`);
     }
     try {
       const userId = await this.getUserId(args.options);

--- a/src/m365/pp/commands/solution/solution-publish.ts
+++ b/src/m365/pp/commands/solution/solution-publish.ts
@@ -121,7 +121,7 @@ class PpSolutionPublishCommand extends PowerPlatformCommand {
         await request.post(requestOptions);
       }
       else {
-        request.post(requestOptions);
+        void request.post(requestOptions);
       }
     }
     catch (err: any) {

--- a/src/m365/purview/commands/threatassessment/threatassessment-list.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-list.ts
@@ -66,7 +66,7 @@ class PurviewThreatAssessmentListCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (this.verbose) {
-      logger.logToStderr('Retrieving a list of threat assessments');
+      await logger.logToStderr('Retrieving a list of threat assessments');
     }
 
     try {

--- a/src/m365/spfx/commands/project/project-azuredevops-pipeline-add.ts
+++ b/src/m365/spfx/commands/project/project-azuredevops-pipeline-add.ts
@@ -122,7 +122,7 @@ class SpfxProjectAzureDevOpsPipelineAddCommand extends BaseProjectCommand {
     const solutionName = JSON.parse(packageJson).name;
 
     if (this.debug) {
-      logger.logToStderr(`Adding Azure DevOps pipeline in the current SPFx project`);
+      await logger.logToStderr(`Adding Azure DevOps pipeline in the current SPFx project`);
     }
 
     try {

--- a/src/m365/spfx/commands/project/project-externalize.ts
+++ b/src/m365/spfx/commands/project/project-externalize.ts
@@ -108,7 +108,7 @@ class SpfxProjectExternalizeCommand extends BaseProjectCommand {
       this.allEditSuggestions.push(...rulesResults.map(x => x.suggestions).reduce((x, y) => [...x, ...y]));
       //removing duplicates
       this.allFindings = this.allFindings.filter((x, i) => this.allFindings.findIndex(y => y.key === x.key) === i);
-      this.writeReport(this.allFindings, this.allEditSuggestions, logger, args.options);
+      await this.writeReport(this.allFindings, this.allEditSuggestions, logger, args.options);
     }
     catch (err: any) {
       throw new CommandError(err);

--- a/src/m365/spfx/commands/project/project-github-workflow-add.ts
+++ b/src/m365/spfx/commands/project/project-github-workflow-add.ts
@@ -135,7 +135,7 @@ class SpfxProjectGithubWorkflowAddCommand extends BaseProjectCommand {
     const solutionName = JSON.parse(packageJson).name;
 
     if (this.debug) {
-      logger.logToStderr(`Adding GitHub workflow in the current SPFx project`);
+      await logger.logToStderr(`Adding GitHub workflow in the current SPFx project`);
     }
 
     try {

--- a/src/m365/spfx/commands/spfx-doctor.ts
+++ b/src/m365/spfx/commands/spfx-doctor.ts
@@ -810,7 +810,7 @@ class SpfxDoctorCommand extends BaseProjectCommand {
 
   private async checkNodeVersion(prerequisites: SpfxVersionPrerequisites): Promise<void> {
     const nodeVersion: string = this.getNodeVersion();
-    this.checkStatus('Node', nodeVersion, prerequisites.node);
+    await this.checkStatus('Node', nodeVersion, prerequisites.node);
   }
 
   private async checkSharePointFrameworkVersion(spfxVersionRequested: string): Promise<void> {
@@ -823,7 +823,7 @@ class SpfxDoctorCommand extends BaseProjectCommand {
       fix: `npm i -g @microsoft/generator-sharepoint@${spfxVersionRequested}`
     };
     if (spfxVersionDetected) {
-      this.checkStatus(`SharePoint Framework`, spfxVersionDetected, versionCheck);
+      await this.checkStatus(`SharePoint Framework`, spfxVersionDetected, versionCheck);
     }
     else {
       const message = `SharePoint Framework v${spfxVersionRequested} not found`;
@@ -841,7 +841,7 @@ class SpfxDoctorCommand extends BaseProjectCommand {
   private async checkYo(prerequisites: SpfxVersionPrerequisites): Promise<void> {
     const yoVersion: string = await this.getPackageVersion('yo', PackageSearchMode.GlobalOnly, HandlePromise.Continue);
     if (yoVersion) {
-      this.checkStatus('yo', yoVersion, prerequisites.yo);
+      await this.checkStatus('yo', yoVersion, prerequisites.yo);
     }
     else {
       const message = 'yo not found';
@@ -858,7 +858,7 @@ class SpfxDoctorCommand extends BaseProjectCommand {
   private async checkGulpCli(prerequisites: SpfxVersionPrerequisites): Promise<void> {
     const gulpCliVersion: string = await this.getPackageVersion('gulp-cli', PackageSearchMode.GlobalOnly, HandlePromise.Continue);
     if (gulpCliVersion) {
-      this.checkStatus('gulp-cli', gulpCliVersion, prerequisites.gulpCli);
+      await this.checkStatus('gulp-cli', gulpCliVersion, prerequisites.gulpCli);
     }
     else {
       const message = 'gulp-cli not found';

--- a/src/m365/spo/commands/commandset/commandset-get.ts
+++ b/src/m365/spo/commands/commandset/commandset-get.ts
@@ -137,7 +137,7 @@ class SpoCommandSetGetCommand extends SpoCommand {
         else {
           const resultAsKeyValuePair = formatting.convertArrayToHashTable('Id', commandSets);
           const commandSet = await cli.handleMultipleResultsFound<CustomAction>(`Multiple command sets with title '${args.options.title}' found.`, resultAsKeyValuePair);
-          logger.log(commandSet);
+          await logger.log(commandSet);
         }
       }
     }

--- a/src/m365/spo/commands/contenttype/contenttype-field-remove.spec.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-field-remove.spec.ts
@@ -492,7 +492,7 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         webUrl: WEB_URL, listTitle: LIST_TITLE, contentTypeId: LIST_CONTENT_TYPE_ID, fieldLinkId: FIELD_LINK_ID,
         updateChildContentTypes: false,
@@ -588,7 +588,7 @@ describe(commands.CONTENTTYPE_FIELD_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         webUrl: WEB_URL, listTitle: LIST_TITLE, contentTypeId: LIST_CONTENT_TYPE_ID, fieldLinkId: FIELD_LINK_ID,
         updateChildContentTypes: false,

--- a/src/m365/spo/commands/file/file-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-remove.ts
@@ -124,7 +124,7 @@ class SpoFileRetentionLabelRemoveCommand extends SpoCommand {
 
   private async getFileProperties(logger: Logger, args: CommandArgs): Promise<{ listItemId: string, listServerRelativeUrl: string }> {
     if (this.verbose) {
-      logger.logToStderr(`Retrieving list and item information for file '${args.options.fileId || args.options.fileUrl}' in site at ${args.options.webUrl}...`);
+      await logger.logToStderr(`Retrieving list and item information for file '${args.options.fileId || args.options.fileUrl}' in site at ${args.options.webUrl}...`);
     }
 
     let requestUrl = `${args.options.webUrl}/_api/web/`;

--- a/src/m365/spo/commands/group/group-member-add.ts
+++ b/src/m365/spo/commands/group/group-member-add.ts
@@ -150,13 +150,13 @@ class SpoGroupMemberAddCommand extends SpoCommand {
       if (args.options.aadGroupIds) {
         args.options.entraGroupIds = args.options.aadGroupIds;
 
-        this.warn(logger, `Option 'aadGroupIds' is deprecated. Please use 'entraGroupIds' instead`);
+        await this.warn(logger, `Option 'aadGroupIds' is deprecated. Please use 'entraGroupIds' instead`);
       }
 
       if (args.options.aadGroupNames) {
         args.options.entraGroupNames = args.options.aadGroupNames;
 
-        this.warn(logger, `Option 'aadGroupNames' is deprecated. Please use 'entraGroupNames' instead`);
+        await this.warn(logger, `Option 'aadGroupNames' is deprecated. Please use 'entraGroupNames' instead`);
       }
 
       const groupId = await this.getGroupId(args, logger);

--- a/src/m365/spo/commands/group/group-member-remove.ts
+++ b/src/m365/spo/commands/group/group-member-remove.ts
@@ -165,13 +165,13 @@ class SpoGroupMemberRemoveCommand extends SpoCommand {
     if (args.options.aadGroupId) {
       args.options.entraGroupId = args.options.aadGroupId;
 
-      this.warn(logger, `Option 'aadGroupId' is deprecated. Please use 'entraGroupId' instead`);
+      await this.warn(logger, `Option 'aadGroupId' is deprecated. Please use 'entraGroupId' instead`);
     }
 
     if (args.options.aadGroupName) {
       args.options.entraGroupName = args.options.aadGroupName;
 
-      this.warn(logger, `Option 'aadGroupName' is deprecated. Please use 'entraGroupName' instead`);
+      await this.warn(logger, `Option 'aadGroupName' is deprecated. Please use 'entraGroupName' instead`);
     }
 
     if (args.options.force) {

--- a/src/m365/spo/commands/list/list-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/list/list-retentionlabel-ensure.ts
@@ -104,7 +104,7 @@ class SpoListRetentionLabelEnsureCommand extends SpoCommand {
 
   private async getListServerRelativeUrl(args: CommandArgs, logger: Logger): Promise<string> {
     if (this.verbose) {
-      logger.logToStderr('Getting the list server relative URL');
+      await logger.logToStderr('Getting the list server relative URL');
     }
 
     if (args.options.listUrl) {

--- a/src/m365/spo/commands/listitem/listitem-batch-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-remove.ts
@@ -159,7 +159,7 @@ class SpoListItemBatchRemoveCommand extends SpoCommand {
     const removeListItems = async (): Promise<void> => {
       try {
         if (this.verbose) {
-          logger.logToStderr('Removing the listitems from SharePoint...');
+          await logger.logToStderr('Removing the listitems from SharePoint...');
         }
 
         let idsToRemove: string[] = [];

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
@@ -142,7 +142,7 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
     }
 
     if (this.verbose) {
-      logger.logToStderr(`Retrieving the name of the retention label based on the Id '${options.id}'...`);
+      await logger.logToStderr(`Retrieving the name of the retention label based on the Id '${options.id}'...`);
     }
 
     const requestUrl: string = `${options.webUrl}/_api/SP.CompliancePolicy.SPPolicyStoreProxy.GetAvailableTagsForSite(siteUrl=@a1)?@a1='${formatting.encodeQueryParameter(options.webUrl)}'`;
@@ -195,7 +195,7 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
     const listAbsoluteUrl = urlUtil.urlCombine(tenantUrl, serverRelativePath);
 
     if (this.verbose) {
-      logger.logToStderr(`List absolute URL found: '${listAbsoluteUrl}'`);
+      await logger.logToStderr(`List absolute URL found: '${listAbsoluteUrl}'`);
     }
 
     return listAbsoluteUrl;

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-remove.ts
@@ -136,7 +136,7 @@ class SpoListItemRetentionLabelRemoveCommand extends SpoCommand {
     }
 
     if (this.verbose) {
-      logger.logToStderr(`Retrieving list absolute URL...`);
+      await logger.logToStderr(`Retrieving list absolute URL...`);
     }
 
     let requestUrl = `${options.webUrl}/_api/web`;
@@ -161,7 +161,7 @@ class SpoListItemRetentionLabelRemoveCommand extends SpoCommand {
     const listAbsoluteUrl = urlUtil.urlCombine(tenantUrl, serverRelativePath);
 
     if (this.verbose) {
-      logger.logToStderr(`List absolute URL found: '${listAbsoluteUrl}'`);
+      await logger.logToStderr(`List absolute URL found: '${listAbsoluteUrl}'`);
     }
 
     return listAbsoluteUrl;

--- a/src/m365/spo/commands/listitem/listitem-roleassignment-add.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleassignment-add.spec.ts
@@ -205,7 +205,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
       throw 'Invalid request';
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
@@ -226,7 +226,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
       throw 'Invalid request';
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
@@ -257,7 +257,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
       throw new CommandError('Unknown case');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
@@ -281,13 +281,13 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
     const error = 'no user found';
     sinon.stub(cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === spoUserGetCommand) {
-        throw error;
+        throw new Error(error);
       }
 
       throw new CommandError('Unknown case');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
@@ -296,7 +296,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
         upn: 'someaccount@tenant.onmicrosoft.com',
         roleDefinitionId: 1073741827
       }
-    });
+    }), new CommandError(error));
   });
 
   it('add role assignment to listitem in list get principal id by group name', async () => {
@@ -318,7 +318,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
       throw new CommandError('Unknown case');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
@@ -342,13 +342,13 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
     const error = 'no group found';
     sinon.stub(cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === spoGroupGetCommand) {
-        throw error;
+        throw new Error(error);
       }
 
       throw new CommandError('Unknown case');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
@@ -357,7 +357,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
         groupName: 'someGroup',
         roleDefinitionId: 1073741827
       }
-    });
+    }), new CommandError(error));
   });
 
   it('add role assignment to listitem in list get role definition id by role definition name', async () => {
@@ -379,7 +379,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
       throw new CommandError('Unknown case');
     });
 
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
@@ -403,13 +403,13 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
     const error = 'no role definition found';
     sinon.stub(cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
       if (command === spoRoleDefinitionListCommand) {
-        throw error;
+        throw new Error(error);
       }
 
       throw new CommandError('Unknown case');
     });
 
-    command.action(logger, {
+    await assert.rejects(command.action(logger, {
       options: {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
@@ -418,7 +418,7 @@ describe(commands.LISTITEM_ROLEASSIGNMENT_ADD, () => {
         principalId: 11,
         roleDefinitionName: 'Full Control'
       }
-    });
+    }), new CommandError(error));
   });
 
   it('correctly handles error when adding role definition fails', async () => {

--- a/src/m365/spo/commands/navigation/navigation-node-set.spec.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-set.spec.ts
@@ -35,6 +35,7 @@ describe(commands.NAVIGATION_NODE_SET, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    auth.connection.spoUrl = 'https://contoso.sharepoint.com';
     commandInfo = cli.getCommandInfo(command);
   });
 

--- a/src/m365/spo/commands/site/site-commsite-enable.ts
+++ b/src/m365/spo/commands/site/site-commsite-enable.ts
@@ -89,7 +89,7 @@ class SpoSiteCommSiteEnableCommand extends SpoCommand {
     const designPackageId = this.getDesignPackageId(args.options);
 
     if (this.verbose) {
-      logger.logToStderr(`Enabling communication site with design package '${designPackageId}' at '${args.options.url}'...`);
+      await logger.logToStderr(`Enabling communication site with design package '${designPackageId}' at '${args.options.url}'...`);
     }
 
     try {

--- a/src/m365/spo/commands/site/site-groupify.spec.ts
+++ b/src/m365/spo/commands/site/site-groupify.spec.ts
@@ -297,11 +297,6 @@ describe(commands.SITE_GROUPIFY, () => {
     await assert.rejects(command.action(logger, { options: { url: 'https://contoso.sharepoint.com/sites/team-a', alias: 'team-a', displayName: 'Team A' } } as any), new CommandError('An error has occurred'));
   });
 
-  it('fails validation if url is not an absolute URL', async () => {
-    const actual = await command.validate({ options: { url: '/sites/team-a', alias: 'team-a', displayName: 'Team A' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('fails validation if url is not a SharePoint URL', async () => {
     const actual = await command.validate({ options: { url: 'http://contoso/sites/team-a', alias: 'team-a', displayName: 'Team A' } }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/spo-search.ts
+++ b/src/m365/spo/commands/spo-search.ts
@@ -218,7 +218,7 @@ class SpoSearchCommand extends SpoCommand {
       }
 
       const results: SearchResult[] = await this.executeSearchQuery(logger, args, webUrl, []);
-      this.printResults(logger, args, results);
+      await this.printResults(logger, args, results);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);

--- a/src/m365/spo/commands/tenant/tenant-appcatalog-add.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-appcatalog-add.spec.ts
@@ -27,6 +27,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    auth.connection.spoUrl = 'https://contoso.sharepoint.com';
     commandInfo = cli.getCommandInfo(command);
   });
 
@@ -940,7 +941,7 @@ describe(commands.TENANT_APPCATALOG_ADD, () => {
   });
 
   it('fails validation if the specified url is not a valid SharePoint URL', async () => {
-    const options: any = { url: '/foo', owner: 'user@contoso.com', timeZone: 4 };
+    const options: any = { url: 'abc', owner: 'user@contoso.com', timeZone: 4 };
     const actual = await command.validate({ options: options }, commandInfo);
     assert.strictEqual(typeof actual, 'string');
   });

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-set.ts
@@ -179,7 +179,7 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
 
   private async getComponentManifest(appCatalogUrl: string, clientSideComponentId: string, logger: Logger): Promise<any> {
     if (this.verbose) {
-      logger.logToStderr('Retrieving component manifest item from the ComponentManifests list on the app catalog site so that we get the solution id');
+      await logger.logToStderr('Retrieving component manifest item from the ComponentManifests list on the app catalog site so that we get the solution id');
     }
 
     const camlQuery = `<View><ViewFields><FieldRef Name='ClientComponentId'></FieldRef><FieldRef Name='SolutionId'></FieldRef><FieldRef Name='ClientComponentManifest'></FieldRef></ViewFields><Query><Where><Eq><FieldRef Name='ClientComponentId' /><Value Type='Guid'>${clientSideComponentId}</Value></Eq></Where></Query></View>`;
@@ -195,7 +195,7 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
     const output = await cli.executeCommandWithOutput(spoListItemListCommand as Command, { options: { ...commandOptions, _: [] } });
 
     if (this.verbose) {
-      logger.logToStderr(output.stderr);
+      await logger.logToStderr(output.stderr);
     }
 
     const outputParsed = JSON.parse(output.stdout);
@@ -209,7 +209,7 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
 
   private async getSolutionFromAppCatalog(appCatalogUrl: string, solutionId: string, logger: Logger): Promise<Solution> {
     if (this.verbose) {
-      logger.logToStderr(`Retrieving solution with id ${solutionId} from the application catalog`);
+      await logger.logToStderr(`Retrieving solution with id ${solutionId} from the application catalog`);
     }
 
     const camlQuery = `<View><ViewFields><FieldRef Name='SkipFeatureDeployment'></FieldRef><FieldRef Name='ContainsTenantWideExtension'></FieldRef></ViewFields><Query><Where><Eq><FieldRef Name='AppProductID' /><Value Type='Guid'>${solutionId}</Value></Eq></Where></Query></View>`;
@@ -225,7 +225,7 @@ class SpoTenantApplicationCustomizerSetCommand extends SpoCommand {
     const output = await cli.executeCommandWithOutput(spoListItemListCommand as Command, { options: { ...commandOptions, _: [] } });
 
     if (this.verbose) {
-      logger.logToStderr(output.stderr);
+      await logger.logToStderr(output.stderr);
     }
 
     const outputParsed = JSON.parse(output.stdout);

--- a/src/m365/spo/commands/tenant/tenant-commandset-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-set.ts
@@ -136,7 +136,7 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
 
   private async getListItemById(logger: Logger, webUrl: string, listServerRelativeUrl: string, id: string): Promise<any> {
     if (this.verbose) {
-      logger.logToStderr(`Getting the list item by id ${id}`);
+      await logger.logToStderr(`Getting the list item by id ${id}`);
     }
     const reqOptions: CliRequestOptions = {
       url: `${webUrl}/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/Items(${id})`,
@@ -151,7 +151,7 @@ class SpoTenantCommandSetSetCommand extends SpoCommand {
 
   private async updateTenantWideExtension(appCatalogUrl: string, options: Options, listServerRelativeUrl: string, logger: Logger): Promise<void> {
     if (this.verbose) {
-      logger.logToStderr('Updating tenant wide extension to the TenantWideExtensions list');
+      await logger.logToStderr('Updating tenant wide extension to the TenantWideExtensions list');
     }
 
     const formValues: any = [];

--- a/src/m365/spo/commands/user/user-ensure.ts
+++ b/src/m365/spo/commands/user/user-ensure.ts
@@ -95,7 +95,7 @@ class SpoUserEnsureCommand extends SpoCommand {
     if (args.options.aadId) {
       args.options.entraId = args.options.aadId;
 
-      this.warn(logger, `Option 'aadId' is deprecated. Please use 'entraId' instead`);
+      await this.warn(logger, `Option 'aadId' is deprecated. Please use 'entraId' instead`);
     }
 
     if (this.verbose) {

--- a/src/m365/teams/commands/app/app-remove.spec.ts
+++ b/src/m365/teams/commands/app/app-remove.spec.ts
@@ -154,7 +154,7 @@ describe(commands.APP_REMOVE, () => {
   it('aborts removing Teams app when prompt not confirmed', async () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    command.action(logger, { options: { id: `e3e29acb-8c79-412b-b746-e6c39ff4cd22` } });
+    await command.action(logger, { options: { id: `e3e29acb-8c79-412b-b746-e6c39ff4cd22` } });
     assert(requests.length === 0);
   });
 

--- a/src/m365/teams/commands/app/app-uninstall.spec.ts
+++ b/src/m365/teams/commands/app/app-uninstall.spec.ts
@@ -116,7 +116,7 @@ describe(commands.APP_UNINSTALL, () => {
 
   it('aborts uninstalling an app from a Microsoft Teams team when prompt not confirmed', async () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
-    command.action(logger, {
+    await command.action(logger, {
       options: {
         teamId: 'c527a470-a882-481c-981c-ee6efaba85c7',
         id: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY='

--- a/src/m365/teams/commands/chat/chat-member-add.ts
+++ b/src/m365/teams/commands/chat/chat-member-add.ts
@@ -115,7 +115,7 @@ class TeamsChatMemberAddCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       if (this.verbose) {
-        logger.logToStderr(`Adding member ${args.options.userId || args.options.userName} to chat with id ${args.options.chatId}...`);
+        await logger.logToStderr(`Adding member ${args.options.userId || args.options.userName} to chat with id ${args.options.chatId}...`);
       }
 
       const chatMemberAddOptions: CliRequestOptions = {

--- a/src/m365/teams/commands/meeting/meeting-list.ts
+++ b/src/m365/teams/commands/meeting/meeting-list.ts
@@ -183,7 +183,7 @@ class TeamsMeetingListCommand extends GraphCommand {
 
     for (let i = 0; i < meetingUrls.length; i += 20) {
       if (this.verbose) {
-        logger.logToStderr(`Retrieving meetings ${i + 1}-${Math.min(i + 20, meetingUrls.length)}...`);
+        await logger.logToStderr(`Retrieving meetings ${i + 1}-${Math.min(i + 20, meetingUrls.length)}...`);
       }
       const batch = meetingUrls.slice(i, i + 20);
       const requestOptions: CliRequestOptions = {

--- a/src/m365/viva/commands/engage/engage-community-get.ts
+++ b/src/m365/viva/commands/engage/engage-community-get.ts
@@ -40,7 +40,7 @@ class VivaEngageCommunityGetCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (this.verbose) {
-      logger.logToStderr(`Getting the information of Viva Engage community with id '${args.options.id}'...`);
+      await logger.logToStderr(`Getting the information of Viva Engage community with id '${args.options.id}'...`);
     }
 
     const requestOptions: CliRequestOptions = {

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -1435,7 +1435,7 @@ export const spo = {
   */
   async getFileAsListItemByUrl(absoluteListUrl: string, url: string, logger?: Logger, verbose?: boolean): Promise<any> {
     if (verbose && logger) {
-      logger.logToStderr(`Getting the file properties with url ${url}`);
+      await logger.logToStderr(`Getting the file properties with url ${url}`);
     }
 
     const serverRelativePath = urlUtil.getServerRelativePath(absoluteListUrl, url);
@@ -1475,7 +1475,7 @@ export const spo = {
     const webUrl = `${parsedUrl.protocol}//${parsedUrl.host}${serverRelativeSiteMatch ?? ''}`;
 
     if (verbose && logger) {
-      logger.logToStderr(`Getting list id...`);
+      await logger.logToStderr(`Getting list id...`);
     }
 
     const listRequestOptions: CliRequestOptions = {
@@ -1491,7 +1491,7 @@ export const spo = {
     const listId = list.Id;
 
     if (verbose && logger) {
-      logger.logToStderr(`Getting request digest for systemUpdate request`);
+      await logger.logToStderr(`Getting request digest for systemUpdate request`);
     }
 
     const res = await spo.getRequestDigest(webUrl);
@@ -1657,7 +1657,7 @@ export const spo = {
    */
   async getSiteId(webUrl: string, logger?: Logger, verbose?: boolean): Promise<string> {
     if (verbose && logger) {
-      logger.logToStderr(`Getting site id for URL: ${webUrl}...`);
+      await logger.logToStderr(`Getting site id for URL: ${webUrl}...`);
     }
 
     const url: URL = new URL(webUrl);
@@ -1695,7 +1695,7 @@ export const spo = {
 
     const response = await request.post<string>(requestOptions);
     if (verbose) {
-      logger.logToStderr('Attempt to get _ObjectIdentity_ key values');
+      await logger.logToStderr('Attempt to get _ObjectIdentity_ key values');
     }
 
     const json: ClientSvcResponse = JSON.parse(response);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "es2020",
+    "module": "esnext",
     "moduleResolution": "Node",
     "lib": ["es2020", "dom"],
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Enabling this additional rule took more effort and changed more than expected.

First, to get `@typescript-eslint/no-floating-promises` working, I updated the compiler option from `es2020` to `esnext`.

With this rule enabled, quite a few tests that never really worked or tested anything valid came to light. 😄 So, a few changes were made there too. In some cases, I couldn't find a way to solve the floating promise issue, so I added `// eslint-disable-next-line @typescript-eslint/no-floating-promises`. If I missed something in those cases, I'm always open to suggestions!

I'm also adding the priority flag to this PR since it’s a big change that affects the entire codebase. Any changes will likely require an intensive rebase.

Closes #6005