### PR TITLE
Adds new command `spo site admin add` Closes #5883

### DIFF
--- a/docs/docs/cmd/spo/site/site-admin-add.mdx
+++ b/docs/docs/cmd/spo/site/site-admin-add.mdx
@@ -1,0 +1,67 @@
+import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# spo site admin add 
+
+Adds a user or group as a site collection administrator
+
+## Usage
+
+```sh
+m365 spo site admin add  [options]
+```
+
+## Options
+
+```md definition-list
+`-u, --siteUrl <siteUrl>`
+: The URL of the SharePoint site
+
+`--userId [userId]`
+: The ID of the user to add as a site collection admin
+
+`--userName [userName]`
+: The user principal name of the user to add as a site collection admin
+
+`--groupId [groupId]`
+: The ID of the Microsoft Entra ID group to add as a site collection admin
+
+`--groupName [groupName]`
+: The name of the Microsoft Entra ID group to add as a site collection admin
+
+`--primary`
+: If set, will add the user as primary site collection admin. The old primary site collection admin will be replaced and set as secondary site collection admin
+
+`--asAdmin`
+: If specified, we will use the SharePoint admin center to execute the command
+```
+
+<Global />
+
+## Remarks
+
+:::info
+
+To use this command with the `--asAdmin` mode, you have to have permissions to access the tenant admin site.
+
+Without this parameter, you have to have site collection admin permissions for the requested site.
+
+:::
+
+## Examples
+
+Add user as primary site collection administrator
+
+```sh
+m365 spo site admin add --siteUrl https://contoso.sharepoint.com --userId 600713c5-53c6-4f24-b454-3c35e22b2639 --primary
+```
+
+Adds group as secondary site collection administrator as SharePoint admin
+
+```sh
+m365 spo site admin add --siteUrl https://contoso.sharepoint.com --groupName SP_Administrators --asAdmin
+```
+## Response
+
+The command won't return a response on success.

--- a/docs/src/config/sidebars.ts
+++ b/docs/src/config/sidebars.ts
@@ -3343,11 +3343,6 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
-              label: 'site admin list',
-              id: 'cmd/spo/site/site-admin-list'
-            },
-            {
-              type: 'doc',
               label: 'site ensure',
               id: 'cmd/spo/site/site-ensure'
             },
@@ -3380,6 +3375,16 @@ const sidebars: SidebarsConfig = {
               type: 'doc',
               label: 'site set',
               id: 'cmd/spo/site/site-set'
+            },
+            {
+              type: 'doc',
+              label: 'site admin add',
+              id: 'cmd/spo/site/site-admin-add'
+            },
+            {
+              type: 'doc',
+              label: 'site admin list',
+              id: 'cmd/spo/site/site-admin-list'
             },
             {
               type: 'doc',

--- a/src/m365/spo/commands.ts
+++ b/src/m365/spo/commands.ts
@@ -243,6 +243,7 @@ export default {
   SERVICEPRINCIPAL_SET: `${prefix} serviceprincipal set`,
   SET: `${prefix} set`,
   SITE_ADD: `${prefix} site add`,
+  SITE_ADMIN_ADD: `${prefix} site admin add`,
   SITE_ADMIN_LIST: `${prefix} site admin list`,
   SITE_APPCATALOG_ADD: `${prefix} site appcatalog add`,
   SITE_APPCATALOG_LIST: `${prefix} site appcatalog list`,

--- a/src/m365/spo/commands/site/SiteAdmin.ts
+++ b/src/m365/spo/commands/site/SiteAdmin.ts
@@ -1,0 +1,49 @@
+export interface AdminUserResult {
+  email: string;
+  loginName: string;
+  name: string;
+  userPrincipalName: string;
+}
+
+export interface AdminResult {
+  value: AdminUserResult[];
+}
+
+export interface SiteUserResult {
+  Email: string;
+  Id: number;
+  IsSiteAdmin: boolean;
+  LoginName: string;
+  PrincipalType: number;
+  Title: string;
+}
+
+export interface SiteResult {
+  value: SiteUserResult[];
+}
+
+export interface AdminCommandResultItem {
+  Id: number | null;
+  Email: string;
+  IsPrimaryAdmin: boolean;
+  LoginName: string;
+  Title: string;
+  PrincipalType: number | null;
+  PrincipalTypeString: string | null;
+}
+
+export interface IGraphUser {
+  userPrincipalName: string;
+}
+
+export interface ISiteOwner {
+  LoginName: string;
+}
+
+export interface ISPSite {
+  Id: string;
+}
+
+export interface ISiteUser {
+  Id: number;
+}

--- a/src/m365/spo/commands/site/SiteProperties.ts
+++ b/src/m365/spo/commands/site/SiteProperties.ts
@@ -2,5 +2,5 @@ export interface SiteProperties {
   Status: string;
   Title: string;
   Url: string;
-  SiteId: string;
+  SiteId?: string;
 }

--- a/src/m365/spo/commands/site/site-admin-add.spec.ts
+++ b/src/m365/spo/commands/site/site-admin-add.spec.ts
@@ -1,0 +1,558 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import auth from '../../../../Auth.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
+import { Logger } from '../../../../cli/Logger.js';
+import { cli } from '../../../../cli/cli.js';
+import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
+import { pid } from '../../../../utils/pid.js';
+import { session } from '../../../../utils/session.js';
+import { sinonUtil } from '../../../../utils/sinonUtil.js';
+import commands from '../../commands.js';
+import command from './site-admin-add.js';
+import { spo } from '../../../../utils/spo.js';
+import { CommandError } from '../../../../Command.js';
+import config from '../../../../config.js';
+import { entraUser } from '../../../../utils/entraUser.js';
+import { entraGroup } from '../../../../utils/entraGroup.js';
+
+describe(commands.SITE_ADMIN_ADD, () => {
+  let log: any[];
+  let logger: Logger;
+  let commandInfo: CommandInfo;
+
+  const listOfAdminsFromAdminSource = [
+    {
+      email: 'user1Email@email.com',
+      loginName: 'i:0#.f|membership|user1loginName@email.com',
+      name: 'user1DisplayName',
+      userPrincipalName: 'user1loginName'
+    },
+    {
+      email: 'user2Email@email.com',
+      loginName: 'i:0#.f|membership|user2loginName@email.com',
+      name: 'user2DisplayName',
+      userPrincipalName: 'user2loginName'
+    }
+  ];
+  const rootUrl = 'https://contoso.sharepoint.com';
+  const adminUrl = 'https://contoso-admin.sharepoint.com';
+  const siteUrl = 'https://contoso.sharepoint.com/sites/site';
+  const siteId = '00000000-0000-0000-0000-000000000010';
+  const adminToAddId = '10000000-1000-0000-0000-000000000000';
+  const adminToAddUPN = 'user3loginName@email.com';
+  const primaryAdminLoginName = 'i:0#.f|membership|userPrimaryAdminEmail@email.com';
+  const groupId = '00000000-1000-0000-0000-000000000000';
+  const groupName = 'TestGroupName';
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
+    sinon.stub(spo, 'getRequestDigest').resolves({
+      FormDigestValue: 'abc',
+      FormDigestTimeoutSeconds: 1800,
+      FormDigestExpiresAt: new Date(),
+      WebFullUrl: 'https://contoso.sharepoint.com'
+    });
+    auth.connection.active = true;
+    auth.connection.spoUrl = 'https://contoso.sharepoint.com';
+    commandInfo = cli.getCommandInfo(command);
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: async (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: async (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: async (msg: string) => {
+        log.push(msg);
+      }
+    };
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      request.post,
+      request.patch,
+      entraGroup.getGroupById,
+      entraGroup.getGroupByDisplayName,
+      entraUser.getUpnByUserId
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+    auth.connection.active = false;
+    auth.connection.spoUrl = undefined;
+  });
+
+  it('fails validation if siteUrl is not a valid SharePoint URL', async () => {
+    const actual = await command.validate({ options: { siteUrl: 'foo', userId: adminToAddId } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if userId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { siteUrl: siteUrl, userId: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if userName is not a valid UPN', async () => {
+    const actual = await command.validate({ options: { siteUrl: siteUrl, userName: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if groupId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { siteUrl: siteUrl, groupId: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation when the siteUrl is a valid SharePoint URL and userId is a valid GUID', async () => {
+    const actual = await command.validate({ options: { siteUrl: siteUrl, userId: adminToAddId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation when the siteUrl is a valid SharePoint URL and userName is a valid UPN', async () => {
+    const actual = await command.validate({ options: { siteUrl: siteUrl, userName: adminToAddUPN } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('adds a user to site collection admins by userId as admin', async () => {
+    sinon.stub(entraUser, 'getUpnByUserId').resolves(adminToAddUPN);
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPOInternalUseOnly.Tenant/SetSiteSecondaryAdministrators`) {
+        return;
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, userId: adminToAddId, asAdmin: true, verbose: true } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      secondaryAdministratorsFieldsData: {
+        siteId: siteId, secondaryAdministratorLoginNames:
+          ['i:0#.f|membership|user1loginName@email.com', 'i:0#.f|membership|user2loginName@email.com', `i:0#.f|membership|${adminToAddUPN}`]
+      }
+    });
+  });
+
+  it('adds a user as primary site collection admins by userName as admin', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/users('user3loginName%40email.com')`) {
+        return { userPrincipalName: adminToAddUPN };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPOInternalUseOnly.Tenant/SetSiteSecondaryAdministrators`) {
+        return;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const patchStub = sinon.stub(request, 'patch').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')`) {
+        return;
+      }
+
+      throw `Invalid PATCH request: ${JSON.stringify(opts, null, 2)}`;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, userName: adminToAddUPN, asAdmin: true, primary: true } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      secondaryAdministratorsFieldsData: {
+        siteId: siteId, secondaryAdministratorLoginNames:
+          ['i:0#.f|membership|user1loginName@email.com', 'i:0#.f|membership|user2loginName@email.com', `i:0#.f|membership|${adminToAddUPN}`]
+      }
+    });
+    assert.deepStrictEqual(patchStub.lastCall.args[0].data, {
+      Owner: `i:0#.f|membership|${adminToAddUPN}`,
+      SetOwnerWithoutUpdatingSecondaryAdmin: true
+    });
+  });
+
+  it('adds a group to site collection admin by groupId as admin - for M365 Group', async () => {
+    sinon.stub(entraGroup, 'getGroupById').resolves({
+      mail: 'mail',
+      id: groupId
+    });
+
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPOInternalUseOnly.Tenant/SetSiteSecondaryAdministrators`) {
+        return;
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, groupId: groupId, asAdmin: true } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      secondaryAdministratorsFieldsData: {
+        siteId: siteId, secondaryAdministratorLoginNames:
+          ['i:0#.f|membership|user1loginName@email.com', 'i:0#.f|membership|user2loginName@email.com', `c:0o.c|federateddirectoryclaimprovider|${groupId}`]
+      }
+    });
+  });
+
+  it('adds a group to site collection admin by groupId as admin - for Security Group', async () => {
+    sinon.stub(entraGroup, 'getGroupById').resolves({
+      mail: undefined,
+      id: groupId
+    });
+
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPOInternalUseOnly.Tenant/SetSiteSecondaryAdministrators`) {
+        return;
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, groupId: groupId, asAdmin: true } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      secondaryAdministratorsFieldsData: {
+        siteId: siteId, secondaryAdministratorLoginNames:
+          ['i:0#.f|membership|user1loginName@email.com', 'i:0#.f|membership|user2loginName@email.com', `c:0t.c|tenant|${groupId}`]
+      }
+    });
+  });
+
+  it('adds a group to site collection admin by groupName as admin', async () => {
+    sinon.stub(entraGroup, 'getGroupByDisplayName').resolves(
+      {
+        mail: undefined,
+        id: groupId
+      }
+    );
+
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPOInternalUseOnly.Tenant/SetSiteSecondaryAdministrators`) {
+        return;
+      }
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, groupName: groupName, asAdmin: true } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      secondaryAdministratorsFieldsData: {
+        siteId: siteId, secondaryAdministratorLoginNames:
+          ['i:0#.f|membership|user1loginName@email.com', 'i:0#.f|membership|user2loginName@email.com', `c:0t.c|tenant|${groupId}`]
+      }
+    });
+  });
+
+  it('adds a group as primary site collection admins by userName as admin', async () => {
+    sinon.stub(entraGroup, 'getGroupByDisplayName').resolves(
+      {
+        mail: undefined,
+        id: groupId
+      }
+    );
+
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: `contoso.sharepoint.com,${siteId},fb0a066f-c10f-4734-94d1-f896de4aa484` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`) {
+        return JSON.stringify({
+          value: listOfAdminsFromAdminSource
+        });
+      }
+
+      if (opts.url === `${adminUrl}/_api/SPOInternalUseOnly.Tenant/SetSiteSecondaryAdministrators`) {
+        return;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const patchStub = sinon.stub(request, 'patch').callsFake(async opts => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')`) {
+        return;
+      }
+
+      throw `Invalid PATCH request: ${JSON.stringify(opts, null, 2)}`;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, groupName: groupName, asAdmin: true, primary: true } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      secondaryAdministratorsFieldsData: {
+        siteId: siteId, secondaryAdministratorLoginNames:
+          ['i:0#.f|membership|user1loginName@email.com', 'i:0#.f|membership|user2loginName@email.com', `c:0t.c|tenant|${groupId}`]
+      }
+    });
+    assert.deepStrictEqual(patchStub.lastCall.args[0].data, {
+      Owner: `c:0t.c|tenant|${groupId}`,
+      SetOwnerWithoutUpdatingSecondaryAdmin: true
+    });
+  });
+
+  it('adds a user to site collection admins by userId', async () => {
+    sinon.stub(entraUser, 'getUpnByUserId').resolves(adminToAddUPN);
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/web/siteusers('i%3A0%23.f%7Cmembership%7Cuser3loginName%40email.com')`) {
+        return;
+      }
+
+      if (opts.url === `${siteUrl}/_api/web/ensureuser` && opts.data.logonName === `i:0#.f|membership|${adminToAddUPN}`) {
+        return { LoginName: `i:0#.f|membership|${adminToAddUPN}` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, userId: adminToAddId, verbose: true } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, { IsSiteAdmin: true });
+  });
+
+  it('adds a user to site collection admins by userName', async () => {
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users('user3loginName%40email.com')`) {
+        return { userPrincipalName: adminToAddUPN };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/web/siteusers('i%3A0%23.f%7Cmembership%7Cuser3loginName%40email.com')`) {
+        return;
+      }
+
+      if (opts.url === `${siteUrl}/_api/web/ensureuser` && opts.data.logonName === `i:0#.f|membership|${adminToAddUPN}`) {
+        return { LoginName: `i:0#.f|membership|${adminToAddUPN}` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, userName: adminToAddUPN } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, { IsSiteAdmin: true });
+  });
+
+  it('adds a group to site collection admin by groupId', async () => {
+    sinon.stub(entraGroup, 'getGroupById').resolves({
+      mail: 'mail',
+      id: groupId
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/web/siteusers('c%3A0o.c%7Cfederateddirectoryclaimprovider%7C${groupId}')`) {
+        return;
+      }
+
+      if (opts.url === `${siteUrl}/_api/web/ensureuser` && opts.data.logonName === `c:0o.c|federateddirectoryclaimprovider|${groupId}`) {
+        return { LoginName: `c:0o.c|federateddirectoryclaimprovider|${groupId}` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, groupId: groupId } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, { IsSiteAdmin: true });
+  });
+
+  it('adds a group to site collection admin by groupName', async () => {
+    sinon.stub(entraGroup, 'getGroupByDisplayName').resolves(
+      {
+        mail: undefined,
+        id: groupId
+      }
+    );
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/web/siteusers('c%3A0t.c%7Ctenant%7C00000000-1000-0000-0000-000000000000')`) {
+        return;
+      }
+
+      if (opts.url === `${siteUrl}/_api/web/ensureuser` && opts.data.logonName === `c:0t.c|tenant|${groupId}`) {
+        return { LoginName: `c:0t.c|tenant|${groupId}` };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, groupName: groupName } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, { IsSiteAdmin: true });
+  });
+
+  it('adds a user as primary site collection admins by userId', async () => {
+    sinon.stub(entraUser, 'getUpnByUserId').resolves(adminToAddUPN);
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `${siteUrl}/_api/site?$select=Id`) {
+        return { Id: siteId };
+      }
+
+      if (opts.url === `${siteUrl}/_api/site/owner?$select=LoginName`) {
+        return { LoginName: primaryAdminLoginName };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async opts => {
+      const userId = 5;
+      if (opts.url === `${siteUrl}/_api/web/siteusers('i%3A0%23.f%7Cmembership%7Cuser3loginName%40email.com')`) {
+        return;
+      }
+
+      if (opts.url === `${siteUrl}/_api/web/siteusers('i%3A0%23.f%7Cmembership%7CuserPrimaryAdminEmail%40email.com')`) {
+        return;
+      }
+
+      if (opts.url === `${siteUrl}/_api/web/ensureuser` && opts.data.logonName === `i:0#.f|membership|${adminToAddUPN}`) {
+        return { LoginName: `i:0#.f|membership|${adminToAddUPN}`, Id: userId };
+      }
+
+      if (opts.url === `${siteUrl}/_vti_bin/client.svc/ProcessQuery` &&
+        opts.data === `<Request xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}"><Actions><SetProperty Id="10" ObjectPathId="2" Name="Owner"><Parameter ObjectPathId="3" /></SetProperty></Actions><ObjectPaths><Property Id="2" ParentId="0" Name="Site" /><Identity Id="3" Name="6d452ba1-40a8-8000-e00d-46e1adaa12bf|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:u:${userId}" /><StaticProperty Id="0" TypeId="{3747adcd-a3c3-41b9-bfab-4a64dd2f1e0a}" Name="Current" /></ObjectPaths></Request>`
+      ) {
+        return;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, { options: { siteUrl: siteUrl, userId: adminToAddId, primary: true } });
+    assert.deepStrictEqual(postStub.getCall(postStub.callCount - 1).args[0].data, { IsSiteAdmin: true });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, { IsSiteAdmin: true });
+  });
+
+  it('correctly handles error when site id is not found for specified site URL in admin mode', async () => {
+    sinon.stub(entraUser, 'getUpnByUserId').resolves(adminToAddUPN);
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: 'Incorrect ID' };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await assert.rejects(command.action(logger, { options: { siteUrl: siteUrl, userId: adminToAddId, asAdmin: true } }),
+      new CommandError(`Site with URL ${siteUrl} not found`));
+  });
+
+  it('correctly handles error when user is not found userId admin mode', async () => {
+    sinon.stub(entraUser, 'getUpnByUserId').resolves(undefined);
+    sinon.stub(request, 'get').callsFake(async opts => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/root?$select=webUrl`) {
+        return { res: { webUrl: rootUrl } };
+      }
+
+      if (opts.url === `https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/site?$select=id`) {
+        return { id: 'Incorrect ID' };
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await assert.rejects(command.action(logger, { options: { siteUrl: siteUrl, userId: adminToAddId, asAdmin: true } }), new CommandError(`User not found.`));
+  });
+});

--- a/src/m365/spo/commands/site/site-admin-add.ts
+++ b/src/m365/spo/commands/site/site-admin-add.ts
@@ -1,0 +1,317 @@
+import { Logger } from '../../../../cli/Logger.js';
+import config from '../../../../config.js';
+import GlobalOptions from '../../../../GlobalOptions.js';
+import request, { CliRequestOptions } from '../../../../request.js';
+import { entraGroup } from '../../../../utils/entraGroup.js';
+import { entraUser } from '../../../../utils/entraUser.js';
+import { formatting } from '../../../../utils/formatting.js';
+import { FormDigestInfo, spo } from '../../../../utils/spo.js';
+import { validation } from '../../../../utils/validation.js';
+import SpoCommand from '../../../base/SpoCommand.js';
+import commands from '../../commands.js';
+import { AdminResult, AdminUserResult, ISiteOwner, ISiteUser, ISPSite } from './SiteAdmin.js';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  siteUrl: string;
+  userId?: string;
+  userName?: string;
+  groupId?: string;
+  groupName?: string;
+  primary?: boolean;
+  asAdmin?: boolean;
+}
+
+class SpoSiteAdminAddCommand extends SpoCommand {
+  public get name(): string {
+    return commands.SITE_ADMIN_ADD;
+  }
+
+  public get description(): string {
+    return 'Adds a user or group as a site collection administrator';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initOptionSets();
+    this.#initTypes();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        userId: typeof args.options.userId !== 'undefined',
+        userName: typeof args.options.userName !== 'undefined',
+        groupId: typeof args.options.groupId !== 'undefined',
+        groupName: typeof args.options.groupName !== 'undefined',
+        primary: !!args.options.primary,
+        asAdmin: !!args.options.asAdmin
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-u, --siteUrl <siteUrl>'
+      },
+      {
+        option: '--userId [userId]'
+      },
+      {
+        option: '--userName [userName]'
+      },
+      {
+        option: '--groupId [groupId]'
+      },
+      {
+        option: '--groupName [groupName]'
+      },
+      {
+        option: '--primary'
+      },
+      {
+        option: '--asAdmin'
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        if (args.options.userId &&
+          !validation.isValidGuid(args.options.userId)) {
+          return `'${args.options.userId}' is not a valid GUID for option 'userId'`;
+        }
+
+        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
+          return `'${args.options.userName}' is not a valid 'userName'`;
+        }
+
+        if (args.options.groupId &&
+          !validation.isValidGuid(args.options.groupId)) {
+          return `'${args.options.groupId}' is not a valid GUID for option 'groupId'`;
+        }
+
+        return validation.isValidSharePointUrl(args.options.siteUrl);
+      }
+    );
+  }
+
+  #initOptionSets(): void {
+    this.optionSets.push({ options: ['userId', 'userName', 'groupId', 'groupName'] });
+  }
+
+  #initTypes(): void {
+    this.types.string.push('siteUrl', 'userId', 'userName', 'groupId', 'groupName');
+    this.types.boolean.push('primary', 'asAdmin');
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      const loginNameToAdd = await this.getCorrectLoginName(args.options);
+      if (args.options.asAdmin) {
+        await this.callActionAsAdmin(logger, args, loginNameToAdd);
+        return;
+      }
+
+      await this.callAction(logger, args, loginNameToAdd);
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+
+  private async callActionAsAdmin(logger: Logger, args: CommandArgs, loginNameToAdd: string): Promise<void> {
+    if (this.verbose) {
+      await logger.logToStderr('Adding site administrator as an administrator...');
+    }
+
+    const adminUrl: string = await spo.getSpoAdminUrl(logger, this.debug);
+    const siteId = await this.getSiteIdBasedOnUrl(args.options.siteUrl, logger);
+    const siteAdmins = (await this.getSiteAdmins(adminUrl, siteId)).map(u => u.loginName);
+    siteAdmins.push(loginNameToAdd);
+    await this.setSiteAdminsAsAdmin(adminUrl, siteId, siteAdmins);
+    if (args.options.primary) {
+      await this.setPrimaryAdminAsAdmin(adminUrl, siteId, loginNameToAdd);
+    }
+  }
+
+  private async getSiteIdBasedOnUrl(siteUrl: string, logger: Logger): Promise<string> {
+    const siteGraphId = await spo.getSiteId(siteUrl, logger, this.verbose);
+    const match = siteGraphId.match(/,([a-f0-9\-]{36}),/i);
+    if (!match) {
+      throw `Site with URL ${siteUrl} not found`;
+    }
+
+    return match[1];
+  }
+
+  private async getSiteAdmins(adminUrl: string, siteId: string): Promise<AdminUserResult[]> {
+    const requestOptions: CliRequestOptions = {
+      url: `${adminUrl}/_api/SPO.Tenant/GetSiteAdministrators?siteId='${siteId}'`,
+      headers: {
+        accept: 'application/json;odata=nometadata',
+        'content-type': 'application/json;charset=utf-8'
+      }
+    };
+
+    const response: string = await request.post<string>(requestOptions);
+    const responseContent: AdminResult = JSON.parse(response);
+    return responseContent.value;
+  }
+
+  private async getCorrectLoginName(options: Options): Promise<string> {
+    if (options.userId || options.userName) {
+      const userPrincipalName = options.userName ? options.userName : await entraUser.getUpnByUserId(options.userId!);
+
+      if (userPrincipalName) {
+        return `i:0#.f|membership|${userPrincipalName}`;
+      }
+
+      throw 'User not found.';
+    }
+    else {
+      const group = options.groupId ? await entraGroup.getGroupById(options.groupId) : await entraGroup.getGroupByDisplayName(options.groupName!);
+      //for entra groups, M365 groups have an associated email and security groups don't
+      if (group?.mail) {
+        //M365 group is prefixed with c:0o.c|federateddirectoryclaimprovider
+        return `c:0o.c|federateddirectoryclaimprovider|${group.id}`;
+      }
+      else {
+        //security group is prefixed with c:0t.c|tenant
+        return `c:0t.c|tenant|${group?.id}`;
+      }
+    }
+  }
+
+  private async setSiteAdminsAsAdmin(adminUrl: string, siteId: string, admins: string[]): Promise<void> {
+    const requestOptions: CliRequestOptions = {
+      url: `${adminUrl}/_api/SPOInternalUseOnly.Tenant/SetSiteSecondaryAdministrators`,
+      headers: {
+        accept: 'application/json;odata=nometadata',
+        'content-type': 'application/json;charset=utf-8'
+      },
+      data: {
+        secondaryAdministratorsFieldsData: {
+          siteId: siteId,
+          secondaryAdministratorLoginNames:
+            admins
+        }
+      }
+    };
+
+    return request.post(requestOptions);
+  }
+
+  private async setPrimaryAdminAsAdmin(adminUrl: string, siteId: string, adminLogin: string): Promise<void> {
+    const requestOptions: CliRequestOptions = {
+      url: `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')`,
+      headers: {
+        accept: 'application/json;odata=nometadata',
+        'content-type': 'application/json;charset=utf-8'
+      },
+      data: {
+        Owner: adminLogin,
+        SetOwnerWithoutUpdatingSecondaryAdmin: true
+      }
+    };
+
+    return request.patch(requestOptions);
+  }
+
+  private async callAction(logger: Logger, args: CommandArgs, loginNameToAdd: string): Promise<void> {
+    if (this.verbose) {
+      await logger.logToStderr('Adding site administrator...');
+    }
+
+    const ensuredUserData = await this.ensureUser(args, loginNameToAdd);
+    await this.setSiteAdmin(args.options.siteUrl, loginNameToAdd);
+
+    if (args.options.primary) {
+      const siteId = await this.getSiteId(args.options.siteUrl);
+      const previousPrimaryOwner = await this.getSiteOwnerLoginName(args.options.siteUrl);
+      await this.setPrimaryOwnerLoginFromSite(logger, args.options.siteUrl, siteId, ensuredUserData);
+      await this.setSiteAdmin(args.options.siteUrl, previousPrimaryOwner);
+    }
+  }
+
+  private async ensureUser(args: CommandArgs, loginName: string): Promise<ISiteUser> {
+    const requestOptions: CliRequestOptions = {
+      url: `${args.options.siteUrl}/_api/web/ensureuser`,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      data: {
+        logonName: loginName
+      },
+      responseType: 'json'
+    };
+
+    return request.post<ISiteUser>(requestOptions);
+  }
+
+  private async setSiteAdmin(siteUrl: string, loginName: string): Promise<void> {
+    const requestOptions: CliRequestOptions = {
+      url: `${siteUrl}/_api/web/siteusers('${formatting.encodeQueryParameter(loginName)}')`,
+      headers: {
+        'accept': 'application/json',
+        'X-Http-Method': 'MERGE',
+        'If-Match': '*'
+      },
+      data: { IsSiteAdmin: true },
+      responseType: 'json'
+    };
+    return request.post(requestOptions);
+  }
+
+  private async getSiteId(siteUrl: string): Promise<string> {
+    const requestOptions: CliRequestOptions = {
+      url: `${siteUrl}/_api/site?$select=Id`,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const response = await request.get<ISPSite>(requestOptions);
+    return response.Id;
+  }
+
+  private async getSiteOwnerLoginName(siteUrl: string): Promise<string> {
+    const requestOptions: CliRequestOptions = {
+      url: `${siteUrl}/_api/site/owner?$select=LoginName`,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const response = await request.get<ISiteOwner>(requestOptions);
+    return response.LoginName;
+  }
+
+  private async setPrimaryOwnerLoginFromSite(logger: Logger, siteUrl: string, siteId: string, loginName: ISiteUser): Promise<string> {
+    const res: FormDigestInfo = await spo.ensureFormDigest(siteUrl, logger, undefined, this.debug);
+    const body = `<Request xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}"><Actions><SetProperty Id="10" ObjectPathId="2" Name="Owner"><Parameter ObjectPathId="3" /></SetProperty></Actions><ObjectPaths><Property Id="2" ParentId="0" Name="Site" /><Identity Id="3" Name="6d452ba1-40a8-8000-e00d-46e1adaa12bf|740c6a0b-85e2-48a0-a494-e0f1759d4aa7:site:${siteId}:u:${loginName.Id}" /><StaticProperty Id="0" TypeId="{3747adcd-a3c3-41b9-bfab-4a64dd2f1e0a}" Name="Current" /></ObjectPaths></Request>`;
+
+    const requestOptions: CliRequestOptions = {
+      url: `${siteUrl}/_vti_bin/client.svc/ProcessQuery`,
+      headers: {
+        'X-RequestDigest': res.FormDigestValue
+      },
+      data: body
+    };
+
+    return request.post<string>(requestOptions);
+  }
+}
+
+export default new SpoSiteAdminAddCommand();

--- a/src/utils/spo.spec.ts
+++ b/src/utils/spo.spec.ts
@@ -2580,4 +2580,37 @@ describe('utils/spo', () => {
       assert.deepStrictEqual(ex, `File Not Found`);
     }
   });
+
+  it(`gets primary admin loginName from admin site`, async () => {
+    const adminUrl = 'https://contoso-admin.sharepoint.com';
+    const siteId = '0ead8b78-89e5-427f-b1bc-6e5a77ac191c';
+    const primaryAdminLoginName = 'user1loginName';
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')?$select=OwnerLoginName`) {
+        return JSON.stringify({ OwnerLoginName: primaryAdminLoginName });
+      }
+
+      throw 'Invalid request';
+    });
+
+    const result = await spo.getPrimaryAdminLoginNameAsAdmin(adminUrl, siteId, logger, true);
+    assert.strictEqual(result, primaryAdminLoginName);
+  });
+
+  it(`gets primary admin loginName from site`, async () => {
+    const siteUrl = 'https://contoso.sharepoint.com';
+    const primaryAdminLoginName = 'user1loginName';
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${siteUrl}/_api/site/owner`) {
+        return { LoginName: primaryAdminLoginName };
+      }
+
+      throw 'Invalid request';
+    });
+
+    const result = await spo.getPrimaryOwnerLoginFromSite(siteUrl, logger, true);
+    assert.strictEqual(result, primaryAdminLoginName);
+  });
 });

--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -1860,5 +1860,56 @@ export const spo = {
 
     const itemsResponse = await request.get<ListItemInstance>(requestOptionsItems);
     return (itemsResponse);
+  },
+
+  /**
+   * Gets the site collection URL for a given web URL using SP Admin site.
+   * @param adminUrl The SharePoint admin URL
+   * @param siteId The site ID
+   * @param logger The logger object
+   * @param verbose If in verbose mode
+   * @returns Owner login name
+   */
+  async getPrimaryAdminLoginNameAsAdmin(adminUrl: string, siteId: string, logger: Logger, verbose: boolean): Promise<string> {
+    if (verbose) {
+      await logger.logToStderr('Getting the primary admin login name...');
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${adminUrl}/_api/SPO.Tenant/sites('${siteId}')?$select=OwnerLoginName`,
+      headers: {
+        accept: 'application/json;odata=nometadata',
+        'content-type': 'application/json;charset=utf-8'
+      }
+    };
+
+    const response: string = await request.get<string>(requestOptions);
+    const responseContent = JSON.parse(response);
+    return responseContent.OwnerLoginName;
+  },
+
+  /**
+   * Gets the primary owner login from a site.
+   * @param siteUrl The site URL
+   * @param logger The logger object
+   * @param verbose If in verbose mode
+   * @returns Owner login name
+   */
+  async getPrimaryOwnerLoginFromSite(siteUrl: string, logger: Logger, verbose: boolean): Promise<string> {
+    if (verbose) {
+      await logger.logToStderr('Getting the primary admin login name...');
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${siteUrl}/_api/site/owner`,
+      method: 'GET',
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const responseContent = await request.get<{ LoginName: string }>(requestOptions);
+    return responseContent?.LoginName;
   }
 };


### PR DESCRIPTION
Adds new command `spo site admin add` 

Closes #5883

As I mentioned in [the comment](https://github.com/pnp/cli-microsoft365/issues/5883#issuecomment-2126440130) there was a case with setting a primary site collection admin without using `--asAdmin` parameter. 

To ensure consistency in both versions of the command, I retrieve the current owner before setting the new primary admin. Then, I reassign the previous owner as a secondary site collection admin. I hope this approach is ok.