### PR TITLE
Extends 'spo user get' command with support for more options. Closes #5516

### DIFF
--- a/docs/docs/cmd/spo/user/user-get.mdx
+++ b/docs/docs/cmd/spo/user/user-get.mdx
@@ -16,41 +16,68 @@ m365 spo user get [options]
 
 ```md definition-list
 `-u, --webUrl <webUrl>`
-: URL of the web to get the user within
+: URL of the web to get the user within.
 
 `-i, --id [id]`
-: ID of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.
+: ID of the user to retrieve information for. Specify either `id`, `loginName`, `email`, `userName`, `entraGroupId`, or `entraGroupName`.
 
 `--email [email]`
-: Email of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.
+: Email of the user to retrieve information for. Specify either `id`, `loginName`, `email`, `userName`, `entraGroupId`, or `entraGroupName`.
 
 `--loginName [loginName]`
-: Login name of the user to retrieve information for. Use either `email`, `id` or `loginName`, but not all.
+: Login name of the user to retrieve information for. Specify either `id`, `loginName`, `email`, `userName`, `entraGroupId`, or `entraGroupName`.
+
+`--userName [userName]`
+: User's UPN (user principal name, eg. megan.bowen@contoso.com). Specify either `id`, `loginName`, `email`, `userName`, `entraGroupId`, or `entraGroupName`.
+
+`--entraGroupId [entraGroupId]`
+: The object ID of the Microsoft Entra group. Specify either `id`, `loginName`, `email`, `userName`, `entraGroupId`, or `entraGroupName`.
+
+`--entraGroupName [entraGroupName]`
+: The name of the Microsoft Entra group. Specify either `id`, `loginName`, `email`, `userName`, `entraGroupId`, or `entraGroupName`.
 ```
 
 <Global />
 
 ## Examples
 
-Get user by email for a web
+Get user by email for a web.
 
 ```sh
 m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --email john.doe@mytenant.onmicrosoft.com
 ```
 
-Get user by ID for a web
+Get user by ID for a web.
 
 ```sh
 m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --id 6
 ```
 
-Get user by login name for a web
+Get user by login name for a web.
 
 ```sh
 m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --loginName "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
 ```
 
-Get the currently logged-in user
+Get user by user's UPN for a web.
+
+```sh
+m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --userName "john.doe@mytenant.onmicrosoft.com"
+```
+
+Get user by entraGroupId for a web.
+
+```sh
+m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --entraGroupId f832a493-de73-4fef-87ed-8c6fffd91be6
+```
+
+Get user by entraGroupName for a web.
+
+```sh
+m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x --entraGroupName "Test Members"
+```
+
+Get the currently logged-in user.
 
 ```sh
 m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x
@@ -134,4 +161,3 @@ m365 spo user get --webUrl https://contoso.sharepoint.com/sites/project-x
 
   </TabItem>
 </Tabs>
-

--- a/src/m365/spo/commands/user/user-get.spec.ts
+++ b/src/m365/spo/commands/user/user-get.spec.ts
@@ -16,8 +16,8 @@ import { settingsNames } from '../../../../settingsNames.js';
 import { formatting } from '../../../../utils/formatting.js';
 
 describe(commands.USER_GET, () => {
-  const validUserName = 'john.deo_hotmail.com#ext#@contoso.onmicrosoft.com';
-  const validEmail = 'john.deo@contoso.onmicrosoft.com';
+  const validUserName = 'john.doe_hotmail.com#ext#@contoso.onmicrosoft.com';
+  const validEmail = 'john.doe@contoso.onmicrosoft.com';
   const validEntraGroupId = '2056d2f6-3257-4253-8cfc-b73393e414e5';
   const validEntraGroupName = 'Finance';
   const validEntraSecurityGroupName = 'EntraGroupTest';
@@ -155,25 +155,10 @@ describe(commands.USER_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('retrieves user by id with output option json', async () => {
+  it('retrieves user by id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/siteusers/GetById') > -1) {
-        return {
-          "value": [{
-            "Id": 6,
-            "IsHiddenInUI": false,
-            "LoginName": "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
-            "Title": "John Doe",
-            "PrincipalType": 1,
-            "Email": "john.deo@mytenant.onmicrosoft.com",
-            "Expiration": "",
-            "IsEmailAuthenticationGuestUser": false,
-            "IsShareByEmailGuestUser": false,
-            "IsSiteAdmin": false,
-            "UserId": { "NameId": "10010001b0c19a2", "NameIdIssuer": "urn:federation:microsoftonline" },
-            "UserPrincipalName": "john.deo@mytenant.onmicrosoft.com"
-          }]
-        };
+      if (opts.url === `${validWebUrl}/_api/web/siteusers/GetById('10')`) {
+        return userResponse;
       }
 
       throw 'Invalid request';
@@ -183,48 +168,18 @@ describe(commands.USER_GET, () => {
       options: {
         output: 'json',
         debug: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        id: 1
+        webUrl: validWebUrl,
+        id: 10
       }
     });
 
-    assert(loggerLogSpy.calledWith({
-      value: [{
-        Id: 6,
-        IsHiddenInUI: false,
-        LoginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
-        Title: "John Doe",
-        PrincipalType: 1,
-        Email: "john.deo@mytenant.onmicrosoft.com",
-        Expiration: "",
-        IsEmailAuthenticationGuestUser: false,
-        IsShareByEmailGuestUser: false,
-        IsSiteAdmin: false,
-        UserId: { NameId: "10010001b0c19a2", NameIdIssuer: "urn:federation:microsoftonline" },
-        UserPrincipalName: "john.deo@mytenant.onmicrosoft.com"
-      }]
-    }));
+    assert(loggerLogSpy.calledWith(userResponse));
   });
 
-  it('retrieves user by email with output option json', async () => {
+  it('retrieves user by email', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/siteusers/GetByEmail') > -1) {
-        return {
-          "value": [{
-            "Id": 6,
-            "IsHiddenInUI": false,
-            "LoginName": "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
-            "Title": "John Doe",
-            "PrincipalType": 1,
-            "Email": "john.deo@mytenant.onmicrosoft.com",
-            "Expiration": "",
-            "IsEmailAuthenticationGuestUser": false,
-            "IsShareByEmailGuestUser": false,
-            "IsSiteAdmin": false,
-            "UserId": { "NameId": "10010001b0c19a2", "NameIdIssuer": "urn:federation:microsoftonline" },
-            "UserPrincipalName": "john.deo@mytenant.onmicrosoft.com"
-          }]
-        };
+      if (opts.url === `${validWebUrl}/_api/web/siteusers/GetByEmail('${formatting.encodeQueryParameter(validEmail)}')`) {
+        return userResponse;
       }
 
       throw 'Invalid request';
@@ -234,48 +189,18 @@ describe(commands.USER_GET, () => {
       options: {
         output: 'json',
         debug: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        email: "john.deo@mytenant.onmicrosoft.com"
+        webUrl: validWebUrl,
+        email: validEmail
       }
     });
 
-    assert(loggerLogSpy.calledWith({
-      value: [{
-        Id: 6,
-        IsHiddenInUI: false,
-        LoginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
-        Title: "John Doe",
-        PrincipalType: 1,
-        Email: "john.deo@mytenant.onmicrosoft.com",
-        Expiration: "",
-        IsEmailAuthenticationGuestUser: false,
-        IsShareByEmailGuestUser: false,
-        IsSiteAdmin: false,
-        UserId: { NameId: "10010001b0c19a2", NameIdIssuer: "urn:federation:microsoftonline" },
-        UserPrincipalName: "john.deo@mytenant.onmicrosoft.com"
-      }]
-    }));
+    assert(loggerLogSpy.calledWith(userResponse));
   });
 
-  it('retrieves user by loginName with output option json', async () => {
+  it('retrieves user by loginName', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/siteusers/GetByLoginName') > -1) {
-        return {
-          "value": [{
-            "Id": 6,
-            "IsHiddenInUI": false,
-            "LoginName": "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
-            "Title": "John Doe",
-            "PrincipalType": 1,
-            "Email": "john.deo@mytenant.onmicrosoft.com",
-            "Expiration": "",
-            "IsEmailAuthenticationGuestUser": false,
-            "IsShareByEmailGuestUser": false,
-            "IsSiteAdmin": false,
-            "UserId": { "NameId": "10010001b0c19a2", "NameIdIssuer": "urn:federation:microsoftonline" },
-            "UserPrincipalName": "john.deo@mytenant.onmicrosoft.com"
-          }]
-        };
+      if (opts.url === `${validWebUrl}/_api/web/siteusers/GetByLoginName('${formatting.encodeQueryParameter(validLoginName)}')`) {
+        return userResponse;
       }
 
       throw 'Invalid request';
@@ -285,30 +210,15 @@ describe(commands.USER_GET, () => {
       options: {
         output: 'json',
         debug: true,
-        webUrl: 'https://contoso.sharepoint.com',
-        loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
+        webUrl: validWebUrl,
+        loginName: validLoginName
       }
     });
 
-    assert(loggerLogSpy.calledWith({
-      value: [{
-        Id: 6,
-        IsHiddenInUI: false,
-        LoginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
-        Title: "John Doe",
-        PrincipalType: 1,
-        Email: "john.deo@mytenant.onmicrosoft.com",
-        Expiration: "",
-        IsEmailAuthenticationGuestUser: false,
-        IsShareByEmailGuestUser: false,
-        IsSiteAdmin: false,
-        UserId: { NameId: "10010001b0c19a2", NameIdIssuer: "urn:federation:microsoftonline" },
-        UserPrincipalName: "john.deo@mytenant.onmicrosoft.com"
-      }]
-    }));
+    assert(loggerLogSpy.calledWith(userResponse));
   });
 
-  it('retrieves user by userName with output option json', async () => {
+  it('retrieves user by userName', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `${validWebUrl}/_api/web/siteusers?$filter=UserPrincipalName eq ('${formatting.encodeQueryParameter(validUserName)}')`) {
         return {
@@ -316,10 +226,8 @@ describe(commands.USER_GET, () => {
         };
       }
 
-      if ((opts.url as string).indexOf('/_api/web/siteusers/GetById') > -1) {
-        return {
-          "value": [userResponse]
-        };
+      if (opts.url === `${validWebUrl}/_api/web/siteusers/GetById('10')`) {
+        return userResponse;
       }
 
       throw 'Invalid request';
@@ -334,12 +242,10 @@ describe(commands.USER_GET, () => {
       }
     });
 
-    assert(loggerLogSpy.calledWith({
-      value: [userResponse]
-    }));
+    assert(loggerLogSpy.calledWith(userResponse));
   });
 
-  it('retrieves m365 group by entraGroupId for mail enabled group with output option json', async () => {
+  it('retrieves m365 group by entraGroupId for mail enabled group', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validEntraGroupId}`) {
         return groupM365Response.value[0];
@@ -347,20 +253,18 @@ describe(commands.USER_GET, () => {
 
       if (opts.url === `${validWebUrl}/_api/web/siteusers/GetByEmail('finance%40contoso.onmicrosoft.com')`) {
         return {
-          "value": [{
-            "Id": 45,
-            "IsHiddenInUI": false,
-            "LoginName": "c:0o.c|federateddirectoryclaimprovider|2056d2f6-3257-4253-8cfc-b73393e414e5",
-            "Title": "Finance",
-            "PrincipalType": 4,
-            "Email": "finance@contoso.onmicrosoft.com",
-            "Expiration": "",
-            "IsEmailAuthenticationGuestUser": false,
-            "IsShareByEmailGuestUser": false,
-            "IsSiteAdmin": false,
-            "UserId": null,
-            "UserPrincipalName": null
-          }]
+          "Id": 45,
+          "IsHiddenInUI": false,
+          "LoginName": "c:0o.c|federateddirectoryclaimprovider|2056d2f6-3257-4253-8cfc-b73393e414e5",
+          "Title": "Finance",
+          "PrincipalType": 4,
+          "Email": "finance@contoso.onmicrosoft.com",
+          "Expiration": "",
+          "IsEmailAuthenticationGuestUser": false,
+          "IsShareByEmailGuestUser": false,
+          "IsSiteAdmin": false,
+          "UserId": null,
+          "UserPrincipalName": null
         };
       }
 
@@ -377,24 +281,22 @@ describe(commands.USER_GET, () => {
     });
 
     assert(loggerLogSpy.calledWith({
-      value: [{
-        "Id": 45,
-        "IsHiddenInUI": false,
-        "LoginName": "c:0o.c|federateddirectoryclaimprovider|2056d2f6-3257-4253-8cfc-b73393e414e5",
-        "Title": "Finance",
-        "PrincipalType": 4,
-        "Email": "finance@contoso.onmicrosoft.com",
-        "Expiration": "",
-        "IsEmailAuthenticationGuestUser": false,
-        "IsShareByEmailGuestUser": false,
-        "IsSiteAdmin": false,
-        "UserId": null,
-        "UserPrincipalName": null
-      }]
+      "Id": 45,
+      "IsHiddenInUI": false,
+      "LoginName": "c:0o.c|federateddirectoryclaimprovider|2056d2f6-3257-4253-8cfc-b73393e414e5",
+      "Title": "Finance",
+      "PrincipalType": 4,
+      "Email": "finance@contoso.onmicrosoft.com",
+      "Expiration": "",
+      "IsEmailAuthenticationGuestUser": false,
+      "IsShareByEmailGuestUser": false,
+      "IsSiteAdmin": false,
+      "UserId": null,
+      "UserPrincipalName": null
     }));
   });
 
-  it('retrieves security group by entraGroupName with output option json', async () => {
+  it('retrieves security group by entraGroupName', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${validEntraSecurityGroupName}'`) {
         return groupSecurityResponse;
@@ -402,20 +304,18 @@ describe(commands.USER_GET, () => {
 
       if (opts.url === `${validWebUrl}/_api/web/siteusers/GetByLoginName('c:0t.c|tenant|${validEntraGroupId}')`) {
         return {
-          "value": [{
-            "Id": 31,
-            "IsHiddenInUI": false,
-            "LoginName": "c:0t.c|tenant|2056d2f6-3257-4253-8cfc-b73393e414e5",
-            "Title": "EntraGroupTest",
-            "PrincipalType": 4,
-            "Email": "",
-            "Expiration": "",
-            "IsEmailAuthenticationGuestUser": false,
-            "IsShareByEmailGuestUser": false,
-            "IsSiteAdmin": false,
-            "UserId": null,
-            "UserPrincipalName": null
-          }]
+          "Id": 31,
+          "IsHiddenInUI": false,
+          "LoginName": "c:0t.c|tenant|2056d2f6-3257-4253-8cfc-b73393e414e5",
+          "Title": "EntraGroupTest",
+          "PrincipalType": 4,
+          "Email": "",
+          "Expiration": "",
+          "IsEmailAuthenticationGuestUser": false,
+          "IsShareByEmailGuestUser": false,
+          "IsSiteAdmin": false,
+          "UserId": null,
+          "UserPrincipalName": null
         };
       }
 
@@ -431,20 +331,18 @@ describe(commands.USER_GET, () => {
     } as any);
 
     assert(loggerLogSpy.calledWith({
-      value: [{
-        "Id": 31,
-        "IsHiddenInUI": false,
-        "LoginName": "c:0t.c|tenant|2056d2f6-3257-4253-8cfc-b73393e414e5",
-        "Title": "EntraGroupTest",
-        "PrincipalType": 4,
-        "Email": "",
-        "Expiration": "",
-        "IsEmailAuthenticationGuestUser": false,
-        "IsShareByEmailGuestUser": false,
-        "IsSiteAdmin": false,
-        "UserId": null,
-        "UserPrincipalName": null
-      }]
+      "Id": 31,
+      "IsHiddenInUI": false,
+      "LoginName": "c:0t.c|tenant|2056d2f6-3257-4253-8cfc-b73393e414e5",
+      "Title": "EntraGroupTest",
+      "PrincipalType": 4,
+      "Email": "",
+      "Expiration": "",
+      "IsEmailAuthenticationGuestUser": false,
+      "IsShareByEmailGuestUser": false,
+      "IsSiteAdmin": false,
+      "UserId": null,
+      "UserPrincipalName": null
     }));
   });
 
@@ -452,20 +350,18 @@ describe(commands.USER_GET, () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === 'https://contoso.sharepoint.com/_api/web/currentuser') {
         return {
-          "value": [{
-            "Id": 6,
-            "IsHiddenInUI": false,
-            "LoginName": "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
-            "Title": "John Doe",
-            "PrincipalType": 1,
-            "Email": "john.deo@mytenant.onmicrosoft.com",
-            "Expiration": "",
-            "IsEmailAuthenticationGuestUser": false,
-            "IsShareByEmailGuestUser": false,
-            "IsSiteAdmin": false,
-            "UserId": { "NameId": "10010001b0c19a2", "NameIdIssuer": "urn:federation:microsoftonline" },
-            "UserPrincipalName": "john.deo@mytenant.onmicrosoft.com"
-          }]
+          "Id": 6,
+          "IsHiddenInUI": false,
+          "LoginName": "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
+          "Title": "John Doe",
+          "PrincipalType": 1,
+          "Email": "john.doe@mytenant.onmicrosoft.com",
+          "Expiration": "",
+          "IsEmailAuthenticationGuestUser": false,
+          "IsShareByEmailGuestUser": false,
+          "IsSiteAdmin": false,
+          "UserId": { "NameId": "10010001b0c19a2", "NameIdIssuer": "urn:federation:microsoftonline" },
+          "UserPrincipalName": "john.doe@mytenant.onmicrosoft.com"
         };
       }
 
@@ -479,20 +375,18 @@ describe(commands.USER_GET, () => {
     });
 
     assert(loggerLogSpy.calledWith({
-      value: [{
-        Id: 6,
-        IsHiddenInUI: false,
-        LoginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
-        Title: "John Doe",
-        PrincipalType: 1,
-        Email: "john.deo@mytenant.onmicrosoft.com",
-        Expiration: "",
-        IsEmailAuthenticationGuestUser: false,
-        IsShareByEmailGuestUser: false,
-        IsSiteAdmin: false,
-        UserId: { NameId: "10010001b0c19a2", NameIdIssuer: "urn:federation:microsoftonline" },
-        UserPrincipalName: "john.deo@mytenant.onmicrosoft.com"
-      }]
+      Id: 6,
+      IsHiddenInUI: false,
+      LoginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com",
+      Title: "John Doe",
+      PrincipalType: 1,
+      Email: "john.doe@mytenant.onmicrosoft.com",
+      Expiration: "",
+      IsEmailAuthenticationGuestUser: false,
+      IsShareByEmailGuestUser: false,
+      IsSiteAdmin: false,
+      UserId: { NameId: "10010001b0c19a2", NameIdIssuer: "urn:federation:microsoftonline" },
+      UserPrincipalName: "john.doe@mytenant.onmicrosoft.com"
     }));
   });
 

--- a/src/m365/spo/commands/user/user-get.spec.ts
+++ b/src/m365/spo/commands/user/user-get.spec.ts
@@ -13,8 +13,98 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './user-get.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { formatting } from '../../../../utils/formatting.js';
 
 describe(commands.USER_GET, () => {
+  const validUserName = 'john.deo_hotmail.com#ext#@contoso.onmicrosoft.com';
+  const validEmail = 'john.deo@contoso.onmicrosoft.com';
+  const validEntraGroupId = '2056d2f6-3257-4253-8cfc-b73393e414e5';
+  const validEntraGroupName = 'Finance';
+  const validEntraSecurityGroupName = 'EntraGroupTest';
+  const validLoginName = `i:0#.f|membership|${validUserName}`;
+  const validWebUrl = 'https://contoso.sharepoint.com/subsite';
+
+  const userResponse = {
+    "Id": 10,
+    "IsHiddenInUI": false,
+    "LoginName": validLoginName,
+    "Title": "John Doe",
+    "PrincipalType": 1,
+    "Email": validEmail,
+    "Expiration": "",
+    "IsEmailAuthenticationGuestUser": false,
+    "IsShareByEmailGuestUser": false,
+    "IsSiteAdmin": false,
+    "UserId": { "NameId": "10010001b0c19a2", "NameIdIssuer": "urn:federation:microsoftonline" },
+    "UserPrincipalName": validUserName
+  };
+
+  const groupM365Response = {
+    value: [{
+      "id": "2056d2f6-3257-4253-8cfc-b73393e414e5",
+      "deletedDateTime": null,
+      "classification": null,
+      "createdDateTime": "2017-11-29T03:27:05Z",
+      "description": "This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.",
+      "displayName": "Finance",
+      "groupTypes": [
+        "Unified"
+      ],
+      "mail": "finance@contoso.onmicrosoft.com",
+      "mailEnabled": true,
+      "mailNickname": "finance",
+      "onPremisesLastSyncDateTime": null,
+      "onPremisesProvisioningErrors": [],
+      "onPremisesSecurityIdentifier": null,
+      "onPremisesSyncEnabled": null,
+      "preferredDataLocation": null,
+      "proxyAddresses": [
+        "SMTP:finance@contoso.onmicrosoft.com"
+      ],
+      "renewedDateTime": "2017-11-29T03:27:05Z",
+      "securityEnabled": false,
+      "visibility": "Public"
+    }]
+  };
+
+  const groupSecurityResponse = {
+    value: [{
+      "id": "2056d2f6-3257-4253-8cfc-b73393e414e5",
+      "deletedDateTime": null,
+      "classification": null,
+      "createdDateTime": "2024-01-27T16:02:56Z",
+      "creationOptions": [],
+      "description": "Entra Group Test",
+      "displayName": "EntraGroupTest",
+      "expirationDateTime": null,
+      "groupTypes": [],
+      "isAssignableToRole": true,
+      "mail": null,
+      "mailEnabled": false,
+      "mailNickname": "f45205a2-d",
+      "membershipRule": null,
+      "membershipRuleProcessingState": null,
+      "onPremisesDomainName": null,
+      "onPremisesLastSyncDateTime": null,
+      "onPremisesNetBiosName": null,
+      "onPremisesSamAccountName": null,
+      "onPremisesSecurityIdentifier": null,
+      "onPremisesSyncEnabled": null,
+      "preferredDataLocation": null,
+      "preferredLanguage": null,
+      "proxyAddresses": [],
+      "renewedDateTime": "2024-01-27T16:02:56Z",
+      "resourceBehaviorOptions": [],
+      "resourceProvisioningOptions": [],
+      "securityEnabled": true,
+      "securityIdentifier": "S-1-12-1-1968173404-1154184881-1694549896-3083850660",
+      "theme": null,
+      "visibility": "Private",
+      "onPremisesProvisioningErrors": [],
+      "serviceProvisioningErrors": []
+    }]
+  };
+
   let log: any[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
@@ -85,6 +175,7 @@ describe(commands.USER_GET, () => {
           }]
         };
       }
+
       throw 'Invalid request';
     });
 
@@ -96,6 +187,7 @@ describe(commands.USER_GET, () => {
         id: 1
       }
     });
+
     assert(loggerLogSpy.calledWith({
       value: [{
         Id: 6,
@@ -134,6 +226,7 @@ describe(commands.USER_GET, () => {
           }]
         };
       }
+
       throw 'Invalid request';
     });
 
@@ -145,6 +238,7 @@ describe(commands.USER_GET, () => {
         email: "john.deo@mytenant.onmicrosoft.com"
       }
     });
+
     assert(loggerLogSpy.calledWith({
       value: [{
         Id: 6,
@@ -183,6 +277,7 @@ describe(commands.USER_GET, () => {
           }]
         };
       }
+
       throw 'Invalid request';
     });
 
@@ -194,6 +289,7 @@ describe(commands.USER_GET, () => {
         loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com"
       }
     });
+
     assert(loggerLogSpy.calledWith({
       value: [{
         Id: 6,
@@ -212,6 +308,145 @@ describe(commands.USER_GET, () => {
     }));
   });
 
+  it('retrieves user by userName with output option json', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${validWebUrl}/_api/web/siteusers?$filter=UserPrincipalName eq ('${formatting.encodeQueryParameter(validUserName)}')`) {
+        return {
+          "value": [userResponse]
+        };
+      }
+
+      if ((opts.url as string).indexOf('/_api/web/siteusers/GetById') > -1) {
+        return {
+          "value": [userResponse]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        output: 'json',
+        debug: true,
+        webUrl: validWebUrl,
+        userName: validUserName
+      }
+    });
+
+    assert(loggerLogSpy.calledWith({
+      value: [userResponse]
+    }));
+  });
+
+  it('retrieves m365 group by entraGroupId for mail enabled group with output option json', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validEntraGroupId}`) {
+        return groupM365Response.value[0];
+      }
+
+      if (opts.url === `${validWebUrl}/_api/web/siteusers/GetByEmail('finance%40contoso.onmicrosoft.com')`) {
+        return {
+          "value": [{
+            "Id": 45,
+            "IsHiddenInUI": false,
+            "LoginName": "c:0o.c|federateddirectoryclaimprovider|2056d2f6-3257-4253-8cfc-b73393e414e5",
+            "Title": "Finance",
+            "PrincipalType": 4,
+            "Email": "finance@contoso.onmicrosoft.com",
+            "Expiration": "",
+            "IsEmailAuthenticationGuestUser": false,
+            "IsShareByEmailGuestUser": false,
+            "IsSiteAdmin": false,
+            "UserId": null,
+            "UserPrincipalName": null
+          }]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        output: 'json',
+        debug: true,
+        webUrl: validWebUrl,
+        entraGroupId: validEntraGroupId
+      }
+    });
+
+    assert(loggerLogSpy.calledWith({
+      value: [{
+        "Id": 45,
+        "IsHiddenInUI": false,
+        "LoginName": "c:0o.c|federateddirectoryclaimprovider|2056d2f6-3257-4253-8cfc-b73393e414e5",
+        "Title": "Finance",
+        "PrincipalType": 4,
+        "Email": "finance@contoso.onmicrosoft.com",
+        "Expiration": "",
+        "IsEmailAuthenticationGuestUser": false,
+        "IsShareByEmailGuestUser": false,
+        "IsSiteAdmin": false,
+        "UserId": null,
+        "UserPrincipalName": null
+      }]
+    }));
+  });
+
+  it('retrieves security group by entraGroupName with output option json', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${validEntraSecurityGroupName}'`) {
+        return groupSecurityResponse;
+      }
+
+      if (opts.url === `${validWebUrl}/_api/web/siteusers/GetByLoginName('c:0t.c|tenant|${validEntraGroupId}')`) {
+        return {
+          "value": [{
+            "Id": 31,
+            "IsHiddenInUI": false,
+            "LoginName": "c:0t.c|tenant|2056d2f6-3257-4253-8cfc-b73393e414e5",
+            "Title": "EntraGroupTest",
+            "PrincipalType": 4,
+            "Email": "",
+            "Expiration": "",
+            "IsEmailAuthenticationGuestUser": false,
+            "IsShareByEmailGuestUser": false,
+            "IsSiteAdmin": false,
+            "UserId": null,
+            "UserPrincipalName": null
+          }]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        output: 'json',
+        webUrl: validWebUrl,
+        entraGroupName: validEntraSecurityGroupName
+      }
+    } as any);
+
+    assert(loggerLogSpy.calledWith({
+      value: [{
+        "Id": 31,
+        "IsHiddenInUI": false,
+        "LoginName": "c:0t.c|tenant|2056d2f6-3257-4253-8cfc-b73393e414e5",
+        "Title": "EntraGroupTest",
+        "PrincipalType": 4,
+        "Email": "",
+        "Expiration": "",
+        "IsEmailAuthenticationGuestUser": false,
+        "IsShareByEmailGuestUser": false,
+        "IsSiteAdmin": false,
+        "UserId": null,
+        "UserPrincipalName": null
+      }]
+    }));
+  });
 
   it('retrieves current logged-in user', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
@@ -233,6 +468,7 @@ describe(commands.USER_GET, () => {
           }]
         };
       }
+
       throw 'Invalid request';
     });
 
@@ -241,6 +477,7 @@ describe(commands.USER_GET, () => {
         webUrl: 'https://contoso.sharepoint.com'
       }
     });
+
     assert(loggerLogSpy.calledWith({
       value: [{
         Id: 6,
@@ -257,6 +494,25 @@ describe(commands.USER_GET, () => {
         UserPrincipalName: "john.deo@mytenant.onmicrosoft.com"
       }]
     }));
+  });
+
+  it('handles generic error when user not found when username is passed', async () => {
+    const err = `User not found: ${validUserName}`;
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `${validWebUrl}/_api/web/siteusers?$filter=UserPrincipalName eq ('${formatting.encodeQueryParameter(validUserName)}')`) {
+        return { "value": [] };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        debug: true,
+        webUrl: validWebUrl,
+        userName: validUserName
+      }
+    }), new CommandError(err));
   });
 
   it('handles error correctly', async () => {
@@ -288,8 +544,27 @@ describe(commands.USER_GET, () => {
     assert.notStrictEqual(actual, true);
   });
 
+  it('fails validation if entraGroupId is not a valid id', async () => {
+    const actual = await command.validate({ options: { webUrl: validWebUrl, entraGroupId: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
 
-  it('fails validation if id, email and loginName options are passed (multiple options)', async () => {
+  it('fails validation if id is not a valid number', async () => {
+    const actual = await command.validate({ options: { webUrl: validWebUrl, id: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if userName is not a valid user principal name', async () => {
+    const actual = await command.validate({ options: { webUrl: validWebUrl, userName: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if email is not a valid user principal name', async () => {
+    const actual = await command.validate({ options: { webUrl: validWebUrl, email: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if id, email, loginName, userName, entraGroupId, and entraGroupName options are passed (multiple options)', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -298,71 +573,37 @@ describe(commands.USER_GET, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1, email: "jonh.deo@mytenant.com", loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if id and email both are passed (multiple options)', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1, email: "jonh.deo@mytenant.com" } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if id and loginName options are passed (multiple options)', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1, loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if email and loginName options are passed (multiple options)', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', email: "jonh.deo@mytenant.com", loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if specified id is not a number', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 'a' } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: validWebUrl, id: 1, email: validEmail, loginName: validLoginName, userName: validUserName, entraGroupId: validEntraGroupId, entraGroupName: validEntraGroupName } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
   it('passes validation url is valid and id is passed', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', id: 1 } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: validWebUrl, id: 1 } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation if the url is valid and email is passed', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', email: "jonh.deo@mytenant.com" } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: validWebUrl, email: validEmail } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
   it('passes validation if the url is valid and loginName is passed', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', loginName: "i:0#.f|membership|john.doe@mytenant.onmicrosoft.com" } }, commandInfo);
+    const actual = await command.validate({ options: { webUrl: validWebUrl, loginName: validLoginName } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation if the url is valid and no other options are provided', async () => {
-    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
+  it('passes validation if the url is valid and userName is passed', async () => {
+    const actual = await command.validate({ options: { webUrl: validWebUrl, userName: validUserName } }, commandInfo);
     assert.strictEqual(actual, true);
   });
-}); 
+
+  it('passes validation if the url is valid and entraGroupName is passed', async () => {
+    const actual = await command.validate({ options: { webUrl: validWebUrl, entraGroupName: validEntraGroupName } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('passes validation if the url is valid and entraGroupId is passed', async () => {
+    const actual = await command.validate({ options: { webUrl: validWebUrl, entraGroupId: validEntraGroupId } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+});

--- a/src/m365/spo/commands/user/user-get.ts
+++ b/src/m365/spo/commands/user/user-get.ts
@@ -1,10 +1,30 @@
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
+import { Group } from '@microsoft/microsoft-graph-types';
+import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
+
+interface SpoUser {
+  Id: number;
+  IsHiddenInUI: boolean;
+  Title: string;
+  PrincipalType: number;
+  Email: string;
+  Expiration: string;
+  IsEmailAuthenticationGuestUser: boolean;
+  IsShareByEmailGuestUser: boolean;
+  IsSiteAdmin: boolean;
+  UserId: {
+    NameId: string;
+    NameIdIssuer: string;
+    urn: string;
+  };
+  UserPrincipalName: string;
+}
 
 interface CommandArgs {
   options: Options;
@@ -12,9 +32,12 @@ interface CommandArgs {
 
 export interface Options extends GlobalOptions {
   webUrl: string;
+  id?: string;
   email?: string;
-  id?: number;
   loginName?: string;
+  userName?: string;
+  entraGroupId?: string;
+  entraGroupName?: string;
 }
 
 class SpoUserGetCommand extends SpoCommand {
@@ -40,7 +63,10 @@ class SpoUserGetCommand extends SpoCommand {
       Object.assign(this.telemetryProperties, {
         id: typeof args.options.id !== 'undefined',
         email: typeof args.options.email !== 'undefined',
-        loginName: typeof args.options.loginName !== 'undefined'
+        loginName: typeof args.options.loginName !== 'undefined',
+        userName: typeof args.options.userName !== 'undefined',
+        entraGroupId: typeof args.options.entraGroupId !== 'undefined',
+        entraGroupName: typeof args.options.entraGroupName !== 'undefined'
       });
     });
   }
@@ -58,6 +84,15 @@ class SpoUserGetCommand extends SpoCommand {
       },
       {
         option: '--loginName [loginName]'
+      },
+      {
+        option: '--userName [userName]'
+      },
+      {
+        option: '--entraGroupId [entraGroupId]'
+      },
+      {
+        option: '--entraGroupName [entraGroupName]'
       }
     );
   }
@@ -70,6 +105,18 @@ class SpoUserGetCommand extends SpoCommand {
           return `Specified id ${args.options.id} is not a number`;
         }
 
+        if (args.options.entraGroupId && !validation.isValidGuid(args.options.entraGroupId)) {
+          return `${args.options.entraId} is not a valid GUID.`;
+        }
+
+        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
+          return `${args.options.userName} is not a valid userName.`;
+        }
+
+        if (args.options.email && !validation.isValidUserPrincipalName(args.options.email)) {
+          return `${args.options.email} is not a valid email.`;
+        }
+
         return validation.isValidSharePointUrl(args.options.webUrl);
       }
     );
@@ -77,7 +124,7 @@ class SpoUserGetCommand extends SpoCommand {
 
   #initOptionSets(): void {
     this.optionSets.push({
-      options: ['id', 'email', 'loginName'],
+      options: ['id', 'email', 'loginName', 'userName', 'entraGroupId', 'entraGroupName'],
       runsWhen: (args) => args.options.id || args.options.loginName || args.options.email
     });
   }
@@ -97,6 +144,26 @@ class SpoUserGetCommand extends SpoCommand {
     }
     else if (args.options.loginName) {
       requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetByLoginName('${formatting.encodeQueryParameter(args.options.loginName)}')`;
+    }
+    else if (args.options.userName) {
+      const user = await this.getUser(args.options);
+
+      if (!user) {
+        throw `User not found: ${args.options.userName}`;
+      }
+
+      requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetById('${formatting.encodeQueryParameter(user.Id.toString())}')`;
+    }
+    else if (args.options.entraGroupId || args.options.entraGroupName) {
+      const entraGroup = await this.getEntraGroup(args.options);
+
+      // For entra groups, M365 groups have an associated email and security groups don't
+      if (entraGroup?.mail) {
+        requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetByEmail('${formatting.encodeQueryParameter(entraGroup.mail)}')`;
+      }
+      else {
+        requestUrl = `${args.options.webUrl}/_api/web/siteusers/GetByLoginName('c:0t.c|tenant|${entraGroup?.id}')`;
+      }
     }
     else {
       requestUrl = `${args.options.webUrl}/_api/web/currentuser`;
@@ -118,6 +185,26 @@ class SpoUserGetCommand extends SpoCommand {
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);
     }
+  }
+
+  private async getUser(options: GlobalOptions): Promise<any> {
+    const requestUrl: string = `${options.webUrl}/_api/web/siteusers?$filter=UserPrincipalName eq ('${formatting.encodeQueryParameter(options.userName)}')`;
+    const requestOptions: CliRequestOptions = {
+      url: requestUrl,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const userInstance = await request.get(requestOptions);
+    return (userInstance as {
+      value: SpoUser[];
+    }).value[0];
+  }
+
+  private async getEntraGroup(options: GlobalOptions): Promise<Group> {
+    return options.entraGroupId ? await entraGroup.getGroupById(options.entraGroupId) : await entraGroup.getGroupByDisplayName(options.entraGroupName);
   }
 }
 


### PR DESCRIPTION
Extends `spo user get` command with support for specifying more options including `userName`, `entraGroupId`, and `entraGroupName`. Closes #5516