### PR TITLE
m365 teams meeting list doesn't work when specifying --userName 

### DIFF
--- a/docs/docs/cmd/teams/meeting/meeting-list.mdx
+++ b/docs/docs/cmd/teams/meeting/meeting-list.mdx
@@ -25,16 +25,20 @@ m365 teams meeting list [options]
 : Set to retrieve only meetings the user is organizer for.
 
 `-u, --userId [userId]`
-: The id of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `id`, `userName` or `email`, but not multiple. Use only when using application permissions.
+: The id of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `userId`, `userName` or `email`, but not multiple. Use only when using application permissions.
 
 `-n, --userName [userName]`
-: The name of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `id`, `userName` or `email`, but not multiple. Use only when using application permissions.
+: The name of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `userId`, `userName` or `email`, but not multiple. Use only when using application permissions.
 
 `--email [email]`
-: The email of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `id`, `userName` or `email`, but not multiple. Use only when using application permissions.
+: The email of the user or shared mailbox, omit to retrieve meetings for current signed in user. Use either `userId`, `userName` or `email`, but not multiple. Use only when using application permissions.
 ```
 
 <Global />
+
+## Remarks
+
+To use application permission for this command, an [application access policy](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy) must be created and assigned to a user. This authorizes the app configured in the policy to retrieve online meetings on behalf of that user.
 
 ## Examples
 


### PR DESCRIPTION
Closes #5968

The command works correctly with both --userName and --userId after configuring the application access policy. Added a remark in the docs to instruct on the correct use of the command with application permission.