### PR TITLE
Extends `cli config` command with custom Entra app options. Closes #5995

### DIFF
--- a/docs/docs/_clisettings.mdx
+++ b/docs/docs/_clisettings.mdx
@@ -2,6 +2,8 @@ Setting name|Definition|Default value
 ------------|----------|-------------
 `authType`|Default login method to use when running `m365 login` without the `--authType` option.|`deviceCode`
 `autoOpenLinksInBrowser`|Automatically open the browser for all commands which return a url and expect the user to copy paste this to the browser. For example when logging in, using `m365 login` in device code mode.|`false`
+`cliEntraAppId`|Id of the custom Entra app to connect to the CLI
+`cliEntraAppTenant`|Tenant Id of the custom Entra app to connect to the CLI 
 `copyDeviceCodeToClipboard`|Automatically copy the device code to the clipboard when running `m365 login` command in device code mode|`false`
 `csvEscape`|Single character used for escaping; only apply to characters matching the quote and the escape options|`"`
 `csvHeader`|Display the column names on the first line|`true`

--- a/docs/docs/cmd/login.mdx
+++ b/docs/docs/cmd/login.mdx
@@ -37,10 +37,10 @@ m365 login [options]
 : Client Secret of the Microsoft Entra application to use for authentication. Required when `authType` is set to `secret`.
 
 `--appId [appId]`
-: App ID of the Microsoft Entra application to use for authentication. If not specified, use the app specified in the `CLIMICROSOFT365_ENTRAAPPID` environment variable. If the environment variable is not defined, use the multitenant PnP Management Shell app
+: App ID of the Microsoft Entra application to use for authentication. If not specified, use the app specified in the `cliEntraAppId` configuration setting. If both not specified, use the app specified in the `CLIMICROSOFT365_ENTRAAPPID` environment variable. If the environment variable is not defined, use the multitenant PnP Management Shell app
 
 `--tenant [tenant]`
-: ID of the tenant from which accounts should be able to authenticate. Use `common` or `organization` if the app is multitenant. If not specified, use the tenant specified in the `CLIMICROSOFT365_TENANT` environment variable. If the environment variable is not defined, use `common` as the tenant identifier
+: ID of the tenant from which accounts should be able to authenticate. Use `common` or `organization` if the app is multitenant. If not specified, use the app specified in the `cliEntraAppTenant` configuration setting. If both not specified, use the tenant specified in the `CLIMICROSOFT365_TENANT` environment variable. If the environment variable is not defined, use `common` as the tenant identifier
 
 `--cloud [cloud]`
 : Cloud to connect to. Allowed values `Public`, `USGov`, `USGovHigh`, `USGovDoD` and `China`. Default `Public`
@@ -61,7 +61,7 @@ When logging in to Microsoft 365 using the user name and password, next to the a
 
 When logging in to Microsoft 365 using a certificate, the CLI for Microsoft 365 will store the contents of the certificate so that it can automatically re-authenticate if necessary. The contents of the certificate are removed by re-authenticating using the device code or by calling the [logout](logout.mdx) command.  
 
-To log in to Microsoft 365 using a certificate or secret, you will typically [create a custom Microsoft Entra application](../user-guide/using-own-identity.mdx). To use this application with the CLI for Microsoft 365, you will set the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the application's ID and the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Microsoft Entra tenant, where you created the Microsoft Entra application. Also, please make sure to read about [the caveats when using the certificate login option](../user-guide/cli-certificate-caveats.mdx).
+To log in to Microsoft 365 using a certificate or secret, you will typically [create a custom Microsoft Entra application](../user-guide/using-own-identity.mdx). To use this application with the CLI for Microsoft 365, you will set the `cliEntraAppId` configuration setting or the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the application's ID and the `cliEntraAppTenant` configuration setting or the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Microsoft Entra tenant, where you created the Microsoft Entra application. Also, please make sure to read about [the caveats when using the certificate login option](../user-guide/cli-certificate-caveats.mdx).
 
 Managed identity in Azure Cloud Shell is the identity of the user. It is neither system- nor user-assigned and it can't be configured. To log in to Microsoft 365 using managed identity in Azure Cloud Shell, set `authType` to `identity` and don't specify the `userName` option.
 

--- a/docs/docs/concepts/authorization-tokens.mdx
+++ b/docs/docs/concepts/authorization-tokens.mdx
@@ -24,7 +24,7 @@ When you decide to use your own Microsoft Entra application, you need to choose 
 
 :::
 
-When specifying a custom Microsoft Entra application to be used by the CLI for Microsoft 365, set the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the ID of your Microsoft Entra application.
+When specifying a custom Microsoft Entra application to be used by the CLI for Microsoft 365, set the `cliEntraAppId` configuration setting or the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the ID of your Microsoft Entra application.
 
 CLI for Microsoft 365 requires the following permissions to Microsoft 365 services:
 

--- a/docs/docs/user-guide/connecting-microsoft-365.mdx
+++ b/docs/docs/user-guide/connecting-microsoft-365.mdx
@@ -54,7 +54,7 @@ Generally, you should use the default device code flow. If you need to use a non
 
 #### Log in using a certificate
 
-Another way to log in to Microsoft 365 in the CLI for Microsoft 365 is by using a certificate. To use this authentication method, set the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the ID of the Microsoft Entra application that you want to use to authenticate the CLI for Microsoft 365 and the `CLIMICROSOFT365_TENANT` environment variable to the ID of your Microsoft Entra ID directory. When calling the login command, set the `authType` option to `certificate` and specify the path to the certificate private key using the `certificateFile` option. Optionally, you can specify the certificate's thumbprint using the `thumbprint` option. If not specified, CLI will automatically calculate it from the specified certificate.
+Another way to log in to Microsoft 365 in the CLI for Microsoft 365 is by using a certificate. To use this authentication method, set the `cliEntraAppId` configuration setting or the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the ID of the Microsoft Entra application that you want to use to authenticate the CLI for Microsoft 365 and the `cliEntraAppTenant` configuration setting or the `CLIMICROSOFT365_TENANT` environment variable to the ID of your Microsoft Entra ID directory. When calling the login command, set the `authType` option to `certificate` and specify the path to the certificate private key using the `certificateFile` option. Optionally, you can specify the certificate's thumbprint using the `thumbprint` option. If not specified, CLI will automatically calculate it from the specified certificate.
 
 To log in to Microsoft 365 using a Personal Information Exchange (.pfx) file, execute:
 
@@ -118,7 +118,7 @@ At this point the `privateKeyWithPassphrase.pem` file can be used to log in the 
 
 #### Log in using a secret
 
-CLI for Microsoft 365 also supports login using a secret. To use this authentication method, set the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the ID of the Microsoft Entra application that you want to use to authenticate the CLI for Microsoft 365 and the `CLIMICROSOFT365_TENANT` environment variable to the ID of your Microsoft Entra ID directory. When calling the login command, set the `authType` option to `secret` and specify the client secret value. 
+CLI for Microsoft 365 also supports login using a secret. To use this authentication method, set the `cliEntraAppId` configuration setting or the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the ID of the Microsoft Entra application that you want to use to authenticate the CLI for Microsoft 365 and the `cliEntraAppTenant` configuration setting or the `CLIMICROSOFT365_TENANT` environment variable to the ID of your Microsoft Entra ID directory. When calling the login command, set the `authType` option to `secret` and specify the client secret value. 
 
 To log in to Microsoft 365 using a secret, execute:
 

--- a/docs/docs/user-guide/using-own-identity.mdx
+++ b/docs/docs/user-guide/using-own-identity.mdx
@@ -107,7 +107,22 @@ This completes the configuration required in the Azure portal. We can now move o
 
 To configure the CLI for Microsoft 365 to use our newly created custom application, we need to tell it the Client ID of our custom application and the Tenant ID of where the custom application has been created.
 
-To do that, we need to create two environment variables, named `CLIMICROSOFT365_ENTRAAPPID` and `CLIMICROSOFT365_TENANT`, giving them the values that you saved earlier.
+To do that, we can use one of two methods:
+1. we can set two configuration settings, named `cliEntraAppId` and `cliEntraAppTenant`, giving them the values that you saved earlier.
+2. we can create two environment variables, named `CLIMICROSOFT365_ENTRAAPPID` and `CLIMICROSOFT365_TENANT`, giving them the values that you saved earlier.
+
+How you set the configuration settings.
+
+```powershell
+m365 cli config set --key cliEntraAppId  --value 506af689-32aa-46c8-afb5-972ebf9d218a   
+m365 cli config set --key cliEntraAppTenant  --value e8954f17-a373-4b61-b54d-45c038fe3188
+```
+
+:::tip
+
+Execute `m365 cli config list` to verify that the configuration settings have been created correctly
+
+:::
 
 How you set the environment variables depends on the operating system and shell that you are using.
 

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -97,8 +97,8 @@ export class Connection {
     this.thumbprint = undefined;
     this.spoUrl = undefined;
     this.spoTenantId = undefined;
-    this.appId = config.cliEntraAppId;
-    this.tenant = config.tenant;
+    this.appId = cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppId, config.cliEntraAppId);
+    this.tenant = cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppTenant, config.tenant);
   }
 }
 
@@ -328,11 +328,11 @@ export class Auth {
     }
 
     const config = {
-      clientId: this.connection.appId,
-      authority: `${Auth.getEndpointForResource('https://login.microsoftonline.com', this.connection.cloudType)}/${this.connection.tenant}`,
+      clientId: cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppId, this.connection.appId),
+      authority: `${Auth.getEndpointForResource('https://login.microsoftonline.com', this.connection.cloudType)}/${cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppTenant, this.connection.tenant)}`,
       azureCloudOptions: {
         azureCloudInstance,
-        tenant: this.connection.tenant
+        tenant: cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppTenant, this.connection.tenant)
       }
     };
 
@@ -894,8 +894,8 @@ export class Auth {
       connectionName: connection.name,
       connectedAs: connection.identityName,
       authType: AuthType[connection.authType],
-      appId: connection.appId,
-      appTenant: connection.tenant,
+      appId: cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppId, this.connection.appId),
+      appTenant: cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppTenant, this.connection.tenant),
       cloudType: CloudType[connection.cloudType]
     };
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -60,7 +60,7 @@ function getConfig(): Configstore {
 }
 
 function getSettingWithDefaultValue<TValue>(settingName: string, defaultValue: TValue): TValue {
-  const configuredValue: TValue | undefined = cli.getConfig().get(settingName);
+  const configuredValue: TValue | undefined =  cli.getConfig().get(settingName);
   if (typeof configuredValue === 'undefined') {
     return defaultValue;
   }

--- a/src/m365/cli/commands/cli-consent.ts
+++ b/src/m365/cli/commands/cli-consent.ts
@@ -1,6 +1,8 @@
+import { cli } from '../../../cli/cli.js';
 import { Logger } from '../../../cli/Logger.js';
 import config from '../../../config.js';
 import GlobalOptions from '../../../GlobalOptions.js';
+import { settingsNames } from '../../../settingsNames.js';
 import AnonymousCommand from '../../base/AnonymousCommand.js';
 import commands from '../commands.js';
 
@@ -68,7 +70,10 @@ class CliConsentCommand extends AnonymousCommand {
         break;
     }
 
-    await logger.log(`To consent permissions for executing ${args.options.service} commands, navigate in your web browser to https://login.microsoftonline.com/${config.tenant}/oauth2/v2.0/authorize?client_id=${config.cliEntraAppId}&response_type=code&scope=${encodeURIComponent(scope)}`);
+    const cliEntraAppId = cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppId, config.cliEntraAppId);
+    const tenant = cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppTenant, config.tenant);
+
+    await logger.log(`To consent permissions for executing ${args.options.service} commands, navigate in your web browser to https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize?client_id=${cliEntraAppId}&response_type=code&scope=${encodeURIComponent(scope)}`);
   }
 
   public async action(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/cli/commands/cli-reconsent.spec.ts
+++ b/src/m365/cli/commands/cli-reconsent.spec.ts
@@ -37,7 +37,18 @@ describe(commands.RECONSENT, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((() => false));
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(opts => {
+      if (opts === 'cliEntraAppId') {
+        return '31359c7f-bd7e-475c-86db-fdb8c937548e';
+      }
+
+      if (opts === 'cliEntraAppTenant') {
+        return 'common';
+      }
+
+      return false;
+    });
+
     openStub = sinon.stub(browserUtil, 'open').callsFake(async () => { return; });
   });
 
@@ -66,7 +77,17 @@ describe(commands.RECONSENT, () => {
 
   it('shows message with url (using autoOpenLinksInBrowser)', async () => {
     getSettingWithDefaultValueStub.restore();
-    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((() => true));
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(opts => {
+      if (opts === 'cliEntraAppId') {
+        return '31359c7f-bd7e-475c-86db-fdb8c937548e';
+      }
+
+      if (opts === 'cliEntraAppTenant') {
+        return 'common';
+      }
+
+      return true;
+    });
 
     openStub.restore();
     openStub = sinon.stub(browserUtil, 'open').callsFake(async (url) => {
@@ -82,7 +103,17 @@ describe(commands.RECONSENT, () => {
 
   it('throws error when open in browser fails', async () => {
     getSettingWithDefaultValueStub.restore();
-    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((() => true));
+    getSettingWithDefaultValueStub = sinon.stub(cli, 'getSettingWithDefaultValue').callsFake(opts => {
+      if (opts === 'cliEntraAppId') {
+        return '31359c7f-bd7e-475c-86db-fdb8c937548e';
+      }
+
+      if (opts === 'cliEntraAppTenant') {
+        return 'common';
+      }
+
+      return true;
+    });
 
     openStub.restore();
     openStub = sinon.stub(browserUtil, 'open').callsFake(async (url) => {

--- a/src/m365/cli/commands/cli-reconsent.ts
+++ b/src/m365/cli/commands/cli-reconsent.ts
@@ -17,7 +17,10 @@ class CliReconsentCommand extends AnonymousCommand {
   }
 
   public async commandAction(logger: Logger): Promise<void> {
-    const url = `https://login.microsoftonline.com/${config.tenant}/oauth2/authorize?client_id=${config.cliEntraAppId}&response_type=code&prompt=admin_consent`;
+    const cliEntraAppId = cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppId, config.cliEntraAppId);
+    const tenant = cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppTenant, config.tenant);
+
+    const url = `https://login.microsoftonline.com/${tenant}/oauth2/authorize?client_id=${cliEntraAppId}&response_type=code&prompt=admin_consent`;
 
     if (cli.getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) === false) {
       await logger.log(`To re-consent the PnP Microsoft 365 Management Shell Microsoft Entra application navigate in your web browser to ${url}`);

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -163,8 +163,8 @@ class LoginCommand extends Command {
       }
 
       const authType = args.options.authType || cli.getSettingWithDefaultValue<string>(settingsNames.authType, 'deviceCode');
-      auth.connection.appId = args.options.appId || config.cliEntraAppId;
-      auth.connection.tenant = args.options.tenant || config.tenant;
+      auth.connection.appId = args.options.appId || cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppId, config.cliEntraAppId);
+      auth.connection.tenant = args.options.tenant || cli.getSettingWithDefaultValue<string>(settingsNames.cliEntraAppTenant, config.tenant);
       auth.connection.name = args.options.connectionName;
 
       switch (authType) {

--- a/src/settingsNames.ts
+++ b/src/settingsNames.ts
@@ -1,6 +1,8 @@
 const settingsNames = {
   authType: 'authType',
   autoOpenLinksInBrowser: 'autoOpenLinksInBrowser',
+  cliEntraAppId: 'cliEntraAppId',
+  cliEntraAppTenant: 'cliEntraAppTenant',
   copyDeviceCodeToClipboard: 'copyDeviceCodeToClipboard',
   csvEscape: 'csvEscape',
   csvHeader: 'csvHeader',


### PR DESCRIPTION
Closes #5995

In this PR, I have included changes to extend the current config settings with two new options.

More info is available in the discussions of these two items #5995 and #5985.
https://github.com/pnp/cli-microsoft365/pull/5985#issuecomment-2071660832

I hope that I have covered all necessary changes in the documentation.