### PR TITLE
Makes option names of "app permission add" plural. Closes #5719

### DIFF
--- a/docs/docs/cmd/app/permission/permission-add.mdx
+++ b/docs/docs/cmd/app/permission/permission-add.mdx
@@ -16,10 +16,10 @@ m365 app permission add [options]
 `--appId [appId]`
 : Client ID of the Microsoft Entra app registered in the .m365rc.json file to retrieve API permissions for.
 
-`--applicationPermission [applicationPermission]`
+`--applicationPermissions [applicationPermissions]`
 : Space-separated list of application permissions to add.
 
-`--delegatedPermission [delegatedPermission]`
+`--delegatedPermissions [delegatedPermissions]`
 : Space-separated list of delegated permissions to add.
 
 `--grantAdminConsent`
@@ -37,19 +37,19 @@ If you have multiple apps registered in your .m365rc.json file, you can specify 
 Adds the specified application permissions to the default app registered in the _.m365rc.json_ file while granting admin consent.
 
 ```sh
-m365 app permission add --applicationPermission 'https://graph.microsoft.com/User.ReadWrite.All https://graph.microsoft.com/User.Read.All' --grantAdminConsent
+m365 app permission add --applicationPermissions 'https://graph.microsoft.com/User.ReadWrite.All https://graph.microsoft.com/User.Read.All' --grantAdminConsent
 ```
 
 Adds the specified delegated permissions to the default app registered in the _.m365rc.json_ file without granting admin consent.
 
 ```sh
-m365 app permission add --delegatedPermission 'https://graph.microsoft.com/offline_access'
+m365 app permission add --delegatedPermissions 'https://graph.microsoft.com/offline_access'
 ```
 
 Adds the specified application and delegated permissions to a specific app registered in the _.m365rc.json_ file while granting admin consent.
 
 ```sh
-m365 app permission add --appId '1663767b-4172-4519-bfd1-28e6ff19055b' --applicationPermission 'https://graph.microsoft.com/User.ReadWrite.All https://graph.microsoft.com/User.Read.All' --delegatedPermission 'https://graph.microsoft.com/offline_access' --grantAdminConsent
+m365 app permission add --appId '1663767b-4172-4519-bfd1-28e6ff19055b' --applicationPermissions 'https://graph.microsoft.com/User.ReadWrite.All https://graph.microsoft.com/User.Read.All' --delegatedPermissions 'https://graph.microsoft.com/offline_access' --grantAdminConsent
 ```
 
 ## Response

--- a/src/m365/app/commands/permission/permission-add.spec.ts
+++ b/src/m365/app/commands/permission/permission-add.spec.ts
@@ -112,7 +112,7 @@ describe(commands.PERMISSION_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { applicationPermission: applicationPermissions, verbose: true } });
+    await command.action(logger, { options: { applicationPermissions: applicationPermissions, verbose: true } });
     assert(patchStub.called);
   });
 
@@ -144,7 +144,7 @@ describe(commands.PERMISSION_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { applicationPermission: applicationPermissions, grantAdminConsent: true, verbose: true } });
+    await command.action(logger, { options: { applicationPermissions: applicationPermissions, grantAdminConsent: true, verbose: true } });
     assert.strictEqual(amountOfPostCalls, 2);
   });
 
@@ -167,7 +167,7 @@ describe(commands.PERMISSION_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { delegatedPermission: delegatedPermissions, verbose: true } });
+    await command.action(logger, { options: { delegatedPermissions: delegatedPermissions, verbose: true } });
     assert(patchStub.called);
   });
 
@@ -200,7 +200,7 @@ describe(commands.PERMISSION_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { delegatedPermission: delegatedPermissions, grantAdminConsent: true, verbose: true } });
+    await command.action(logger, { options: { delegatedPermissions: delegatedPermissions, grantAdminConsent: true, verbose: true } });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, {
       clientId: servicePrincipalId,
       consentType: 'AllPrincipals',
@@ -244,7 +244,7 @@ describe(commands.PERMISSION_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { delegatedPermission: delegatedPermissions, applicationPermission: applicationPermissions, grantAdminConsent: true, verbose: true } });
+    await command.action(logger, { options: { delegatedPermissions: delegatedPermissions, applicationPermissions: applicationPermissions, grantAdminConsent: true, verbose: true } });
     assert.strictEqual(amountOfPostCalls, 3);
   });
 
@@ -260,7 +260,7 @@ describe(commands.PERMISSION_ADD, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { applicationPermission: applicationPermissions, verbose: true } }),
+    await assert.rejects(command.action(logger, { options: { applicationPermissions: applicationPermissions, verbose: true } }),
       new CommandError(`App with id ${appId} not found in Microsoft Entra ID.`));
   });
 
@@ -279,7 +279,7 @@ describe(commands.PERMISSION_ADD, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { applicationPermission: api, verbose: true } }),
+    await assert.rejects(command.action(logger, { options: { applicationPermissions: api, verbose: true } }),
       new CommandError(`Service principal ${servicePrincipalName} not found`));
   });
 
@@ -299,26 +299,26 @@ describe(commands.PERMISSION_ADD, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { applicationPermission: api, verbose: true } }),
+    await assert.rejects(command.action(logger, { options: { applicationPermissions: api, verbose: true } }),
       new CommandError(`Permission ${permissionName} for service principal ${servicePrincipalName} not found`));
   });
 
-  it('passes validation if applicationPermission is passed', async () => {
-    const actual = await command.validate({ options: { applicationPermission: applicationPermissions } }, commandInfo);
+  it('passes validation if applicationPermissions is passed', async () => {
+    const actual = await command.validate({ options: { applicationPermissions: applicationPermissions } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation if delegatedPermission is passed', async () => {
-    const actual = await command.validate({ options: { delegatedPermission: delegatedPermissions } }, commandInfo);
+  it('passes validation if delegatedPermissions is passed', async () => {
+    const actual = await command.validate({ options: { delegatedPermissions: delegatedPermissions } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation if both applicationPermission or delegatedPermission are passed', async () => {
-    const actual = await command.validate({ options: { applicationPermission: applicationPermissions, delegatedPermission: delegatedPermissions } }, commandInfo);
+  it('passes validation if both applicationPermissions or delegatedPermissions are passed', async () => {
+    const actual = await command.validate({ options: { applicationPermissions: applicationPermissions, delegatedPermissions: delegatedPermissions } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation if both applicationPermission or delegatedPermission is not passed', async () => {
+  it('fails validation if both applicationPermissions or delegatedPermissions is not passed', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;

--- a/src/m365/app/commands/permission/permission-add.ts
+++ b/src/m365/app/commands/permission/permission-add.ts
@@ -13,8 +13,8 @@ interface CommandArgs {
 
 interface Options extends GlobalOptions {
   appId?: string;
-  applicationPermission?: string;
-  delegatedPermission?: string;
+  applicationPermissions?: string;
+  delegatedPermissions?: string;
   grantAdminConsent?: boolean;
 }
 
@@ -50,8 +50,8 @@ class AppPermissionAddCommand extends AppCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         appId: typeof args.options.appId !== 'undefined',
-        applicationPermission: typeof args.options.applicationPermission !== 'undefined',
-        delegatedPermission: typeof args.options.delegatedPermission !== 'undefined',
+        applicationPermissions: typeof args.options.applicationPermissions !== 'undefined',
+        delegatedPermissions: typeof args.options.delegatedPermissions !== 'undefined',
         grantAdminConsent: !!args.options.grantAdminConsent
       });
     });
@@ -60,16 +60,16 @@ class AppPermissionAddCommand extends AppCommand {
   #initOptions(): void {
     this.options.unshift(
       { option: '--appId [appId]' },
-      { option: '--applicationPermission [applicationPermission]' },
-      { option: '--delegatedPermission [delegatedPermission]' },
+      { option: '--applicationPermissions [applicationPermissions]' },
+      { option: '--delegatedPermissions [delegatedPermissions]' },
       { option: '--grantAdminConsent' }
     );
   }
 
   #initOptionSets(): void {
     this.optionSets.push({
-      options: ['applicationPermission', 'delegatedPermission'],
-      runsWhen: (args) => args.options.delegatedPermission === undefined && args.options.applicationPermission === undefined
+      options: ['applicationPermissions', 'delegatedPermissions'],
+      runsWhen: (args) => args.options.delegatedPermissions === undefined && args.options.applicationPermissions === undefined
     });
   }
 
@@ -79,13 +79,13 @@ class AppPermissionAddCommand extends AppCommand {
       const servicePrincipals = await odata.getAllItems<ServicePrincipal>(`${this.resource}/v1.0/myorganization/servicePrincipals?$select=appId,appRoles,id,oauth2PermissionScopes,servicePrincipalNames`);
       const appPermissions: AppPermission[] = [];
 
-      if (args.options.delegatedPermission) {
-        const delegatedPermissions = await this.getRequiredResourceAccessForApis(servicePrincipals, args.options.delegatedPermission, ScopeType.Scope, appPermissions, logger);
+      if (args.options.delegatedPermissions) {
+        const delegatedPermissions = await this.getRequiredResourceAccessForApis(servicePrincipals, args.options.delegatedPermissions, ScopeType.Scope, appPermissions, logger);
         this.addPermissionsToResourceArray(delegatedPermissions, appObject.requiredResourceAccess!);
       }
 
-      if (args.options.applicationPermission) {
-        const applicationPermissions = await this.getRequiredResourceAccessForApis(servicePrincipals, args.options.applicationPermission, ScopeType.Role, appPermissions, logger);
+      if (args.options.applicationPermissions) {
+        const applicationPermissions = await this.getRequiredResourceAccessForApis(servicePrincipals, args.options.applicationPermissions, ScopeType.Role, appPermissions, logger);
         this.addPermissionsToResourceArray(applicationPermissions, appObject.requiredResourceAccess!);
       }
 


### PR DESCRIPTION
Makes option names of "app permission add" in plural form. Closes #5719
The options `applicationPermission` and `delegatedPermission` are renamed to `applicationPermissions` and `delegatedPermissions`.
