### PR TITLE
Removes aad aliases. Closes #5676

### DIFF
--- a/.github/workflows/release_v9.yml
+++ b/.github/workflows/release_v9.yml
@@ -1,0 +1,201 @@
+name: Release v9
+
+on:
+  push:
+    branches: [v9]
+
+jobs:
+  build:
+    if: github.repository_owner == 'pnp'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        node: [20]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            **/node_modules
+          key: node_modules-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
+      - name: Restore dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Compress output (non-Windows)
+        if: matrix.os != 'windows-latest'
+        run: tar -cvf build.tar --exclude node_modules ./
+      - name: Compress output (Windows)
+        if: matrix.os == 'windows-latest'
+        run: 7z a -ttar -xr!node_modules -r build.tar .
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.os }}-${{ matrix.node }}
+          path: build.tar
+  test:
+    if: github.repository_owner == 'pnp'
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        # node versions to run tests on
+        nodeRun: [20]
+        # node version on which code was built and should be tested
+        nodeBuild: [20]
+        include:
+          - os: ubuntu-latest
+            nodeRun: 18
+            nodeBuild: 20
+
+    steps:
+      - name: Configure pagefile
+        if: matrix.os == 'windows-latest'
+        uses: al-cheb/configure-pagefile-action@v1.4
+        with:
+          minimum-size: 16GB
+          disk-root: "C:"
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.os }}-${{ matrix.nodeBuild }}
+      - name: Unpack build artifact (non-Windows)
+        if: matrix.os != 'windows-latest'
+        run: tar -xvf build.tar && rm build.tar
+      - name: Unpack build artifact (Windows)
+        if: matrix.os == 'windows-latest'
+        run: 7z x build.tar && del build.tar
+      - name: Use Node.js ${{ matrix.nodeRun }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.nodeRun }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            **/node_modules
+          key: node_modules-${{ matrix.os }}-${{ matrix.nodeBuild }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
+      - name: Restore dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Test with coverage
+        # we run coverage only on Node that was used to build
+        if: matrix.nodeRun == matrix.nodeBuild
+        run: npm test
+      - name: Test without coverage
+        # we want to run tests on older Node versions to ensure that code works
+        if: matrix.nodeRun != matrix.nodeBuild
+        run: npm run test:test
+      - name: Compress output (non-Windows)
+        if: matrix.nodeRun == matrix.nodeBuild && matrix.os != 'windows-latest'  && always()
+        run: tar -cvf coverage.tar coverage
+      - name: Compress output (Windows)
+        if: matrix.nodeRun == matrix.nodeBuild && matrix.os == 'windows-latest' && always()
+        run: 7z a -ttar -r coverage.tar coverage
+      - uses: actions/upload-artifact@v4
+        if: matrix.nodeRun == matrix.nodeBuild && always()
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.nodeRun }}
+          path: coverage.tar
+  
+  publish_v9:
+    if: github.repository_owner == 'pnp'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-ubuntu-latest-20
+      - name: Unpack build artifact
+        run: tar -xvf build.tar && rm build.tar
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            **/node_modules
+          key: node_modules-ubuntu-latest-20-${{ hashFiles('**/npm-shrinkwrap.json') }}
+      - name: Restore dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Stamp beta to package version
+        run: node scripts/update-package-version.js $GITHUB_SHA
+      - name: Publish @nine
+        run: npm publish --tag nine --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - name: Compress output
+        run: tar -cvf build.tar --exclude node_modules ./
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-ubuntu-latest-20
+          path: build.tar
+          overwrite: true
+
+  deploy_docker:
+    if: github.repository_owner == 'pnp'
+    needs: publish_v9
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-ubuntu-latest-20
+      - name: Unpack build artifact
+        run: tar -xvf build.tar && rm build.tar
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract version from package
+        id: package_version
+        run: |
+          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - name: Wait for npm publish
+        run: node scripts/wait-npm-publish.js nine ${{ steps.package_version.outputs.version }}
+      - name: Build and push ${{ steps.package_version.outputs.version }}
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: m365pnp/cli-microsoft365:${{ steps.package_version.outputs.version }}
+          build-args: |
+            CLI_VERSION=${{ steps.package_version.outputs.version }}
+      - name: Build and push nine
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: m365pnp/cli-microsoft365:nine
+          build-args: |
+            CLI_VERSION=${{ steps.package_version.outputs.version }}

--- a/docs/docs/cmd/spo/group/group-member-add.mdx
+++ b/docs/docs/cmd/spo/group/group-member-add.mdx
@@ -25,32 +25,26 @@ m365 spo group member add [options]
 : Name of the SharePoint Group to which the user needs to be added. Specify either `groupId` or `groupName`.
 
 `--userNames [userNames]`
-: User's UPN (user principal name, eg. megan.bowen@contoso.com). If multiple users need to be added, they have to be comma-separated (e.g. megan.bowen@contoso.com,alex.wilber@contoso.com). Specify either `userIds`, `userNames`, `emails`, `aadGroupIds` or `aadGroupNames`.
+: User's UPN (user principal name, eg. megan.bowen@contoso.com). If multiple users need to be added, they have to be comma-separated (e.g. megan.bowen@contoso.com,alex.wilber@contoso.com). Specify either `userIds`, `userNames`, `emails`, `entraGroupIds` or `entraGroupNames`.
 
 `--emails [emails]`
-: User's email (eg. megan.bowen@contoso.com). If multiple users need to be added, they have to be comma-separated (e.g. megan.bowen@contoso.com,alex.wilber@contoso.com). Specify either `userIds`, `userNames`, `emails`, `aadGroupIds` or `aadGroupNames`.
+: User's email (eg. megan.bowen@contoso.com). If multiple users need to be added, they have to be comma-separated (e.g. megan.bowen@contoso.com,alex.wilber@contoso.com). Specify either `userIds`, `userNames`, `emails`, `entraGroupIds` or `entraGroupNames`.
 
 `--userIds [userIds]`
-: The user Id of the user to add as a member. (Id of the site user, for example: 14) If multiple users need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds` or `aadGroupNames`.
+: The user Id of the user to add as a member. (Id of the site user, for example: 14) If multiple users need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `entraGroupIds` or `entraGroupNames`.
 
 `--entraGroupIds [entraGroupIds]`
-: The object Id of the Entra group to add as a member. If multiple groups need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames`.
-
-`--aadGroupIds [aadGroupIds]`
-: (deprecated. Use `entraGroupIds` instead) The object ID of the Microsoft Entra group to add as a member. If multiple groups need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames`.
+: The object Id of the Entra group to add as a member. If multiple groups need to be added, the Ids have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `entraGroupIds`, or `entraGroupNames`.
 
 `--entraGroupNames [entraGroupNames]`
-: The name of the Entra group to add as a member. If multiple groups need to be added, they have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames`.
-
-`--aadGroupNames [aadGroupNames]`
-: (deprecated. Use `entraGroupNames` instead) The name of the Microsoft Entra group to add as a member. If multiple groups need to be added, they have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames`.
+: The name of the Entra group to add as a member. If multiple groups need to be added, they have to be comma-separated. Specify either `userIds`, `userNames`, `emails`, `entraGroupIds`, or `entraGroupNames`.
 ```
 
 <Global />
 
 ## Remarks
 
-For the `userIds`, `userNames`, `emails`, `aadGroupIds`, `entraGroupIds`, `aadGroupNames`, or `entraGroupNames` options you can specify multiple values by separating them with a comma. If one of the specified entries is not valid, the command will fail with an error message showing the list of invalid values.
+For the `userIds`, `userNames`, `emails`, `entraGroupIds`, or `entraGroupNames` options you can specify multiple values by separating them with a comma. If one of the specified entries is not valid, the command will fail with an error message showing the list of invalid values.
 
 ## Examples
 

--- a/docs/docs/cmd/spo/group/group-member-remove.mdx
+++ b/docs/docs/cmd/spo/group/group-member-remove.mdx
@@ -23,25 +23,19 @@ m365 spo group member remove [options]
 : Name of the SharePoint group from which user has to be removed. Specify either `groupName` or `groupId`, but not both.
 
 `--userName [userName]`
-: The UPN (user principal name, eg. megan.bowen@contoso.com) of the user that needs to be removed. Specify either `userName`, `email`, `userId`, `aadGroupId` or `aadGroupName`.
+: The UPN (user principal name, eg. megan.bowen@contoso.com) of the user that needs to be removed. Specify either `userName`, `email`, `userId`, `entraGroupId` or `entraGroupName`.
 
 `--email [email]`
-: The email of the user to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId` or `aadGroupName`.
+: The email of the user to remove as a member. Specify either `userName`, `email`, `userId`, `entraGroupId` or `entraGroupName`.
 
 `--userId [userId]`
-: The user Id (Id of the site user, eg. 14) of the user to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId` or `aadGroupName`.
+: The user Id (Id of the site user, eg. 14) of the user to remove as a member. Specify either `userName`, `email`, `userId`, `entraGroupId` or `entraGroupName`.
 
 `--entraGroupId [entraGroupId]`
-: The object Id of the Entra group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId`, `entraGroupId`, `aadGroupName`, or `entraGroupName`.
-
-`--aadGroupId [aadGroupId]`
-: (deprecated. Use `entraGroupId` instead) The object ID of the Microsoft Entra group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId`, `entraGroupId`, `aadGroupName`, or `entraGroupName`.
+: The object Id of the Entra group to remove as a member. Specify either `userName`, `email`, `userId`, `entraGroupId`, or `entraGroupName`.
 
 `--entraGroupName [entraGroupName]`
-: The name of the Entra group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId`, `entraGroupId`, `aadGroupName`, or `entraGroupName`.
-
-`--aadGroupName [aadGroupName]`
-: (deprecated. Use `entraGroupName` instead) The name of the Microsoft Entra group to remove as a member. Specify either `userName`, `email`, `userId`, `aadGroupId`, `entraGroupId`, `aadGroupName`, or `entraGroupName`.
+: The name of the Entra group to remove as a member. Specify either `userName`, `email`, `userId`, `entraGroupId`, or `entraGroupName`.
 ```
 
 <Global />

--- a/docs/docs/cmd/spo/user/user-ensure.mdx
+++ b/docs/docs/cmd/spo/user/user-ensure.mdx
@@ -19,13 +19,10 @@ m365 spo user ensure [options]
 : Absolute URL of the site.
 
 `--entraId [--entraId]`
-: Id of the user in Entra. Specify either `aadId`, `entraId`, or `userName`.
-
-`--aadId [--aadId]`
-: (deprecated. Use `entraId` instead) Id of the user in Microsoft Entra. Specify either `aadId`, `entraId`, or `userName`.
+: Id of the user in Entra. Specify either `entraId` or `userName`.
 
 `--userName [userName]`
-: User's UPN (user principal name, e.g. john@contoso.com). Specify either `aadId`, `entraId`, or `userName`.
+: User's UPN (user principal name, e.g. john@contoso.com). Specify either `entraId` or `userName`.
 ```
 
 <Global />

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -49,9 +49,6 @@ const config: Config = {
       'client-redirects',
       {
         createRedirects(routePath) {
-          if (routePath.includes('/entra')) {
-            return [routePath.replace('/entra', '/aad')];
-          }
           if (routePath.includes('/viva/engage')) {
             return [routePath.replace('/viva/engage', '/yammer')];
           }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@pnp/cli-microsoft365",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pnp/cli-microsoft365",
-      "version": "8.1.0",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "^14.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/cli-microsoft365",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Manage Microsoft 365 and SharePoint Framework projects on any platform",
   "license": "MIT",
   "main": "./dist/api.js",

--- a/src/m365/spo/commands/group/group-member-add.ts
+++ b/src/m365/spo/commands/group/group-member-add.ts
@@ -20,9 +20,7 @@ interface Options extends GlobalOptions {
   emails?: string;
   userIds?: string;
   entraGroupIds?: string;
-  aadGroupIds?: string;
   entraGroupNames?: string;
-  aadGroupNames?: string;
 }
 
 class SpoGroupMemberAddCommand extends SpoCommand {
@@ -57,9 +55,7 @@ class SpoGroupMemberAddCommand extends SpoCommand {
         emails: typeof args.options.emails !== 'undefined',
         userIds: typeof args.options.userIds !== 'undefined',
         entraGroupIds: typeof args.options.entraGroupIds !== 'undefined',
-        aadGroupIds: typeof args.options.aadGroupIds !== 'undefined',
-        entraGroupNames: typeof args.options.entraGroupNames !== 'undefined',
-        aadGroupNames: typeof args.options.aadGroupNames !== 'undefined'
+        entraGroupNames: typeof args.options.entraGroupNames !== 'undefined'
       });
     });
   }
@@ -88,13 +84,7 @@ class SpoGroupMemberAddCommand extends SpoCommand {
         option: '--entraGroupIds [entraGroupIds]'
       },
       {
-        option: '--aadGroupIds [aadGroupIds]'
-      },
-      {
         option: '--entraGroupNames [entraGroupNames]'
-      },
-      {
-        option: '--aadGroupNames [aadGroupNames]'
       }
     );
   }
@@ -139,13 +129,6 @@ class SpoGroupMemberAddCommand extends SpoCommand {
           }
         }
 
-        if (args.options.aadGroupIds) {
-          const isValidArray = validation.isValidGuidArray(args.options.aadGroupIds);
-          if (isValidArray !== true) {
-            return `Option 'aadGroupIds' contains one or more invalid GUIDs: ${isValidArray}.`;
-          }
-        }
-
         return true;
       }
     );
@@ -154,28 +137,16 @@ class SpoGroupMemberAddCommand extends SpoCommand {
   #initOptionSets(): void {
     this.optionSets.push(
       { options: ['groupId', 'groupName'] },
-      { options: ['userNames', 'emails', 'userIds', 'entraGroupIds', 'aadGroupIds', 'entraGroupNames', 'aadGroupNames'] }
+      { options: ['userNames', 'emails', 'userIds', 'entraGroupIds', 'entraGroupNames'] }
     );
   }
 
   #initTypes(): void {
-    this.types.string.push('webUrl', 'groupName', 'userNames', 'emails', 'userIds', 'entraGroupIds', 'aadGroupIds', 'entraGroupNames', 'aadGroupNames');
+    this.types.string.push('webUrl', 'groupName', 'userNames', 'emails', 'userIds', 'entraGroupIds', 'entraGroupNames');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      if (args.options.aadGroupIds) {
-        args.options.entraGroupIds = args.options.aadGroupIds;
-
-        await this.warn(logger, `Option 'aadGroupIds' is deprecated. Please use 'entraGroupIds' instead.`);
-      }
-
-      if (args.options.aadGroupNames) {
-        args.options.entraGroupNames = args.options.aadGroupNames;
-
-        await this.warn(logger, `Option 'aadGroupNames' is deprecated. Please use 'entraGroupNames' instead.`);
-      }
-
       const loginNames = await this.getLoginNames(logger, args.options);
 
       let apiUrl = `${args.options.webUrl}/_api/web/SiteGroups`;

--- a/src/m365/spo/commands/group/group-member-remove.spec.ts
+++ b/src/m365/spo/commands/group/group-member-remove.spec.ts
@@ -157,7 +157,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
         debug: true,
         webUrl: "https://contoso.sharepoint.com/sites/SiteA",
         groupName: "Site A Visitors",
-        aadGroupName: "Microsoft Entra Security Group"
+        entraGroupName: "Microsoft Entra Security Group"
       }
     });
 
@@ -217,7 +217,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
         debug: true,
         webUrl: "https://contoso.sharepoint.com/sites/SiteA",
         groupName: "Site A Visitors",
-        aadGroupId: "5786b8e8-c495-4734-b345-756733960730",
+        entraGroupId: "5786b8e8-c495-4734-b345-756733960730",
         force: true
       }
     });
@@ -706,17 +706,6 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
         webUrl: "https://contoso.sharepoint.com/sites/SiteA",
         groupId: 3,
         entraGroupId: 'Invalid GUID'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if aadGroupId is not a valid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: "https://contoso.sharepoint.com/sites/SiteA",
-        groupId: 3,
-        aadGroupId: 'Invalid GUID'
       }
     }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/group/group-member-remove.ts
+++ b/src/m365/spo/commands/group/group-member-remove.ts
@@ -22,9 +22,7 @@ interface Options extends GlobalOptions {
   email?: string;
   userId?: number;
   entraGroupId?: string;
-  aadGroupId?: string;
   entraGroupName?: string;
-  aadGroupName?: string;
   force?: boolean;
 }
 
@@ -55,9 +53,7 @@ class SpoGroupMemberRemoveCommand extends SpoCommand {
         email: (!(!args.options.email)).toString(),
         userId: (!(!args.options.userId)).toString(),
         entraGroupId: (!(!args.options.entraGroupId)).toString(),
-        aadGroupId: (!(!args.options.groupId)).toString(),
         entraGroupName: (!(!args.options.entraGroupName)).toString(),
-        aadGroupName: (!(!args.options.aadGroupName)).toString(),
         force: (!(!args.options.force)).toString()
       });
     });
@@ -87,13 +83,7 @@ class SpoGroupMemberRemoveCommand extends SpoCommand {
         option: '--entraGroupId [entraGroupId]'
       },
       {
-        option: '--aadGroupId [aadGroupId]'
-      },
-      {
         option: '--entraGroupName [entraGroupName]'
-      },
-      {
-        option: '--aadGroupName [aadGroupName]'
       },
       {
         option: '-f, --force'
@@ -124,10 +114,6 @@ class SpoGroupMemberRemoveCommand extends SpoCommand {
           return `${args.options.entraGroupId} is not a valid GUID`;
         }
 
-        if (args.options.aadGroupId && !validation.isValidGuid(args.options.aadGroupId as string)) {
-          return `${args.options.aadGroupId} is not a valid GUID`;
-        }
-
         return validation.isValidSharePointUrl(args.options.webUrl);
       }
     );
@@ -136,7 +122,7 @@ class SpoGroupMemberRemoveCommand extends SpoCommand {
   #initOptionSets(): void {
     this.optionSets.push(
       { options: ['groupName', 'groupId'] },
-      { options: ['userName', 'email', 'userId', 'entraGroupId', 'aadGroupId', 'entraGroupName', 'aadGroupName'] }
+      { options: ['userName', 'email', 'userId', 'entraGroupId', 'entraGroupName'] }
     );
   }
 
@@ -162,18 +148,6 @@ class SpoGroupMemberRemoveCommand extends SpoCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (args.options.aadGroupId) {
-      args.options.entraGroupId = args.options.aadGroupId;
-
-      await this.warn(logger, `Option 'aadGroupId' is deprecated. Please use 'entraGroupId' instead`);
-    }
-
-    if (args.options.aadGroupName) {
-      args.options.entraGroupName = args.options.aadGroupName;
-
-      await this.warn(logger, `Option 'aadGroupName' is deprecated. Please use 'entraGroupName' instead`);
-    }
-
     if (args.options.force) {
       if (this.debug) {
         await logger.logToStderr('Confirmation bypassed by entering confirm option. Removing the user from SharePoint Group...');

--- a/src/m365/spo/commands/user/user-ensure.spec.ts
+++ b/src/m365/spo/commands/user/user-ensure.spec.ts
@@ -116,23 +116,6 @@ describe(commands.USER_ENSURE, () => {
     assert(loggerLogSpy.calledWith(ensuredUserResponse));
   });
 
-  it('ensures user for a specific web by aadId', async () => {
-    sinon.stub(entraUser, 'getUpnByUserId').callsFake(async () => {
-      return validUserName;
-    });
-
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `${validWebUrl}/_api/web/ensureuser`) {
-        return ensuredUserResponse;
-      }
-
-      throw 'Invalid request';
-    });
-
-    await command.action(logger, { options: { verbose: true, webUrl: validWebUrl, aadId: validEntraId } });
-    assert(loggerLogSpy.calledWith(ensuredUserResponse));
-  });
-
   it('throws error message when no user was found with a specific id', async () => {
     sinon.stub(entraUser, 'getUpnByUserId').callsFake(async (id) => {
       throw {
@@ -186,11 +169,6 @@ describe(commands.USER_ENSURE, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if aadId is not a valid id', async () => {
-    const actual = await command.validate({ options: { webUrl: validWebUrl, aadId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
   it('fails validation if userName is not a valid user principal name', async () => {
     const actual = await command.validate({ options: { webUrl: validWebUrl, userName: 'invalid' } }, commandInfo);
     assert.notStrictEqual(actual, true);
@@ -198,11 +176,6 @@ describe(commands.USER_ENSURE, () => {
 
   it('passes validation if the url is valid and entraId is a valid id', async () => {
     const actual = await command.validate({ options: { webUrl: validWebUrl, entraId: validEntraId } }, commandInfo);
-    assert.strictEqual(actual, true);
-  });
-
-  it('passes validation if the url is valid and aadId is a valid id', async () => {
-    const actual = await command.validate({ options: { webUrl: validWebUrl, aadId: validEntraId } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 

--- a/src/m365/spo/commands/user/user-ensure.ts
+++ b/src/m365/spo/commands/user/user-ensure.ts
@@ -13,7 +13,6 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   webUrl: string;
   entraId?: string;
-  aadId?: string;
   userName?: string;
 }
 
@@ -39,7 +38,6 @@ class SpoUserEnsureCommand extends SpoCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         entraId: typeof args.options.entraId !== 'undefined',
-        aadId: typeof args.options.aadId !== 'undefined',
         userName: typeof args.options.userName !== 'undefined'
       });
     });
@@ -52,9 +50,6 @@ class SpoUserEnsureCommand extends SpoCommand {
       },
       {
         option: '--entraId [entraId]'
-      },
-      {
-        option: '--aadId [aadId]'
       },
       {
         option: '--userName [userName]'
@@ -74,10 +69,6 @@ class SpoUserEnsureCommand extends SpoCommand {
           return `${args.options.entraId} is not a valid GUID.`;
         }
 
-        if (args.options.aadId && !validation.isValidGuid(args.options.aadId)) {
-          return `${args.options.aadId} is not a valid GUID.`;
-        }
-
         if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
           return `${args.options.userName} is not a valid userName.`;
         }
@@ -88,16 +79,10 @@ class SpoUserEnsureCommand extends SpoCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push({ options: ['entraId', 'aadId', 'userName'] });
+    this.optionSets.push({ options: ['entraId', 'userName'] });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (args.options.aadId) {
-      args.options.entraId = args.options.aadId;
-
-      await this.warn(logger, `Option 'aadId' is deprecated. Please use 'entraId' instead`);
-    }
-
     if (this.verbose) {
       await logger.logToStderr(`Ensuring user ${args.options.entraId || args.options.userName} at site ${args.options.webUrl}`);
     }


### PR DESCRIPTION
Removes aad aliases. Closes #5676

- Removed the clientside redirects from `/cmd/aad` to `/cmd/entra` in the docs.
- Removed deprecated `--aadGroupIds` and `--aadGroupNames` options in `spo group member add`.
- Removed deprecated `--aadGroupIds` and `--aadGroupNames` options in `spo group member remove`.
- Removed deprecated `--aadId` option in `spo user ensure`.