### PR TITLE
Align options with naming convention. Closes #5616

### DIFF
--- a/docs/docs/cmd/entra/group/group-user-list.mdx
+++ b/docs/docs/cmd/entra/group/group-user-list.mdx
@@ -22,10 +22,10 @@ m365 aad group user list [options]
 
 ```md definition-list
 `-i, --groupId [groupId]`
-: The ID of the Entra group. Specify `groupId` or `groupDisplayName` but not both.
+: The ID of the Entra group. Specify `groupId` or `groupName` but not both.
 
-`-n, --groupDisplayName [groupDisplayName]`
-: The display name of the Entra group. Specify `groupId` or `groupDisplayName` but not both.
+`-n, --groupName [groupName]`
+: The display name of the Entra group. Specify `groupId` or `groupName` but not both.
 
 `-r, --role [role]`
 : Filter the results to only users with the given role: `Owner`, `Member`.
@@ -54,25 +54,25 @@ m365 entra group user list --groupId 03cba9da-3974-46c1-afaf-79caa2e45bbe
 List all owners from a group specified by display name.
 
 ```sh
-m365 entra group user list --groupDisplayName Developers --role Owner
+m365 entra group user list --groupName Developers --role Owner
 ```
 
 List all group users from a group specified by name. For each one return the display name, e-mail address, and manager display name.
 
 ```sh
-m365 entra group user list --groupDisplayName Developers --properties "displayName,mail,manager/displayName"
+m365 entra group user list --groupName Developers --properties "displayName,mail,manager/displayName"
 ```
 
 List all group users from a group specified by name. For each one return the display name, e-mail address, and manager information.
 
 ```sh
-m365 entra group user list --groupDisplayName Developers --properties "displayName,mail,manager/*"
+m365 entra group user list --groupName Developers --properties "displayName,mail,manager/*"
 ```
 
 List all group members that are guest users.
 
 ```sh
-m365 entra group user list --groupDisplayName Developers --filter "userType eq 'Guest'"
+m365 entra group user list --groupName Developers --filter "userType eq 'Guest'"
 ```
 
 ## Response

--- a/docs/docs/cmd/entra/m365group/m365group-conversation-post-list.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-conversation-post-list.mdx
@@ -22,10 +22,10 @@ m365 aad m365group conversation post list [options]
 
 ```md definition-list
 `-i, --groupId [groupId]`
-: The Id of the Microsoft 365 Group. You can specify the groupId or groupDisplayName, but not both.
+: The Id of the Microsoft 365 Group. You can specify the groupId or groupName, but not both.
 
-`-d, --groupDisplayName [groupDisplayName]`
-: The Displayname of the Microsoft 365 Group. You can specify the groupId or groupDisplayName, but not both.
+`-d, --groupName [groupName]`
+: The Displayname of the Microsoft 365 Group. You can specify the groupId or groupName, but not both.
 
 `-t, --threadId <threadId>`
 : The ID of the thread to retrieve details for
@@ -41,10 +41,10 @@ Lists the posts of the specific conversation of Microsoft 365 group by groupId
 m365 entra m365group conversation post list --groupId '00000000-0000-0000-0000-000000000000' --threadId 'AAQkADkwN2Q2NDg1LWQ3ZGYtNDViZi1iNGRiLTVhYjJmN2Q5NDkxZQAQAOnRAfDf71lIvrdK85FAn5E='
 ```
 
-Lists the posts of the specific conversation of Microsoft 365 group by groupDisplayName
+Lists the posts of the specific conversation of Microsoft 365 group by groupName
 
 ```sh
-m365 entra m365group conversation post list --groupDisplayName 'MyGroup' --threadId 'AAQkADkwN2Q2NDg1LWQ3ZGYtNDViZi1iNGRiLTVhYjJmN2Q5NDkxZQAQAOnRAfDf71lIvrdK85FAn5E='
+m365 entra m365group conversation post list --groupName 'MyGroup' --threadId 'AAQkADkwN2Q2NDg1LWQ3ZGYtNDViZi1iNGRiLTVhYjJmN2Q5NDkxZQAQAOnRAfDf71lIvrdK85FAn5E='
 ```
 
 ## Response

--- a/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-list.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-list.mdx
@@ -21,7 +21,7 @@ m365 aad m365group recyclebinitem list [options]
 ## Options
 
 ```md definition-list
-`-d, --groupDisplayName [groupDisplayName]`
+`-d, --groupName [groupName]`
 : Lists groups with DisplayName starting with the specified value
 
 `-m, --groupMailNickname [groupMailNickname]`
@@ -41,7 +41,7 @@ m365 entra m365group recyclebinitem list
 List deleted Microsoft 365 Groups with display name starting with _Project_
 
 ```sh
-m365 entra m365group recyclebinitem list --groupDisplayName Project
+m365 entra m365group recyclebinitem list --groupName Project
 ```
 
 List deleted Microsoft 365 Groups mail nick name starting with _team_
@@ -53,7 +53,7 @@ m365 entra m365group recyclebinitem list --groupMailNickname team
 List deleted Microsoft 365 Groups mail nick name starting with _team_ and with display name starting with _Project_
 
 ```sh
-m365 entra m365group recyclebinitem list --groupMailNickname team --groupDisplayName Project
+m365 entra m365group recyclebinitem list --groupMailNickname team --groupName Project
 ```
 
 ## Response

--- a/docs/docs/cmd/outlook/message/message-get.mdx
+++ b/docs/docs/cmd/outlook/message/message-get.mdx
@@ -19,10 +19,10 @@ m365 outlook message get [options]
 : ID of the message.
 
 `--userId [userId]`
-: ID of the user from which to retrieve the message. Specify either `userId` or `userPrincipalName`, but not both. This option is required when using application permissions.
+: ID of the user from which to retrieve the message. Specify either `userId` or `userName`, but not both. This option is required when using application permissions.
 
-`--userPrincipalName [userPrincipalName]`
-: UPN of the user from which to retrieve the message Specify either `userId` or `userPrincipalName`, but not both. This option is required when using application permissions.
+`--userName [userName]`
+: UPN of the user from which to retrieve the message Specify either `userId` or `userName`, but not both. This option is required when using application permissions.
 ```
 
 <Global />
@@ -38,7 +38,7 @@ m365 outlook message get --id AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYm
 Get a specific message using delegated permissions from a shared mailbox.
 
 ```sh
-m365 outlook message get --id AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA= --userPrincipalName sharedmailbox@tenant.com
+m365 outlook message get --id AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA= --userName sharedmailbox@tenant.com
 ```
 
 Get a specific message from a specific user retrieved by user ID using application permissions.
@@ -50,7 +50,7 @@ m365 outlook message get --id AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYm
 Get a specific message from a specific user retrieved by user principal name using application permissions.
 
 ```sh
-m365 outlook message get --id AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA= --userPrincipalName user@tenant.com
+m365 outlook message get --id AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA= --userName user@tenant.com
 ```
 
 ## Response

--- a/src/m365/entra/commands/group/group-user-list.spec.ts
+++ b/src/m365/entra/commands/group/group-user-list.spec.ts
@@ -19,7 +19,7 @@ import aadCommands from '../../aadCommands.js';
 
 describe(commands.GROUP_USER_LIST, () => {
   const groupId = '2c1ba4c4-cd9b-4417-832f-92a34bc34b2a';
-  const groupDisplayName = 'CLI Test Group';
+  const groupName = 'CLI Test Group';
 
   let log: string[];
   let logger: Logger;
@@ -180,7 +180,7 @@ describe(commands.GROUP_USER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, groupDisplayName: groupDisplayName } });
+    await command.action(logger, { options: { verbose: true, groupName: groupName } });
 
     assert(loggerLogSpy.calledOnceWithExactly([
       {
@@ -235,7 +235,7 @@ describe(commands.GROUP_USER_LIST, () => {
     });
 
     sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(groupDisplayName)}'&$select=id`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(groupName)}'&$select=id`) {
         return {
           value: [
             { id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f' },
@@ -249,14 +249,14 @@ describe(commands.GROUP_USER_LIST, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        groupDisplayName: groupDisplayName
+        groupName: groupName
       }
     }), new CommandError(`Multiple groups with name 'CLI Test Group' found. Found: 9b1b1e42-794b-4c71-93ac-5ed92488b67f, 9b1b1e42-794b-4c71-93ac-5ed92488b67g.`));
   });
 
   it('handles selecting single result when multiple Microsoft Entra groups with the specified name found and cli is set to prompt', async () => {
     sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(groupDisplayName)}'&$select=id`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(groupName)}'&$select=id`) {
         return {
           value: [
             { id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f' },
@@ -276,7 +276,7 @@ describe(commands.GROUP_USER_LIST, () => {
 
     sinon.stub(cli, 'handleMultipleResultsFound').resolves({ id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f' });
 
-    await command.action(logger, { options: { groupDisplayName: groupDisplayName, role: "Owner" } });
+    await command.action(logger, { options: { groupName: groupName, role: "Owner" } });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00000000-0000-0000-0000-000000000000",

--- a/src/m365/entra/commands/group/group-user-list.ts
+++ b/src/m365/entra/commands/group/group-user-list.ts
@@ -15,7 +15,7 @@ interface CommandArgs {
 
 interface Options extends GlobalOptions {
   groupId?: string;
-  groupDisplayName?: string;
+  groupName?: string;
   role?: string;
   properties?: string;
   filter?: string;
@@ -55,7 +55,7 @@ class EntraGroupUserListCommand extends GraphCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         groupId: typeof args.options.groupId !== 'undefined',
-        groupDisplayName: typeof args.options.groupDisplayName !== 'undefined',
+        groupName: typeof args.options.groupName !== 'undefined',
         role: typeof args.options.role !== 'undefined',
         properties: typeof args.options.properties !== 'undefined',
         filter: typeof args.options.filter !== 'undefined'
@@ -69,7 +69,7 @@ class EntraGroupUserListCommand extends GraphCommand {
         option: "-i, --groupId [groupId]"
       },
       {
-        option: "-n, --groupDisplayName [groupDisplayName]"
+        option: "-n, --groupName [groupName]"
       },
       {
         option: "-r, --role [role]",
@@ -87,7 +87,7 @@ class EntraGroupUserListCommand extends GraphCommand {
   #initOptionSets(): void {
     this.optionSets.push(
       {
-        options: ['groupId', 'groupDisplayName']
+        options: ['groupId', 'groupName']
       }
     );
   }
@@ -154,7 +154,7 @@ class EntraGroupUserListCommand extends GraphCommand {
       await logger.logToStderr('Retrieving Group Id...');
     }
 
-    return await entraGroup.getGroupIdByDisplayName(options.groupDisplayName!);
+    return await entraGroup.getGroupIdByDisplayName(options.groupName!);
   }
 
   private async getUsers(options: Options, role: string, groupId: string, logger: Logger): Promise<ExtendedUser[]> {

--- a/src/m365/entra/commands/m365group/m365group-conversation-post-list.spec.ts
+++ b/src/m365/entra/commands/m365group/m365group-conversation-post-list.spec.ts
@@ -135,7 +135,7 @@ describe(commands.M365GROUP_CONVERSATION_POST_LIST, () => {
   it('defines correct properties for the default output', () => {
     assert.deepStrictEqual(command.defaultProperties(), ['receivedDateTime', 'id']);
   });
-  it('fails validation if groupId and groupDisplayName specified', async () => {
+  it('fails validation if groupId and groupName specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -144,10 +144,10 @@ describe(commands.M365GROUP_CONVERSATION_POST_LIST, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { groupId: '1caf7dcd-7e83-4c3a-94f7-932a1299c844', groupDisplayName: 'MyGroup', threadId: '123' } }, commandInfo);
+    const actual = await command.validate({ options: { groupId: '1caf7dcd-7e83-4c3a-94f7-932a1299c844', groupName: 'MyGroup', threadId: '123' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
-  it('fails validation if neither groupId nor groupDisplayName specified', async () => {
+  it('fails validation if neither groupId nor groupName specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -187,7 +187,7 @@ describe(commands.M365GROUP_CONVERSATION_POST_LIST, () => {
       jsonOutput.value
     ));
   });
-  it('Retrieve posts for the specified conversation threadId of m365 group groupDisplayName in the tenant (verbose)', async () => {
+  it('Retrieve posts for the specified conversation threadId of m365 group groupName in the tenant (verbose)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf('/groups?$filter=displayName') > -1) {
         return {
@@ -208,7 +208,7 @@ describe(commands.M365GROUP_CONVERSATION_POST_LIST, () => {
     await command.action(logger, {
       options: {
         verbose: true,
-        groupDisplayName: "MyGroup",
+        groupName: "MyGroup",
         threadId: "AAQkADkwN2Q2NDg1LWQ3ZGYtNDViZi1iNGRiLTVhYjJmN2Q5NDkxZQAQAOnRAfDf71lIvrdK85FAn5E="
       }
     });

--- a/src/m365/entra/commands/m365group/m365group-conversation-post-list.ts
+++ b/src/m365/entra/commands/m365group/m365group-conversation-post-list.ts
@@ -15,7 +15,7 @@ interface CommandArgs {
 
 interface Options extends GlobalOptions {
   groupId?: string;
-  groupDisplayName?: string;
+  groupName?: string;
   threadId: string;
 }
 
@@ -45,7 +45,7 @@ class EntraM365GroupConversationPostListCommand extends GraphCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         groupId: typeof args.options.groupId !== 'undefined',
-        groupDisplayName: typeof args.options.groupDisplayName !== 'undefined'
+        groupName: typeof args.options.groupName !== 'undefined'
       });
     });
   }
@@ -56,7 +56,7 @@ class EntraM365GroupConversationPostListCommand extends GraphCommand {
         option: '-i, --groupId [groupId]'
       },
       {
-        option: '-d, --groupDisplayName [groupDisplayName]'
+        option: '-d, --groupName [groupName]'
       },
       {
         option: '-t, --threadId <threadId>'
@@ -77,7 +77,7 @@ class EntraM365GroupConversationPostListCommand extends GraphCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push({ options: ['groupId', 'groupDisplayName'] });
+    this.optionSets.push({ options: ['groupId', 'groupName'] });
   }
 
   public defaultProperties(): string[] | undefined {
@@ -108,7 +108,7 @@ class EntraM365GroupConversationPostListCommand extends GraphCommand {
       return formatting.encodeQueryParameter(args.options.groupId);
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.groupDisplayName!);
+    const group = await entraGroup.getGroupByDisplayName(args.options.groupName!);
     return group.id!;
   }
 }

--- a/src/m365/entra/commands/m365group/m365group-recyclebinitem-list.spec.ts
+++ b/src/m365/entra/commands/m365group/m365group-recyclebinitem-list.spec.ts
@@ -371,7 +371,7 @@ describe(commands.M365GROUP_RECYCLEBINITEM_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupDisplayName: 'Deleted' } });
+    await command.action(logger, { options: { groupName: 'Deleted' } });
     assert(loggerLogSpy.calledWith([
       {
         "id": "010d2f0a-0c17-4ec8-b694-e85bbe607013",
@@ -605,7 +605,7 @@ describe(commands.M365GROUP_RECYCLEBINITEM_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupDisplayName: 'Deleted', groupMailNickname: 'd_team' } });
+    await command.action(logger, { options: { groupName: 'Deleted', groupMailNickname: 'd_team' } });
     assert(loggerLogSpy.calledWith([
       {
         "id": "010d2f0a-0c17-4ec8-b694-e85bbe607013",
@@ -667,11 +667,11 @@ describe(commands.M365GROUP_RECYCLEBINITEM_LIST, () => {
     await assert.rejects(command.action(logger, { options: { mailNickname: 'd_team' } }), new CommandError(errorMessage));
   });
 
-  it('supports specifying groupDisplayName', () => {
+  it('supports specifying groupName', () => {
     const options = command.options;
     let containsOption = false;
     options.forEach(o => {
-      if (o.option.indexOf('--groupDisplayName') > -1) {
+      if (o.option.indexOf('--groupName') > -1) {
         containsOption = true;
       }
     });

--- a/src/m365/entra/commands/m365group/m365group-recyclebinitem-list.ts
+++ b/src/m365/entra/commands/m365group/m365group-recyclebinitem-list.ts
@@ -12,7 +12,7 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  groupDisplayName?: string;
+  groupName?: string;
   groupMailNickname?: string;
 }
 
@@ -39,7 +39,7 @@ class EntraM365GroupRecycleBinItemListCommand extends GraphCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        groupDisplayName: typeof args.options.groupDisplayName !== 'undefined',
+        groupName: typeof args.options.groupName !== 'undefined',
         groupMailNickname: typeof args.options.groupMailNickname !== 'undefined'
       });
     });
@@ -48,7 +48,7 @@ class EntraM365GroupRecycleBinItemListCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-d, --groupDisplayName [groupDisplayName]'
+        option: '-d, --groupName [groupName]'
       },
       {
         option: '-m, --groupMailNickname [groupMailNickname]'
@@ -65,7 +65,7 @@ class EntraM365GroupRecycleBinItemListCommand extends GraphCommand {
 
     try {
       const filter: string = `?$filter=groupTypes/any(c:c+eq+'Unified')`;
-      const displayNameFilter: string = args.options.groupDisplayName ? ` and startswith(DisplayName,'${formatting.encodeQueryParameter(args.options.groupDisplayName).replace(/'/g, `''`)}')` : '';
+      const displayNameFilter: string = args.options.groupName ? ` and startswith(DisplayName,'${formatting.encodeQueryParameter(args.options.groupName).replace(/'/g, `''`)}')` : '';
       const mailNicknameFilter: string = args.options.groupMailNickname ? ` and startswith(MailNickname,'${formatting.encodeQueryParameter(args.options.groupMailNickname).replace(/'/g, `''`)}')` : '';
       const topCount: string = '&$top=100';
       const endpoint: string = `${this.resource}/v1.0/directory/deletedItems/Microsoft.Graph.Group${filter}${displayNameFilter}${mailNicknameFilter}${topCount}`;

--- a/src/m365/outlook/commands/message/message-get.spec.ts
+++ b/src/m365/outlook/commands/message/message-get.spec.ts
@@ -17,7 +17,7 @@ import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.MESSAGE_GET, () => {
   const messageId = 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA=';
-  const userPrincipalName = 'user@tenant.com';
+  const userName = 'user@tenant.com';
   const userId = '6799fd1a-723b-4eb7-8e52-41ae530274ca';
   const emailResponse = {
     "id": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA=",
@@ -144,16 +144,16 @@ describe(commands.MESSAGE_GET, () => {
     assert(loggerLogSpy.calledWith(emailResponse));
   });
 
-  it('retrieves specific message using delegated permissions from a shared mailbox using userPrincipalName as option', async () => {
+  it('retrieves specific message using delegated permissions from a shared mailbox using userName as option', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users/${userPrincipalName}/messages/${messageId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${userName}/messages/${messageId}`) {
         return emailResponse;
       }
 
       throw `Invalid request`;
     });
 
-    await command.action(logger, { options: { verbose: true, id: messageId, userPrincipalName: userPrincipalName } });
+    await command.action(logger, { options: { verbose: true, id: messageId, userName: userName } });
     assert(loggerLogSpy.calledWith(emailResponse));
   });
 
@@ -183,18 +183,18 @@ describe(commands.MESSAGE_GET, () => {
       new CommandError(`Graph error occurred`));
   });
 
-  it('retrieves specific message using application permissions and using userPrincipalName as option', async () => {
+  it('retrieves specific message using application permissions and using userName as option', async () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users/${userPrincipalName}/messages/${messageId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${userName}/messages/${messageId}`) {
         return emailResponse;
       }
 
       throw `Invalid request`;
     });
 
-    await command.action(logger, { options: { verbose: true, id: messageId, userPrincipalName: userPrincipalName } });
+    await command.action(logger, { options: { verbose: true, id: messageId, userName: userName } });
     assert(loggerLogSpy.calledWith(emailResponse));
   });
 
@@ -228,18 +228,18 @@ describe(commands.MESSAGE_GET, () => {
       new CommandError(`Graph error occurred`));
   });
 
-  it('throws error if something fails using application permissions and userPrincipalName as option', async () => {
+  it('throws error if something fails using application permissions and userName as option', async () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/users/${userPrincipalName}/messages/${messageId}`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/users/${userName}/messages/${messageId}`) {
         throw `Graph error occurred`;
       }
 
       throw `Invalid request`;
     });
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, userPrincipalName: userPrincipalName } } as any),
+    await assert.rejects(command.action(logger, { options: { id: messageId, userName: userName } } as any),
       new CommandError(`Graph error occurred`));
   });
 
@@ -260,27 +260,27 @@ describe(commands.MESSAGE_GET, () => {
     assert.equal(actual, true);
   });
 
-  it('throws an error when the upn or userprincipalname is not defined when signed in using app only authentication', async () => {
+  it('throws an error when the upn or userName is not defined when signed in using app only authentication', async () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
     await assert.rejects(command.action(logger, { options: { id: messageId } } as any),
-      new CommandError(`The option 'userId' or 'userPrincipalName' is required when retrieving an email using app only credentials`));
+      new CommandError(`The option 'userId' or 'userName' is required when retrieving an email using app only credentials`));
   });
 
-  it('throws an error when the upn or userprincipalname are both defined when signed in using app only authentication', async () => {
+  it('throws an error when the upn or userName are both defined when signed in using app only authentication', async () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId, userPrincipalName: userPrincipalName } } as any),
-      new CommandError(`Both options 'userId' and 'userPrincipalName' cannot be set when retrieving an email using app only credentials`));
+    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId, userName: userName } } as any),
+      new CommandError(`Both options 'userId' and 'userName' cannot be set when retrieving an email using app only credentials`));
   });
 
-  it('throws an error when the upn and userprincipalname are both filled in when signed in using delegated authentication', async () => {
+  it('throws an error when the upn and userName are both filled in when signed in using delegated authentication', async () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId, userPrincipalName: userPrincipalName } } as any),
-      new CommandError(`Both options 'userId' and 'userPrincipalName' cannot be set when retrieving an email using delegated credentials`));
+    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId, userName: userName } } as any),
+      new CommandError(`Both options 'userId' and 'userName' cannot be set when retrieving an email using delegated credentials`));
   });
 });

--- a/src/m365/outlook/commands/message/message-get.ts
+++ b/src/m365/outlook/commands/message/message-get.ts
@@ -13,7 +13,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   id: string;
   userId?: string;
-  userPrincipalName?: string;
+  userName?: string;
 }
 
 class OutlookMessageGetCommand extends GraphCommand {
@@ -36,7 +36,7 @@ class OutlookMessageGetCommand extends GraphCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         userId: typeof args.options.userId !== 'undefined',
-        userPrincipalName: typeof args.options.userPrincipalName !== 'undefined'
+        userName: typeof args.options.userName !== 'undefined'
       });
     });
   }
@@ -50,7 +50,7 @@ class OutlookMessageGetCommand extends GraphCommand {
         option: '--userId [userId]'
       },
       {
-        option: '--userPrincipalName [userPrincipalName]'
+        option: '--userName [userName]'
       }
     );
   }
@@ -65,21 +65,21 @@ class OutlookMessageGetCommand extends GraphCommand {
       let requestUrl = '';
 
       if (isAppOnlyAccessToken) {
-        if (!args.options.userId && !args.options.userPrincipalName) {
-          throw `The option 'userId' or 'userPrincipalName' is required when retrieving an email using app only credentials`;
+        if (!args.options.userId && !args.options.userName) {
+          throw `The option 'userId' or 'userName' is required when retrieving an email using app only credentials`;
         }
-        if (args.options.userId && args.options.userPrincipalName) {
-          throw `Both options 'userId' and 'userPrincipalName' cannot be set when retrieving an email using app only credentials`;
+        if (args.options.userId && args.options.userName) {
+          throw `Both options 'userId' and 'userName' cannot be set when retrieving an email using app only credentials`;
         }
-        requestUrl += `users/${args.options.userId ? args.options.userId : args.options.userPrincipalName}`;
+        requestUrl += `users/${args.options.userId ? args.options.userId : args.options.userName}`;
       }
       else {
-        if (args.options.userId && args.options.userPrincipalName) {
-          throw `Both options 'userId' and 'userPrincipalName' cannot be set when retrieving an email using delegated credentials`;
+        if (args.options.userId && args.options.userName) {
+          throw `Both options 'userId' and 'userName' cannot be set when retrieving an email using delegated credentials`;
         }
 
-        if (args.options.userId || args.options.userPrincipalName) {
-          requestUrl += `users/${args.options.userId ? args.options.userId : args.options.userPrincipalName}`;
+        if (args.options.userId || args.options.userName) {
+          requestUrl += `users/${args.options.userId ? args.options.userId : args.options.userName}`;
         }
         else {
           requestUrl += 'me';


### PR DESCRIPTION
Align options with naming convention. Closes #5616

Renamed the following options:

Command | Current option | Desired option
------------|------------------|-----------------
[aad group user list](https://pnp.github.io/cli-microsoft365/cmd/aad/group/group-user-list) | groupDisplayName | groupName
[aad m365group conversation post list](https://pnp.github.io/cli-microsoft365/cmd/aad/m365group/m365group-conversation-post-list) | groupDisplayName | groupName
[aad m365group recyclebinitem list](https://pnp.github.io/cli-microsoft365/cmd/aad/m365group/m365group-recyclebinitem-list) | groupDisplayName | groupName
[outlook message get](https://pnp.github.io/cli-microsoft365/cmd/outlook/message/message-get) | userPrincipalName | userName