### PR TITLE
Removes duplicate property from "spo list list" command. Closes #6042

### DIFF
--- a/docs/docs/cmd/spo/list/list-list.mdx
+++ b/docs/docs/cmd/spo/list/list-list.mdx
@@ -126,8 +126,7 @@ m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --fil
       "ParserDisabled": false,
       "ServerTemplateCanCreateFolders": false,
       "TemplateFeatureId": "00000000-0000-0000-0000-000000000000",
-      "Title": "Theme Gallery",
-      "Url": "/_catalogs/theme"
+      "Title": "Theme Gallery"
     }
   ]
   ```
@@ -136,17 +135,17 @@ m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --fil
   <TabItem value="Text">
 
   ```text
-  Id                                    Url
+  Id                                    Title
   ------------------------------------  ----------------
-  66e5148c-7060-4479-88e7-636d79579148  /_catalogs/theme
+  66e5148c-7060-4479-88e7-636d79579148  Theme Gallery
   ```
 
   </TabItem>
   <TabItem value="CSV">
 
   ```csv
-  Id,Url
-  Theme Gallery,/_catalogs/theme,66e5148c-7060-4479-88e7-636d79579148
+  Id,Title
+  66e5148c-7060-4479-88e7-636d79579148,Theme Gallery
   ```
 
   </TabItem>
@@ -211,7 +210,6 @@ m365 spo list list --webUrl https://contoso.sharepoint.com/sites/project-x --fil
   ServerTemplateCanCreateFolders | true
   TemplateFeatureId | 00000000-0000-0000-0000-000000000000
   Title | Theme Gallery
-  Url | //\_catalogs/theme
   ```
 
   </TabItem>

--- a/src/m365/spo/commands/list/list-list.spec.ts
+++ b/src/m365/spo/commands/list/list-list.spec.ts
@@ -119,7 +119,7 @@ describe(commands.LIST_LIST, () => {
   });
 
   it('defines correct properties for the default output', () => {
-    assert.deepStrictEqual(command.defaultProperties(), ['Title', 'Url', 'Id']);
+    assert.deepStrictEqual(command.defaultProperties(), ['Title', 'Id']);
   });
 
   it('retrieves all lists', async () => {
@@ -149,8 +149,7 @@ describe(commands.LIST_LIST, () => {
             ParentWebUrl: "/",
             RootFolder: {
               ServerRelativeUrl: "/Lists/test"
-            },
-            Url: "/Lists/test"
+            }
           }]
         };
       }
@@ -169,8 +168,7 @@ describe(commands.LIST_LIST, () => {
       ParentWebUrl: "/",
       RootFolder: {
         ServerRelativeUrl: "/Lists/test"
-      },
-      Url: "/Lists/test"
+      }
     }]));
   });
 

--- a/src/m365/spo/commands/list/list-list.ts
+++ b/src/m365/spo/commands/list/list-list.ts
@@ -31,7 +31,7 @@ class SpoListListCommand extends SpoCommand {
   }
 
   public defaultProperties(): string[] | undefined {
-    return ['Title', 'Url', 'Id'];
+    return ['Title', 'Id'];
   }
 
   constructor() {
@@ -85,10 +85,6 @@ class SpoListListCommand extends SpoCommand {
       }
 
       const listInstances = await odata.getAllItems<ListInstance>(`${args.options.webUrl}/_api/web/lists?${queryParams.join('&')}`);
-      listInstances.forEach(l => {
-        l.Url = l.RootFolder.ServerRelativeUrl;
-      });
-
       await logger.log(listInstances);
     }
     catch (err: any) {


### PR DESCRIPTION
Removes duplicate property called `Url` from `spo list list` command. Closes #6042