### PR TITLE
Removed deprecated CLI environment variables. Closes #5918

### DIFF
--- a/docs/docs/user-guide/connecting-microsoft-365.mdx
+++ b/docs/docs/user-guide/connecting-microsoft-365.mdx
@@ -152,7 +152,7 @@ When logging in to Microsoft 365 using a secret, CLI for Microsoft 365 will pers
 
 #### Login without setting the environment variables
 
-In all the examples above, we make use of the `CLIMICROSOFT365_AADAPPID` and `CLIMICROSOFT365_TENANT` environment variables. If you don't want to set these environment variables, you can specify the options `appId` and `tenant` when logging in to Microsoft 365.
+In all the examples above, we make use of the `CLIMICROSOFT365_ENTRAAPPID` and `CLIMICROSOFT365_TENANT` environment variables. If you don't want to set these environment variables, you can specify the options `appId` and `tenant` when logging in to Microsoft 365.
 
 Below would be the command to log in to Microsoft 365 using a Personal Information Exchange (.pfx) file, execute:
 

--- a/docs/docs/v9-upgrade-guidance.mdx
+++ b/docs/docs/v9-upgrade-guidance.mdx
@@ -1,0 +1,13 @@
+# v9 Upgrade Guidance
+
+The v9 of CLI for Microsoft 365 introduces several breaking changes. To help you upgrade to the latest version of CLI for Microsoft 365, we've listed those changes along with any actions you may need to take.
+
+## CLI environment variables
+
+### Removed deprecated CLI environment variables
+
+For this new major version, we've removed the deprecated `AAD` CLI environment variables. We have renamed `CLIMICROSOFT365_AADAPPID` variable to `CLIMICROSOFT365_ENTRAAPPID`.
+
+#### What action do I need to take?
+
+Please, check the user guidance [Log in to Microsoft 365](./user-guide/connecting-microsoft-365.mdx) command to see the updated environment variables to use.

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -8,13 +8,6 @@ describe('Config', () => {
     assert.strictEqual(config.default.tenant, 'tenant123');
   });
 
-  it('returns process.env CLIMICROSOFT365_AADAPPID value', async () => {
-    process.env.CLIMICROSOFT365_AADAPPID = 'appId123';
-
-    const config = await import(`./config.js#${Math.random()}`);
-    assert.strictEqual(config.default.cliEntraAppId, 'appId123');
-  });
-
   it('returns process.env CLIMICROSOFT365_ENTRAAPPID value', async () => {
     process.env.CLIMICROSOFT365_ENTRAAPPID = 'appId123';
 
@@ -29,8 +22,7 @@ describe('Config', () => {
     assert.strictEqual(config.default.tenant, 'common');
   });
 
-  it('returns default value since env CLIMICROSOFT365_AADAPPID or CLIMICROSOFT365_ENTRAAPPID not present', async () => {
-    delete process.env.CLIMICROSOFT365_AADAPPID;
+  it('returns default value since env CLIMICROSOFT365_ENTRAAPPID not present', async () => {
     delete process.env.CLIMICROSOFT365_ENTRAAPPID;
 
     const config = await import(`./config.js#${Math.random()}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ const cliEntraAppId: string = '31359c7f-bd7e-475c-86db-fdb8c937548e';
 export default {
   applicationName: `CLI for Microsoft 365 v${app.packageJson().version}`,
   delimiter: 'm365\$',
-  cliEntraAppId: process.env.CLIMICROSOFT365_ENTRAAPPID || process.env.CLIMICROSOFT365_AADAPPID || cliEntraAppId,
+  cliEntraAppId: process.env.CLIMICROSOFT365_ENTRAAPPID || cliEntraAppId,
   tenant: process.env.CLIMICROSOFT365_TENANT || 'common',
   configstoreName: 'cli-m365-config'
 };


### PR DESCRIPTION
Removed deprecated CLI environment variables. Closes #5918

Renamed `CLIMICROSOFT365_AADAPPID` to `CLIMICROSOFT365_ENTRAAPPID`.