### PR TITLE
Fixes 'spo contenttype list' text output

### DIFF
--- a/docs/docs/cmd/spo/contenttype/contenttype-list.mdx
+++ b/docs/docs/cmd/spo/contenttype/contenttype-list.mdx
@@ -90,7 +90,7 @@ m365 spo contenttype list --webUrl "https://contoso.sharepoint.com/sites/contoso
   ```text
   StringId                                                                    Name                             Hidden  ReadOnly  Sealed                                                                           
   --------------------------------------------------------------------------  -------------------------------  ------  --------  ------
-  0x01007926A45D687BA842B947286090B8F67D                                      PnP Alert                        false   false     false                                                                            0x01007CE30DD1206047728BAFD1C39A850120                                      Official Notice                  false   false     false                                                                            0x0100807FBAC5EB8A4653B8D24775195B5463                                      Phone Call Memo                  false   false     false
+  0x01007926A45D687BA842B947286090B8F67D                                      PnP Alert                        false   false     false
   ```
 
   </TabItem>


### PR DESCRIPTION
Noticed some wrong formatting in the text output for the command `spo command contenttype list`