### PR TITLE
Aligns options of "entra enterpriseapp" commands. Closes #6155

### DIFF
--- a/docs/docs/cmd/entra/enterpriseapp/enterpriseapp-add.mdx
+++ b/docs/docs/cmd/entra/enterpriseapp/enterpriseapp-add.mdx
@@ -22,39 +22,39 @@ m365 entra sp add [options]
 ## Options
 
 ```md definition-list
-`--appId [appId]`
-: ID of the app for which the enterprise application should be created
+`-i, --id [id]`
+: ID of the app for which the enterprise application should be created.
 
-`--appName [appName]`
-: Display name of the app for which the enterprise application should be created
+`-n, --displayName [displayName]`
+: Display name of the app for which the enterprise application should be created.
 
 `--objectId [objectId]`
-: ObjectId of the app for which the enterprise application should be created
+: ObjectId of the app for which the enterprise application should be created.
 ```
 
 <Global />
 
 ## Remarks
 
-Specify either the `appId`, `appName` or `objectId`. If you specify more than one option value, the command will fail with an error.
+Specify either the `id`, `displayName` or `objectId`. If you specify more than one option value, the command will fail with an error.
 
 If you register an application in the portal, an application object as well as an enterprise application object are automatically created in your home tenant. If you register an application using CLI for Microsoft 365 or the Microsoft Graph, you'll need to create the enterprise application separately. To register/create an application using the CLI for Microsoft 365, use the [m365 entra app add](../app/app-add.mdx) command.
 
 ## Examples
 
-Creates an enterprise application for a registered Entra app with appId _b2307a39-e878-458b-bc90-03bc578531d6_.
+Creates an enterprise application for a registered Entra app with the specified id.
 
 ```sh
-m365 entra enterpriseapp add --appId b2307a39-e878-458b-bc90-03bc578531d6
+m365 entra enterpriseapp add --id b2307a39-e878-458b-bc90-03bc578531d6
 ```
 
-Creates an enterprise application for a registered Entra app with appName _Microsoft Graph_.
+Creates an enterprise application for a registered Entra app with the specified displayName.
 
 ```sh
-m365 entra enterpriseapp add --appName "Microsoft Graph"
+m365 entra enterpriseapp add --displayName "Microsoft Graph"
 ```
 
-Creates an enterprise application for a registered Entra app with objectId _b2307a39-e878-458b-bc90-03bc578531d6_.
+Creates an enterprise application for a registered Entra app with the specified objectId.
 
 ```sh
 m365 entra enterpriseapp add --objectId b2307a39-e878-458b-bc90-03bc578531d6
@@ -172,7 +172,7 @@ m365 entra enterpriseapp add --objectId b2307a39-e878-458b-bc90-03bc578531d6
   <TabItem value="Markdown">
 
   ```md
-  # entra enterpriseapp add --appId "8da75b6a-4272-4b17-8ee1-20ba66e2b06f"
+  # entra enterpriseapp add --id "8da75b6a-4272-4b17-8ee1-20ba66e2b06f"
 
   Date: 2023-06-02
 

--- a/docs/docs/cmd/entra/enterpriseapp/enterpriseapp-get.mdx
+++ b/docs/docs/cmd/entra/enterpriseapp/enterpriseapp-get.mdx
@@ -22,40 +22,40 @@ m365 entra sp get [options]
 ## Options
 
 ```md definition-list
-`-i, --appId [appId]`
-: ID of the application for which the enterprise application should be retrieved
+`-i, --id [id]`
+: ID of the application for which the enterprise application should be retrieved.
 
-`-n, --appDisplayName [appDisplayName]`
-: Display name of the application for which the enterprise application should be retrieved
+`-n, --displayName [displayName]`
+: Display name of the application for which the enterprise application should be retrieved.
 
-`--appObjectId [appObjectId]`
-: ObjectId of the application for which the enterprise application should be retrieved
+`--objectId [objectId]`
+: ObjectId of the application for which the enterprise application should be retrieved.
 ```
 
 <Global />
 
 ## Remarks
 
-Specify either the `appId`, `appObjectId` or `appDisplayName`. If you specify more than one option value, the command will fail with an error.
+Specify either the `id`, `objectId` or `displayName`. If you specify more than one option value, the command will fail with an error.
 
 ## Examples
 
-Return details about the enterprise application with appId _b2307a39-e878-458b-bc90-03bc578531d6_.
+Return details about the enterprise application with the specified id.
 
 ```sh
-m365 entra enterpriseapp get --appId b2307a39-e878-458b-bc90-03bc578531d6
+m365 entra enterpriseapp get --id b2307a39-e878-458b-bc90-03bc578531d6
 ```
 
-Return details about the _Microsoft Graph_ enterprise application.
+Return details about the enterprise application with the specified displayName.
 
 ```sh
-m365 entra enterpriseapp get --appDisplayName "Microsoft Graph"
+m365 entra enterpriseapp get --displayName "Microsoft Graph"
 ```
 
-Return details about the enterprise application with ObjectId _b2307a39-e878-458b-bc90-03bc578531dd_.
+Return details about the enterprise application with the specified ObjectId.
 
 ```sh
-m365 entra enterpriseapp get --appObjectId b2307a39-e878-458b-bc90-03bc578531dd
+m365 entra enterpriseapp get --objectId b2307a39-e878-458b-bc90-03bc578531dd
 ```
 
 ## Response
@@ -69,7 +69,7 @@ m365 entra enterpriseapp get --appObjectId b2307a39-e878-458b-bc90-03bc578531dd
     "deletedDateTime": null,
     "accountEnabled": true,
     "alternativeNames": [],
-    "appDisplayName": "LinkedIn",
+    "displayName": "LinkedIn",
     "appDescription": null,
     "appId": "ac7c9b4b-83b0-4a5e-ace2-a3530162c8f8",
     "applicationTemplateId": null,
@@ -152,7 +152,7 @@ m365 entra enterpriseapp get --appObjectId b2307a39-e878-458b-bc90-03bc578531dd
   addIns                                : []
   alternativeNames                      : []
   appDescription                        : null
-  appDisplayName                        : LinkedIn
+  displayName                        : LinkedIn
   appId                                 : ac7c9b4b-83b0-4a5e-ace2-a3530162c8f8
   appOwnerOrganizationId                : c2b2a0f7-fa44-4929-a994-757b7b998f01
   appRoleAssignmentRequired             : true
@@ -190,7 +190,7 @@ m365 entra enterpriseapp get --appObjectId b2307a39-e878-458b-bc90-03bc578531dd
   <TabItem value="CSV">
 
   ```csv
-  id,accountEnabled,appDisplayName,appId,appOwnerOrganizationId,appRoleAssignmentRequired,createdDateTime,displayName,homepage,servicePrincipalType,signInAudience
+  id,accountEnabled,displayName,appId,appOwnerOrganizationId,appRoleAssignmentRequired,createdDateTime,displayName,homepage,servicePrincipalType,signInAudience
   b62fe6f3-5746-49be-af60-eaa24d66754a,1,LinkedIn,ac7c9b4b-83b0-4a5e-ace2-a3530162c8f8,c2b2a0f7-fa44-4929-a994-757b7b998f01,1,2022-12-12T15:41:42Z,LinkedIn,https://account.activedirectory.windowsazure.com:444/applications/default.aspx?metadata=linkedin|ISV9.3|primary|z,Application,AzureADMyOrg
   ```
 
@@ -198,7 +198,7 @@ m365 entra enterpriseapp get --appObjectId b2307a39-e878-458b-bc90-03bc578531dd
   <TabItem value="Markdown">
 
   ```md
-  # entra enterpriseapp get --appId "ac7c9b4b-83b0-4a5e-ace2-a3530162c8f8"
+  # entra enterpriseapp get --id "ac7c9b4b-83b0-4a5e-ace2-a3530162c8f8"
 
   Date: 2023-06-02
 
@@ -208,7 +208,7 @@ m365 entra enterpriseapp get --appObjectId b2307a39-e878-458b-bc90-03bc578531dd
   ---------|-------
   id | b62fe6f3-5746-49be-af60-eaa24d66754a
   accountEnabled | true
-  appDisplayName | LinkedIn
+  displayName | LinkedIn
   appId | ac7c9b4b-83b0-4a5e-ace2-a3530162c8f8
   appOwnerOrganizationId | c2b2a0f7-fa44-4929-a994-757b7b998f01
   appRoleAssignmentRequired | true

--- a/docs/docs/cmd/entra/enterpriseapp/enterpriseapp-list.mdx
+++ b/docs/docs/cmd/entra/enterpriseapp/enterpriseapp-list.mdx
@@ -22,24 +22,24 @@ m365 entra sp list [options]
 ## Options
 
 ```md definition-list
-`--displayName [displayName]`
-: Returns only enterprise applications with the specified name
+`-n, --displayName [displayName]`
+: Returns only enterprise applications with the specified name.
 
 `--tag [tag]`
-: Returns only enterprise applications with the specified tag
+: Returns only enterprise applications with the specified tag.
 ```
 
 <Global />
 
 ## Examples
 
-Return a list of all enterprise applications
+Returns a list of all enterprise applications.
 
 ```sh
 m365 entra enterpriseapp list
 ```
 
-Return a list of all enterprise applications that comply with the display name and the tag parameters
+Returns a list of all enterprise applications that comply with the specified display name and the tag parameters.
 
 ```sh
 m365 entra enterpriseapp list --displayName "My custom enterprise application" --tag "WindowsAzureActiveDirectoryIntegratedApp"

--- a/docs/docs/v9-upgrade-guidance.mdx
+++ b/docs/docs/v9-upgrade-guidance.mdx
@@ -1,0 +1,34 @@
+# v9 Upgrade Guidance
+
+The v9 of CLI for Microsoft 365 introduces several breaking changes. To help you upgrade to the latest version of CLI for Microsoft 365, we've listed those changes along with any actions you may need to take.
+
+## Enterprise application (or service principal)
+
+### Aligns options of `entra enterpriseapp` commands
+
+For this new major version, we've aligned the options of the `entra enterpriseapp` commands as follows: 
+
+[entra enterpriseapp add](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-add)
+
+| Old v8 option | New v9 option |
+|---------------|---------------|
+| --appId [appId] | -i, --id [id] |
+| --appName [appName] | -n, --displayName [displayName] |
+
+[entra enterpriseapp get](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-get)
+
+| Old v8 option | New v9 option |
+|---------------|---------------|
+| -i, --appId [appId] | -i, --id [id] |
+| -n, --appDisplayName [appDisplayName] | -n, --displayName [displayName] |
+| --appObjectId [appObjectId] | --objectId [objectId] |
+
+[entra enterpriseapp list](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-list)
+
+| Old v8 option | New v9 option |
+|---------------|---------------|
+| --displayName [displayName] | -n, --displayName [displayName] |
+
+#### What action do I need to take?
+
+Please, check the documentation of the [entra enterpriseapp add](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-add), [entra enterpriseapp get](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-get), and [entra enterpriseapp list](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-list) commands to see the updated options and adjust your scripts accordingly.

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.spec.ts
@@ -79,7 +79,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     assert.deepStrictEqual(alias, [aadCommands.SP_ADD, commands.SP_ADD]);
   });
 
-  it('fails validation if neither the appId, appName, nor objectId option specified', async () => {
+  it('fails validation if neither the id, displayName, nor objectId option specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -92,8 +92,8 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if the appId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appId: '123' } }, commandInfo);
+  it('fails validation if the id is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { id: '123' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
@@ -102,7 +102,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if both appId and appName are specified', async () => {
+  it('fails validation if both id and displayName are specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -111,11 +111,11 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { appId: '00000000-0000-0000-0000-000000000000', appName: 'abc' } }, commandInfo);
+    const actual = await command.validate({ options: { id: '00000000-0000-0000-0000-000000000000', displayName: 'abc' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if both appName and objectId are specified', async () => {
+  it('fails validation if both displayName and objectId are specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -124,11 +124,11 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { appName: 'abc', objectId: '123' } }, commandInfo);
+    const actual = await command.validate({ options: { displayName: 'abc', objectId: '123' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if both appId and objectId are specified', async () => {
+  it('fails validation if both id and objectId are specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -137,17 +137,17 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { appId: '00000000-0000-0000-0000-000000000000', objectId: '00000000-0000-0000-0000-000000000000' } }, commandInfo);
+    const actual = await command.validate({ options: { id: '00000000-0000-0000-0000-000000000000', objectId: '00000000-0000-0000-0000-000000000000' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('passes validation when the appId option specified', async () => {
-    const actual = await command.validate({ options: { appId: '00000000-0000-0000-0000-000000000000' } }, commandInfo);
+  it('passes validation when the id option specified', async () => {
+    const actual = await command.validate({ options: { id: '00000000-0000-0000-0000-000000000000' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation when the appName option specified', async () => {
-    const actual = await command.validate({ options: { appName: 'abc' } }, commandInfo);
+  it('passes validation when the displayName option specified', async () => {
+    const actual = await command.validate({ options: { displayName: 'abc' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
@@ -156,22 +156,22 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('supports specifying appId', () => {
+  it('supports specifying id', () => {
     const options = command.options;
     let containsOption = false;
     options.forEach(o => {
-      if (o.option.indexOf('--appId') > -1) {
+      if (o.option.indexOf('--id') > -1) {
         containsOption = true;
       }
     });
     assert(containsOption);
   });
 
-  it('supports specifying appName', () => {
+  it('supports specifying displayName', () => {
     const options = command.options;
     let containsOption = false;
     options.forEach(o => {
-      if (o.option.indexOf('--appName') > -1) {
+      if (o.option.indexOf('--displayName') > -1) {
         containsOption = true;
       }
     });
@@ -190,7 +190,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
   });
 
   it('correctly handles API OData error', async () => {
-    sinon.stub(request, 'get').rejects({
+    sinon.stub(request, 'post').rejects({
       error: {
         'odata.error': {
           code: '-1, InvalidOperationException',
@@ -201,7 +201,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6' } } as any),
+    await assert.rejects(command.action(logger, { options: { id: '65415bb1-9267-4313-bbf5-ae259732ee12' } } as any),
       new CommandError('An error has occurred'));
   });
 
@@ -260,7 +260,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     await assert.rejects(command.action(logger, {
       options: {
         debug: true,
-        appName: 'Test App'
+        displayName: 'Test App'
       }
     }), new CommandError("Multiple Entra apps with name 'Test App' found. Found: ee091f63-9e48-4697-8462-7cfbf7410b8e, e9fd0957-049f-40d0-8d1d-112320fb1cbd."));
   });
@@ -309,7 +309,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     await command.action(logger, {
       options: {
         debug: true,
-        appName: 'Test App'
+        displayName: 'Test App'
       }
     });
     assert(loggerLogSpy.calledWith({
@@ -319,7 +319,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     }));
   });
 
-  it('creates an enterprise application for a registered Entra app by appId', async () => {
+  it('creates an enterprise application for a registered Entra app by id', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/servicePrincipals`) {
         return {
@@ -333,7 +333,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
 
     await command.action(logger, {
       options: {
-        appId: '65415bb1-9267-4313-bbf5-ae259732ee12'
+        id: '65415bb1-9267-4313-bbf5-ae259732ee12'
       }
     });
     assert(loggerLogSpy.calledWith({
@@ -343,7 +343,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     }));
   });
 
-  it('creates an enterprise application for a registered Entra app by appName', async () => {
+  it('creates an enterprise application for a registered Entra app by displayName', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/v1.0/applications?$filter=displayName eq `) > -1) {
         return {
@@ -375,7 +375,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     await command.action(logger, {
       options: {
         debug: true,
-        appName: 'foo'
+        displayName: 'foo'
       }
     });
     assert(loggerLogSpy.calledWith({

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.ts
@@ -13,8 +13,8 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  appId?: string;
-  appName?: string;
+  id?: string;
+  displayName?: string;
   objectId?: string;
 }
 
@@ -43,8 +43,8 @@ class EntraEnterpriseAppAddCommand extends GraphCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        appId: (!(!args.options.appId)).toString(),
-        appName: (!(!args.options.appName)).toString(),
+        id: (!(!args.options.id)).toString(),
+        displayName: (!(!args.options.displayName)).toString(),
         objectId: (!(!args.options.objectId)).toString()
       });
     });
@@ -53,10 +53,10 @@ class EntraEnterpriseAppAddCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '--appId [appId]'
+        option: '-i, --id [id]'
       },
       {
-        option: '--appName [appName]'
+        option: '-n, --displayName [displayName]'
       },
       {
         option: '--objectId [objectId]'
@@ -67,12 +67,12 @@ class EntraEnterpriseAppAddCommand extends GraphCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (args.options.appId && !validation.isValidGuid(args.options.appId)) {
-          return `${args.options.appId} is not a valid appId GUID`;
+        if (args.options.id && !validation.isValidGuid(args.options.id)) {
+          return `${args.options.id} is not a valid GUID`;
         }
 
         if (args.options.objectId && !validation.isValidGuid(args.options.objectId)) {
-          return `${args.options.objectId} is not a valid objectId GUID`;
+          return `${args.options.objectId} is not a valid GUID`;
         }
 
         return true;
@@ -81,17 +81,17 @@ class EntraEnterpriseAppAddCommand extends GraphCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push({ options: ['appId', 'appName', 'objectId'] });
+    this.optionSets.push({ options: ['id', 'displayName', 'objectId'] });
   }
 
   private async getAppId(args: CommandArgs): Promise<string> {
-    if (args.options.appId) {
-      return args.options.appId;
+    if (args.options.id) {
+      return args.options.id;
     }
 
     let spMatchQuery: string = '';
-    if (args.options.appName) {
-      spMatchQuery = `displayName eq '${formatting.encodeQueryParameter(args.options.appName)}'`;
+    if (args.options.displayName) {
+      spMatchQuery = `displayName eq '${formatting.encodeQueryParameter(args.options.displayName)}'`;
     }
     else if (args.options.objectId) {
       spMatchQuery = `id eq '${formatting.encodeQueryParameter(args.options.objectId)}'`;
@@ -115,7 +115,7 @@ class EntraEnterpriseAppAddCommand extends GraphCommand {
 
     if (response.value.length > 1) {
       const resultAsKeyValuePair = formatting.convertArrayToHashTable('appId', response.value);
-      const result = await cli.handleMultipleResultsFound<{ appId: string }>(`Multiple Entra apps with name '${args.options.appName}' found.`, resultAsKeyValuePair);
+      const result = await cli.handleMultipleResultsFound<{ appId: string }>(`Multiple Entra apps with name '${args.options.displayName}' found.`, resultAsKeyValuePair);
       return result.appId;
     }
 

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
@@ -106,11 +106,11 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, appDisplayName: 'foo' } });
+    await command.action(logger, { options: { debug: true, displayName: 'foo' } });
     assert(loggerLogSpy.calledWith(spAppInfo));
   });
 
-  it('retrieves information about the specified enterprise application using its appId', async () => {
+  it('retrieves information about the specified enterprise application using its id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/v1.0/servicePrincipals?$filter=appId eq `) > -1) {
         return spAppInfo;
@@ -123,11 +123,11 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { appId: '65415bb1-9267-4313-bbf5-ae259732ee12' } });
+    await command.action(logger, { options: { id: '65415bb1-9267-4313-bbf5-ae259732ee12' } });
     assert(loggerLogSpy.calledWith(spAppInfo));
   });
 
-  it('retrieves information about the specified enterprise application using its appObjectId', async () => {
+  it('retrieves information about the specified enterprise application using its objectId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/v1.0/servicePrincipals?$filter=objectId eq `) > -1) {
         return spAppInfo;
@@ -140,7 +140,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { appObjectId: '59e617e5-e447-4adc-8b88-00af644d7c92' } });
+    await command.action(logger, { options: { objectId: '59e617e5-e447-4adc-8b88-00af644d7c92' } });
     assert(loggerLogSpy.calledWith(spAppInfo));
   });
 
@@ -206,7 +206,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
     await assert.rejects(command.action(logger, {
       options: {
         debug: true,
-        appDisplayName: 'foo'
+        displayName: 'foo'
       }
     }), new CommandError("Multiple Entra apps with name 'foo' found. Found: be559819-b036-470f-858b-281c4e808403, 93d75ef9-ba9b-4361-9a47-1f6f7478f05f."));
   });
@@ -252,7 +252,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
 
     sinon.stub(cli, 'handleMultipleResultsFound').resolves(spAppInfo.value[0]);
 
-    await command.action(logger, { options: { debug: true, appDisplayName: 'foo' } });
+    await command.action(logger, { options: { debug: true, displayName: 'foo' } });
     assert(loggerLogSpy.calledWith(spAppInfo));
   });
 
@@ -271,12 +271,12 @@ describe(commands.ENTERPRISEAPP_GET, () => {
     await assert.rejects(command.action(logger, {
       options: {
         debug: true,
-        appDisplayName: 'Test App'
+        displayName: 'Test App'
       }
     }), new CommandError(`The specified Entra app does not exist`));
   });
 
-  it('fails validation if neither the appId nor the appDisplayName option specified', async () => {
+  it('fails validation if neither the id nor the displayName option specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -289,22 +289,22 @@ describe(commands.ENTERPRISEAPP_GET, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if the appId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appId: '123' } }, commandInfo);
+  it('fails validation if the id is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { id: '123' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('passes validation when the appId option specified', async () => {
-    const actual = await command.validate({ options: { appId: '6a7b1395-d313-4682-8ed4-65a6265a6320' } }, commandInfo);
+  it('passes validation when the id option specified', async () => {
+    const actual = await command.validate({ options: { id: '6a7b1395-d313-4682-8ed4-65a6265a6320' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation when the appDisplayName option specified', async () => {
-    const actual = await command.validate({ options: { appDisplayName: 'Microsoft Graph' } }, commandInfo);
+  it('passes validation when the displayName option specified', async () => {
+    const actual = await command.validate({ options: { displayName: 'Microsoft Graph' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('fails validation when both the appId and appDisplayName are specified', async () => {
+  it('fails validation when both the id and displayName are specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -313,16 +313,16 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { appId: '6a7b1395-d313-4682-8ed4-65a6265a6320', appDisplayName: 'Microsoft Graph' } }, commandInfo);
+    const actual = await command.validate({ options: { id: '6a7b1395-d313-4682-8ed4-65a6265a6320', displayName: 'Microsoft Graph' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if the appObjectId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appObjectId: '123' } }, commandInfo);
+  it('fails validation if the objectId is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { objectId: '123' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if both appId and appDisplayName are specified', async () => {
+  it('fails validation if both id and displayName are specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -331,11 +331,11 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { appId: '123', appDisplayName: 'abc' } }, commandInfo);
+    const actual = await command.validate({ options: { id: '123', displayName: 'abc' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if appObjectId and appDisplayName are specified', async () => {
+  it('fails validation if objectId and displayName are specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -344,26 +344,26 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({ options: { appDisplayName: 'abc', appObjectId: '123' } }, commandInfo);
+    const actual = await command.validate({ options: { displayName: 'abc', objectId: '123' } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 
-  it('supports specifying appId', () => {
+  it('supports specifying id', () => {
     const options = command.options;
     let containsOption = false;
     options.forEach(o => {
-      if (o.option.indexOf('--appId') > -1) {
+      if (o.option.indexOf('--id') > -1) {
         containsOption = true;
       }
     });
     assert(containsOption);
   });
 
-  it('supports specifying appDisplayName', () => {
+  it('supports specifying displayName', () => {
     const options = command.options;
     let containsOption = false;
     options.forEach(o => {
-      if (o.option.indexOf('--appDisplayName') > -1) {
+      if (o.option.indexOf('--displayName') > -1) {
         containsOption = true;
       }
     });

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.ts
@@ -13,9 +13,9 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  appId?: string;
-  appDisplayName?: string;
-  appObjectId?: string;
+  id?: string;
+  displayName?: string;
+  objectId?: string;
 }
 
 class EntraEnterpriseAppGetCommand extends GraphCommand {
@@ -43,9 +43,9 @@ class EntraEnterpriseAppGetCommand extends GraphCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        appId: (!(!args.options.appId)).toString(),
-        appDisplayName: (!(!args.options.appDisplayName)).toString(),
-        appObjectId: (!(!args.options.appObjectId)).toString()
+        id: (!(!args.options.id)).toString(),
+        displayName: (!(!args.options.displayName)).toString(),
+        objectId: (!(!args.options.objectId)).toString()
       });
     });
   }
@@ -53,13 +53,13 @@ class EntraEnterpriseAppGetCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-i, --appId [appId]'
+        option: '-i, --id [id]'
       },
       {
-        option: '-n, --appDisplayName [appDisplayName]'
+        option: '-n, --displayName [displayName]'
       },
       {
-        option: '--appObjectId [appObjectId]'
+        option: '--objectId [objectId]'
       }
     );
   }
@@ -67,12 +67,12 @@ class EntraEnterpriseAppGetCommand extends GraphCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (args.options.appId && !validation.isValidGuid(args.options.appId)) {
-          return `${args.options.appId} is not a valid appId GUID`;
+        if (args.options.id && !validation.isValidGuid(args.options.id)) {
+          return `${args.options.id} is not a valid GUID`;
         }
 
-        if (args.options.appObjectId && !validation.isValidGuid(args.options.appObjectId)) {
-          return `${args.options.appObjectId} is not a valid objectId GUID`;
+        if (args.options.objectId && !validation.isValidGuid(args.options.objectId)) {
+          return `${args.options.objectId} is not a valid GUID`;
         }
 
         return true;
@@ -81,20 +81,20 @@ class EntraEnterpriseAppGetCommand extends GraphCommand {
   }
 
   #initOptionSets(): void {
-    this.optionSets.push({ options: ['appId', 'appDisplayName', 'appObjectId'] });
+    this.optionSets.push({ options: ['id', 'displayName', 'objectId'] });
   }
 
   private async getSpId(args: CommandArgs): Promise<string> {
-    if (args.options.appObjectId) {
-      return args.options.appObjectId;
+    if (args.options.objectId) {
+      return args.options.objectId;
     }
 
     let spMatchQuery: string = '';
-    if (args.options.appDisplayName) {
-      spMatchQuery = `displayName eq '${formatting.encodeQueryParameter(args.options.appDisplayName)}'`;
+    if (args.options.displayName) {
+      spMatchQuery = `displayName eq '${formatting.encodeQueryParameter(args.options.displayName)}'`;
     }
-    else if (args.options.appId) {
-      spMatchQuery = `appId eq '${formatting.encodeQueryParameter(args.options.appId)}'`;
+    else if (args.options.id) {
+      spMatchQuery = `appId eq '${formatting.encodeQueryParameter(args.options.id)}'`;
     }
 
     const idRequestOptions: CliRequestOptions = {
@@ -115,7 +115,7 @@ class EntraEnterpriseAppGetCommand extends GraphCommand {
 
     if (response.value.length > 1) {
       const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', response.value);
-      const result = await cli.handleMultipleResultsFound<{ id: string }>(`Multiple Entra apps with name '${args.options.appDisplayName}' found.`, resultAsKeyValuePair);
+      const result = await cli.handleMultipleResultsFound<{ id: string }>(`Multiple Entra apps with name '${args.options.displayName}' found.`, resultAsKeyValuePair);
       return result.id;
     }
 

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.ts
@@ -50,7 +50,7 @@ class EntraEnterpriseAppListCommand extends GraphCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '--displayName [displayName]'
+        option: '-n, --displayName [displayName]'
       },
       {
         option: '--tag [tag]'


### PR DESCRIPTION
Aligns options of below "entra enterpriseapp" commands. Closes #6155

[entra enterpriseapp add](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-add)
[entra enterpriseapp get](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-get)
[entra enterpriseapp list](https://pnp.github.io/cli-microsoft365/cmd/entra/enterpriseapp/enterpriseapp-list)

All commands use the same aligned options as follows:

- `-i, --id [id]`
- `-n, --displayName [displayName]`
- `--objectId [objectId]`