### PR TITLE
Enhances 'spo list roleassignment' commands with Entra groups.

### DIFF
--- a/docs/docs/cmd/spo/list/list-roleassignment-add.mdx
+++ b/docs/docs/cmd/spo/list/list-roleassignment-add.mdx
@@ -26,13 +26,19 @@ m365 spo list roleassignment add [options]
 : Relative URL of the list. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `--principalId [principalId]`
-: SharePoint ID of principal it may be either user id or group id we want to add permissions to. Specify either `principalId`, `upn`, or `groupName` but not multiple.
+: SharePoint ID of principal it may be either user id or group id we want to add permissions to. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
 
 `--upn [upn]`
-: The upn/email of user to assign role to. Specify either `principalId`, `upn`, or `groupName` but not multiple.
+: The upn/email of user to assign role to. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
+
+`--entraGroupId [entraGroupId]`
+: ID of the Microsoft Entra group to assign permissions to. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
+
+`--entraGroupName [entraGroupName]`
+: Display name of the Microsoft Entra group to assign permissions to. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
 
 `--groupName [groupName]`
-: The group name of Microsoft Entra or SharePoint group. Specify either `principalId`, `upn`, or `groupName` but not multiple.
+: The group name of Microsoft Entra or SharePoint group. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
 
 `--roleDefinitionId [roleDefinitionId]`
 : ID of role definition. Specify either `roleDefinitionId` or `roleDefinitionName` but not both.
@@ -79,6 +85,12 @@ Adds role assignment to list by title located in a specific site for given princ
 
 ```sh
 m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "someList" --principalId 11 --roleDefinitionName "Full Control"
+```
+
+Adds role assignment to list for a Microsoft Entra group specified by display name.
+
+```sh
+m365 spo list roleassignment add --webUrl "https://contoso.sharepoint.com/sites/project-x" --listTitle "someList" --entraGroupName "Marketing" --roleDefinitionName "Full Control"
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/list/list-roleassignment-remove.mdx
+++ b/docs/docs/cmd/spo/list/list-roleassignment-remove.mdx
@@ -26,13 +26,19 @@ m365 spo list roleassignment remove [options]
 : Relative URL of the list. Specify either `listId`, `listTitle`, or `listUrl` but not multiple.
 
 `--principalId [principalId]`
-: SharePoint ID of principal it may be either user id or group id you want to remove permissions. Specify either `principalId`, `upn`, or `groupName` but not multiple.
+: SharePoint ID of principal it may be either user id or group id you want to remove permissions. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
 
 `--upn [upn]`
-: The upn/email of user. Specify either `principalId`, `upn`, or `groupName` but not multiple.
+: The upn/email of user. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
 
 `--groupName [groupName]`
-: The group name of Microsoft Entra or SharePoint group. Specify either `principalId`, `upn`, or `groupName` but not multiple.
+: The group name of Microsoft Entra or SharePoint group. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
+
+`--entraGroupId [entraGroupId]`
+: ID of the Microsoft Entra group. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
+
+`--entraGroupName [entraGroupName]`
+: Display name of the Microsoft Entra group. Specify either `principalId`, `upn`, `groupName`, `entraGroupId`, or `entraGroupName`.
 
 `-f, --force`
 : Don't prompt for confirming removing the role assignment.
@@ -58,6 +64,12 @@ Remove roleassignment from list by url based on principal Id.
 
 ```sh
 m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales" --listUrl '/sites/contoso-sales/lists/Events' --principalId 2
+```
+
+Remove roleassignment from Microsoft Entra group specified by display name.
+
+```sh
+m365 spo list roleassignment remove --webUrl "https://contoso.sharepoint.com/sites/contoso-sales" --listUrl '/sites/contoso-sales/lists/Events' --entraGroupName "Sales Team"
 ```
 
 ## Response

--- a/src/m365/spo/commands/list/list-roleassignment-add.spec.ts
+++ b/src/m365/spo/commands/list/list-roleassignment-add.spec.ts
@@ -14,11 +14,16 @@ import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import { RoleDefinition } from '../roledefinition/RoleDefinition.js';
 import command from './list-roleassignment-add.js';
+import { settingsNames } from '../../../../settingsNames.js';
+import { entraGroup } from '../../../../utils/entraGroup.js';
 
 describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+
+  const webUrl = 'https://contoso.sharepoint.com/sites/Marketing';
+
   const userResponse = {
     Id: 11,
     IsHiddenInUI: false,
@@ -37,8 +42,23 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     UserPrincipalName: 'john.doe@contoso.com'
   };
 
+  const entraGroupResponse = {
+    Id: 15,
+    IsHiddenInUI: false,
+    LoginName: 'c:0o.c|federateddirectoryclaimprovider|27ae47f1-48f1-46f3-980b-d3c1470e398d',
+    Title: 'Marketing members',
+    PrincipalType: 1,
+    Email: '',
+    Expiration: '',
+    IsEmailAuthenticationGuestUser: false,
+    IsShareByEmailGuestUser: false,
+    IsSiteAdmin: false,
+    UserId: null,
+    UserPrincipalName: null
+  };
+
   const groupResponse = {
-    Id: 11,
+    Id: 12,
     IsHiddenInUI: false,
     LoginName: "groupname",
     Title: "groupname",
@@ -79,11 +99,57 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     RoleTypeKindValue: "Reader"
   };
 
+  const graphGroup = {
+    id: '27ae47f1-48f1-46f3-980b-d3c1470e398d',
+    deletedDateTime: null,
+    classification: null,
+    createdDateTime: '2024-03-22T20:18:37Z',
+    creationOptions: [],
+    description: null,
+    displayName: 'Marketing',
+    expirationDateTime: null,
+    groupTypes: [
+      'Unified'
+    ],
+    isAssignableToRole: null,
+    mail: 'Marketing@milanhdev.onmicrosoft.com',
+    mailEnabled: true,
+    mailNickname: 'Marketing',
+    membershipRule: null,
+    membershipRuleProcessingState: null,
+    onPremisesDomainName: null,
+    onPremisesLastSyncDateTime: null,
+    onPremisesNetBiosName: null,
+    onPremisesSamAccountName: null,
+    onPremisesSecurityIdentifier: null,
+    onPremisesSyncEnabled: null,
+    preferredDataLocation: null,
+    preferredLanguage: null,
+    proxyAddresses: [
+      'SPO:SPO_de7704ba-415d-4dd0-9bbd-fa565007a87e@SPO_18c58817-3bc9-489d-ac63-f7264fb357e5',
+      'SMTP:Marketing@milanhdev.onmicrosoft.com'
+    ],
+    renewedDateTime: '2024-03-22T20:18:37Z',
+    resourceBehaviorOptions: [],
+    resourceProvisioningOptions: [],
+    securityEnabled: true,
+    securityIdentifier: 'S-1-12-1-665733105-1190349041-3268610968-2369326662',
+    theme: null,
+    uniqueName: null,
+    visibility: 'Private',
+    onPremisesProvisioningErrors: [],
+    serviceProvisioningErrors: []
+  };
+
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').returns();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => settingName === settingsNames.prompt ? false : defaultValue);
+    sinon.stub(entraGroup, 'getGroupById').withArgs(graphGroup.id).resolves(graphGroup);
+    sinon.stub(entraGroup, 'getGroupByDisplayName').withArgs(graphGroup.displayName).resolves(graphGroup);
+    sinon.stub(spo, 'ensureEntraGroup').withArgs(webUrl, graphGroup).resolves(entraGroupResponse);
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
   });
@@ -107,7 +173,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     sinonUtil.restore([
       request.post,
       spo.getGroupByName,
-      spo.getUserByEmail,
+      spo.ensureUser,
       spo.getRoleDefinitionByName
     ]);
   });
@@ -165,9 +231,29 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('add role assignment on list by title and role definition id', async () => {
+  it('fails validation if the upn option is not a valid user principal name', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', upn: 'invalid', roleDefinitionId: 1073741827 } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the upn option is a valid user principal name', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', upn: 'john.doe@contoso.com', roleDefinitionId: 1073741827 } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if the entraGroupId option is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', entraGroupId: 'invalid', roleDefinitionId: 1073741827 } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the entraGroupId option is a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', entraGroupId: '37455d5c-e466-4e49-8eba-808b5acec21b', roleDefinitionId: 1073741827 } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('adds role assignment on list by title and role definition id', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('_api/web/lists/getByTitle(\'test\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists/getByTitle('test')/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
@@ -176,7 +262,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listTitle: 'test',
         principalId: 11,
@@ -185,9 +271,9 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     });
   });
 
-  it('add role assignment on list by id and role definition id', async () => {
+  it('adds role assignment on list by id and role definition id', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
@@ -196,7 +282,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         principalId: 11,
@@ -205,9 +291,9 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     });
   });
 
-  it('add role assignment on list by url and role definition id', async () => {
+  it('adds role assignment on list by url and role definition id', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/GetList(\'%2Fsites%2Fdocuments\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetList('%2Fsites%2Fdocuments')/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
@@ -216,7 +302,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listUrl: 'sites/documents',
         principalId: 11,
@@ -225,20 +311,20 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     });
   });
 
-  it('add role assignment on list get principal id by upn', async () => {
+  it('adds role assignment on list and gets principal id by upn', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(spo, 'getUserByEmail').resolves(userResponse);
+    sinon.stub(spo, 'ensureUser').resolves(userResponse);
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         upn: 'someaccount@tenant.onmicrosoft.com',
@@ -249,7 +335,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly handles error when upn does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
@@ -257,22 +343,22 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
     });
 
     const error = 'User cannot be found.';
-    sinon.stub(spo, 'getUserByEmail').rejects(new Error(error));
+    sinon.stub(spo, 'ensureUser').rejects(new Error(error));
 
     await assert.rejects(command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         upn: 'someaccount@tenant.onmicrosoft.com',
         roleDefinitionId: 1073741827
       }
-    } as any), new CommandError(error));
+    }), new CommandError(error));
   });
 
-  it('add role assignment on list get principal id by group name', async () => {
+  it('adds role assignment on list and gets principal id by group name', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='12',roledefid='1073741827')`) {
         return;
       }
 
@@ -283,7 +369,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         groupName: 'someGroup',
@@ -294,7 +380,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly handles error when group does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
@@ -306,18 +392,18 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         groupName: 'someGroup',
         roleDefinitionId: 1073741827
       }
-    } as any), new CommandError(error));
+    }), new CommandError(error));
   });
 
-  it('add role assignment on list get role definition id by role definition name', async () => {
+  it('adds role assignment on list and gets role definition id by role definition name', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
@@ -328,7 +414,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         principalId: 11,
@@ -339,7 +425,7 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
   it('correctly handles error when role definition does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/addroleassignment(principalid=\'11\',roledefid=\'1073741827\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='11',roledefid='1073741827')`) {
         return;
       }
 
@@ -351,12 +437,52 @@ describe(commands.LIST_ROLEASSIGNMENT_ADD, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         principalId: 11,
         roleDefinitionName: 'Full Control'
       }
-    } as any), new CommandError(error));
+    }), new CommandError(error));
+  });
+
+  it('correctly adds role assignments for a Microsoft Entra group specified by ID', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='15',roledefid='1073741827')`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        webUrl: 'https://contoso.sharepoint.com/sites/Marketing',
+        listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
+        entraGroupId: graphGroup.id,
+        roleDefinitionId: 1073741827
+      }
+    });
+  });
+
+  it('correctly adds role assignments for a Microsoft Entra group specified by display name', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/addroleassignment(principalid='15',roledefid='1073741827')`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        webUrl: 'https://contoso.sharepoint.com/sites/Marketing',
+        listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
+        entraGroupName: graphGroup.displayName,
+        roleDefinitionId: 1073741827
+      }
+    });
   });
 });

--- a/src/m365/spo/commands/list/list-roleassignment-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-roleassignment-remove.spec.ts
@@ -11,16 +11,108 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import spoGroupGetCommand from '../group/group-get.js';
-import spoUserGetCommand from '../user/user-get.js';
 import command from './list-roleassignment-remove.js';
+import { settingsNames } from '../../../../settingsNames.js';
+import { spo } from '../../../../utils/spo.js';
+import { entraGroup } from '../../../../utils/entraGroup.js';
 
 describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
   let log: any[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let requests: any[];
   let promptIssued: boolean = false;
+
+  const webUrl = 'https://contoso.sharepoint.com/sites/Marketing';
+
+  const userResponse = {
+    Id: 11,
+    IsHiddenInUI: false,
+    LoginName: "i:0#.f|membership|someaccount@tenant.onmicrosoft.com",
+    Title: "Some Account",
+    PrincipalType: 1,
+    Email: "someaccount@tenant.onmicrosoft.com",
+    Expiration: "",
+    IsEmailAuthenticationGuestUser: false,
+    IsShareByEmailGuestUser: false,
+    IsSiteAdmin: true,
+    UserId: {
+      NameId: "1003200097d06dd6",
+      NameIdIssuer: "urn:federation:microsoftonline"
+    },
+    UserPrincipalName: "someaccount@tenant.onmicrosoft.com"
+  };
+
+  const groupResponse = {
+    Id: 12,
+    IsHiddenInUI: false,
+    LoginName: "otherGroup",
+    Title: "otherGroup",
+    PrincipalType: 8,
+    AllowMembersEditMembership: false,
+    AllowRequestToJoinLeave: false,
+    AutoAcceptRequestToJoinLeave: false,
+    Description: "",
+    OnlyAllowMembersViewMembership: true,
+    OwnerTitle: "Some Account",
+    RequestToJoinLeaveEmailSetting: null
+  };
+
+  const entraGroupResponse = {
+    Id: 15,
+    IsHiddenInUI: false,
+    LoginName: 'c:0o.c|federateddirectoryclaimprovider|27ae47f1-48f1-46f3-980b-d3c1470e398d',
+    Title: 'Marketing members',
+    PrincipalType: 1,
+    Email: '',
+    Expiration: '',
+    IsEmailAuthenticationGuestUser: false,
+    IsShareByEmailGuestUser: false,
+    IsSiteAdmin: false,
+    UserId: null,
+    UserPrincipalName: null
+  };
+
+  const graphGroup = {
+    id: '27ae47f1-48f1-46f3-980b-d3c1470e398d',
+    deletedDateTime: null,
+    classification: null,
+    createdDateTime: '2024-03-22T20:18:37Z',
+    creationOptions: [],
+    description: null,
+    displayName: 'Marketing',
+    expirationDateTime: null,
+    groupTypes: [
+      'Unified'
+    ],
+    isAssignableToRole: null,
+    mail: 'Marketing@milanhdev.onmicrosoft.com',
+    mailEnabled: true,
+    mailNickname: 'Marketing',
+    membershipRule: null,
+    membershipRuleProcessingState: null,
+    onPremisesDomainName: null,
+    onPremisesLastSyncDateTime: null,
+    onPremisesNetBiosName: null,
+    onPremisesSamAccountName: null,
+    onPremisesSecurityIdentifier: null,
+    onPremisesSyncEnabled: null,
+    preferredDataLocation: null,
+    preferredLanguage: null,
+    proxyAddresses: [
+      'SPO:SPO_de7704ba-415d-4dd0-9bbd-fa565007a87e@SPO_18c58817-3bc9-489d-ac63-f7264fb357e5',
+      'SMTP:Marketing@milanhdev.onmicrosoft.com'
+    ],
+    renewedDateTime: '2024-03-22T20:18:37Z',
+    resourceBehaviorOptions: [],
+    resourceProvisioningOptions: [],
+    securityEnabled: true,
+    securityIdentifier: 'S-1-12-1-665733105-1190349041-3268610968-2369326662',
+    theme: null,
+    uniqueName: null,
+    visibility: 'Private',
+    onPremisesProvisioningErrors: [],
+    serviceProvisioningErrors: []
+  };
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -29,13 +121,10 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
-      if (settingName === 'prompt') {
-        return false;
-      }
-
-      return defaultValue;
-    });
+    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => settingName === settingsNames.prompt ? false : defaultValue);
+    sinon.stub(entraGroup, 'getGroupById').withArgs(graphGroup.id).resolves(graphGroup);
+    sinon.stub(entraGroup, 'getGroupByDisplayName').withArgs(graphGroup.displayName).resolves(graphGroup);
+    sinon.stub(spo, 'ensureEntraGroup').withArgs(webUrl, graphGroup).resolves(entraGroupResponse);
   });
 
   beforeEach(() => {
@@ -51,10 +140,9 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
         log.push(msg);
       }
     };
-    requests = [];
-    sinon.stub(cli, 'promptForConfirmation').callsFake(() => {
+    sinon.stub(cli, 'promptForConfirmation').callsFake(async () => {
       promptIssued = true;
-      return Promise.resolve(false);
+      return false;
     });
 
     promptIssued = false;
@@ -63,7 +151,8 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.post,
-      cli.executeCommandWithOutput,
+      spo.ensureUser,
+      spo.getGroupByName,
       cli.promptForConfirmation
     ]);
   });
@@ -111,9 +200,29 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('remove role assignment from list by title', async () => {
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('_api/web/lists/getByTitle(\'test\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+  it('fails validation if the upn option is not a valid user principal name', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', upn: 'invalid' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the upn option is a valid user principal name', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', upn: 'john.doe@contoso.com' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if the entraGroupId option is not a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', entraGroupId: '12345' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if the entraGroupId option is a valid GUID', async () => {
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com', listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF', entraGroupId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('removes role assignment from list by title', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists/getByTitle('test')/roleassignments/removeroleassignment(principalid='11')`) {
         return;
       }
 
@@ -122,18 +231,20 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listTitle: 'test',
         principalId: 11,
         force: true
       }
     });
+
+    assert(postStub.calledOnce);
   });
 
-  it('remove role assignment from list by id', async () => {
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+  it('removes role assignment from list by id', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/removeroleassignment(principalid='11')`) {
         return;
       }
 
@@ -142,18 +253,20 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         principalId: 11,
         force: true
       }
     });
+
+    assert(postStub.calledOnce);
   });
 
-  it('remove role assignment from list by url', async () => {
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/GetList(\'%2Fsites%2Fdocuments\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+  it('removes role assignment from list by url', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetList(\'%2Fsites%2Fdocuments\')/roleassignments/removeroleassignment(principalid='11')`) {
         return;
       }
 
@@ -162,62 +275,52 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listUrl: 'sites/documents',
         principalId: 11,
         force: true
       }
     });
+
+    assert(postStub.calledOnce);
   });
 
-  it('remove role assignment from list get principal id by upn', async () => {
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+  it('removes role assignment from list get principal id by upn', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/removeroleassignment(principalid='11')`) {
         return;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoUserGetCommand) {
-        return {
-          stdout: '{"Id": 11,"IsHiddenInUI": false,"LoginName": "i:0#.f|membership|someaccount@tenant.onmicrosoft.com","Title": "Some Account","PrincipalType": 1,"Email": "someaccount@tenant.onmicrosoft.com","Expiration": "","IsEmailAuthenticationGuestUser": false,"IsShareByEmailGuestUser": false,"IsSiteAdmin": true,"UserId": {"NameId": "1003200097d06dd6","NameIdIssuer": "urn:federation:microsoftonline"},"UserPrincipalName": "someaccount@tenant.onmicrosoft.com"}'
-        };
-      }
-
-      throw new CommandError('Unknown case');
-    });
+    sinon.stub(spo, 'ensureUser').withArgs('https://contoso.sharepoint.com', 'someaccount@tenant.onmicrosoft.com').resolves(userResponse);
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         upn: 'someaccount@tenant.onmicrosoft.com',
         force: true
       }
     });
+
+    assert(postStub.calledOnce);
   });
 
   it('correctly handles error when upn does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/removeroleassignment(principalid='11')`) {
         return;
       }
 
       throw 'Invalid request';
     });
 
-    const error = 'no user found';
-    sinon.stub(cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoUserGetCommand) {
-        throw error;
-      }
-
-      throw new CommandError('Unknown case');
-    });
+    const error = 'User was not found';
+    sinon.stub(spo, 'ensureUser').rejects({ error: { 'odata.error': { message: { value: error } } } });
 
     await assert.rejects(command.action(logger, {
       options: {
@@ -232,26 +335,18 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
 
   it('remove role assignment from list get principal id by group name', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/removeroleassignment(principalid='12')`) {
         return;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoGroupGetCommand) {
-        return {
-          stdout: '{"Id": 11,"IsHiddenInUI": false,"LoginName": "otherGroup","Title": "otherGroup","PrincipalType": 8,"AllowMembersEditMembership": false,"AllowRequestToJoinLeave": false,"AutoAcceptRequestToJoinLeave": false,"Description": "","OnlyAllowMembersViewMembership": true,"OwnerTitle": "Some Account","RequestToJoinLeaveEmailSetting": null}'
-        };
-      }
-
-      throw new CommandError('Unknown case');
-    });
+    sinon.stub(spo, 'getGroupByName').withArgs('https://contoso.sharepoint.com', 'someGroup', logger, true).resolves(groupResponse);
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         groupName: 'someGroup',
@@ -262,7 +357,7 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
 
   it('correctly handles error when group does not exist', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/removeroleassignment(principalid='12')`) {
         return;
       }
 
@@ -270,94 +365,129 @@ describe(commands.LIST_ROLEASSIGNMENT_REMOVE, () => {
     });
 
     const error = 'no group found';
-    sinon.stub(cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoGroupGetCommand) {
-        throw error;
-      }
-
-      throw new CommandError('Unknown case');
-    });
+    sinon.stub(spo, 'getGroupByName').rejects({ error: { 'odata.error': { message: { value: error } } } });
 
     await assert.rejects(command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         groupName: 'someGroup',
         force: true
       }
-    } as any), new CommandError(error));
+    }), new CommandError(error));
   });
 
   it('aborts removing role assignment when prompt not confirmed', async () => {
+    const postStub = sinon.stub(request, 'post').resolves();
+
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         groupName: 'someGroup'
       }
     });
-    assert(requests.length === 0);
+
+    assert(postStub.notCalled);
   });
 
   it('prompts before removing role assignment when confirmation argument not passed (Id)', async () => {
+    sinon.stub(request, 'post').resolves();
+
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
-        listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
+        listUrl: '/Lists/Tasks',
         groupName: 'someGroup'
       }
     });
-
 
     assert(promptIssued);
   });
 
   it('prompts before removing role assignment when confirmation argument not passed (Title)', async () => {
+    sinon.stub(request, 'post').resolves();
+
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listTitle: 'someList',
         groupName: 'someGroup'
       }
     });
 
-
     assert(promptIssued);
   });
 
   it('removes role assignment when prompt confirmed', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf('/_api/web/lists(guid\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')/roleassignments/removeroleassignment(principalid=\'11\')') > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/removeroleassignment(principalid='12')`) {
         return;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(cli, 'executeCommandWithOutput').callsFake(async (command): Promise<any> => {
-      if (command === spoGroupGetCommand) {
-        return {
-          stdout: '{"Id": 11,"IsHiddenInUI": false,"LoginName": "otherGroup","Title": "otherGroup","PrincipalType": 8,"AllowMembersEditMembership": false,"AllowRequestToJoinLeave": false,"AutoAcceptRequestToJoinLeave": false,"Description": "","OnlyAllowMembersViewMembership": true,"OwnerTitle": "Some Account","RequestToJoinLeaveEmailSetting": null}'
-        };
-      }
-
-      throw new CommandError('Unknown case');
-    });
+    sinon.stub(spo, 'getGroupByName').withArgs('https://contoso.sharepoint.com', 'someGroup', logger, true).resolves(groupResponse);
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
       options: {
-        debug: true,
+        verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
         groupName: 'someGroup'
       }
     });
+  });
+
+  it('removes role assignments for a Microsoft Entra group by id', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/removeroleassignment(principalid='15')`) {
+        return;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        webUrl: webUrl,
+        listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
+        entraGroupId: graphGroup.id,
+        force: true
+      }
+    });
+
+    assert(postStub.calledOnce);
+  });
+
+  it('removes role assignments for a Microsoft Entra group by display name', async () => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `${webUrl}/_api/web/lists(guid'0CD891EF-AFCE-4E55-B836-FCE03286CCCF')/roleassignments/removeroleassignment(principalid='15')`) {
+        return;
+      }
+
+      throw 'Invalid request: ' + opts.url;
+    });
+
+    await command.action(logger, {
+      options: {
+        verbose: true,
+        webUrl: webUrl,
+        listId: '0CD891EF-AFCE-4E55-B836-FCE03286CCCF',
+        entraGroupName: graphGroup.displayName,
+        force: true
+      }
+    });
+
+    assert(postStub.calledOnce);
   });
 });


### PR DESCRIPTION
Closes #6194

--- 

Made some extra optimizations. For example:
- In the remove command, I removed the sub-command calling since we want to move away from this approach.
- In the add command, I made sure that all users are ensured before adding permissions. Right now you get an error if you specify a user that is not yet registered in the site collection.
