### PR TITLE
Remove deprecated option "--wait" from "spo site remove" command. Closes #5956

### DIFF
--- a/docs/docs/cmd/spo/site/site-remove.mdx
+++ b/docs/docs/cmd/spo/site/site-remove.mdx
@@ -22,9 +22,6 @@ m365 spo site remove [options]
 `--fromRecycleBin`
 : Set to remove the site from the recycle bin.
 
-`--wait`
-: (deprecated) Wait for the site to be removed before completing the command.
-
 `-f, --force`
 : Don't prompt for confirmation.
 ```

--- a/docs/docs/v9-upgrade-guidance.mdx
+++ b/docs/docs/v9-upgrade-guidance.mdx
@@ -1,0 +1,13 @@
+# v9 Upgrade Guidance
+
+The v9 of CLI for Microsoft 365 introduces several breaking changes. To help you upgrade to the latest version of CLI for Microsoft 365, we've listed those changes along with any actions you may need to take.
+
+## SharePoint
+
+### Removed the deprecated `wait` option and output from the `spo site remove` command
+
+For this new major version, we've removed the deprecated `wait` option from the `spo site remove` command.
+
+#### What action do I need to take?
+
+In the [spo site remove](./cmd/spo/site/site-remove.mdx) command, remove deprecated `wait` option from your scripts.

--- a/src/m365/spo/commands/site/site-remove.spec.ts
+++ b/src/m365/spo/commands/site/site-remove.spec.ts
@@ -360,16 +360,6 @@ describe(commands.SITE_REMOVE, () => {
       new CommandError('Site is currently not in the recycle bin. Remove --fromRecycleBin if you want to remove it as active site.'));
   });
 
-  it(`correctly shows deprecation warning for option 'wait'`, async () => {
-    const chalk = (await import('chalk')).default;
-    const loggerErrSpy = sinon.spy(logger, 'logToStderr');
-
-    await command.action(logger, { options: { url: siteUrl, wait: true } });
-    assert(loggerErrSpy.calledWith(chalk.yellow(`Option 'wait' is deprecated and will be removed in the next major release.`)));
-
-    sinonUtil.restore(loggerErrSpy);
-  });
-
   it('prompts before removing the site when force option not passed', async () => {
     await command.action(logger, { options: { url: siteUrl, verbose: true } });
     assert(promptIssued);

--- a/src/m365/spo/commands/site/site-remove.ts
+++ b/src/m365/spo/commands/site/site-remove.ts
@@ -19,7 +19,6 @@ interface Options extends GlobalOptions {
   url: string;
   skipRecycleBin?: boolean;
   fromRecycleBin?: boolean;
-  wait?: boolean;
   force?: boolean;
 }
 
@@ -55,7 +54,6 @@ class SpoSiteRemoveCommand extends SpoCommand {
       Object.assign(this.telemetryProperties, {
         skipRecycleBin: !!args.options.skipRecycleBin,
         fromRecycleBin: !!args.options.fromRecycleBin,
-        wait: !!args.options.wait,
         force: !!args.options.force
       });
     });
@@ -71,9 +69,6 @@ class SpoSiteRemoveCommand extends SpoCommand {
       },
       {
         option: '--fromRecycleBin'
-      },
-      {
-        option: '--wait'
       },
       {
         option: '-f, --force'
@@ -105,14 +100,10 @@ class SpoSiteRemoveCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push('url');
-    this.types.boolean.push('skipRecycleBin', 'fromRecycleBin', 'wait', 'force');
+    this.types.boolean.push('skipRecycleBin', 'fromRecycleBin', 'force');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (args.options.wait) {
-      await this.warn(logger, `Option 'wait' is deprecated and will be removed in the next major release.`);
-    }
-
     if (args.options.force) {
       await this.removeSite(logger, args.options);
     }


### PR DESCRIPTION
Remove deprecated `--wait` option from `spo site remove` command. Closes #5956