### PR TITLE
Updated "cli doctor" command response. Closes #5923

### DIFF
--- a/docs/docs/cmd/cli/cli-doctor.mdx
+++ b/docs/docs/cmd/cli/cli-doctor.mdx
@@ -22,7 +22,7 @@ This command gets all the necessary diagnostic information needed to triage and 
 
 ## Examples
 
-Retrieve diagnostic information
+Retrieve diagnostic information.
 
 ```sh
 m365 cli doctor
@@ -42,8 +42,8 @@ m365 cli doctor
     },
     "cliVersion": "6.1.0",
     "nodeVersion": "v16.13.0",
-    "cliAadAppId": "31359c7f-bd7e-475c-86db-fdb8c937548e",
-    "cliAadAppTenant": "common",
+    "cliEntraAppId": "31359c7f-bd7e-475c-86db-fdb8c937548e",
+    "cliEntraAppTenant": "common",
     "authMode": "DeviceCode",
     "cliEnvironment": "",
     "cliConfig": {
@@ -61,23 +61,23 @@ m365 cli doctor
   <TabItem value="Text">
 
   ```text
-  authMode       : DeviceCode
-  cliAadAppId    : 31359c7f-bd7e-475c-86db-fdb8c937548e
-  cliAadAppTenant: common
-  cliConfig      : {"output":"json","showHelpOnFailure":false}
-  cliEnvironment :
-  cliVersion     : 6.1.0
-  nodeVersion    : v16.13.0
-  os             : {"platform":"win32","version":"Windows 10 Pro","release":"10.0.19045"}
-  roles          : []
-  scopes         : ["AllSites.FullControl"]
+  authMode          : DeviceCode
+  cliEntraAppId     : 31359c7f-bd7e-475c-86db-fdb8c937548e
+  cliEntraAppTenant : common
+  cliConfig         : {"output":"json","showHelpOnFailure":false}
+  cliEnvironment    :
+  cliVersion        : 6.1.0
+  nodeVersion       : v16.13.0
+  os                : {"platform":"win32","version":"Windows 10 Pro","release":"10.0.19045"}
+  roles             : []
+  scopes            : ["AllSites.FullControl"]
   ```
 
   </TabItem>
   <TabItem value="CSV">
 
   ```csv
-  os,cliVersion,nodeVersion,cliAadAppId,cliAadAppTenant,authMode,cliEnvironment,cliConfig,roles,scopes
+  os,cliVersion,nodeVersion,cliEntraAppId,cliEntraAppTenant,authMode,cliEnvironment,cliConfig,roles,scopes
   "{""platform"":""win32"",""version"":""Windows 10 Pro"",""release"":""10.0.19045""}",6.1.0,v16.13.0,31359c7f-bd7e-475c-86db-fdb8c937548e,common,DeviceCode,,"{""output"":""json"",""showHelpOnFailure"":false}",[],"[""AllSites.FullControl""]"
   ```
 
@@ -93,12 +93,11 @@ m365 cli doctor
   ---------|-------
   cliVersion | 6.1.0
   nodeVersion | v16.13.0
-  cliAadAppId | 31359c7f-bd7e-475c-86db-fdb8c937548e
-  cliAadAppTenant | common
+  cliEntraAppId | 31359c7f-bd7e-475c-86db-fdb8c937548e
+  cliEntraAppTenant | common
   authMode | DeviceCode
   cliEnvironment |
   ```
 
   </TabItem>
 </Tabs>
-

--- a/docs/docs/v9-upgrade-guidance.mdx
+++ b/docs/docs/v9-upgrade-guidance.mdx
@@ -1,0 +1,15 @@
+# v9 Upgrade Guidance
+
+The v9 of CLI for Microsoft 365 introduces several breaking changes. To help you upgrade to the latest version of CLI for Microsoft 365, we've listed those changes along with any actions you may need to take.
+
+## CLI Doctor
+
+### Updated output of `cli doctor` command
+
+For this new major version, we've adjusted the output of the `cli doctor` command to align the renaming of Azure AD to Microsoft Entra ID.
+
+The output is updated with `cliAadAppId` as `cliEntraAppId` and `cliAadAppTenant` as `cliEntraAppTenant`.
+
+#### What action do I need to take?
+
+Please, check the documentation of the [cli doctor](./cmd/cli/cli-doctor.mdx) command to see the updated output and adjust your scripts accordingly.

--- a/src/m365/cli/commands/cli-doctor.spec.ts
+++ b/src/m365/cli/commands/cli-doctor.spec.ts
@@ -91,8 +91,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
       authMode: 'DeviceCode',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -164,8 +164,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
       authMode: 'DeviceCode',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -211,8 +211,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
       authMode: 'DeviceCode',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -255,8 +255,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
       authMode: 'DeviceCode',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -292,8 +292,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
       authMode: 'DeviceCode',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -336,8 +336,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
       authMode: 'DeviceCode',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -372,8 +372,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
       authMode: 'Certificate',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -408,8 +408,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: { debug: true } });
     assert(loggerLogSpy.calledWith({
       authMode: 'Certificate',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'single',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'single',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -444,8 +444,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: { debug: true } });
     assert(loggerLogSpy.calledWith({
       authMode: 'Certificate',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -480,8 +480,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: { debug: true } });
     assert(loggerLogSpy.calledWith({
       authMode: 'Certificate',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: 'docker',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -509,8 +509,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: { debug: true } });
     assert(loggerLogSpy.calledWith({
       authMode: 'Certificate',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -520,7 +520,6 @@ describe(commands.DOCTOR, () => {
       scopes: {}
     }));
   });
-
 
   it('returns empty roles and scopes in diagnostic information when access token is invalid', async () => {
     sinon.stub(auth.connection, 'accessTokens').value({
@@ -539,8 +538,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: { debug: true } });
     assert(loggerLogSpy.calledWith({
       authMode: 'Certificate',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {},
@@ -577,8 +576,8 @@ describe(commands.DOCTOR, () => {
     await command.action(logger, { options: {} });
     assert(loggerLogSpy.calledWith({
       authMode: 'DeviceCode',
-      cliAadAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
-      cliAadAppTenant: 'common',
+      cliEntraAppId: '31359c7f-bd7e-475c-86db-fdb8c937548e',
+      cliEntraAppTenant: 'common',
       cliEnvironment: '',
       cliVersion: '3.11.0',
       cliConfig: {

--- a/src/m365/cli/commands/cli-doctor.ts
+++ b/src/m365/cli/commands/cli-doctor.ts
@@ -14,8 +14,8 @@ interface CliDiagnosticInfo {
     release: string;
   };
   authMode: string;
-  cliAadAppId: string;
-  cliAadAppTenant: string;
+  cliEntraAppId: string;
+  cliEntraAppTenant: string;
   cliEnvironment: string;
   nodeVersion: string;
   cliVersion: string;
@@ -55,8 +55,8 @@ class CliDoctorCommand extends Command {
       },
       cliVersion: app.packageJson().version,
       nodeVersion: process.version,
-      cliAadAppId: auth.connection.appId,
-      cliAadAppTenant: validation.isValidGuid(auth.connection.tenant) ? 'single' : auth.connection.tenant,
+      cliEntraAppId: auth.connection.appId,
+      cliEntraAppTenant: validation.isValidGuid(auth.connection.tenant) ? 'single' : auth.connection.tenant,
       authMode: AuthType[auth.connection.authType],
       cliEnvironment: process.env.CLIMICROSOFT365_ENV ? process.env.CLIMICROSOFT365_ENV : '',
       cliConfig: cli.getConfig().all,


### PR DESCRIPTION
Updated `cli doctor` command response. Closes #5923

Adjusted the output of the `cli doctor` command to align the renaming of Azure AD to Microsoft Entra ID.
The output is updated with `cliAadAppId` as `cliEntraAppId` and `cliAadAppTenant` as `cliEntraAppTenant`.