### PR TITLE
Updates script sample

### DIFF
--- a/docs/docs/sample-scripts/spo/copy-files-to-another-library/assets/sample.json
+++ b/docs/docs/sample-scripts/spo/copy-files-to-another-library/assets/sample.json
@@ -22,7 +22,7 @@
     "metadata": [
       {
         "key": "CLI-FOR-MICROSOFT365",
-        "value": "6.3.0"
+        "value": "8.0.0"
       }
     ],
     "thumbnails": [

--- a/docs/docs/sample-scripts/spo/copy-files-to-another-library/index.mdx
+++ b/docs/docs/sample-scripts/spo/copy-files-to-another-library/index.mdx
@@ -40,7 +40,7 @@ This script shows how you can use the CLI to:
         }
       }
 
-      $allFiles = m365 spo file list --webUrl "$tenatUrl$sourceSite" --folder $folder.substring(1) --output 'json'
+      $allFiles = m365 spo file list --webUrl "$tenatUrl$sourceSite" --folderUrl $folder.substring(1) --output 'json'
       $allFiles = $allFiles | ConvertFrom-Json
       foreach ($file in $allFiles) {
         $fileUrl = $file.ServerRelativeUrl -replace $sourceSite, ''
@@ -88,9 +88,9 @@ This script shows how you can use the CLI to:
   }
 
   $tenatUrl = 'https://contoso.sharepoint.com'
-  $sourceLibrary = 'Shared%20Documents'
+  $sourceLibrary = 'Shared Documents'
   $sourceSite = '/sites/FromSite'
-  $targetLibrary = 'Shared%20Documents'
+  $targetLibrary = 'Shared Documents'
   $targetSite = '/sites/ToSite'
   $copyKeepingSameFolderStructure = $false
   Copy-LibraryToLibrary -tenatUrl $tenatUrl -sourceLibrary $sourceLibrary -sourceSite $sourceSite -targetLibrary $targetLibrary -targetSite $targetSite -copyKeepingSameFolderStructure $copyKeepingSameFolderStructure

--- a/docs/docs/sample-scripts/spo/copy-files-to-another-library/index.mdx
+++ b/docs/docs/sample-scripts/spo/copy-files-to-another-library/index.mdx
@@ -57,17 +57,17 @@ This script shows how you can use the CLI to:
     [Parameter(Mandatory = $True)][bool] $copyKeepingSameFolderStructure) {
     if ($copyKeepingSameFolderStructure) {
       Write-host "Copy the same structure"
-      
+
       $allFolders = m365 spo folder list --webUrl "$tenatUrl$sourceSite" --parentFolderUrl "/$sourceLibrary" --output 'json'
       $allFolders = $allFolders | ConvertFrom-Json
       foreach ($folder in $allFolders) {
         if ($folder.Name -ne 'Forms') {
           $folderName = $folder.Name
-          m365 spo folder copy --webUrl "$tenatUrl$sourceSite" --sourceUrl "/$sourceLibrary/$folderName" --targetUrl "$targetSite/$targetLibrary" --allowSchemaMismatch
+          m365 spo folder copy --webUrl "$tenatUrl$sourceSite" --sourceUrl "/$sourceLibrary/$folderName" --targetUrl "$targetSite/$targetLibrary"
         }
       }
-      
-      $allFiles = m365 spo file list --webUrl "$tenatUrl$sourceSite" --folder $sourceLibrary --output 'json'
+
+      $allFiles = m365 spo file list --webUrl "$tenatUrl$sourceSite" --folderUrl $sourceLibrary --output 'json'
       $allFiles = $allFiles | ConvertFrom-Json
       foreach ($file in $allFiles) {
         $fileUrl = $file.ServerRelativeUrl -replace $sourceSite, ''


### PR DESCRIPTION
## Some Context

I got a help request with one of our scripts. The gentleman who contacted me tried to use one of our scripts to [copy the contents of one lib to a different one](https://pnp.github.io/cli-microsoft365/sample-scripts/spo/copy-files-to-another-library/).
When I investigated the issue I noticed the script sample was outdated. It will work fine with the mentioned CLI version at that time which is v6 but instead of just pointing to use an older version of CLI it's easier to update it to be valid with latest (v8) version

## What was changed
based on upgrade guidance 
![image](https://github.com/user-attachments/assets/6b3e46d9-219b-4ef0-bd47-703225b121e3)

![image](https://github.com/user-attachments/assets/07eabe32-019c-4271-a134-32f6c2d6aa0c)


## 📷 Result

Running the script 
![image](https://github.com/user-attachments/assets/087a947d-65b9-4fb1-b1f3-cec6e25519fd)

Result (full folder and file structure copied over)
![image](https://github.com/user-attachments/assets/d3d56853-4379-46e6-a00b-ce5d226daf73)

