### PR TITLE
Fixes issues with number parameters validation. Closes #6211

### DIFF
--- a/src/cli/cli.spec.ts
+++ b/src/cli/cli.spec.ts
@@ -1859,4 +1859,16 @@ describe('cli', () => {
     await cli.execute(['cli', 'completion', 'sh', 'update']);
     assert(loadAllCommandsInfoStub.calledWith(true));
   });
+
+  it('yargs parser has correct configuration set', async () => {
+    const yargsConfiguration = cli.yargsConfiguration;
+
+    assert.notStrictEqual(yargsConfiguration, undefined);
+    assert.strictEqual(yargsConfiguration!['parse-numbers'], true);
+    assert.strictEqual(yargsConfiguration!['strip-aliased'], true);
+    assert.strictEqual(yargsConfiguration!['strip-dashed'], true);
+    assert.strictEqual(yargsConfiguration!['dot-notation'], false);
+    assert.strictEqual(yargsConfiguration!['boolean-negation'], true);
+    assert.strictEqual(yargsConfiguration!['camel-case-expansion'], false);
+  });
 });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -166,7 +166,7 @@ async function execute(rawArgs: string[]): Promise<void> {
     if (!result.success) {
       return cli.closeWithError(result.error, cli.optionsFromArgs, true);
     }
-    
+
     finalArgs = result.data;
   }
   else {
@@ -478,9 +478,12 @@ function getCommandOptionsFromArgs(args: string[], commandInfo: CommandInfo | un
   const yargsOptions: yargs.Options = {
     alias: {},
     configuration: {
-      "parse-numbers": false,
+      "parse-numbers": true,
       "strip-aliased": true,
-      "strip-dashed": true
+      "strip-dashed": true,
+      "dot-notation": false,
+      "boolean-negation": true,
+      "camel-case-expansion": false
     }
   };
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -48,6 +48,14 @@ const defaultHelpMode = 'options';
 const defaultHelpTarget = 'console';
 const helpModes: string[] = ['options', 'examples', 'remarks', 'response', 'full'];
 const helpTargets: string[] = ['console', 'web'];
+const yargsConfiguration: Partial<yargs.Configuration> = {
+  'parse-numbers': true,
+  'strip-aliased': true,
+  'strip-dashed': true,
+  'dot-notation': false,
+  'boolean-negation': true,
+  'camel-case-expansion': false
+};
 
 function getConfig(): Configstore {
   if (!_config) {
@@ -477,14 +485,7 @@ function getCommandOptions(command: Command): CommandOptionInfo[] {
 function getCommandOptionsFromArgs(args: string[], commandInfo: CommandInfo | undefined): yargs.Arguments {
   const yargsOptions: yargs.Options = {
     alias: {},
-    configuration: {
-      "parse-numbers": true,
-      "strip-aliased": true,
-      "strip-dashed": true,
-      "dot-notation": false,
-      "boolean-negation": true,
-      "camel-case-expansion": false
-    }
+    configuration: yargsConfiguration
   };
 
   let argsToParse = args;
@@ -1018,5 +1019,6 @@ export const cli = {
   printAvailableCommands,
   promptForConfirmation,
   promptForSelection,
-  shouldTrimOutput
+  shouldTrimOutput,
+  yargsConfiguration
 };


### PR DESCRIPTION
## 🎯 Aim

This is a prototype PR that aims to solve problems with parsing number options when not passed as strings

Closes #6211

## 📷 Result

It seems to be working properly with numbers as well as with content type IDs (0x0...)

![image](https://github.com/user-attachments/assets/5a183a0e-da53-4482-bbbe-67bbdc5e06d2)

![Untitled1](https://github.com/user-attachments/assets/e1d5052b-e220-4d41-b071-3bd545f2a940)

![image](https://github.com/user-attachments/assets/b4613e71-dc61-449d-bc82-159f01720a7e)

