### PR TITLE
WIP: Implements accessToken as new authType. Closes #5816

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -513,11 +513,12 @@ export default abstract class Command {
   }
 
   private loadValuesFromAccessToken(args: CommandArgs): void {
-    if (!auth.connection.accessTokens[auth.defaultResource]) {
+    const resource = Object.keys(auth.connection.accessTokens)[0];
+    if (!auth.connection.accessTokens[resource]) {
       return;
     }
 
-    const token = auth.connection.accessTokens[auth.defaultResource].accessToken;
+    const token = auth.connection.accessTokens[resource].accessToken;
     const optionNames: string[] = Object.getOwnPropertyNames(args.options);
     optionNames.forEach(option => {
       const value = args.options[option];
@@ -527,7 +528,7 @@ export default abstract class Command {
 
       const lowerCaseValue = value.toLowerCase().trim();
       if (lowerCaseValue === '@meid' || lowerCaseValue === '@meusername') {
-        const isAppOnlyAccessToken = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken);
+        const isAppOnlyAccessToken = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[resource].accessToken);
         if (isAppOnlyAccessToken) {
           throw `It's not possible to use ${value} with application permissions`;
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export default {
   applicationName: `CLI for Microsoft 365 v${app.packageJson().version}`,
   delimiter: 'm365\$',
   cliEntraAppId: process.env.CLIMICROSOFT365_ENTRAAPPID || process.env.CLIMICROSOFT365_AADAPPID || cliEntraAppId,
+  cliEnvEntraAppId: process.env.CLIMICROSOFT365_ENTRAAPPID || process.env.CLIMICROSOFT365_AADAPPID,
   tenant: process.env.CLIMICROSOFT365_TENANT || 'common',
   configstoreName: 'cli-m365-config'
 };

--- a/src/m365/commands/status.ts
+++ b/src/m365/commands/status.ts
@@ -1,4 +1,4 @@
-import auth from '../../Auth.js';
+import auth, { AuthType } from '../../Auth.js';
 import { Logger } from '../../cli/Logger.js';
 import Command, { CommandArgs, CommandError } from '../../Command.js';
 import commands from './commands.js';
@@ -15,7 +15,14 @@ class StatusCommand extends Command {
   public async commandAction(logger: Logger): Promise<void> {
     if (auth.connection.active) {
       try {
-        await auth.ensureAccessToken(auth.defaultResource, logger, this.debug);
+        if (auth.connection.authType !== AuthType.AccessToken) {
+          await auth.ensureAccessToken(auth.defaultResource, logger, this.debug);
+        }
+        else {
+          for (const resource of Object.keys(auth.connection.accessTokens)) {
+            await auth.ensureAccessToken(resource, logger, this.debug);
+          }
+        }
       }
       catch (err: any) {
         if (this.debug) {

--- a/src/m365/entra/commands/app/app-add.ts
+++ b/src/m365/entra/commands/app/app-add.ts
@@ -268,7 +268,7 @@ class EntraAppAddCommand extends GraphCommand {
       // directory. If we in the future extend the command with allowing
       // users to create Microsoft Entra app in a different directory, we'll need to
       // adjust this
-      appInfo.tenantId = accessToken.getTenantIdFromAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken);
+      appInfo.tenantId = accessToken.getTenantIdFromAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken);
       appInfo = await this.updateAppFromManifest(args, appInfo);
       appInfo = await this.grantAdminConsent(appInfo, args.options.grantAdminConsent, logger);
       appInfo = await this.configureUri(args, appInfo, logger);

--- a/src/m365/entra/commands/m365group/m365group-set.ts
+++ b/src/m365/entra/commands/m365group/m365group-set.ts
@@ -176,7 +176,7 @@ class EntraM365GroupSetCommand extends GraphCommand {
     await this.showDeprecationWarning(logger, aadCommands.M365GROUP_SET, commands.M365GROUP_SET);
 
     try {
-      if ((args.options.allowExternalSenders !== undefined || args.options.autoSubscribeNewMembers !== undefined) && accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken)) {
+      if ((args.options.allowExternalSenders !== undefined || args.options.autoSubscribeNewMembers !== undefined) && accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken)) {
         throw `Option 'allowExternalSenders' and 'autoSubscribeNewMembers' can only be used when using delegated permissions.`;
       }
 

--- a/src/m365/entra/commands/pim/pim-role-assignment-add.ts
+++ b/src/m365/entra/commands/pim/pim-role-assignment-add.ts
@@ -188,7 +188,7 @@ class EntraPimRoleAssignmentAddCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     const { userId, userName, groupId, groupName, startDateTime, endDateTime, ticketNumber, ticketSystem } = args.options;
     try {
-      const token = auth.connection.accessTokens[auth.defaultResource].accessToken;
+      const token = auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken;
       const isAppOnlyAccessToken = accessToken.isAppOnlyAccessToken(token);
 
       if (isAppOnlyAccessToken) {
@@ -271,7 +271,7 @@ class EntraPimRoleAssignmentAddCommand extends GraphCommand {
       await logger.logToStderr(`Retrieving id of the current user`);
     }
 
-    const token = auth.connection.accessTokens[auth.defaultResource].accessToken;
+    const token = auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken;
     return accessToken.getUserIdFromAccessToken(token);
   }
 

--- a/src/m365/entra/commands/user/user-set.ts
+++ b/src/m365/entra/commands/user/user-set.ts
@@ -253,10 +253,10 @@ class EntraUserSetCommand extends GraphCommand {
 
     try {
       if (args.options.currentPassword) {
-        if (args.options.id && args.options.id !== accessToken.getUserIdFromAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken)) {
+        if (args.options.id && args.options.id !== accessToken.getUserIdFromAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken)) {
           throw `You can only change your own password. Please use --id @meId to reference to your own userId`;
         }
-        else if (args.options.userName && args.options.userName.toLowerCase() !== accessToken.getUserNameFromAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken).toLowerCase()) {
+        else if (args.options.userName && args.options.userName.toLowerCase() !== accessToken.getUserNameFromAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken).toLowerCase()) {
           throw 'You can only change your own password. Please use --userName @meUserName to reference to your own user principal name';
         }
       }

--- a/src/m365/file/commands/convert/convert-pdf.ts
+++ b/src/m365/file/commands/convert/convert-pdf.ts
@@ -80,7 +80,7 @@ class FileConvertPdfCommand extends GraphCommand {
     let targetIsLocalFile: boolean = true;
     let error: any;
 
-    const isAppOnlyAccessToken: boolean | undefined = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken);
+    const isAppOnlyAccessToken: boolean | undefined = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken);
     if (typeof isAppOnlyAccessToken === 'undefined') {
       throw 'Unable to determine authentication type';
     }

--- a/src/m365/outlook/commands/message/message-list.ts
+++ b/src/m365/outlook/commands/message/message-list.ts
@@ -142,7 +142,7 @@ class OutlookMessageListCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      if (!args.options.userId && !args.options.userName && accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken)) {
+      if (!args.options.userId && !args.options.userName && accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken)) {
         throw 'You must specify either the userId or userName option when using app-only permissions.';
       }
 

--- a/src/m365/outlook/commands/message/message-remove.ts
+++ b/src/m365/outlook/commands/message/message-remove.ts
@@ -87,7 +87,7 @@ class OutlookMessageRemoveCommand extends GraphCommand {
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    const isAppOnlyAccessToken: boolean | undefined = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken);
+    const isAppOnlyAccessToken: boolean | undefined = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken);
     let principalUrl = '';
 
     if (isAppOnlyAccessToken) {

--- a/src/m365/pa/commands/app/app-permission-remove.ts
+++ b/src/m365/pa/commands/app/app-permission-remove.ts
@@ -190,7 +190,7 @@ class PaAppPermissionRemoveCommand extends PowerAppsCommand {
       return userId;
     }
 
-    return `tenant-${accessToken.getTenantIdFromAccessToken(Auth.connection.accessTokens[Auth.defaultResource].accessToken)}`;
+    return `tenant-${accessToken.getTenantIdFromAccessToken(Auth.connection.accessTokens[Object.keys(Auth.connection.accessTokens)[0]].accessToken)}`;
   }
 }
 

--- a/src/m365/purview/commands/auditlog/auditlog-list.ts
+++ b/src/m365/purview/commands/auditlog/auditlog-list.ts
@@ -121,7 +121,7 @@ class PurviewAuditLogListCommand extends O365MgmtCommand {
         await logger.logToStderr(`Getting audit logs for content type '${args.options.contentType}' within a time frame from '${startTime.toISOString()}' to '${endTime.toISOString()}'.`);
       }
 
-      const tenantId = accessToken.getTenantIdFromAccessToken(Auth.connection.accessTokens[Auth.defaultResource].accessToken);
+      const tenantId = accessToken.getTenantIdFromAccessToken(Auth.connection.accessTokens[Object.keys(Auth.connection.accessTokens)[0]].accessToken);
       const contentTypeValue = args.options.contentType === 'DLP' ? 'DLP.All' : 'Audit.' + args.options.contentType;
 
       await this.ensureSubscription(tenantId, contentTypeValue);

--- a/src/m365/teams/commands/meeting/meeting-attendancereport-get.ts
+++ b/src/m365/teams/commands/meeting/meeting-attendancereport-get.ts
@@ -107,7 +107,7 @@ class TeamsMeetingAttendancereportGetCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const isAppOnlyAccessToken: boolean | undefined = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken);
+      const isAppOnlyAccessToken: boolean | undefined = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken);
       if (isAppOnlyAccessToken && !args.options.userId && !args.options.userName && !args.options.email) {
         throw `The option 'userId', 'userName' or 'email' is required when retrieving meeting attendance report using app only permissions.`;
       }

--- a/src/m365/tenant/commands/id/id-get.ts
+++ b/src/m365/tenant/commands/id/id-get.ts
@@ -49,7 +49,7 @@ class TenantIdGetCommand extends Command {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     let domainName: string | undefined = args.options.domainName;
     if (!domainName) {
-      const userName: string = accessToken.getUserNameFromAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken);
+      const userName: string = accessToken.getUserNameFromAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken);
       domainName = userName.split('@')[1];
     }
 

--- a/src/m365/tenant/commands/info/info-get.ts
+++ b/src/m365/tenant/commands/info/info-get.ts
@@ -75,7 +75,7 @@ class TenantInfoGetCommand extends GraphCommand {
     const tenantId: string | undefined = args.options.tenantId;
 
     if (!domainName && !tenantId) {
-      const userName: string = accessToken.getUserNameFromAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken);
+      const userName: string = accessToken.getUserNameFromAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken);
       domainName = userName.split('@')[1];
     }
 

--- a/src/m365/viva/commands/engage/engage-community-add.ts
+++ b/src/m365/viva/commands/engage/engage-community-add.ts
@@ -126,7 +126,7 @@ class VivaEngageCommunityAddCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     const { displayName, description, privacy, adminEntraIds, adminEntraUserNames, wait } = args.options;
 
-    const isAppOnlyAccessToken = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[auth.defaultResource].accessToken);
+    const isAppOnlyAccessToken = accessToken.isAppOnlyAccessToken(auth.connection.accessTokens[Object.keys(auth.connection.accessTokens)[0]].accessToken);
     if (isAppOnlyAccessToken && !adminEntraIds && !adminEntraUserNames) {
       this.handleError(`Specify at least one admin using either adminEntraIds or adminEntraUserNames options when using application permissions.`);
     }

--- a/src/utils/accessToken.ts
+++ b/src/utils/accessToken.ts
@@ -96,6 +96,74 @@ export const accessToken = {
     return userId;
   },
 
+  getAppIdFromAccessToken(accessToken: string): string {
+    let appId: string = '';
+
+    if (!accessToken || accessToken.length === 0) {
+      return appId;
+    }
+
+    const chunks = accessToken.split('.');
+    if (chunks.length !== 3) {
+      return appId;
+    }
+
+    const tokenString: string = Buffer.from(chunks[1], 'base64').toString();
+    try {
+      const token: any = JSON.parse(tokenString);
+      appId = token.appid;
+    }
+    catch {
+    }
+
+    return appId;
+  },
+
+  getAudienceFromAccessToken(accessToken: string): string {
+    let audience: string = '';
+
+    if (!accessToken || accessToken.length === 0) {
+      return audience;
+    }
+
+    const chunks = accessToken.split('.');
+    if (chunks.length !== 3) {
+      return audience;
+    }
+
+    const tokenString: string = Buffer.from(chunks[1], 'base64').toString();
+    try {
+      const token: any = JSON.parse(tokenString);
+      audience = token.aud;
+    }
+    catch {
+    }
+
+    return audience;
+  },
+
+  getExpirationFromAccessToken(accessToken: string): Date | undefined {
+    if (!accessToken || accessToken.length === 0) {
+      return undefined;
+    }
+
+    const chunks = accessToken.split('.');
+    if (chunks.length !== 3) {
+      return undefined;
+    }
+
+    const tokenString: string = Buffer.from(chunks[1], 'base64').toString();
+    try {
+      const token: any = JSON.parse(tokenString);
+      const expiration = token.exp;
+      return new Date(expiration * 1000);
+    }
+    catch {
+    }
+
+    return;
+  },
+
   /**
    * Asserts the presence of a delegated access token.
    * @throws {CommandError} Will throw an error if the access token is not available.


### PR DESCRIPTION
Closes #5816

Implements accessToken as new authType. 

Ok, this is a work in progress, I haven't implemented tests yet, but I'd really like some opinion here.
I've implemented the basics, you can use one or more access tokens. It doesn't matter which ones you use. 

Our logic normally checked if a token for the graph was available during login. For accessToken auth I'm working around that. It checks all tokens that you've passed, it doesn't depend on the graph. If you just use a SharePoint token, you'll be able to execute SharePoint commands, but not graph commands, and the other way around.

Try it out like:

```posh
m365 login --authType accessToken --accessToken "ey...1"
```

or:

```posh
m365 login --authType accessToken --accessToken "ey...1" --accessToken "ey...2"
```