### PR TITLE
Remove deprecated option `username` from `entra m365group user set`, Closes #6224

### DIFF
--- a/docs/docs/cmd/entra/m365group/m365group-user-set.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-user-set.mdx
@@ -35,14 +35,11 @@ m365 aad teams user set
 `--teamName [teamName]`
 : The display name of the Microsoft Teams team. Specify only one of the following: `groupId`, `groupName`, `teamId`, or `teamName`.
 
-`-n, --userName [userName]`
-: (deprecated) User's UPN (User Principal Name), e.g. johndoe@example.com.
-
 `--ids [ids]`
-: Microsoft Entra IDs of users. You can also pass a comma-separated list of IDs. Specify only one of the following `userName`, `ids` or `userNames`.
+: Microsoft Entra IDs of users. You can also pass a comma-separated list of IDs. Specify only one of the following `ids` or `userNames`.
 
 `--userNames [userNames]`
-: The user principal names of users. You can also pass a comma-separated list of UPNs. Specify only one of the following `userName`, `ids` or `userNames`.
+: The user principal names of users. You can also pass a comma-separated list of UPNs. Specify only one of the following `ids` or `userNames`.
 
 `-r, --role <role>`
 : Role to set for the given user in the specified Microsoft 365 Group or Microsoft Teams team. Allowed values: `Owner`, `Member`
@@ -59,7 +56,7 @@ The command will return an error if the user already has the specified role in t
 Promote a single user to Owner of the given Microsoft 365 Group
 
 ```sh
-m365 entra m365group user set --groupId '00000000-0000-0000-0000-000000000000' --userName 'anne.matthews@contoso.onmicrosoft.com' --role Owner
+m365 entra m365group user set --groupId '00000000-0000-0000-0000-000000000000' --userNames 'anne.matthews@contoso.onmicrosoft.com' --role Owner
 ```
 
 Promote multiple users specified by the userNames parameter to Owner of the given Microsoft 365 Group
@@ -77,7 +74,7 @@ m365 entra m365group user set --groupId '00000000-0000-0000-0000-000000000000' -
 Demote a single user from Owner to Member in the given Microsoft 365 Group
 
 ```sh
-m365 entra m365group user set --groupId '00000000-0000-0000-0000-000000000000' --userName 'anne.matthews@contoso.onmicrosoft.com' --role Member
+m365 entra m365group user set --groupId '00000000-0000-0000-0000-000000000000' --userNames 'anne.matthews@contoso.onmicrosoft.com' --role Member
 ```
 
 Demote multiple users specified by the userNames parameter from Owner to Member of the given Microsoft Teams team

--- a/docs/docs/v10-upgrade-guidance.mdx
+++ b/docs/docs/v10-upgrade-guidance.mdx
@@ -68,7 +68,7 @@ The deprecated Guest value was removed from the `role` option in the [aad m365gr
 
 #### What action do I need to take?
 
-Please, check the documentation of the aad m365group user list](./cmd/entra/m365group/m365group-user-list.mdx) command to see the updated ``role` option and adjust your scripts accordingly.
+Please, check the documentation of the [aad m365group user list](./cmd/entra/m365group/m365group-user-list.mdx) command to see the updated ``role` option and adjust your scripts accordingly.
 
 #### Aligned options with naming convention
 
@@ -129,6 +129,14 @@ We've enhanced the [entra m365group set](./cmd/entra/m365group/m365group-set.mdx
 #### What action do I need to take?
 
 Make sure that if you are currently updating groups using the `displayName` option, you update your scripts to use the `newDisplayName` option instead.
+
+### Removed deprecated option `username` from `entra m365group user set` command.
+
+The deprecated option `username` was removed from the [entra m365group user set](./cmd/entra/m365group/m365group-user-set.mdx) command.
+
+#### What action do I need to take?
+
+Please, check the documentation of the [entra m365group user set](./cmd/entra/m365group/m365group-user-set.mdx) command to see the updated `username` option and adjust your scripts accordingly.
 
 ## SharePoint
 

--- a/src/m365/entra/commands/m365group/m365group-user-set.spec.ts
+++ b/src/m365/entra/commands/m365group/m365group-user-set.spec.ts
@@ -518,7 +518,7 @@ describe(commands.M365GROUP_USER_SET, () => {
     sinonUtil.restore(entraGroup.isUnifiedGroup);
     sinon.stub(entraGroup, 'isUnifiedGroup').resolves(false);
 
-    await assert.rejects(command.action(logger, { options: { groupId: groupId, userName: 'anne.matthews@contoso.onmicrosoft.com' } } as any),
+    await assert.rejects(command.action(logger, { options: { groupId: groupId, userNames: userUpns.join(',') } } as any),
       new CommandError(`Specified group with id '${groupId}' is not a Microsoft 365 group.`));
   });
 });

--- a/src/m365/entra/commands/m365group/m365group-user-set.ts
+++ b/src/m365/entra/commands/m365group/m365group-user-set.ts
@@ -15,7 +15,6 @@ interface CommandArgs {
 }
 
 interface Options extends GlobalOptions {
-  userName?: string;
   ids?: string;
   userNames?: string;
   groupId?: string;
@@ -66,9 +65,6 @@ class EntraM365GroupUserSetCommand extends GraphCommand {
 
   #initOptions(): void {
     this.options.unshift(
-      {
-        option: '-n, --userName [userName]'
-      },
       {
         option: '--ids [ids]'
       },
@@ -130,22 +126,17 @@ class EntraM365GroupUserSetCommand extends GraphCommand {
 
   #initOptionSets(): void {
     this.optionSets.push({ options: ['groupId', 'groupName', 'teamId', 'teamName'] });
-    this.optionSets.push({ options: ['userName', 'ids', 'userNames'] });
+    this.optionSets.push({ options: ['ids', 'userNames'] });
   }
 
   #initTypes(): void {
-    this.types.string.push('userName', 'ids', 'userNames', 'groupId', 'groupName', 'teamId', 'teamName', 'role');
+    this.types.string.push('ids', 'userNames', 'groupId', 'groupName', 'teamId', 'teamName', 'role');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     await this.showDeprecationWarning(logger, aadCommands.M365GROUP_USER_SET, commands.M365GROUP_USER_SET);
 
-    if (args.options.userName) {
-      await this.warn(logger, `Option 'userName' is deprecated. Please use 'ids' or 'userNames' instead.`);
-    }
-
     try {
-      const userNames = args.options.userNames || args.options.userName;
       const groupId: string = await this.getGroupId(logger, args);
       const isUnifiedGroup = await entraGroup.isUnifiedGroup(groupId);
 
@@ -153,7 +144,7 @@ class EntraM365GroupUserSetCommand extends GraphCommand {
         throw Error(`Specified group with id '${groupId}' is not a Microsoft 365 group.`);
       }
 
-      const userIds: string[] = await this.getUserIds(logger, args.options.ids, userNames);
+      const userIds: string[] = await this.getUserIds(logger, args.options.ids, args.options.userNames);
 
       // we can't simply switch the role
       // first add users to the new role


### PR DESCRIPTION
There are 2 examples in the doc file about a single user. I was not sure whether to keep it and change it to the new used option `usernames`, or to remove them. I opted to go for the first situation. Let me know if you opt for the 2nd situation 

Closes #6224