### PR TITLE
Fixes casing and autocomplete for enums based on zod

### DIFF
--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -12,8 +12,8 @@ import commands from './commands.js';
 
 const options = globalOptionsZod
   .extend({
-    authType: zod.alias('t', z.nativeEnum(AuthType).optional()),
-    cloud: z.nativeEnum(CloudType).optional().default(CloudType.Public),
+    authType: zod.alias('t', zod.coercedEnum(AuthType).optional()),
+    cloud: zod.coercedEnum(CloudType).optional().default(CloudType.Public),
     userName: zod.alias('u', z.string().optional()),
     password: zod.alias('p', z.string().optional()),
     certificateFile: zod.alias('c', z.string().optional()


### PR DESCRIPTION
This PR introduces two changes:

1. A new zod schema type for using enums, which adds support for case-insensitive parsing of enum values for commands
2. Building command autocomplete off of enum values rather than names (`deviceCode` instead of `DeviceCode`)