### PR TITLE
Fixes handling multi-value properties in external item add.

### DIFF
--- a/docs/docs/cmd/external/item/item-add.mdx
+++ b/docs/docs/cmd/external/item/item-add.mdx
@@ -63,13 +63,13 @@ For more information about using these options, see the Microsoft Graph API docu
 Creates an external item with simple properties that everyone is allowed to access
 
 ```sh
-m365 external item add --id "pnp-ensure-siteassets-library" --connectionId "samplesolutiongallery" --content "Ensure that the Site Assets library is created." --title "Ensure the Site Assets Library is created" --description "Ensure that the Site Assets library is created." --authors "Phil Harding" --acls "grant,everyone,everyone"
+m365 external item add --id "pnp-ensure-siteassets-library" --externalConnectionId "samplesolutiongallery" --content "Ensure that the Site Assets library is created." --title "Ensure the Site Assets Library is created" --description "Ensure that the Site Assets library is created." --authors "Phil Harding" --acls "grant,everyone,everyone"
 ```
 
 Creates an external item with multi-value properties accessible only to users from the specified Entra group
 
 ```sh
-m365 external item add --id "pnp-ensure-siteassets-library" --connectionId "samplesolutiongallery" --content "Ensure that the Site Assets library is created." --title "Ensure the Site Assets Library is created" --description "Ensure that the Site Assets library is created." --authors@odata.type "Collection(String)" --authors "Phil Harding;#Steve Smith" --acls "grant,group,Super users"
+m365 external item add --id "pnp-ensure-siteassets-library" --externalConnectionId "samplesolutiongallery" --content "Ensure that the Site Assets library is created." --title "Ensure the Site Assets Library is created" --description "Ensure that the Site Assets library is created." --authors@odata.type "Collection(String)" --authors "Phil Harding;#Steve Smith" --acls "grant,group,Super users"
 ```
 
 ## Response
@@ -123,7 +123,7 @@ m365 external item add --id "pnp-ensure-siteassets-library" --connectionId "samp
   <TabItem value="Markdown">
 
   ```md
-  # m365 external item add --id "pnp-ensure-siteassets-library" --connectionId "samplesolutiongallery" --content "Ensure that the Site Assets library is created." --title "Ensure the Site Assets Library is created" --description "Ensure that the Site Assets library is created." --authors "Phil Harding" --acls "grant,everyone,everyone"
+  # m365 external item add --id "pnp-ensure-siteassets-library" --externalConnectionId "samplesolutiongallery" --content "Ensure that the Site Assets library is created." --title "Ensure the Site Assets Library is created" --description "Ensure that the Site Assets library is created." --authors "Phil Harding" --acls "grant,everyone,everyone"
 
   Date: 2023-10-28
 

--- a/src/m365/external/commands/item/item-add.spec.ts
+++ b/src/m365/external/commands/item/item-add.spec.ts
@@ -129,10 +129,7 @@ describe(commands.ITEM_ADD, () => {
       acls: 'grant,group,Admins',
       ticketTitle: 'Something went wrong ticket',
       priority: 'high',
-      // this is how assignee@odata.type is parsed by minimist
-      'assignee@odata': {
-        type: 'Collection(String)'
-      },
+      'assignee@odata.type': 'Collection(String)',
       assignee: 'Steve;#Brian'
     };
     await command.action(logger, { options } as any);

--- a/src/m365/external/commands/item/item-add.ts
+++ b/src/m365/external/commands/item/item-add.ts
@@ -125,8 +125,7 @@ class ExternalItemAddCommand extends GraphCommand {
     };
 
     // we need to rewrite the @odata properties to the correct format
-    // because . in @odata.type is interpreted by minimist as a child property
-    // we also need to extract multiple values for collections into arrays
+    // to extract multiple values for collections into arrays
     this.rewriteCollectionProperties(args.options);
     this.addUnknownOptionsToPayload(requestBody.properties, args.options);
 
@@ -166,12 +165,9 @@ class ExternalItemAddCommand extends GraphCommand {
 
   private rewriteCollectionProperties(options: any): void {
     Object.getOwnPropertyNames(options).forEach(name => {
-      if (!name.endsWith('@odata')) {
+      if (!name.includes('@odata')) {
         return;
       }
-
-      options[`${name}.type`] = options[name].type;
-      delete options[name];
 
       // convert the value of a collection to an array
       const nameWithoutOData: string = name.substring(0, name.indexOf('@odata'));


### PR DESCRIPTION
Fixes a bug in handling multi-value properties in the `external item add` command. The bug was caused by us replacing minimist with yargs, which parses options in a different way.