### PR TITLE
remove obsolete example due to changes in user roles in #5558

### DIFF
--- a/docs/docs/cmd/entra/m365group/m365group-user-list.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-user-list.mdx
@@ -63,12 +63,6 @@ List specific properties for all group users from a group specified by ID.
 m365 entra m365group user list --groupId 03cba9da-3974-46c1-afaf-79caa2e45bbe --properties "id,jobTitle,companyName,accountEnabled"
 ```
 
-List all group members that are guest users.
-
-```sh
-m365 entra m365group user list --groupDisplayName Developers --filter "userType eq 'Guest'"
-```
-
 ## Response
 
 <Tabs>


### PR DESCRIPTION
In #5558, the removal of the `Guest` value from the user's `role` was introduced. Issue #6272 should remove the obsolete example.

Closes #6272.