### PR TITLE
Fixes syntax highlighting

### DIFF
--- a/docs/src/config/darkCodeTheme.ts
+++ b/docs/src/config/darkCodeTheme.ts
@@ -128,6 +128,13 @@ export default {
       style: {
         color: '#E3E3E3'
       }
+    },
+    {
+      types: ['boolean'],
+      languages: ['json'],
+      style: {
+        color: '#569CD6'
+      }
     }
   ]
 } satisfies PrismTheme;

--- a/docs/src/config/lightCodeTheme.ts
+++ b/docs/src/config/lightCodeTheme.ts
@@ -116,6 +116,13 @@ export default {
       style: {
         color: '#A0A0A0'
       }
+    },
+    {
+      types: ['boolean'],
+      languages: ['json'],
+      style: {
+        color: '#0000FF'
+      }
     }
   ]
 } satisfies PrismTheme;


### PR DESCRIPTION
Noticed that the syntax highlighting of booleans is not working properly anymore. Booleans should have the same color as `null` values.

![image](https://github.com/user-attachments/assets/88b1fbcd-0d6e-46c4-b741-d6f06d4a9abe)
