### PR TITLE
Adds `spp model apply` command. Closes #6119

### DIFF
--- a/docs/docs/cmd/spp/model/model-apply.mdx
+++ b/docs/docs/cmd/spp/model/model-apply.mdx
@@ -1,0 +1,79 @@
+import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# spp model apply
+
+Applies (or syncs) a trained document understanding model to a document library
+
+## Usage
+
+```sh
+m365 spp model apply [options]
+```
+
+## Options
+
+```md definition-list
+`-u, --webUrl <webUrl>`
+: The URL of the web where the library is located.
+
+`-c --contentCenterUrl <contentCenterUrl>`
+: The URL of the content center site where model is located.
+
+`-i, --id [id]`
+: The unique ID of the model. Specify either `id` or `title` but not both.
+
+`-t, --title [title]`
+: The display name of the model. Specify either `id` or `title` but not both.
+
+`--listTitle [listTitle]`
+: The title of the document library to which the model will be applied. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
+
+`--listId [listId]`
+: The ID of the library to which the model will be applied. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
+
+`--listUrl [listUrl]`
+: Server or web-relative URL of the library to which the model will be applied. Specify either `listTitle`, `listId`, or `listUrl` but not multiple.
+
+`--viewOption [viewOption]`
+: Defines whether the model view should be set as the default view for the document library. Allowed values are: `NewViewAsDefault`, `DoNotChangeDefault`, `TileViewAsDefault`. The default value is `NewViewAsDefault`.
+```
+
+<Global />
+
+## Examples
+
+Applies a trained document understanding model using its unique ID to a document library, identified by its title.
+
+```sh
+m365 spp model apply --webUrl "https://contoso.sharepoint.com" --contentCenterUrl "https://contoso.sharepoint.com/sites/ContentCenter" --id "7645e69d-21fb-4a24-a17a-9bdfa7cb63dc" --listTitle "Shared Documents"
+```
+
+Applies a trained document understanding model using its display name to a document library, identified by its title.
+
+```sh
+m365 spp model apply --webUrl "https://contoso.sharepoint.com" --contentCenterUrl "https://contoso.sharepoint.com/sites/ContentCenter" --title "ModelExample" --listTitle "Shared Documents"
+```
+
+Applies a trained document understanding model using its display name to a document library, identified by its URL.
+
+```sh
+m365 spp model apply --webUrl "https://contoso.sharepoint.com" --contentCenterUrl "https://contoso.sharepoint.com/sites/ContentCenter" --title "ModelExample" --listUrl "/Shared Documents"
+```
+
+Applies a trained document understanding model using its display name to a document library, identified by its unique ID.
+
+```sh
+m365 spp model apply --webUrl "https://contoso.sharepoint.com" --contentCenterUrl "https://contoso.sharepoint.com/sites/ContentCenter" --title "ModelExample" --listId "b4cfa0d9-b3d7-49ae-a0f0-f14ffdd005f7"
+```
+
+Applies a trained document understanding model using its display name to a document library, identified by its unique ID. Without changing a default document library view.
+
+```sh
+m365 spp model apply --webUrl "https://contoso.sharepoint.com" --contentCenterUrl "https://contoso.sharepoint.com/sites/ContentCenter" --title "ModelExample" --listId "b4cfa0d9-b3d7-49ae-a0f0-f14ffdd005f7" --viewOption "DoNotChangeDefault"
+```
+
+## Response
+
+The command won't return a response on success.

--- a/docs/src/config/sidebars.ts
+++ b/docs/src/config/sidebars.ts
@@ -4202,6 +4202,11 @@ const sidebars: SidebarsConfig = {
           model: [
             {
               type: 'doc',
+              label: 'model apply',
+              id: 'cmd/spp/model/model-apply'
+            },
+            {
+              type: 'doc',
               label: 'model get',
               id: 'cmd/spp/model/model-get'
             },

--- a/src/m365/spp/commands.ts
+++ b/src/m365/spp/commands.ts
@@ -2,6 +2,7 @@ const prefix: string = 'spp';
 
 export default {
   CONTENTCENTER_LIST: `${prefix} contentcenter list`,
+  MODEL_APPLY: `${prefix} model apply`,
   MODEL_GET: `${prefix} model get`,
   MODEL_LIST: `${prefix} model list`,
   MODEL_REMOVE: `${prefix} model remove`

--- a/src/m365/spp/commands/model/model-apply.spec.ts
+++ b/src/m365/spp/commands/model/model-apply.spec.ts
@@ -1,0 +1,566 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
+import { Logger } from '../../../../cli/Logger.js';
+import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
+import { pid } from '../../../../utils/pid.js';
+import { session } from '../../../../utils/session.js';
+import { sinonUtil } from '../../../../utils/sinonUtil.js';
+import commands from '../../commands.js';
+import command from './model-apply.js';
+import { spp } from '../../../../utils/spp.js';
+import { CommandError } from '../../../../Command.js';
+import { z } from 'zod';
+
+describe(commands.MODEL_APPLY, () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodTypeAny;
+
+  const publicationsResult = {
+    Details: [
+      {
+        ErrorMessage: null,
+        Publication: {},
+        StatusCode: 201
+      }
+    ],
+    TotalFailures: 0,
+    TotalSuccesses: 1
+  };
+  const listResponse = {
+    RootFolder: {
+      ServerRelativeUrl: '/sites/portal/Shared Documents'
+    },
+    BaseType: 1
+  };
+  const modelResponse = {
+    UniqueId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f'
+  };
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').resolves();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
+    sinon.stub(spp, 'assertSiteIsContentCenter').resolves();
+    auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: async (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: async (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: async (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      request.post,
+      spp.getModelById,
+      spp.getModelByTitle
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+    auth.connection.active = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.MODEL_APPLY);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('passes validation when required parameters are valid with model id and list id', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation when required parameters are valid with model title and list id', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation when required parameters are valid with model id and list title', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle', listTitle: 'Documents' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation when required parameters are valid with model id and list URL', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle', listUrl: '/Shared Documents' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation when required parameters are valid with model title and list id and correct viewOption is provided', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', viewOption: 'NewViewAsDefault' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation when webUrl is not valid', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'invalidUrl', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', viewOption: 'NewViewAsDefault' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation when contentCenterUrl is not valid', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'invalidUrl', title: 'ModelTitle', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', viewOption: 'NewViewAsDefault' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation when model id is not valid', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: 'invalidId', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', viewOption: 'NewViewAsDefault' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation when list id is not valid', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle', listId: 'invalidId', viewOption: 'NewViewAsDefault' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation when viewOption is not valid', async () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', viewOption: 'InvalidViewOption' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('does not log any output', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', verbose: false } });
+    assert(loggerLogSpy.notCalled);
+  });
+
+  it('applies a model to document library by id and list id', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    const stubPost = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', verbose: true } });
+    assert.deepStrictEqual(stubPost.lastCall.args[0].data, {
+      __metadata: {
+        type: "Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData"
+      },
+      Publications: {
+        results: [
+          {
+            ModelUniqueId: "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+            TargetSiteUrl: "https://contoso.sharepoint.com/sites/sales",
+            TargetLibraryServerRelativeUrl: "/sites/portal/Shared Documents",
+            TargetWebServerRelativeUrl: "/sites/sales",
+            ViewOption: "NewViewAsDefault"
+          }
+        ]
+      }
+    });
+  });
+
+  it('applies a model to document library by id and list id to subsite', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/subsite/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return {
+          RootFolder: {
+            ServerRelativeUrl: '/sites/portal/subsite/Shared Documents'
+          },
+          BaseType: 1
+        };
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    const stubPost = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales/subsite', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', verbose: true } });
+    assert.deepStrictEqual(stubPost.lastCall.args[0].data, {
+      __metadata: {
+        type: "Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData"
+      },
+      Publications: {
+        results: [
+          {
+            ModelUniqueId: "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+            TargetSiteUrl: "https://contoso.sharepoint.com/sites/sales/subsite",
+            TargetLibraryServerRelativeUrl: "/sites/portal/subsite/Shared Documents",
+            TargetWebServerRelativeUrl: "/sites/sales/subsite",
+            ViewOption: "NewViewAsDefault"
+          }
+        ]
+      }
+    });
+  });
+
+  it('applies a model to document library by id and list title', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists/getByTitle('Documents')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    const stubPost = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listTitle: 'Documents' } });
+    assert.deepStrictEqual(stubPost.lastCall.args[0].data, {
+      __metadata: {
+        type: "Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData"
+      },
+      Publications: {
+        results: [
+          {
+            ModelUniqueId: "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+            TargetSiteUrl: "https://contoso.sharepoint.com/sites/sales",
+            TargetLibraryServerRelativeUrl: "/sites/portal/Shared Documents",
+            TargetWebServerRelativeUrl: "/sites/sales",
+            ViewOption: "NewViewAsDefault"
+          }
+        ]
+      }
+    });
+  });
+
+  it('applies a model to document library by title and list id', async () => {
+    sinon.stub(spp, 'getModelByTitle').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    const stubPost = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d' } });
+    assert.deepStrictEqual(stubPost.lastCall.args[0].data, {
+      __metadata: {
+        type: "Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData"
+      },
+      Publications: {
+        results: [
+          {
+            ModelUniqueId: "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+            TargetSiteUrl: "https://contoso.sharepoint.com/sites/sales",
+            TargetLibraryServerRelativeUrl: "/sites/portal/Shared Documents",
+            TargetWebServerRelativeUrl: "/sites/sales",
+            ViewOption: "NewViewAsDefault"
+          }
+        ]
+      }
+    });
+  });
+
+  it('applies a model to document library by id and list url', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/GetList('%2Fsites%2Fsales%2FShared%20Documents')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    const stubPost = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listUrl: '/Shared Documents' } });
+    assert.deepStrictEqual(stubPost.lastCall.args[0].data, {
+      __metadata: {
+        type: "Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData"
+      },
+      Publications: {
+        results: [
+          {
+            ModelUniqueId: "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+            TargetSiteUrl: "https://contoso.sharepoint.com/sites/sales",
+            TargetLibraryServerRelativeUrl: "/sites/portal/Shared Documents",
+            TargetWebServerRelativeUrl: "/sites/sales",
+            ViewOption: "NewViewAsDefault"
+          }
+        ]
+      }
+    });
+  });
+
+  it('applies a model to document library by id and list id and DoNotChangeDefault viewOption', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    const stubPost = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', viewOption: 'DoNotChangeDefault' } });
+    assert.deepStrictEqual(stubPost.lastCall.args[0].data, {
+      __metadata: {
+        type: "Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData"
+      },
+      Publications: {
+        results: [
+          {
+            ModelUniqueId: "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+            TargetSiteUrl: "https://contoso.sharepoint.com/sites/sales",
+            TargetLibraryServerRelativeUrl: "/sites/portal/Shared Documents",
+            TargetWebServerRelativeUrl: "/sites/sales",
+            ViewOption: "DoNotChangeDefault"
+          }
+        ]
+      }
+    });
+  });
+
+  it('applies a model to document library by id and list id and TileViewAsDefault viewOption', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    const stubPost = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', viewOption: 'TileViewAsDefault' } });
+    assert.deepStrictEqual(stubPost.lastCall.args[0].data, {
+      __metadata: {
+        type: "Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData"
+      },
+      Publications: {
+        results: [
+          {
+            ModelUniqueId: "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+            TargetSiteUrl: "https://contoso.sharepoint.com/sites/sales",
+            TargetLibraryServerRelativeUrl: "/sites/portal/Shared Documents",
+            TargetWebServerRelativeUrl: "/sites/sales",
+            ViewOption: "TileViewAsDefault"
+          }
+        ]
+      }
+    });
+  });
+
+  it('applies a model to document library by title with classifier suffix and by list id', async () => {
+    sinon.stub(spp, 'getModelByTitle').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    const stubPost = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return publicationsResult;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle.classifier', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', viewOption: 'DoNotChangeDefault' } });
+    assert.deepStrictEqual(stubPost.lastCall.args[0].data, {
+      __metadata: {
+        type: "Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData"
+      },
+      Publications: {
+        results: [
+          {
+            ModelUniqueId: "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
+            TargetSiteUrl: "https://contoso.sharepoint.com/sites/sales",
+            TargetLibraryServerRelativeUrl: "/sites/portal/Shared Documents",
+            TargetWebServerRelativeUrl: "/sites/sales",
+            ViewOption: "DoNotChangeDefault"
+          }
+        ]
+      }
+    });
+  });
+
+  it('correctly handles error when list is not found', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        throw {
+          error: {
+            "odata.error": {
+              code: "-1, Microsoft.SharePoint.Client.ResourceNotFoundException",
+              message: {
+                lang: "en-US",
+                value: "List does not exist. The page you selected contains a list that does not exist. It may have been deleted by another user."
+              }
+            }
+          }
+        };
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d' } }),
+      new CommandError('List does not exist. The page you selected contains a list that does not exist. It may have been deleted by another user.'));
+  });
+
+  it('correctly handles error when try to applies a model to SP list', async () => {
+    sinon.stub(spp, 'getModelById').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return {
+          RootFolder: {
+            ServerRelativeUrl: '/sites/portal/lists/SPList'
+          },
+          BaseType: 0
+        };
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', verbose: true } }),
+      new CommandError('The specified list is not a document library.'));
+  });
+
+  it('correctly handles error when model is not found by its id', async () => {
+    sinon.stub(spp, 'getModelById').rejects({
+      error: {
+        "odata.error": {
+          code: "-1, Microsoft.Office.Server.ContentCenter.ModelNotFoundException",
+          message: {
+            lang: "en-US",
+            value: "File Not Found."
+          }
+        }
+      }
+    });
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', verbose: true } }),
+      new CommandError('File Not Found.'));
+  });
+
+  it('correctly handles error when applies a model failed', async () => {
+    sinon.stub(spp, 'getModelByTitle').resolves(modelResponse);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/sales/_api/web/lists(guid'421b1e42-794b-4c71-93ac-5ed92488b67d')?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`) {
+        return listResponse;
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/contentCenter/_api/machinelearning/publications`) {
+        return {
+          Details: [
+            {
+              ErrorMessage: 'The content type is bound to another model. Please unpublish the existing model or remove the content type in order to publish the model.',
+              Publication: {},
+              StatusCode: 400
+            }
+          ],
+          TotalFailures: 1,
+          TotalSuccesses: 0
+        };
+      }
+
+      throw `${opts.url} is invalid request`;
+    });
+
+    await assert.rejects(command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/sales', contentCenterUrl: 'https://contoso.sharepoint.com/sites/contentCenter', title: 'ModelTitle.classifier', listId: '421b1e42-794b-4c71-93ac-5ed92488b67d', verbose: true } }),
+      new CommandError('The content type is bound to another model. Please unpublish the existing model or remove the content type in order to publish the model.'));
+  });
+});

--- a/src/m365/spp/commands/model/model-apply.ts
+++ b/src/m365/spp/commands/model/model-apply.ts
@@ -1,0 +1,158 @@
+import { Logger } from '../../../../cli/Logger.js';
+import request, { CliRequestOptions } from '../../../../request.js';
+import { formatting } from '../../../../utils/formatting.js';
+import { spp } from '../../../../utils/spp.js';
+import { urlUtil } from '../../../../utils/urlUtil.js';
+import { validation } from '../../../../utils/validation.js';
+import SpoCommand from '../../../base/SpoCommand.js';
+import { ListInstance } from '../../../spo/commands/list/ListInstance.js';
+import commands from '../../commands.js';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
+import { zod } from '../../../../utils/zod.js';
+
+const options = globalOptionsZod
+  .extend({
+    contentCenterUrl: zod.alias('c', z.string()
+      .refine(url => validation.isValidSharePointUrl(url) === true, url => ({
+        message: `'${url}' is not a valid SharePoint Online site URL.`
+      }))
+    ),
+    webUrl: zod.alias('u', z.string()
+      .refine(url => validation.isValidSharePointUrl(url) === true, url => ({
+        message: `'${url}' is not a valid SharePoint Online site URL.`
+      }))
+    ),
+    id: zod.alias('i', z.string()
+      .refine(id => validation.isValidGuid(id) === true, id => ({
+        message: `${id} is not a valid GUID for option.`
+      }))
+      .optional()),
+    title: zod.alias('t', z.string()).optional(),
+    listTitle: z.string().optional(),
+    listId: z.string()
+      .refine(listId => validation.isValidGuid(listId) === true, listId => ({
+        message: `${listId} is not a valid GUID for option.`
+      })).optional(),
+    listUrl: z.string().optional(),
+    viewOption: z.enum(['NewViewAsDefault', 'DoNotChangeDefault', 'TileViewAsDefault']).optional()
+  })
+  .strict();
+
+declare type Options = z.infer<typeof options>;
+
+interface CommandArgs {
+  options: Options;
+}
+
+class SppModelApplyCommand extends SpoCommand {
+  public get name(): string {
+    return commands.MODEL_APPLY;
+  }
+
+  public get description(): string {
+    return 'Applies (or syncs) a trained document understanding model to a document library';
+  }
+
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
+  }
+
+  public getRefinedSchema(schema: typeof options): z.ZodEffects<any> | undefined {
+    return schema
+      .refine(options => [options.id, options.title].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'id' or 'title'.`
+      })
+      .refine(options => [options.listTitle, options.listId, options.listUrl].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'listTitle', 'listId' or 'listUrl'.`
+      });
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    try {
+      if (this.verbose) {
+        await logger.log(`Applying a model to a document library...`);
+      }
+
+      const contentCenterUrl = urlUtil.removeTrailingSlashes(args.options.contentCenterUrl);
+      await spp.assertSiteIsContentCenter(contentCenterUrl, logger, this.verbose);
+
+      let model = null;
+      if (args.options.title) {
+        model = await spp.getModelByTitle(contentCenterUrl, args.options.title, logger, this.verbose);
+      }
+      else {
+        model = await spp.getModelById(contentCenterUrl, args.options.id!, logger, this.verbose);
+      }
+
+      if (this.verbose) {
+        await logger.log(`Retrieving list information...`);
+      }
+      const listInstance = await this.getListInfo(args.options.webUrl, args.options.listId, args.options.listTitle, args.options.listUrl);
+
+      if (listInstance.BaseType !== 1) {
+        throw `The specified list is not a document library.`;
+      }
+
+      const requestOptions: CliRequestOptions = {
+        url: `${contentCenterUrl}/_api/machinelearning/publications`,
+        headers: {
+          accept: 'application/json;odata=nometadata',
+          "Content-Type": 'application/json;odata=verbose'
+        },
+        responseType: 'json',
+        data: {
+          __metadata: { type: 'Microsoft.Office.Server.ContentCenter.SPMachineLearningPublicationsEntityData' },
+          Publications: {
+            results: [
+              {
+                ModelUniqueId: model.UniqueId,
+                TargetSiteUrl: args.options.webUrl,
+                TargetWebServerRelativeUrl: urlUtil.getServerRelativePath(args.options.webUrl, ''),
+                TargetLibraryServerRelativeUrl: listInstance.RootFolder.ServerRelativeUrl,
+                ViewOption: args.options.viewOption ?? "NewViewAsDefault"
+              }
+            ]
+          }
+        }
+      };
+
+      const result = await request.post<any>(requestOptions);
+      const resultDetails = result.Details;
+
+      if (resultDetails && resultDetails[0]?.ErrorMessage) {
+        throw resultDetails[0].ErrorMessage;
+      }
+    }
+    catch (err: any) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+
+  private getListInfo(webUrl: string, listId?: string, listTitle?: string, listUrl?: string): Promise<ListInstance> {
+    let requestUrl = `${webUrl}/_api/web`;
+
+    if (listId) {
+      requestUrl += `/lists(guid'${formatting.encodeQueryParameter(listId)}')`;
+    }
+    else if (listTitle) {
+      requestUrl += `/lists/getByTitle('${formatting.encodeQueryParameter(listTitle)}')`;
+    }
+    else if (listUrl) {
+      const listServerRelativeUrl: string = urlUtil.getServerRelativePath(webUrl, listUrl);
+      requestUrl += `/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')`;
+    }
+
+    const requestOptions: CliRequestOptions = {
+      url: `${requestUrl}?$select=BaseType,RootFolder/ServerRelativeUrl&$expand=RootFolder`,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    return request.get<ListInstance>(requestOptions);
+  }
+}
+
+export default new SppModelApplyCommand();

--- a/src/m365/spp/commands/model/model-list.ts
+++ b/src/m365/spp/commands/model/model-list.ts
@@ -63,7 +63,7 @@ class SppModelListCommand extends SpoCommand {
       }
 
       const siteUrl = urlUtil.removeTrailingSlashes(args.options.siteUrl);
-      await spp.assertSiteIsContentCenter(siteUrl);
+      await spp.assertSiteIsContentCenter(siteUrl, logger, this.verbose);
 
       const result = await odata.getAllItems<any>(`${siteUrl}/_api/machinelearning/models`);
       await logger.log(result);

--- a/src/m365/spp/commands/model/model-remove.ts
+++ b/src/m365/spp/commands/model/model-remove.ts
@@ -102,7 +102,7 @@ class SppModelRemoveCommand extends SpoCommand {
       }
 
       const siteUrl = urlUtil.removeTrailingSlashes(args.options.siteUrl);
-      await spp.assertSiteIsContentCenter(siteUrl);
+      await spp.assertSiteIsContentCenter(siteUrl, logger, this.verbose);
       let requestUrl = `${siteUrl}/_api/machinelearning/models/`;
 
       if (args.options.title) {

--- a/src/utils/spp.spec.ts
+++ b/src/utils/spp.spec.ts
@@ -4,9 +4,86 @@ import sinon from 'sinon';
 import { spp } from './spp.js';
 import { sinonUtil } from './sinonUtil.js';
 import request from '../request.js';
+import { Logger } from '../cli/Logger.js';
 
 describe('utils/spp', () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
   const siteUrl = 'https://contoso.sharepoint.com';
+  const model = {
+    "AIBuilderHybridModelType": null,
+    "AzureCognitivePrebuiltModelName": null,
+    "BaseContentTypeName": null,
+    "ConfidenceScore": "{\"trainingStatus\":{\"kind\":\"original\",\"ClassifierStatus\":{\"TrainingStatus\":\"success\",\"TimeStamp\":1716547860981},\"ExtractorsStatus\":[{\"TimeStamp\":1716547860173,\"ExtractorName\":\"Name\",\"TrainingStatus\":\"success\"}]},\"modelAccuracy\":{\"Classifier\":1,\"Extractors\":{\"Name\":0.333333343}},\"perSampleAccuracy\":{\"1\":{\"Classifier\":1,\"Extractors\":{\"Name\":1}},\"2\":{\"Classifier\":1,\"Extractors\":{\"Name\":0}},\"3\":{\"Classifier\":1,\"Extractors\":{\"Name\":0}},\"4\":{\"Classifier\":1,\"Extractors\":{\"Name\":0}},\"5\":{\"Classifier\":1,\"Extractors\":{\"Name\":0}},\"6\":{\"Classifier\":1,\"Extractors\":{\"Name\":1}}},\"perSamplePrediction\":{\"1\":{\"Extractors\":{\"Name\":[\"FirstName\"]}},\"2\":{\"Extractors\":{\"Name\":[]}},\"3\":{\"Extractors\":{\"Name\":[]}},\"4\":{\"Extractors\":{\"Name\":[]}},\"5\":{\"Extractors\":{\"Name\":[]}},\"6\":{\"Extractors\":{\"Name\":[]}}},\"trainingFailures\":{}}",
+    "ContentTypeGroup": "Intelligent Document Content Types",
+    "ContentTypeId": "0x010100A5C3671D1FB1A64D9F280C628D041692",
+    "ContentTypeName": "TeachingModel",
+    "Created": "2024-05-23T16:51:29Z",
+    "CreatedBy": "i:0#.f|membership|user@contoso.onmicrosoft.com",
+    "DriveId": "b!qTVLltt1P02LUgejOy6O_1amoFeu1EJBlawH83UtYbQs_H3KVKAcQpuQOpNLl646",
+    "Explanations": "{\"Classifier\":[{\"id\":\"950f39cd-5e72-4442-ae8a-ea4bae32962c\",\"kind\":\"regexFeature\",\"name\":\"Email address\",\"active\":true,\"pattern\":\"[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}\"},{\"id\":\"d3f2940d-1df1-4ba8-975a-db3a4d626d5c\",\"kind\":\"dictionaryFeature\",\"name\":\"FirstName\",\"active\":true,\"nGrams\":[\"FirstName\"],\"caseSensitive\":false,\"ignoreDigitIdentity\":false,\"ignoreLetterIdentity\":false},{\"id\":\"077966e1-73be-44c9-855f-a4eade6a280b\",\"kind\":\"modelFeature\",\"name\":\"Name\",\"active\":true,\"modelReference\":\"Name\",\"conceptId\":\"309b64e5-acd5-4538-a5b6-c6bfcdc1ffbf\"}],\"Extractors\":{\"Name\":[{\"id\":\"69e412bc-e5bc-4657-b378-34a01966bb92\",\"kind\":\"dictionaryFeature\",\"name\":\"Before label\",\"active\":true,\"nGrams\":[\"Test\",\"'Surname\",\"Test (\"],\"caseSensitive\":false,\"ignoreDigitIdentity\":false,\"ignoreLetterIdentity\":false}]}}",
+    "ID": 1,
+    "LastTrained": "2024-05-24T17:51:16Z",
+    "ListID": "ca7dfc2c-a054-421c-9b90-3a934b97ae3a",
+    "ModelSettings": "{\"ModelOrigin\":{\"LibraryId\":\"8a6027ab-c584-4394-ba9c-3dc4dd152b65\",\"Published\":false,\"SelecteFileUniqueIds\":[]}}",
+    "ModelType": 2,
+    "Modified": "2024-05-24T17:51:02Z",
+    "ModifiedBy": "i:0#.f|membership|user@contoso.onmicrosoft.com",
+    "ObjectId": "01HQDCWVGIEBDRN3RVK5A3UJW3M4TCMT45",
+    "PublicationType": 0,
+    "Schemas": "{\"Version\":2,\"Extractors\":{\"Name\":{\"concepts\":{\"309b64e5-acd5-4538-a5b6-c6bfcdc1ffbf\":{\"name\":\"Name\"}},\"relationships\":[],\"id\":\"Name\"}}}",
+    "SourceSiteUrl": "https://contoso.sharepoint.com/sites/SyntexTest",
+    "SourceUrl": null,
+    "SourceWebServerRelativeUrl": "/sites/SyntexTest",
+    "UniqueId": "164720c8-35ee-4157-ba26-db6726264f9d"
+  };
+
+  const modelWithoutAdditionalData = {
+    "AIBuilderHybridModelType": null,
+    "AzureCognitivePrebuiltModelName": null,
+    "BaseContentTypeName": null,
+    "ConfidenceScore": null,
+    "ContentTypeGroup": "Intelligent Document Content Types",
+    "ContentTypeId": "0x010100A5C3671D1FB1A64D9F280C628D041692",
+    "ContentTypeName": "TeachingModel",
+    "Created": "2024-05-23T16:51:29Z",
+    "CreatedBy": "i:0#.f|membership|user@contoso.onmicrosoft.com",
+    "DriveId": "b!qTVLltt1P02LUgejOy6O_1amoFeu1EJBlawH83UtYbQs_H3KVKAcQpuQOpNLl646",
+    "Explanations": null,
+    "ID": 1,
+    "LastTrained": "2024-05-24T17:51:16Z",
+    "ListID": "ca7dfc2c-a054-421c-9b90-3a934b97ae3a",
+    "ModelSettings": null,
+    "ModelType": 2,
+    "Modified": "2024-05-24T17:51:02Z",
+    "ModifiedBy": "i:0#.f|membership|user@contoso.onmicrosoft.com",
+    "ObjectId": "01HQDCWVGIEBDRN3RVK5A3UJW3M4TCMT45",
+    "PublicationType": 0,
+    "Schemas": null,
+    "SourceSiteUrl": "https://contoso.sharepoint.com/sites/SyntexTest",
+    "SourceUrl": null,
+    "SourceWebServerRelativeUrl": "/sites/SyntexTest",
+    "UniqueId": "164720c8-35ee-4157-ba26-db6726264f9d"
+  };
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: async (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: async (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: async (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
   afterEach(() => {
     sinonUtil.restore([
       request.get
@@ -28,7 +105,7 @@ describe('utils/spp', () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(spp.assertSiteIsContentCenter(siteUrl), Error('https://contoso.sharepoint.com is not a content site.'));
+    await assert.rejects(spp.assertSiteIsContentCenter(siteUrl, logger, false), Error('https://contoso.sharepoint.com is not a content site.'));
   });
 
   it('calls api correctly and does not throw an error when site is a content center using assertSiteIsContentCenter', async () => {
@@ -42,7 +119,130 @@ describe('utils/spp', () => {
       throw 'Invalid request';
     });
 
-    await spp.assertSiteIsContentCenter(siteUrl);
+    await spp.assertSiteIsContentCenter(siteUrl, logger, false);
     assert(stubGet.calledOnce);
+  });
+
+  it('calls api correctly and shows verbose message using assertSiteIsContentCenter', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web?$select=WebTemplateConfiguration`) {
+        return {
+          WebTemplateConfiguration: 'CONTENTCTR#0'
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await spp.assertSiteIsContentCenter(siteUrl, logger, true);
+    assert(loggerLogSpy.calledOnce);
+  });
+
+
+  it('retrieves model by id', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/machinelearning/models/getbyuniqueid('9b1b1e42-794b-4c71-93ac-5ed92488b67f')`) {
+        return model;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const actual = await spp.getModelById('https://contoso.sharepoint.com/sites/portal', '9b1b1e42-794b-4c71-93ac-5ed92488b67f', logger, false);
+    assert.deepStrictEqual(actual, model);
+  });
+
+  it('retrieves model by id with verbose message', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/machinelearning/models/getbyuniqueid('9b1b1e42-794b-4c71-93ac-5ed92488b67f')`) {
+        return model;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await spp.getModelById('https://contoso.sharepoint.com/sites/portal', '9b1b1e42-794b-4c71-93ac-5ed92488b67f', logger, true);
+    assert(loggerLogSpy.calledOnce);
+  });
+
+  it('retrieves model by title', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/machinelearning/models/getbytitle('modelname.classifier')`) {
+        return model;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const actual = await spp.getModelByTitle('https://contoso.sharepoint.com/sites/portal', 'ModelName', logger, false);
+    assert.deepStrictEqual(actual, model);
+  });
+
+  it('retrieves model by title with verbose message', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/machinelearning/models/getbytitle('modelname.classifier')`) {
+        return model;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await spp.getModelByTitle('https://contoso.sharepoint.com/sites/portal', 'ModelName', logger, true);
+    assert(loggerLogSpy.calledOnce);
+  });
+
+  it('retrieves model without additional information by title', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/machinelearning/models/getbytitle('modelname.classifier')`) {
+        return modelWithoutAdditionalData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const actual = await spp.getModelByTitle('https://contoso.sharepoint.com/sites/portal', 'ModelName', logger, false);
+    assert.deepStrictEqual(actual, modelWithoutAdditionalData);
+  });
+
+  it('retrieves model by title with classifier suffix', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/machinelearning/models/getbytitle('modelname.classifier')`) {
+        return model;
+      }
+
+      throw 'Invalid request';
+    });
+
+
+    const actual = await spp.getModelByTitle('https://contoso.sharepoint.com/sites/portal', 'ModelName.classifier', logger, false);
+    assert.deepStrictEqual(actual, model);
+  });
+
+  it('correctly handles a model is not found error by id', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/machinelearning/models/getbyuniqueid('9b1b1e42-794b-4c71-93ac-5ed92488b67f')`) {
+        throw Error('File Not Found.');
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(spp.getModelById('https://contoso.sharepoint.com/sites/portal', '9b1b1e42-794b-4c71-93ac-5ed92488b67f', logger, false),
+      Error('File Not Found.'));
+  });
+
+  it('correctly handles a model is not found error by title', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/portal/_api/machinelearning/models/getbytitle('invalidtitle.classifier')`) {
+        return {
+          "odata.null": true
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(spp.getModelByTitle('https://contoso.sharepoint.com/sites/portal', 'invalidTitle', logger, false),
+      Error('Model not found.'));
   });
 });

--- a/src/utils/spp.ts
+++ b/src/utils/spp.ts
@@ -1,4 +1,6 @@
+import { Logger } from '../cli/Logger.js';
 import request, { CliRequestOptions } from '../request.js';
+import { formatting } from './formatting.js';
 
 export interface SppModel {
   ConfidenceScore?: string;
@@ -13,9 +15,15 @@ export const spp = {
   /**
    * Asserts whether the specified site is a content center
    * @param siteUrl The URL of the site to check
+   * @param logger Logger instance
+   * @param verbose Whether to log verbose messages
    * @throws error when site is not a content center.
    */
-  async assertSiteIsContentCenter(siteUrl: string): Promise<void> {
+  async assertSiteIsContentCenter(siteUrl: string, logger: Logger, verbose: boolean): Promise<void> {
+    if (verbose) {
+      await logger.log(`Asserting if ${siteUrl} is a valid content center...`);
+    }
+
     const requestOptions: CliRequestOptions = {
       url: `${siteUrl}/_api/web?$select=WebTemplateConfiguration`,
       headers: {
@@ -29,5 +37,66 @@ export const spp = {
     if (response.WebTemplateConfiguration !== 'CONTENTCTR#0') {
       throw Error(`${siteUrl} is not a content site.`);
     }
+  },
+  /**
+   * Gets a SharePoint Premium model by title
+   * @param contentCenterUrl a content center site URL
+   * @param title model title
+   * @param logger Logger instance
+   * @param verbose Whether to log verbose messages
+   * @returns SharePoint Premium model
+   */
+  async getModelByTitle(contentCenterUrl: string, title: string, logger: Logger, verbose: boolean): Promise<SppModel> {
+    if (verbose) {
+      await logger.log(`Retrieving model information...`);
+    }
+
+    let requestTitle = title.toLowerCase();
+
+    if (!requestTitle.endsWith('.classifier')) {
+      requestTitle += '.classifier';
+    }
+
+    const requestUrl = `${contentCenterUrl}/_api/machinelearning/models/getbytitle('${formatting.encodeQueryParameter(requestTitle)}')`;
+    const requestOptions: CliRequestOptions = {
+      url: requestUrl,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const result = await request.get<SppModel>(requestOptions);
+
+    if ((result as any)['odata.null'] === true) {
+      throw Error("Model not found.");
+    }
+
+    return result;
+  },
+  /**
+   * Gets a SharePoint Premium model by unique id
+   * @param contentCenterUrl a content center site URL
+   * @param id model unique id
+   * @param logger Logger instance
+   * @param verbose Whether to log verbose messages
+   * @returns SharePoint Premium model
+   */
+  async getModelById(contentCenterUrl: string, id: string, logger: Logger, verbose: boolean): Promise<SppModel> {
+    if (verbose) {
+      await logger.log(`Retrieving model information from...`);
+    }
+
+    const requestUrl = `${contentCenterUrl}/_api/machinelearning/models/getbyuniqueid('${id}')`;
+
+    const requestOptions: CliRequestOptions = {
+      url: requestUrl,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    return await request.get<SppModel>(requestOptions);
   }
 };


### PR DESCRIPTION
Adds `spp model apply` command. Closes #6119

- I have made some changes to the command compared to the initial specification.

I realized I forgot to add a parameter needed to locate the content site where the model is stored: `contentCenterUrl`
Let me know if name is ok. We can change it to modelContentSiteUrl or something else.

- I also modified the `viewOption` parameter. During testing, I saw that it’s possible to set three different values:`NewViewAsDefault`, `DoNotChangeDefault`, `TileViewAsDefault`

- The API does not return an error when attempting to apply a model to a custom SharePoint List. However, I’ve added a condition to check if the list is a document library. I hope that’s ok.

- potentially, when the `spp model get` command is approved, the `getModel` function from this command should be exported to the `spp.ts` file so it can be used by both commands.