### PR TITLE
Fixes missing alias to `sp` in some `enterpriseapp` commands. Closes #6476

### DIFF
--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.spec.ts
@@ -68,6 +68,11 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('defines correct alias', () => {
+    const alias = command.alias();
+    assert.deepStrictEqual(alias, [commands.SP_ADD]);
+  });
+
   it('fails validation if neither the id, displayName, nor objectId option specified', async () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.ts
@@ -26,6 +26,10 @@ class EntraEnterpriseAppAddCommand extends GraphCommand {
     return 'Creates an enterprise application (or service principal) for a registered Entra app';
   }
 
+  public alias(): string[] | undefined {
+    return [commands.SP_ADD];
+  }
+
   constructor() {
     super();
 

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
@@ -82,6 +82,11 @@ describe(commands.ENTERPRISEAPP_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('defines correct alias', () => {
+    const alias = command.alias();
+    assert.deepStrictEqual(alias, [commands.SP_GET]);
+  });
+
   it('retrieves information about the specified enterprise application using its display name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/v1.0/servicePrincipals?$filter=displayName eq `) > -1) {

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.ts
@@ -26,6 +26,10 @@ class EntraEnterpriseAppGetCommand extends GraphCommand {
     return 'Gets information about an Enterprise Application';
   }
 
+  public alias(): string[] | undefined {
+    return [commands.SP_GET];
+  }
+
   constructor() {
     super();
 

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.spec.ts
@@ -134,6 +134,11 @@ describe(commands.ENTERPRISEAPP_LIST, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('defines correct alias', () => {
+    const alias = command.alias();
+    assert.deepStrictEqual(alias, [commands.SP_LIST]);
+  });
+
   it('defines correct properties for the default output', () => {
     assert.deepStrictEqual(command.defaultProperties(), ['appId', 'displayName', 'tag']);
   });

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.ts
@@ -26,6 +26,10 @@ class EntraEnterpriseAppListCommand extends GraphCommand {
     return 'Lists the enterprise applications (or service principals) in Entra ID';
   }
 
+  public alias(): string[] | undefined {
+    return [commands.SP_LIST];
+  }
+
   constructor() {
     super();
 


### PR DESCRIPTION
## 🎯 Aim 

The aim is to add (readd) alias to `sp` for `add`, `list`, `get` commands in `enterpriseapp` area

## 📸 Result

![image](https://github.com/user-attachments/assets/947641d9-c0ab-443c-be9e-9e1b7f8df4a9)

## 🔗 Issue

Closes #6476
