### PR TITLE
Fixes copy job polling. Closes #6422

### DIFF
--- a/src/utils/spo.ts
+++ b/src/utils/spo.ts
@@ -2210,7 +2210,16 @@ export const spo = {
     }
 
     // Get the destination object information
-    const objectInfo = logs.find(l => l.Event === 'JobFinishedObjectInfo') as CopyJobObjectInfo;
+    let objectInfo = logs.find(l => l.Event === 'JobFinishedObjectInfo') as CopyJobObjectInfo;
+
+    // In rare cases, the object info may not be available yet
+    if (!objectInfo) {
+      // By doing a final poll, we can get the object info
+      progress = await request.post<{ JobState: number; Logs: string[] }>(requestOptions);
+      const newLogs = progress.Logs?.map(l => JSON.parse(l));
+      objectInfo = newLogs.find(l => l.Event === 'JobFinishedObjectInfo') as CopyJobObjectInfo;
+    }
+
     return objectInfo;
   },
 


### PR DESCRIPTION
Closes #6422

---

This issue occurs rarely (about 5% of the requests). Sometimes, the job is finished, but the result log was not retrieved from the final poll. Seems like I'm especially encountering this issue with files with quite some version history. By doing an additional poll, the object info seems to be returned. By doing this, it seems like 100% of the requests are working now for me.