### PR TITLE
Fixes: Allow saving SP page with an existing collapsible section. Closes #6462

### DIFF
--- a/src/m365/spo/commands/page/canvasContent.ts
+++ b/src/m365/spo/commands/page/canvasContent.ts
@@ -1,9 +1,11 @@
+import { ClientSideControlPosition, ZoneGroupMetadata } from "./clientsidepages";
+
 export interface Control {
   controlType?: number;
   displayMode: number;
   emphasis?: { zoneEmphasis?: number };
   id?: string;
-  position: ControlPosition;
+  position: ClientSideControlPosition;
   reservedHeight?: number;
   reservedWidth?: number;
   webPartData?: any;
@@ -44,22 +46,4 @@ export interface BackgroundControl {
     },
     dataVersion: string;
   }
-}
-
-interface ControlPosition {
-  controlIndex?: number;
-  layoutIndex: number;
-  sectionFactor: number;
-  sectionIndex: number;
-  zoneIndex: number;
-  isLayoutReflowOnTop?: boolean;
-  zoneId?: string;
-}
-
-interface ZoneGroupMetadata {
-  type: number;
-  isExpanded: boolean;
-  showDividerLine: boolean;
-  iconAlignment: string;
-  displayName?: string;
 }

--- a/src/m365/spo/commands/page/page-clientsidewebpart-add.spec.ts
+++ b/src/m365/spo/commands/page/page-clientsidewebpart-add.spec.ts
@@ -2605,6 +2605,113 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
     }));
   });
 
+  it('adds web part to a column in collapsible section when order 1 specified', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
+        return {
+          "IsPageCheckedOutToCurrentUser": true,
+          "CanvasContent1": `[{"controlType":4,"editorType":"CKEditor","id":"24cebf73-d376-48e5-9b76-39b967c8dfd9","position":{"controlIndex":1,"sectionFactor":12,"sectionIndex":1,"zoneIndex":1,"zoneId":"e524fc79-e526-4da5-82e6-361018dedc67"},"addedFromPersistedData":true,"innerHTML":"<p>test</p>","emphasis":{"zoneEmphasis":0},"zoneGroupMetadata":{"type":1,"isExpanded":true,"showDividerLine":false,"iconAlignment":"left","displayName":"Test"}},{"controlType":0,"pageSettingsSlice":{"isDefaultDescription":true,"isDefaultThumbnail":true,"isSpellCheckEnabled":true,"globalRichTextStylingVersion":1,"rtePageSettings":{"contentVersion":5,"indentationVersion":2},"isEmailReady":false,"webPartsPageSettings":{"isTitleHeadingLevelsEnabled":false}}}]`
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
+        return clientSideWebParts;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          webPartId: 'e377ea37-9047-43b9-8cdb-a761be2f8e09',
+          order: 1
+        }
+      });
+    assert.strictEqual(replaceId(JSON.stringify(postStub.lastCall.args[0].data)), '{"CanvasContent1":"[{\\"controlType\\":3,\\"displayMode\\":2,\\"id\\":\\"89c644b3-f69c-4e84-85d7-dfa04c6163b5\\",\\"position\\":{\\"controlIndex\\":1,\\"sectionFactor\\":12,\\"sectionIndex\\":1,\\"zoneIndex\\":1,\\"zoneId\\":\\"e524fc79-e526-4da5-82e6-361018dedc67\\"},\\"webPartId\\":\\"e377ea37-9047-43b9-8cdb-a761be2f8e09\\",\\"emphasis\\":{},\\"zoneGroupMetadata\\":{\\"type\\":1,\\"isExpanded\\":true,\\"showDividerLine\\":false,\\"iconAlignment\\":\\"left\\",\\"displayName\\":\\"Test\\"},\\"webPartData\\":{\\"dataVersion\\":\\"1.0\\",\\"description\\":\\"Display a key location on a map\\",\\"id\\":\\"e377ea37-9047-43b9-8cdb-a761be2f8e09\\",\\"instanceId\\":\\"89c644b3-f69c-4e84-85d7-dfa04c6163b5\\",\\"properties\\":{\\"pushPins\\":[],\\"maxNumberOfPushPins\\":1,\\"shouldShowPushPinTitle\\":true,\\"zoomLevel\\":12,\\"mapType\\":\\"road\\"},\\"title\\":\\"Bing maps\\"}},{\\"controlType\\":4,\\"editorType\\":\\"CKEditor\\",\\"id\\":\\"24cebf73-d376-48e5-9b76-39b967c8dfd9\\",\\"position\\":{\\"controlIndex\\":2,\\"sectionFactor\\":12,\\"sectionIndex\\":1,\\"zoneIndex\\":1,\\"zoneId\\":\\"e524fc79-e526-4da5-82e6-361018dedc67\\"},\\"addedFromPersistedData\\":true,\\"innerHTML\\":\\"<p>test</p>\\",\\"emphasis\\":{\\"zoneEmphasis\\":0},\\"zoneGroupMetadata\\":{\\"type\\":1,\\"isExpanded\\":true,\\"showDividerLine\\":false,\\"iconAlignment\\":\\"left\\",\\"displayName\\":\\"Test\\"}},{\\"controlType\\":0,\\"pageSettingsSlice\\":{\\"isDefaultDescription\\":true,\\"isDefaultThumbnail\\":true,\\"isSpellCheckEnabled\\":true,\\"globalRichTextStylingVersion\\":1,\\"rtePageSettings\\":{\\"contentVersion\\":5,\\"indentationVersion\\":2},\\"isEmailReady\\":false,\\"webPartsPageSettings\\":{\\"isTitleHeadingLevelsEnabled\\":false}}}]"}');
+  });
+
+  it('adds web part to a column with background settings order 1 specified', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
+        return {
+          "IsPageCheckedOutToCurrentUser": true,
+          "CanvasContent1": `[{"controlType":4,"editorType":"CKEditor","id":"24cebf73-d376-48e5-9b76-39b967c8dfd9","position":{"controlIndex":1,"sectionFactor":12,"sectionIndex":1,"zoneIndex":1,"zoneId":"e524fc79-e526-4da5-82e6-361018dedc67"},"addedFromPersistedData":true,"zoneGroupMetadata":{"type":0,"isExpanded":true,"showDividerLine":false,"iconAlignment":"left","displayName":"Test"},"innerHTML":"<p>test</p>"},{"controlType":0,"pageSettingsSlice":{"isDefaultDescription":true,"isDefaultThumbnail":true,"isSpellCheckEnabled":true,"globalRichTextStylingVersion":1,"rtePageSettings":{"contentVersion":5,"indentationVersion":2},"isEmailReady":false,"webPartsPageSettings":{"isTitleHeadingLevelsEnabled":false}}},{"controlType":14,"webPartData":{"properties":{"zoneBackground":{"e524fc79-e526-4da5-82e6-361018dedc67":{"type":"gradient","gradient":"radial-gradient(55.05% 96.28% at -5.05% -8.89%, #585984 0%, rgba(88, 89, 132, 0) 100%),linear-gradient(72.98deg, #AD8D8E 0.02%, #2A2A56 102.53%)","useLightText":true,"overlay":{"color":"#000000","opacity":60}}}},"serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.0"}}]`
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
+        return clientSideWebParts;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          webPartId: 'e377ea37-9047-43b9-8cdb-a761be2f8e09',
+          order: 1
+        }
+      });
+    assert.strictEqual(replaceId(JSON.stringify(postStub.lastCall.args[0].data)), '{"CanvasContent1":"[{\\"controlType\\":3,\\"displayMode\\":2,\\"id\\":\\"89c644b3-f69c-4e84-85d7-dfa04c6163b5\\",\\"position\\":{\\"controlIndex\\":1,\\"sectionFactor\\":12,\\"sectionIndex\\":1,\\"zoneIndex\\":1,\\"zoneId\\":\\"e524fc79-e526-4da5-82e6-361018dedc67\\"},\\"webPartId\\":\\"e377ea37-9047-43b9-8cdb-a761be2f8e09\\",\\"emphasis\\":{},\\"zoneGroupMetadata\\":{\\"type\\":0,\\"isExpanded\\":true,\\"showDividerLine\\":false,\\"iconAlignment\\":\\"left\\",\\"displayName\\":\\"Test\\"},\\"webPartData\\":{\\"dataVersion\\":\\"1.0\\",\\"description\\":\\"Display a key location on a map\\",\\"id\\":\\"e377ea37-9047-43b9-8cdb-a761be2f8e09\\",\\"instanceId\\":\\"89c644b3-f69c-4e84-85d7-dfa04c6163b5\\",\\"properties\\":{\\"pushPins\\":[],\\"maxNumberOfPushPins\\":1,\\"shouldShowPushPinTitle\\":true,\\"zoomLevel\\":12,\\"mapType\\":\\"road\\"},\\"title\\":\\"Bing maps\\"}},{\\"controlType\\":4,\\"editorType\\":\\"CKEditor\\",\\"id\\":\\"24cebf73-d376-48e5-9b76-39b967c8dfd9\\",\\"position\\":{\\"controlIndex\\":2,\\"sectionFactor\\":12,\\"sectionIndex\\":1,\\"zoneIndex\\":1,\\"zoneId\\":\\"e524fc79-e526-4da5-82e6-361018dedc67\\"},\\"addedFromPersistedData\\":true,\\"zoneGroupMetadata\\":{\\"type\\":0,\\"isExpanded\\":true,\\"showDividerLine\\":false,\\"iconAlignment\\":\\"left\\",\\"displayName\\":\\"Test\\"},\\"innerHTML\\":\\"<p>test</p>\\"},{\\"controlType\\":0,\\"pageSettingsSlice\\":{\\"isDefaultDescription\\":true,\\"isDefaultThumbnail\\":true,\\"isSpellCheckEnabled\\":true,\\"globalRichTextStylingVersion\\":1,\\"rtePageSettings\\":{\\"contentVersion\\":5,\\"indentationVersion\\":2},\\"isEmailReady\\":false,\\"webPartsPageSettings\\":{\\"isTitleHeadingLevelsEnabled\\":false}}},{\\"controlType\\":14,\\"webPartData\\":{\\"properties\\":{\\"zoneBackground\\":{\\"e524fc79-e526-4da5-82e6-361018dedc67\\":{\\"type\\":\\"gradient\\",\\"gradient\\":\\"radial-gradient(55.05% 96.28% at -5.05% -8.89%, #585984 0%, rgba(88, 89, 132, 0) 100%),linear-gradient(72.98deg, #AD8D8E 0.02%, #2A2A56 102.53%)\\",\\"useLightText\\":true,\\"overlay\\":{\\"color\\":\\"#000000\\",\\"opacity\\":60}}}},\\"serverProcessedContent\\":{\\"htmlStrings\\":{},\\"searchablePlainTexts\\":{},\\"imageSources\\":{},\\"links\\":{}},\\"dataVersion\\":\\"1.0\\"}}]"}');
+  });
+
+  it('adds web part to a column with background settings and collapsible section', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
+        return {
+          "IsPageCheckedOutToCurrentUser": true,
+          "CanvasContent1": `[{"controlType":4,"editorType":"CKEditor","id":"24cebf73-d376-48e5-9b76-39b967c8dfd9","position":{"controlIndex":1,"sectionFactor":12,"sectionIndex":1,"zoneIndex":1,"zoneId":"e524fc79-e526-4da5-82e6-361018dedc67"},"addedFromPersistedData":true,"zoneGroupMetadata":{"type":1,"isExpanded":true,"showDividerLine":false,"iconAlignment":"left","displayName":"Test"},"innerHTML":"<p>test</p>"},{"controlType":0,"pageSettingsSlice":{"isDefaultDescription":true,"isDefaultThumbnail":true,"isSpellCheckEnabled":true,"globalRichTextStylingVersion":1,"rtePageSettings":{"contentVersion":5,"indentationVersion":2},"isEmailReady":false,"webPartsPageSettings":{"isTitleHeadingLevelsEnabled":false}}},{"controlType":14,"webPartData":{"properties":{"zoneBackground":{"e524fc79-e526-4da5-82e6-361018dedc67":{"type":"gradient","gradient":"radial-gradient(55.05% 96.28% at -5.05% -8.89%, #585984 0%, rgba(88, 89, 132, 0) 100%), linear-gradient(72.98deg, #AD8D8E 0.02%, #2A2A56 102.53%)","useLightText":true,"overlay":{"color":"#000000","opacity":60}}}},"serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.0"}}]`
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
+        return clientSideWebParts;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          webPartId: 'e377ea37-9047-43b9-8cdb-a761be2f8e09'
+        }
+      });
+    assert.strictEqual(replaceId(JSON.stringify(postStub.lastCall.args[0].data)), '{"CanvasContent1":"[{\\"controlType\\":4,\\"editorType\\":\\"CKEditor\\",\\"id\\":\\"24cebf73-d376-48e5-9b76-39b967c8dfd9\\",\\"position\\":{\\"controlIndex\\":1,\\"sectionFactor\\":12,\\"sectionIndex\\":1,\\"zoneIndex\\":1,\\"zoneId\\":\\"e524fc79-e526-4da5-82e6-361018dedc67\\"},\\"addedFromPersistedData\\":true,\\"zoneGroupMetadata\\":{\\"type\\":1,\\"isExpanded\\":true,\\"showDividerLine\\":false,\\"iconAlignment\\":\\"left\\",\\"displayName\\":\\"Test\\"},\\"innerHTML\\":\\"<p>test</p>\\"},{\\"controlType\\":3,\\"displayMode\\":2,\\"id\\":\\"89c644b3-f69c-4e84-85d7-dfa04c6163b5\\",\\"position\\":{\\"controlIndex\\":2,\\"sectionFactor\\":12,\\"sectionIndex\\":1,\\"zoneIndex\\":1,\\"zoneId\\":\\"e524fc79-e526-4da5-82e6-361018dedc67\\"},\\"webPartId\\":\\"e377ea37-9047-43b9-8cdb-a761be2f8e09\\",\\"emphasis\\":{},\\"zoneGroupMetadata\\":{\\"type\\":1,\\"isExpanded\\":true,\\"showDividerLine\\":false,\\"iconAlignment\\":\\"left\\",\\"displayName\\":\\"Test\\"},\\"webPartData\\":{\\"dataVersion\\":\\"1.0\\",\\"description\\":\\"Display a key location on a map\\",\\"id\\":\\"e377ea37-9047-43b9-8cdb-a761be2f8e09\\",\\"instanceId\\":\\"89c644b3-f69c-4e84-85d7-dfa04c6163b5\\",\\"properties\\":{\\"pushPins\\":[],\\"maxNumberOfPushPins\\":1,\\"shouldShowPushPinTitle\\":true,\\"zoomLevel\\":12,\\"mapType\\":\\"road\\"},\\"title\\":\\"Bing maps\\"}},{\\"controlType\\":0,\\"pageSettingsSlice\\":{\\"isDefaultDescription\\":true,\\"isDefaultThumbnail\\":true,\\"isSpellCheckEnabled\\":true,\\"globalRichTextStylingVersion\\":1,\\"rtePageSettings\\":{\\"contentVersion\\":5,\\"indentationVersion\\":2},\\"isEmailReady\\":false,\\"webPartsPageSettings\\":{\\"isTitleHeadingLevelsEnabled\\":false}}},{\\"controlType\\":14,\\"webPartData\\":{\\"properties\\":{\\"zoneBackground\\":{\\"e524fc79-e526-4da5-82e6-361018dedc67\\":{\\"type\\":\\"gradient\\",\\"gradient\\":\\"radial-gradient(55.05% 96.28% at -5.05% -8.89%, #585984 0%, rgba(88, 89, 132, 0) 100%), linear-gradient(72.98deg, #AD8D8E 0.02%, #2A2A56 102.53%)\\",\\"useLightText\\":true,\\"overlay\\":{\\"color\\":\\"#000000\\",\\"opacity\\":60}}}},\\"serverProcessedContent\\":{\\"htmlStrings\\":{},\\"searchablePlainTexts\\":{},\\"imageSources\\":{},\\"links\\":{}},\\"dataVersion\\":\\"1.0\\"}}]"}');
+  });
+
   it('correctly handles sections in reverse order', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {

--- a/src/m365/spo/commands/page/page-clientsidewebpart-add.ts
+++ b/src/m365/spo/commands/page/page-clientsidewebpart-add.ts
@@ -270,7 +270,8 @@ class SpoPageClientSideWebPartAddCommand extends SpoCommand {
         id: webPart.id,
         position: Object.assign({}, control.position),
         webPartId: webPart.webPartId,
-        emphasis: {}
+        emphasis: {},
+        zoneGroupMetadata: control.zoneGroupMetadata
       }, webPart);
 
       if (!control.controlType) {

--- a/src/m365/spo/commands/page/page-section-add.ts
+++ b/src/m365/spo/commands/page/page-section-add.ts
@@ -7,7 +7,7 @@ import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
 import { BackgroundControl, Control } from './canvasContent.js';
-import { CanvasSectionTemplate } from './clientsidepages.js';
+import { CanvasColumnFactorType, CanvasSectionTemplate } from './clientsidepages.js';
 
 interface CommandArgs {
   options: Options;
@@ -372,7 +372,7 @@ class SpoPageSectionAddCommand extends SpoCommand {
     return columns;
   }
 
-  private getColumn(zoneIndex: number, sectionIndex: number, sectionFactor: number, args: CommandArgs, zoneId?: string): Control {
+  private getColumn(zoneIndex: number, sectionIndex: number, sectionFactor: CanvasColumnFactorType, args: CommandArgs, zoneId?: string): Control {
     const { zoneEmphasis, isCollapsibleSection, isExpanded, showDivider, iconAlignment, collapsibleTitle } = args.options;
     const columnValue: Control = {
       displayMode: 2,

--- a/src/m365/spo/commands/page/page-text-add.spec.ts
+++ b/src/m365/spo/commands/page/page-text-add.spec.ts
@@ -17,7 +17,6 @@ import command from './page-text-add.js';
 describe(commands.PAGE_TEXT_ADD, () => {
   let log: string[];
   let logger: Logger;
-  let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
@@ -49,7 +48,6 @@ describe(commands.PAGE_TEXT_ADD, () => {
         log.push(msg);
       }
     };
-    loggerLogSpy = sinon.spy(logger, 'log');
     loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
   });
 
@@ -75,7 +73,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('adds text to an empty modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -140,9 +138,9 @@ describe(commands.PAGE_TEXT_ADD, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
-        return {};
+        return;
       }
 
       throw 'Invalid request';
@@ -156,12 +154,15 @@ describe(commands.PAGE_TEXT_ADD, () => {
           text: 'Hello world'
         }
       });
-    assert(loggerLogSpy.notCalled);
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true&#125;&#125;"><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
   });
 
   it('adds text to an empty modern page (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -227,9 +228,8 @@ describe(commands.PAGE_TEXT_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
-        JSON.stringify(opts.data).indexOf(`&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;\\"><div data-sp-rte=\\"\\"><p>Hello world</p></div></div></div>"}`) > -1) {
-        return {};
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields`) {
+        return;
       }
 
       throw 'Invalid request';
@@ -249,7 +249,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('adds text to an empty modern page on root of tenant (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -315,9 +315,8 @@ describe(commands.PAGE_TEXT_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='/sitepages/page.aspx')/ListItemAllFields`) > -1 &&
-        JSON.stringify(opts.data).indexOf(`&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;\\"><div data-sp-rte=\\"\\"><p>Hello world</p></div></div></div>"}`) > -1) {
-        return {};
+      if (opts.url === `https://contoso.sharepoint.com/_api/web/GetFileByServerRelativePath(DecodedUrl='/sitepages/page.aspx')/ListItemAllFields`) {
+        return;
       }
 
       throw 'Invalid request';
@@ -337,10 +336,8 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('appends text to a modern page which already had some text', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (
-        (opts.url as string).indexOf(
-          `/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
-        ) > -1
+      if (opts.url ===
+        `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
       ) {
         return {
           ListItemAllFields: {
@@ -406,9 +403,9 @@ describe(commands.PAGE_TEXT_ADD, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
-        return {};
+        return;
       }
 
       throw 'Invalid request';
@@ -422,15 +419,16 @@ describe(commands.PAGE_TEXT_ADD, () => {
           text: 'Hello world'
         }
       });
-    assert(loggerLogSpy.notCalled);
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;e278967c-6f89-4601-a30b-f132dc48d55b&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;2,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
   });
 
   it('adds text in the specified order to a modern page which already had some text', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (
-        (opts.url as string).indexOf(
-          `/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
-        ) > -1
+      if (opts.url ===
+        `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
       ) {
         return {
           ListItemAllFields: {
@@ -496,9 +494,9 @@ describe(commands.PAGE_TEXT_ADD, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
-        return {};
+        return;
       }
 
       throw 'Invalid request';
@@ -513,16 +511,16 @@ describe(commands.PAGE_TEXT_ADD, () => {
           order: 2
         }
       });
-    assert(loggerLogSpy.notCalled);
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;e278967c-6f89-4601-a30b-f132dc48d55b&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;2,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;"><div data-sp-rte=""><p>Hello world 1.1<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;cc988078-be29-4999-a5e2-4aa0f9a04ab4&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;3,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;"><div data-sp-rte=""><p>Hello world 2<\/p><\/div><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
   });
 
   it('adds text to a modern page without specifying the page file extension', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (
-        (opts.url as string).indexOf(
-          `/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`
-        ) > -1
-      ) {
+      if (opts.url ===
+        `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -587,9 +585,9 @@ describe(commands.PAGE_TEXT_ADD, () => {
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
-        return {};
+        return;
       }
 
       throw 'Invalid request';
@@ -603,12 +601,460 @@ describe(commands.PAGE_TEXT_ADD, () => {
           text: 'Hello world'
         }
       });
-    assert(loggerLogSpy.notCalled);
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true&#125;&#125;"><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
+  });
+
+  it('adds text to a modern page with existing empty collapsable section and page settings control', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url ===
+        `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
+        return {
+          ListItemAllFields: {
+            CommentsDisabled: false,
+            FileSystemObjectType: 0,
+            Id: 1,
+            ServerRedirectedEmbedUri: null,
+            ServerRedirectedEmbedUrl: '',
+            ContentTypeId: '0x0101009D1CB255DA76424F860D91F20E6C41180062FDF2882AB3F745ACB63105A3C623C9',
+            FileLeafRef: 'Home.aspx',
+            ComplianceAssetId: null,
+            WikiField: null,
+            Title: 'Home',
+            ClientSideApplicationId: 'b6917cb1-93a0-4b97-a84d-7cf49975d4ec',
+            PageLayoutType: 'Home',
+            CanvasContent1: '<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;id&quot;&#58;&quot;emptySection&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1,&quot;layoutIndex&quot;&#58;1&#125;,&quot;zoneGroupMetadata&quot;&#58;&#123;&quot;type&quot;&#58;1,&quot;isExpanded&quot;&#58;true,&quot;showDividerLine&quot;&#58;true,&quot;iconAlignment&quot;&#58;&quot;left&quot;,&quot;displayName&quot;&#58;&quot;Test1&quot;&#125;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;0,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;4,&quot;indentationVersion&quot;&#58;1&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;\"></div></div>',
+            BannerImageUrl: {
+              Description: '/_layouts/15/images/sitepagethumbnail.png',
+              Url: 'https://contoso.sharepoint.com/_layouts/15/images/sitepagethumbnail.png'
+            },
+            Description: 'Lorem ipsum Dolor samet Lorem ipsum',
+            PromotedState: null,
+            FirstPublishedDate: null,
+            LayoutWebpartsContent: null,
+            AuthorsId: null,
+            AuthorsStringId: null,
+            OriginalSourceUrl: null,
+            ID: 1,
+            Created: '2018-01-20T09:54:41',
+            AuthorId: 1073741823,
+            Modified: '2018-04-12T12:42:47',
+            EditorId: 12,
+            OData__CopySource: null,
+            CheckoutUserId: null,
+            OData__UIVersionString: '7.0',
+            GUID: 'edaab907-e729-48dd-9e73-26487c0cf592'
+          },
+          CheckInComment: '',
+          CheckOutType: 2,
+          ContentTag: '{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25,1',
+          CustomizedPageStatus: 1,
+          ETag: '"{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25"',
+          Exists: true,
+          IrmEnabled: false,
+          Length: '805',
+          Level: 1,
+          LinkingUri: null,
+          LinkingUrl: '',
+          MajorVersion: 7,
+          MinorVersion: 0,
+          Name: 'home.aspx',
+          ServerRelativeUrl: '/sites/team-a/SitePages/home.aspx',
+          TimeCreated: '2018-01-20T08:54:41Z',
+          TimeLastModified: '2018-04-12T10:42:46Z',
+          Title: 'Home',
+          UIVersion: 3584,
+          UIVersionLabel: '7.0',
+          UniqueId: 'e82a21d1-ca2c-4854-98f2-012ac0e7fa09'
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          text: 'Hello world'
+        }
+      });
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;,&quot;zoneGroupMetadata&quot;&#58;&#123;&quot;type&quot;&#58;1,&quot;isExpanded&quot;&#58;true,&quot;showDividerLine&quot;&#58;true,&quot;iconAlignment&quot;&#58;&quot;left&quot;,&quot;displayName&quot;&#58;&quot;Test1&quot;&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;0,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;4,&quot;indentationVersion&quot;&#58;1&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;"><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
+  });
+
+  it('adds text to a modern page with existing collapsable section with existing text webpart', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
+        return {
+          ListItemAllFields: {
+            CommentsDisabled: false,
+            FileSystemObjectType: 0,
+            Id: 1,
+            ServerRedirectedEmbedUri: null,
+            ServerRedirectedEmbedUrl: '',
+            ContentTypeId: '0x0101009D1CB255DA76424F860D91F20E6C41180062FDF2882AB3F745ACB63105A3C623C9',
+            FileLeafRef: 'Home.aspx',
+            ComplianceAssetId: null,
+            WikiField: null,
+            Title: 'Home',
+            ClientSideApplicationId: 'b6917cb1-93a0-4b97-a84d-7cf49975d4ec',
+            PageLayoutType: 'Home',
+            CanvasContent1: '<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;4,&quot;id&quot;&#58;&quot;2730c9fa-2138-477c-a237-1a9a168ad2f0&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1,&quot;layoutIndex&quot;&#58;1&#125;,&quot;zoneGroupMetadata&quot;&#58;&#123;&quot;type&quot;&#58;1,&quot;isExpanded&quot;&#58;true,&quot;showDividerLine&quot;&#58;true,&quot;iconAlignment&quot;&#58;&quot;left&quot;,&quot;displayName&quot;&#58;&quot;Test1&quot;&#125;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"><div data-sp-rte=\"\"><p>text</p></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;0,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;4,&quot;indentationVersion&quot;&#58;1&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;\"></div></div>',
+            BannerImageUrl: {
+              Description: '/_layouts/15/images/sitepagethumbnail.png',
+              Url: 'https://contoso.sharepoint.com/_layouts/15/images/sitepagethumbnail.png'
+            },
+            Description: 'Lorem ipsum Dolor samet Lorem ipsum',
+            PromotedState: null,
+            FirstPublishedDate: null,
+            LayoutWebpartsContent: null,
+            AuthorsId: null,
+            AuthorsStringId: null,
+            OriginalSourceUrl: null,
+            ID: 1,
+            Created: '2018-01-20T09:54:41',
+            AuthorId: 1073741823,
+            Modified: '2018-04-12T12:42:47',
+            EditorId: 12,
+            OData__CopySource: null,
+            CheckoutUserId: null,
+            OData__UIVersionString: '7.0',
+            GUID: 'edaab907-e729-48dd-9e73-26487c0cf592'
+          },
+          CheckInComment: '',
+          CheckOutType: 2,
+          ContentTag: '{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25,1',
+          CustomizedPageStatus: 1,
+          ETag: '"{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25"',
+          Exists: true,
+          IrmEnabled: false,
+          Length: '805',
+          Level: 1,
+          LinkingUri: null,
+          LinkingUrl: '',
+          MajorVersion: 7,
+          MinorVersion: 0,
+          Name: 'home.aspx',
+          ServerRelativeUrl: '/sites/team-a/SitePages/home.aspx',
+          TimeCreated: '2018-01-20T08:54:41Z',
+          TimeLastModified: '2018-04-12T10:42:46Z',
+          Title: 'Home',
+          UIVersion: 3584,
+          UIVersionLabel: '7.0',
+          UniqueId: 'e82a21d1-ca2c-4854-98f2-012ac0e7fa09'
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          text: 'Hello world'
+        }
+      });
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;2730c9fa-2138-477c-a237-1a9a168ad2f0&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;,&quot;zoneGroupMetadata&quot;&#58;&#123;&quot;type&quot;&#58;1,&quot;isExpanded&quot;&#58;true,&quot;showDividerLine&quot;&#58;true,&quot;iconAlignment&quot;&#58;&quot;left&quot;,&quot;displayName&quot;&#58;&quot;Test1&quot;&#125;&#125;"><div data-sp-rte=""><p>text<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;2,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1&#125;,&quot;zoneGroupMetadata&quot;&#58;&#123;&quot;type&quot;&#58;1,&quot;isExpanded&quot;&#58;true,&quot;showDividerLine&quot;&#58;true,&quot;iconAlignment&quot;&#58;&quot;left&quot;,&quot;displayName&quot;&#58;&quot;Test1&quot;&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;0,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;4,&quot;indentationVersion&quot;&#58;1&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;"><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
+  });
+
+  it('adds text to a modern page with background setting and existing text webpart', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
+        return {
+          ListItemAllFields: {
+            CommentsDisabled: false,
+            FileSystemObjectType: 0,
+            Id: 1,
+            ServerRedirectedEmbedUri: null,
+            ServerRedirectedEmbedUrl: '',
+            ContentTypeId: '0x0101009D1CB255DA76424F860D91F20E6C41180062FDF2882AB3F745ACB63105A3C623C9',
+            FileLeafRef: 'Home.aspx',
+            ComplianceAssetId: null,
+            WikiField: null,
+            Title: 'Home',
+            ClientSideApplicationId: 'b6917cb1-93a0-4b97-a84d-7cf49975d4ec',
+            PageLayoutType: 'Home',
+            CanvasContent1: '<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;24cebf73-d376-48e5-9b76-39b967c8dfd9&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"><div data-sp-rte=\"\"><p>test</p></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;1,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;5,&quot;indentationVersion&quot;&#58;2&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;\"></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;14&#125;\"><div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" data-sp-webpartdata=\"&#123;&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;zoneBackground&quot;&#58;&#123;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#58;&#123;&quot;type&quot;&#58;&quot;gradient&quot;,&quot;gradient&quot;&#58;&quot;linear-gradient(72.44deg, #E6FBFE 0%, #EDDDFB 100%)&quot;,&quot;useLightText&quot;&#58;false,&quot;overlay&quot;&#58;&#123;&quot;color&quot;&#58;&quot;#FFFFFF&quot;,&quot;opacity&quot;&#58;0&#125;&#125;&#125;&#125;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;&#125;\"><div data-sp-componentid=\"\"></div><div data-sp-htmlproperties=\"\"></div></div></div></div>',
+            BannerImageUrl: {
+              Description: '/_layouts/15/images/sitepagethumbnail.png',
+              Url: 'https://contoso.sharepoint.com/_layouts/15/images/sitepagethumbnail.png'
+            },
+            Description: 'Lorem ipsum Dolor samet Lorem ipsum',
+            PromotedState: null,
+            FirstPublishedDate: null,
+            LayoutWebpartsContent: null,
+            AuthorsId: null,
+            AuthorsStringId: null,
+            OriginalSourceUrl: null,
+            ID: 1,
+            Created: '2018-01-20T09:54:41',
+            AuthorId: 1073741823,
+            Modified: '2018-04-12T12:42:47',
+            EditorId: 12,
+            OData__CopySource: null,
+            CheckoutUserId: null,
+            OData__UIVersionString: '7.0',
+            GUID: 'edaab907-e729-48dd-9e73-26487c0cf592'
+          },
+          CheckInComment: '',
+          CheckOutType: 2,
+          ContentTag: '{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25,1',
+          CustomizedPageStatus: 1,
+          ETag: '"{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25"',
+          Exists: true,
+          IrmEnabled: false,
+          Length: '805',
+          Level: 1,
+          LinkingUri: null,
+          LinkingUrl: '',
+          MajorVersion: 7,
+          MinorVersion: 0,
+          Name: 'home.aspx',
+          ServerRelativeUrl: '/sites/team-a/SitePages/home.aspx',
+          TimeCreated: '2018-01-20T08:54:41Z',
+          TimeLastModified: '2018-04-12T10:42:46Z',
+          Title: 'Home',
+          UIVersion: 3584,
+          UIVersionLabel: '7.0',
+          UniqueId: 'e82a21d1-ca2c-4854-98f2-012ac0e7fa09'
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          text: 'Hello world'
+        }
+      });
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;24cebf73-d376-48e5-9b76-39b967c8dfd9&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;&#125;"><div data-sp-rte=""><p>test<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;2,&quot;sectionFactor&quot;&#58;12,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;1,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;5,&quot;indentationVersion&quot;&#58;2&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;"><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;14&#125;"><div data-sp-webpart="" data-sp-webpartdataversion="1.0" data-sp-webpartdata="&#123;&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;zoneBackground&quot;&#58;&#123;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#58;&#123;&quot;type&quot;&#58;&quot;gradient&quot;,&quot;gradient&quot;&#58;&quot;linear-gradient\(72.44deg, #E6FBFE 0%, #EDDDFB 100%\)&quot;,&quot;useLightText&quot;&#58;false,&quot;overlay&quot;&#58;&#123;&quot;color&quot;&#58;&quot;#FFFFFF&quot;,&quot;opacity&quot;&#58;0&#125;&#125;&#125;&#125;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;&#125;"><div data-sp-componentid=""><\/div><div data-sp-htmlproperties=""><\/div><\/div><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
+  });
+
+  it('adds text to a modern page on specific section and column with background setting and existing text webpart', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
+        return {
+          ListItemAllFields: {
+            CommentsDisabled: false,
+            FileSystemObjectType: 0,
+            Id: 1,
+            ServerRedirectedEmbedUri: null,
+            ServerRedirectedEmbedUrl: '',
+            ContentTypeId: '0x0101009D1CB255DA76424F860D91F20E6C41180062FDF2882AB3F745ACB63105A3C623C9',
+            FileLeafRef: 'Home.aspx',
+            ComplianceAssetId: null,
+            WikiField: null,
+            Title: 'Home',
+            ClientSideApplicationId: 'b6917cb1-93a0-4b97-a84d-7cf49975d4ec',
+            PageLayoutType: 'Home',
+            CanvasContent1: '<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;24cebf73-d376-48e5-9b76-39b967c8dfd9&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;6,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"><div data-sp-rte=\"\"><p>test</p></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;id&quot;&#58;&quot;emptySection&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;6,&quot;sectionIndex&quot;&#58;2,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;1,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;5,&quot;indentationVersion&quot;&#58;2&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;\"></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;14&#125;\"><div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" data-sp-webpartdata=\"&#123;&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;zoneBackground&quot;&#58;&#123;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#58;&#123;&quot;type&quot;&#58;&quot;gradient&quot;,&quot;gradient&quot;&#58;&quot;linear-gradient(72.44deg, #E6FBFE 0%, #EDDDFB 100%)&quot;,&quot;useLightText&quot;&#58;false,&quot;overlay&quot;&#58;&#123;&quot;color&quot;&#58;&quot;#FFFFFF&quot;,&quot;opacity&quot;&#58;0&#125;&#125;&#125;&#125;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;&#125;\"><div data-sp-componentid=\"\"></div><div data-sp-htmlproperties=\"\"></div></div></div></div>',
+            BannerImageUrl: {
+              Description: '/_layouts/15/images/sitepagethumbnail.png',
+              Url: 'https://contoso.sharepoint.com/_layouts/15/images/sitepagethumbnail.png'
+            },
+            Description: 'Lorem ipsum Dolor samet Lorem ipsum',
+            PromotedState: null,
+            FirstPublishedDate: null,
+            LayoutWebpartsContent: null,
+            AuthorsId: null,
+            AuthorsStringId: null,
+            OriginalSourceUrl: null,
+            ID: 1,
+            Created: '2018-01-20T09:54:41',
+            AuthorId: 1073741823,
+            Modified: '2018-04-12T12:42:47',
+            EditorId: 12,
+            OData__CopySource: null,
+            CheckoutUserId: null,
+            OData__UIVersionString: '7.0',
+            GUID: 'edaab907-e729-48dd-9e73-26487c0cf592'
+          },
+          CheckInComment: '',
+          CheckOutType: 2,
+          ContentTag: '{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25,1',
+          CustomizedPageStatus: 1,
+          ETag: '"{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25"',
+          Exists: true,
+          IrmEnabled: false,
+          Length: '805',
+          Level: 1,
+          LinkingUri: null,
+          LinkingUrl: '',
+          MajorVersion: 7,
+          MinorVersion: 0,
+          Name: 'home.aspx',
+          ServerRelativeUrl: '/sites/team-a/SitePages/home.aspx',
+          TimeCreated: '2018-01-20T08:54:41Z',
+          TimeLastModified: '2018-04-12T10:42:46Z',
+          Title: 'Home',
+          UIVersion: 3584,
+          UIVersionLabel: '7.0',
+          UniqueId: 'e82a21d1-ca2c-4854-98f2-012ac0e7fa09'
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          text: 'Hello world',
+          section: 1,
+          column: 2
+        }
+      });
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;24cebf73-d376-48e5-9b76-39b967c8dfd9&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;6,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;&#125;"><div data-sp-rte=""><p>test<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;6,&quot;sectionIndex&quot;&#58;2,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;1,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;5,&quot;indentationVersion&quot;&#58;2&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;"><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;14&#125;"><div data-sp-webpart="" data-sp-webpartdataversion="1.0" data-sp-webpartdata="&#123;&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;zoneBackground&quot;&#58;&#123;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#58;&#123;&quot;type&quot;&#58;&quot;gradient&quot;,&quot;gradient&quot;&#58;&quot;linear-gradient\(72.44deg, #E6FBFE 0%, #EDDDFB 100%\)&quot;,&quot;useLightText&quot;&#58;false,&quot;overlay&quot;&#58;&#123;&quot;color&quot;&#58;&quot;#FFFFFF&quot;,&quot;opacity&quot;&#58;0&#125;&#125;&#125;&#125;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;&#125;"><div data-sp-componentid=""><\/div><div data-sp-htmlproperties=""><\/div><\/div><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
+  });
+
+  it('adds text to a modern page on specific section and column with background setting, collapsible section and existing text webpart', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
+        return {
+          ListItemAllFields: {
+            CommentsDisabled: false,
+            FileSystemObjectType: 0,
+            Id: 1,
+            ServerRedirectedEmbedUri: null,
+            ServerRedirectedEmbedUrl: '',
+            ContentTypeId: '0x0101009D1CB255DA76424F860D91F20E6C41180062FDF2882AB3F745ACB63105A3C623C9',
+            FileLeafRef: 'Home.aspx',
+            ComplianceAssetId: null,
+            WikiField: null,
+            Title: 'Home',
+            ClientSideApplicationId: 'b6917cb1-93a0-4b97-a84d-7cf49975d4ec',
+            PageLayoutType: 'Home',
+            CanvasContent1: '<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;4,&quot;id&quot;&#58;&quot;24cebf73-d376-48e5-9b76-39b967c8dfd9&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;6,&quot;zoneIndex&quot;&#58;1,&quot;layoutIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;,&quot;addedFromPersistedData&quot;&#58;true,&quot;zoneGroupMetadata&quot;&#58;&#123;&quot;type&quot;&#58;1,&quot;isExpanded&quot;&#58;true,&quot;showDividerLine&quot;&#58;false,&quot;iconAlignment&quot;&#58;&quot;left&quot;,&quot;displayName&quot;&#58;&quot;Test&quot;&#125;&#125;\"><div data-sp-rte=\"\"><p>test</p></div></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;id&quot;&#58;&quot;emptySection&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionIndex&quot;&#58;2,&quot;sectionFactor&quot;&#58;6,&quot;zoneIndex&quot;&#58;1,&quot;layoutIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;,&quot;addedFromPersistedData&quot;&#58;true&#125;\"></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;1,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;5,&quot;indentationVersion&quot;&#58;2&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;\"></div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" data-sp-controldata=\"&#123;&quot;controlType&quot;&#58;14&#125;\"><div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" data-sp-webpartdata=\"&#123;&quot;properties&quot;&#58;&#123;&quot;zoneBackground&quot;&#58;&#123;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#58;&#123;&quot;type&quot;&#58;&quot;gradient&quot;,&quot;gradient&quot;&#58;&quot;radial-gradient(55.05% 96.28% at -5.05% -8.89%, #585984 0%, rgba(88, 89, 132, 0) 100%),\\n    linear-gradient(72.98deg, #AD8D8E 0.02%, #2A2A56 102.53%)&quot;,&quot;useLightText&quot;&#58;true,&quot;overlay&quot;&#58;&#123;&quot;color&quot;&#58;&quot;#000000&quot;,&quot;opacity&quot;&#58;60&#125;&#125;&#125;&#125;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.0&quot;&#125;\"><div data-sp-componentid=\"\"></div><div data-sp-htmlproperties=\"\"></div></div></div></div>',
+            BannerImageUrl: {
+              Description: '/_layouts/15/images/sitepagethumbnail.png',
+              Url: 'https://contoso.sharepoint.com/_layouts/15/images/sitepagethumbnail.png'
+            },
+            Description: 'Lorem ipsum Dolor samet Lorem ipsum',
+            PromotedState: null,
+            FirstPublishedDate: null,
+            LayoutWebpartsContent: null,
+            AuthorsId: null,
+            AuthorsStringId: null,
+            OriginalSourceUrl: null,
+            ID: 1,
+            Created: '2018-01-20T09:54:41',
+            AuthorId: 1073741823,
+            Modified: '2018-04-12T12:42:47',
+            EditorId: 12,
+            OData__CopySource: null,
+            CheckoutUserId: null,
+            OData__UIVersionString: '7.0',
+            GUID: 'edaab907-e729-48dd-9e73-26487c0cf592'
+          },
+          CheckInComment: '',
+          CheckOutType: 2,
+          ContentTag: '{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25,1',
+          CustomizedPageStatus: 1,
+          ETag: '"{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25"',
+          Exists: true,
+          IrmEnabled: false,
+          Length: '805',
+          Level: 1,
+          LinkingUri: null,
+          LinkingUrl: '',
+          MajorVersion: 7,
+          MinorVersion: 0,
+          Name: 'home.aspx',
+          ServerRelativeUrl: '/sites/team-a/SitePages/home.aspx',
+          TimeCreated: '2018-01-20T08:54:41Z',
+          TimeLastModified: '2018-04-12T10:42:46Z',
+          Title: 'Home',
+          UIVersion: 3584,
+          UIVersionLabel: '7.0',
+          UniqueId: 'e82a21d1-ca2c-4854-98f2-012ac0e7fa09'
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === "https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/sitepages/page.aspx')/ListItemAllFields") {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          text: 'Hello world',
+          section: 1,
+          column: 2
+        }
+      });
+
+    const regex = /<div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;24cebf73-d376-48e5-9b76-39b967c8dfd9&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;6,&quot;sectionIndex&quot;&#58;1,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;,&quot;zoneGroupMetadata&quot;&#58;&#123;&quot;type&quot;&#58;1,&quot;isExpanded&quot;&#58;true,&quot;showDividerLine&quot;&#58;false,&quot;iconAlignment&quot;&#58;&quot;left&quot;,&quot;displayName&quot;&#58;&quot;Test&quot;&#125;&#125;"><div data-sp-rte=""><p>test<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;4,&quot;editorType&quot;&#58;&quot;CKEditor&quot;,&quot;id&quot;&#58;&quot;([0-9a-fA-F-]{36})&quot;,&quot;position&quot;&#58;&#123;&quot;controlIndex&quot;&#58;1,&quot;sectionFactor&quot;&#58;6,&quot;sectionIndex&quot;&#58;2,&quot;zoneIndex&quot;&#58;1,&quot;zoneId&quot;&#58;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#125;,&quot;zoneGroupMetadata&quot;&#58;&#123;&quot;type&quot;&#58;1,&quot;isExpanded&quot;&#58;true,&quot;showDividerLine&quot;&#58;false,&quot;iconAlignment&quot;&#58;&quot;left&quot;,&quot;displayName&quot;&#58;&quot;Test&quot;&#125;&#125;"><div data-sp-rte=""><p>Hello world<\/p><\/div><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;0,&quot;pageSettingsSlice&quot;&#58;&#123;&quot;isDefaultDescription&quot;&#58;true,&quot;isDefaultThumbnail&quot;&#58;true,&quot;isSpellCheckEnabled&quot;&#58;true,&quot;globalRichTextStylingVersion&quot;&#58;1,&quot;rtePageSettings&quot;&#58;&#123;&quot;contentVersion&quot;&#58;5,&quot;indentationVersion&quot;&#58;2&#125;,&quot;isEmailReady&quot;&#58;false,&quot;webPartsPageSettings&quot;&#58;&#123;&quot;isTitleHeadingLevelsEnabled&quot;&#58;false&#125;&#125;&#125;"><\/div><div data-sp-canvascontrol="" data-sp-canvasdataversion="1.0" data-sp-controldata="&#123;&quot;controlType&quot;&#58;14&#125;"><div data-sp-webpart="" data-sp-webpartdataversion="1.0" data-sp-webpartdata="&#123;&quot;dataVersion&quot;&#58;&quot;1.0&quot;,&quot;properties&quot;&#58;&#123;&quot;zoneBackground&quot;&#58;&#123;&quot;e524fc79-e526-4da5-82e6-361018dedc67&quot;&#58;&#123;&quot;type&quot;&#58;&quot;gradient&quot;,&quot;gradient&quot;&#58;&quot;radial-gradient\(55.05% 96.28% at -5.05% -8.89%, #585984 0%, rgba\(88, 89, 132, 0\) 100%\),\\n    linear-gradient\(72.98deg, #AD8D8E 0.02%, #2A2A56 102.53%\)&quot;,&quot;useLightText&quot;&#58;true,&quot;overlay&quot;&#58;&#123;&quot;color&quot;&#58;&quot;#000000&quot;,&quot;opacity&quot;&#58;60&#125;&#125;&#125;&#125;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;&#125;"><div data-sp-componentid=""><\/div><div data-sp-htmlproperties=""><\/div><\/div><\/div><\/div>/;
+
+    assert.match(postStub.lastCall.args[0].data.CanvasContent1, regex);
   });
 
   it('correctly handles OData error when adding text to a non-existing page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/foo.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/foo.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         throw { error: { 'odata.error': { message: { value: 'The file /sites/team-a/SitePages/foo.aspx does not exist' } } } };
       }
 
@@ -627,7 +1073,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles OData error when adding text to a page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -708,7 +1154,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles error if target page is not a modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -777,7 +1223,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles invalid section error when adding text to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -855,7 +1301,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles invalid column error when adding text to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,
@@ -934,7 +1380,7 @@ describe(commands.PAGE_TEXT_ADD, () => {
 
   it('correctly handles error when parsing modern page contents', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/GetFileByServerRelativePath(DecodedUrl='/sites/team-a/SitePages/page.aspx')?$expand=ListItemAllFields/ClientSideApplicationId`) {
         return {
           ListItemAllFields: {
             CommentsDisabled: false,

--- a/src/m365/spo/commands/page/page-text-add.ts
+++ b/src/m365/spo/commands/page/page-text-add.ts
@@ -7,6 +7,7 @@ import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
 import {
+  CanvasSection,
   ClientSidePage,
   ClientSideText
 } from './clientsidepages.js';
@@ -117,6 +118,13 @@ class SpoPageTextAddCommand extends SpoCommand {
 
       const section: number = (args.options.section || 1) - 1;
       const column: number = (args.options.column || 1) - 1;
+
+      // Add a new section when page does not contain any sections
+      if (page.sections.length < 1) {
+        const newSection = new CanvasSection(page, 1);
+        newSection.defaultColumn;
+        page.sections.push(newSection);
+      }
 
       // Make sure the section is in range
       if (section >= page.sections.length) {


### PR DESCRIPTION
Closes #6462
Changes in `page clientsidewebpart add` and `page text add` commands to handle existing collapsible sections when saving an SP page.

In this PR, I have also updated the `page text add` test file to align with the latest recommendations.

Just one comment, I believe we also need to add some handlers for the controlType":0,"pageSettingsSlice... element, which is also visible in the page context.


