### PR TITLE
💡New command  :  tenant report settings set - closes #6247

### DIFF
--- a/docs/docs/cmd/tenant/report/report-settings-set.mdx
+++ b/docs/docs/cmd/tenant/report/report-settings-set.mdx
@@ -66,4 +66,4 @@ This command returns a `204 No content` response code.
       }
     ```
   </TabItem>
-<Tabs>
+</Tabs>

--- a/docs/docs/cmd/tenant/report/report-settings-set.mdx
+++ b/docs/docs/cmd/tenant/report/report-settings-set.mdx
@@ -1,0 +1,67 @@
+import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# report settings set
+
+Update (adminReportSettings) tenant-level settings for Microsoft 365 reports
+
+## Usage
+
+```sh
+m365 tenant report settings set [options]
+```
+
+## Options
+
+```md definition-list
+`-h, --hideUserInformation  <hideUserInformation>`
+: Determines whether all reports conceal user information such as usernames, groups, and sites.  
+
+`--verbose`
+: Runs command with verbose logging
+
+`--debug`
+: Runs command with debug logging
+
+```
+
+<Global />
+
+## Remarks
+
+Please refer to the [Graph documentation page](https://learn.microsoft.com/en-in/graph/api/adminreportsettings-update?view=graph-rest-1.0&tabs=http).
+
+:::note
+
+This command returns a `204 No content` response code. To see the default logs, we recommed you to run the command with `---verbose or --debug` options
+
+## Examples
+
+Set `displayConcealedNames` to true. 
+
+```sh
+m365 tenant report settings set --hideUserInformation true
+```
+
+Set `displayConcealedNames` to false. 
+
+```sh
+m365 tenant report settings set --hideUserInformation false
+```
+
+
+## Response
+
+:::note
+
+This command returns a `204 No content` response code.
+
+<Tabs>
+  <TabItem value="JSON">
+
+    ```json
+      {
+        
+      }
+    ```

--- a/docs/docs/cmd/tenant/report/report-settings-set.mdx
+++ b/docs/docs/cmd/tenant/report/report-settings-set.mdx
@@ -2,9 +2,9 @@ import Global from '/docs/cmd/_global.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# report settings set
+# tenant report settings set
 
-Update (adminReportSettings) tenant-level settings for Microsoft 365 reports
+Update tenant-level settings for Microsoft 365 reports
 
 ## Usage
 
@@ -15,55 +15,22 @@ m365 tenant report settings set [options]
 ## Options
 
 ```md definition-list
-`-h, --hideUserInformation  <hideUserInformation>`
-: Determines whether all reports conceal user information such as usernames, groups, and sites.  
-
-`--verbose`
-: Runs command with verbose logging
-
-`--debug`
-: Runs command with debug logging
+`-h, --hideUserInformation <hideUserInformation>`
+: Determines whether all reports conceal user information such as usernames, groups, and sites. If false, all reports show identifiable information.
 
 ```
 
 <Global />
 
-## Remarks
-
-Please refer to the [Graph documentation page](https://learn.microsoft.com/en-in/graph/api/adminreportsettings-update?view=graph-rest-1.0&tabs=http).
-
-:::note
-
-This command returns a `204 No content` response code. To see the default logs, we recommed you to run the command with `---verbose or --debug` options
-
 ## Examples
 
-Set `displayConcealedNames` to true. 
+Conceal user information in Microsoft 365 reports
 
 ```sh
 m365 tenant report settings set --hideUserInformation true
 ```
 
-Set `displayConcealedNames` to false. 
-
-```sh
-m365 tenant report settings set --hideUserInformation false
-```
-
-
 ## Response
 
-:::note
+The command won't return a response on success
 
-This command returns a `204 No content` response code.
-
-<Tabs>
-  <TabItem value="JSON">
-
-    ```json
-      {
-        
-      }
-    ```
-  </TabItem>
-</Tabs>

--- a/docs/docs/cmd/tenant/report/report-settings-set.mdx
+++ b/docs/docs/cmd/tenant/report/report-settings-set.mdx
@@ -31,4 +31,3 @@ m365 tenant report settings set --displayConcealedNames true
 ## Response
 
 The command won't return a response on success
-

--- a/docs/docs/cmd/tenant/report/report-settings-set.mdx
+++ b/docs/docs/cmd/tenant/report/report-settings-set.mdx
@@ -65,3 +65,5 @@ This command returns a `204 No content` response code.
         
       }
     ```
+  </TabItem>
+<Tabs>

--- a/docs/docs/cmd/tenant/report/report-settings-set.mdx
+++ b/docs/docs/cmd/tenant/report/report-settings-set.mdx
@@ -1,6 +1,4 @@
 import Global from '/docs/cmd/_global.mdx';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # tenant report settings set
 
@@ -15,7 +13,7 @@ m365 tenant report settings set [options]
 ## Options
 
 ```md definition-list
-`-h, --hideUserInformation <hideUserInformation>`
+`-d, --displayConcealedNames <displayConcealedNames>`
 : Determines whether all reports conceal user information such as usernames, groups, and sites. If false, all reports show identifiable information.
 
 ```
@@ -24,10 +22,10 @@ m365 tenant report settings set [options]
 
 ## Examples
 
-Conceal user information in Microsoft 365 reports
+Set to display concealed user information in Microsoft 365 reports
 
 ```sh
-m365 tenant report settings set --hideUserInformation true
+m365 tenant report settings set --displayConcealedNames true
 ```
 
 ## Response

--- a/docs/src/config/sidebars.ts
+++ b/docs/src/config/sidebars.ts
@@ -964,6 +964,11 @@ const sidebars: SidebarsConfig = {
               type: 'doc',
               label: 'report servicesusercounts',
               id: 'cmd/tenant/report/report-servicesusercounts'
+            },
+            {
+              type: 'doc',
+              label: 'tenant report settings set',
+              id: 'cmd/tenant/report/report-tenantsettings-set'
             }
           ]
         },

--- a/docs/src/config/sidebars.ts
+++ b/docs/src/config/sidebars.ts
@@ -967,8 +967,8 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
-              label: 'tenant report settings set',
-              id: 'cmd/tenant/report/report-tenantsettings-set'
+              label: 'report settings set',
+              id: 'cmd/tenant/report/report-settings-set'
             }
           ]
         },

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ export default {
     'https://graph.microsoft.com/Place.Read.All',
     'https://graph.microsoft.com/Policy.Read.All',
     'https://graph.microsoft.com/RecordsManagement.ReadWrite.All',
-    'https://graph.microsoft.com/Reports.Read.All',
+    'https://graph.microsoft.com/Reports.ReadWrite.All',
     'https://graph.microsoft.com/RoleAssignmentSchedule.ReadWrite.Directory',
     'https://graph.microsoft.com/RoleEligibilitySchedule.Read.Directory',
     'https://graph.microsoft.com/SecurityEvents.Read.All',

--- a/src/m365/tenant/commands.ts
+++ b/src/m365/tenant/commands.ts
@@ -15,7 +15,7 @@ export default {
   REPORT_OFFICE365ACTIVATIONSUSERDETAIL: `${prefix} report office365activationsuserdetail`,
   REPORT_OFFICE365ACTIVATIONSUSERCOUNTS: `${prefix} report office365activationsusercounts`,
   REPORT_SERVICESUSERCOUNTS: `${prefix} report servicesusercounts`,
-  REPORT_TENANTSETTINGS_SET: `${prefix} report settings set`,
+  REPORT_SETTINGS_SET: `${prefix} report settings set`,
   SECURITY_ALERTS_LIST: `${prefix} security alerts list`,
   SERVICEANNOUNCEMENT_HEALTHISSUE_GET: `${prefix} serviceannouncement healthissue get`,
   SERVICEANNOUNCEMENT_HEALTH_GET: `${prefix} serviceannouncement health get`,

--- a/src/m365/tenant/commands.ts
+++ b/src/m365/tenant/commands.ts
@@ -15,6 +15,7 @@ export default {
   REPORT_OFFICE365ACTIVATIONSUSERDETAIL: `${prefix} report office365activationsuserdetail`,
   REPORT_OFFICE365ACTIVATIONSUSERCOUNTS: `${prefix} report office365activationsusercounts`,
   REPORT_SERVICESUSERCOUNTS: `${prefix} report servicesusercounts`,
+  REPORT_TENANTSETTINGS_SET: `${prefix} report settings set`,
   SECURITY_ALERTS_LIST: `${prefix} security alerts list`,
   SERVICEANNOUNCEMENT_HEALTHISSUE_GET: `${prefix} serviceannouncement healthissue get`,
   SERVICEANNOUNCEMENT_HEALTH_GET: `${prefix} serviceannouncement health get`,

--- a/src/m365/tenant/commands/report/report-settings-set.spec.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.spec.ts
@@ -13,7 +13,7 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './report-settings-set.js';
 
-describe(commands.REPORT_TENANTSETTINGS_SET, () => {
+describe(commands.REPORT_SETTINGS_SET, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
@@ -54,7 +54,7 @@ describe(commands.REPORT_TENANTSETTINGS_SET, () => {
   });
 
   it('has correct name', () => {
-    assert.strictEqual(command.name, commands.REPORT_TENANTSETTINGS_SET);
+    assert.strictEqual(command.name, commands.REPORT_SETTINGS_SET);
   });
 
   it('has a description', () => {

--- a/src/m365/tenant/commands/report/report-settings-set.spec.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.spec.ts
@@ -129,5 +129,4 @@ describe(commands.REPORT_SETTINGS_SET, () => {
       new CommandError('An error has occurred')
     );
   });
-
 });

--- a/src/m365/tenant/commands/report/report-settings-set.spec.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.spec.ts
@@ -64,26 +64,26 @@ describe(commands.REPORT_SETTINGS_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if --hideUserInformation is not a boolean', async () => {
+  it('fails validation if --displayConcealedNames is not a boolean', async () => {
     const result = commandOptionsSchema.safeParse({
-      hideUserInformation: 'not-boolean'
+      displayConcealedNames: 'not-boolean'
     });
     assert.strictEqual(result.success, false);
     if (!result.success) {
-      assert.strictEqual(result.error.issues[0].message, "'hideUserInformation' must be a boolean");
+      assert.strictEqual(result.error.issues[0].message, "Expected boolean, received string");
     }
   });
 
-  it('passes validation if --hideUserInformation is true', async () => {
+  it('passes validation if --displayConcealedNames is true', async () => {
     const result = commandOptionsSchema.safeParse({
-      hideUserInformation: true
+      displayConcealedNames: true
     });
     assert.strictEqual(result.success, true);
   });
 
-  it('passes validation if --hideUserInformation is false', async () => {
+  it('passes validation if --displayConcealedNames is false', async () => {
     const result = commandOptionsSchema.safeParse({
-      hideUserInformation: false
+      displayConcealedNames: false
     });
     assert.strictEqual(result.success, true);
   });
@@ -98,7 +98,7 @@ describe(commands.REPORT_SETTINGS_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { hideUserInformation: true, verbose: true } });
+    await command.action(logger, { options: { displayConcealedNames: true, verbose: true } });
 
     assert(logToStderrSpy.calledWith('Updating report settings displayConcealedNames to true'));
   });
@@ -112,7 +112,7 @@ describe(commands.REPORT_SETTINGS_SET, () => {
       return Promise.reject('Invalid request');
     });
     await command.action(logger, {
-      options: { hideUserInformation: true }
+      options: { displayConcealedNames: true }
     });
   });
 

--- a/src/m365/tenant/commands/report/report-settings-set.spec.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import request from '../../../../request.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
@@ -14,8 +16,7 @@ import command from './report-settings-set.js';
 describe(commands.REPORT_TENANTSETTINGS_SET, () => {
   let log: string[];
   let logger: Logger;
-
-
+  let commandInfo: CommandInfo;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -23,6 +24,7 @@ describe(commands.REPORT_TENANTSETTINGS_SET, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
@@ -57,6 +59,33 @@ describe(commands.REPORT_TENANTSETTINGS_SET, () => {
 
   it('has a description', () => {
     assert.notStrictEqual(command.description, null);
+  });
+
+  it('fails validation if --hideUserInformation is not a boolean', async () => {
+    const result = await command.validate({
+      options: {
+        hideUserInformation: 'not-boolean'
+      }
+    }, commandInfo);
+    assert.strictEqual(result, `'hideUserInformation' must be a boolean.`);
+  });
+
+  it('passes validation if --hideUserInformation is true', async () => {
+    const result = await command.validate({
+      options: {
+        hideUserInformation: true
+      }
+    }, commandInfo);
+    assert.strictEqual(result, true);
+  });
+
+  it('passes validation if --hideUserInformation is false', async () => {
+    const result = await command.validate({
+      options: {
+        hideUserInformation: false
+      }
+    }, commandInfo);
+    assert.strictEqual(result, true);
   });
 
   it('logs verbose message when verbose option is enabled', async () => {

--- a/src/m365/tenant/commands/report/report-settings-set.spec.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.spec.ts
@@ -60,10 +60,11 @@ describe(commands.REPORT_TENANTSETTINGS_SET, () => {
   });
 
   it('logs a message when updating settings in verbose mode', async () => {
-    command.action(logger, { options: { verbose: true, hideUserInformation: true } });
+    await command.action(logger, { options: { verbose: true, hideUserInformation: true } });
     await command.action(logger, { options: { hideUserInformation: true } });
     assert(loggerLogSpy.calledWith('Updating report settings...'));
   });
+
 
 
   it('patches the tenant settings report with the specified settings', async () => {

--- a/src/m365/tenant/commands/report/report-settings-set.spec.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.spec.ts
@@ -1,0 +1,96 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import auth from '../../../../Auth.js';
+import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
+import request from '../../../../request.js';
+import { telemetry } from '../../../../telemetry.js';
+import { pid } from '../../../../utils/pid.js';
+import { session } from '../../../../utils/session.js';
+import { sinonUtil } from '../../../../utils/sinonUtil.js';
+import commands from '../../commands.js';
+import command from './report-settings-set.js';
+
+describe(commands.REPORT_TENANTSETTINGS_SET, () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogSpy: sinon.SinonSpy;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').resolves();
+    sinon.stub(telemetry, 'trackEvent').returns();
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
+    auth.connection.active = true;
+  });
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: async (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: async (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: async (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogSpy = sinon.spy(logger, 'log');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.patch
+    ]);
+  });
+
+  after(() => {
+    sinon.restore();
+    auth.connection.active = false;
+  });
+
+  it('has correct name', () => {
+    assert.strictEqual(command.name, commands.REPORT_TENANTSETTINGS_SET);
+  });
+
+  it('has a description', () => {
+    assert.notStrictEqual(command.description, null);
+  });
+
+  it('logs a message when updating settings in verbose mode', async () => {
+    command.action(logger, { options: { verbose: true, hideUserInformation: true } });
+    await command.action(logger, { options: { hideUserInformation: true } });
+    assert(loggerLogSpy.calledWith('Updating report settings...'));
+  });
+
+
+  it('patches the tenant settings report with the specified settings', async () => {
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/reportSettings`) {
+        return Promise.resolve();
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    await command.action(logger, {
+      options: { hideUserInformation: true }
+    });
+  });
+
+  it('handles error when retrieving tenant report settings failed', async () => {
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/admin/reportSettings`) {
+        throw { error: { message: 'An error has occurred' } };
+      }
+      throw `Invalid request`;
+    });
+
+    await assert.rejects(
+      command.action(logger, { options: {} } as any),
+      new CommandError('An error has occurred')
+    );
+  });
+
+});

--- a/src/m365/tenant/commands/report/report-settings-set.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.ts
@@ -27,6 +27,7 @@ class TenantReportSettingsSetCommand extends GraphCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initTypes();
+    this.#initValidators();
   }
 
   #initTelemetry(): void {
@@ -51,6 +52,19 @@ class TenantReportSettingsSetCommand extends GraphCommand {
     );
   }
 
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        const { hideUserInformation } = args.options;
+
+        if (typeof hideUserInformation !== 'boolean') {
+          return `'hideUserInformation' must be a boolean.`;
+        }
+
+        return true;
+      }
+    );
+  }
 
   #initTypes(): void {
     this.types.boolean.push('hideUserInformation');

--- a/src/m365/tenant/commands/report/report-settings-set.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.ts
@@ -14,7 +14,7 @@ interface Options extends GlobalOptions {
 
 class TenantReportSettingsSetCommand extends GraphCommand {
   public get name(): string {
-    return commands.REPORT_TENANTSETTINGS_SET;
+    return commands.REPORT_SETTINGS_SET;
   }
 
   public get description(): string {

--- a/src/m365/tenant/commands/report/report-settings-set.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.ts
@@ -1,3 +1,4 @@
+//import { boolean } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
@@ -26,7 +27,6 @@ class TenantReportSettingsSetCommand extends GraphCommand {
 
     this.#initTelemetry();
     this.#initOptions();
-    this.#initValidators();
     this.#initTypes();
   }
 
@@ -52,53 +52,34 @@ class TenantReportSettingsSetCommand extends GraphCommand {
     );
   }
 
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (typeof args.options.hideUserInformation !== 'boolean') {
-          return `${args.options.hideUserInformation} is not a boolean`;
-        }
-
-        if (typeof args.options.hideUserInformation === 'undefined') {
-          return 'specify to hideUserInformation to true or false';
-        }
-
-        return true;
-      }
-    );
-  }
 
   #initTypes(): void {
     this.types.boolean.push('hideUserInformation');
   }
 
-  public allowUnknownOptions(): boolean | undefined {
-    return false;
-  }
-
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
-    if (this.verbose) {
-      await logger.logToStderr('Updating report settings...');
-    }
-    const requestOptions: CliRequestOptions = {
-      url: `${this.resource}/v1.0/admin/reportSettings`,
-      headers: {
-        accept: 'application/json;odata.metadata=none',
-        'content-type': 'application/json'
-      },
-      responseType: 'json',
-      // displayConcealedNames If set to true, all reports conceal user information such as usernames, groups, and sites. If false, all reports show identifiable information
-      data: {
-        'displayConcealedNames': args.options.hideUserInformation
-      }
-    };
-
     try {
+      if (this.verbose) {
+        await logger.logToStderr(`Updating report settings displayConcealedNames to '${args.options.hideUserInformation}'...`);
+      }
+      const requestOptions: CliRequestOptions = {
+        url: `${this.resource}/v1.0/admin/reportSettings`,
+        headers: {
+          accept: 'application/json;odata.metadata=none',
+          'content-type': 'application/json'
+        },
+        responseType: 'json',
+        // displayConcealedNames If set to true, all reports conceal user information such as usernames, groups, and sites. If false, all reports show identifiable information
+        data: {
+          'displayConcealedNames': args.options.hideUserInformation
+        }
+      };
       await request.patch(requestOptions);
       if (this.verbose) {
-        await logger.logToStderr('Report settings updated');
+        await logger.logToStderr(`Report settings displayConcealedNames updated to '${args.options.hideUserInformation}'`);
       }
-    } catch (err) {
+    }
+    catch (err) {
       this.handleRejectedODataJsonPromise(err);
     }
   }

--- a/src/m365/tenant/commands/report/report-settings-set.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.ts
@@ -60,7 +60,7 @@ class TenantReportSettingsSetCommand extends GraphCommand {
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       if (this.verbose) {
-        await logger.logToStderr(`Updating report settings displayConcealedNames to '${args.options.hideUserInformation}'...`);
+        await logger.logToStderr(`Updating report settings '${args.options.hideUserInformation}'...`);
       }
       const requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/admin/reportSettings`,
@@ -75,9 +75,6 @@ class TenantReportSettingsSetCommand extends GraphCommand {
         }
       };
       await request.patch(requestOptions);
-      if (this.verbose) {
-        await logger.logToStderr(`Report settings displayConcealedNames updated to '${args.options.hideUserInformation}'`);
-      }
     }
     catch (err) {
       this.handleRejectedODataJsonPromise(err);

--- a/src/m365/tenant/commands/report/report-settings-set.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.ts
@@ -1,0 +1,107 @@
+import { Logger } from '../../../../cli/Logger.js';
+import GlobalOptions from '../../../../GlobalOptions.js';
+import request, { CliRequestOptions } from '../../../../request.js';
+import GraphCommand from '../../../base/GraphCommand.js';
+import commands from '../../commands.js';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  hideUserInformation: boolean;
+}
+
+class TenantReportSettingsSetCommand extends GraphCommand {
+  public get name(): string {
+    return commands.REPORT_TENANTSETTINGS_SET;
+  }
+
+  public get description(): string {
+    return 'Sets the tenant settings report';
+  }
+
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+    this.#initValidators();
+    this.#initTypes();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      // Add unknown options to telemetry
+      const unknownOptions = Object.keys(this.getUnknownOptions(args.options));
+      const unknownOptionsObj = unknownOptions.reduce((obj, key) => ({ ...obj, [key]: true }), {});
+
+      Object.assign(this.telemetryProperties, {
+        hideUserInformation: typeof args.options.hideUserInformation !== 'undefined',
+        ...unknownOptionsObj
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-h, --hideUserInformation  <hideUserInformation>',
+        autocomplete: ['true', 'false']
+      }
+    );
+  }
+
+  #initValidators(): void {
+    this.validators.push(
+      async (args: CommandArgs) => {
+        if (typeof args.options.hideUserInformation !== 'boolean') {
+          return `${args.options.hideUserInformation} is not a boolean`;
+        }
+
+        if (typeof args.options.hideUserInformation === 'undefined') {
+          return 'specify to hideUserInformation to true or false';
+        }
+
+        return true;
+      }
+    );
+  }
+
+  #initTypes(): void {
+    this.types.boolean.push('hideUserInformation');
+  }
+
+  public allowUnknownOptions(): boolean | undefined {
+    return false;
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (this.verbose) {
+      await logger.logToStderr('Updating report settings...');
+    }
+    const requestOptions: CliRequestOptions = {
+      url: `${this.resource}/v1.0/admin/reportSettings`,
+      headers: {
+        accept: 'application/json;odata.metadata=none',
+        'content-type': 'application/json'
+      },
+      responseType: 'json',
+      // displayConcealedNames If set to true, all reports conceal user information such as usernames, groups, and sites. If false, all reports show identifiable information
+      data: {
+        'displayConcealedNames': args.options.hideUserInformation
+      }
+    };
+
+    try {
+      await request.patch(requestOptions);
+      if (this.verbose) {
+        await logger.logToStderr('Report settings updated');
+      }
+    } catch (err) {
+      this.handleRejectedODataJsonPromise(err);
+    }
+  }
+}
+
+export default new TenantReportSettingsSetCommand();

--- a/src/m365/tenant/commands/report/report-settings-set.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.ts
@@ -4,13 +4,11 @@ import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 import { z } from 'zod';
 import { globalOptionsZod } from '../../../../Command.js';
+import { zod } from '../../../../utils/zod.js';
 
 const options = globalOptionsZod
   .extend({
-    hideUserInformation: z
-      // eslint-disable-next-line camelcase
-      .boolean({ invalid_type_error: "'hideUserInformation' must be a boolean" })
-      .refine(value => typeof value === 'boolean', { message: "'hideUserInformation' must be a boolean" })
+    displayConcealedNames: zod.alias('d', z.boolean())
   })
   .strict();
 
@@ -35,9 +33,9 @@ class TenantReportSettingsSetCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
-      const { hideUserInformation } = args.options;
+      const { displayConcealedNames } = args.options;
       if (this.verbose) {
-        await logger.logToStderr(`Updating report settings displayConcealedNames to ${hideUserInformation}`);
+        await logger.logToStderr(`Updating report settings displayConcealedNames to ${displayConcealedNames}`);
       }
 
       const requestOptions: CliRequestOptions = {
@@ -48,7 +46,7 @@ class TenantReportSettingsSetCommand extends GraphCommand {
         },
         responseType: 'json',
         data: {
-          displayConcealedNames: hideUserInformation
+          displayConcealedNames: displayConcealedNames
         }
       };
 

--- a/src/m365/tenant/commands/report/report-settings-set.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.ts
@@ -1,4 +1,3 @@
-//import { boolean } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
@@ -57,11 +56,15 @@ class TenantReportSettingsSetCommand extends GraphCommand {
     this.types.boolean.push('hideUserInformation');
   }
 
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
+
+      const { hideUserInformation } = args.options;
       if (this.verbose) {
-        await logger.logToStderr(`Updating report settings '${args.options.hideUserInformation}'...`);
+        await logger.logToStderr(`Updating report settings displayConcealedNames to ${hideUserInformation}`);
       }
+
       const requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/admin/reportSettings`,
         headers: {
@@ -69,11 +72,11 @@ class TenantReportSettingsSetCommand extends GraphCommand {
           'content-type': 'application/json'
         },
         responseType: 'json',
-        // displayConcealedNames If set to true, all reports conceal user information such as usernames, groups, and sites. If false, all reports show identifiable information
         data: {
           'displayConcealedNames': args.options.hideUserInformation
         }
       };
+
       await request.patch(requestOptions);
     }
     catch (err) {


### PR DESCRIPTION
New command  :  tenant report settings set - closes #6247 

## Explanation 

This command can be used to update (adminReportSettings) tenant-level settings for Microsoft 365 reports.
Please refer to the [Graph documentation page](https://learn.microsoft.com/en-in/graph/api/adminreportsettings-update?view=graph-rest-1.0&tabs=http).

## Usage

```sh
m365 tenant report settings set [options]
```

## test screens
Below has set `--hideUserInformation` to `false`
<img width="947" alt="image" src="https://github.com/user-attachments/assets/c1f606a1-7cbd-4e80-8aa2-3a66218c374b" />

below is the screen from the Admin center

<img width="1115" alt="image" src="https://github.com/user-attachments/assets/62f2f849-c54a-40d4-9afc-b62e276e366a" />

Below has set `--hideUserInformation` to `true`

<img width="766" alt="image" src="https://github.com/user-attachments/assets/5665951b-c76c-4498-a28e-ff5b41593b78" />


below is the screen from the Admin center

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/d920ddac-1aea-4738-b5e3-20276372e21e" />

Below screen shows further validations

<img width="545" alt="image" src="https://github.com/user-attachments/assets/6e408e8b-81a8-4843-9e73-3d58d4299400" />


Thanks,
Nish
