### PR TITLE
Fixes `page clientsidewebpart add` for the vertical sections. Closes #6265

### DIFF
--- a/docs/docs/cmd/spo/page/page-clientsidewebpart-add.mdx
+++ b/docs/docs/cmd/spo/page/page-clientsidewebpart-add.mdx
@@ -32,13 +32,16 @@ m365 spo page clientsidewebpart add [options]
 : JSON string with web part data as retrieved from the web part maintenance mode. Specify either `webPartProperties` or `webPartData` but not both.
 
 `--section [section]`
-: Number of the section to which the web part should be added (1 or higher).
+: Number of the section to which the web part should be added (1 or higher). Specify `section` or `verticalSection` but not both.
 
 `--column [column]`
-: Number of the column in which the web part should be added (1 or higher).
+: Number of the column in which the web part should be added (1 or higher). Specify `column` or `verticalSection` but not both.
 
 `--order [order]`
 : Order of the web part in the column.
+
+`--verticalSection`
+: Specifies that the web part should be added to the vertical section. 
 ```
 
 <Global />
@@ -85,6 +88,12 @@ Add the standard Image web part with the preconfigured image
 
 ```sh
 m365 spo page clientsidewebpart add --webUrl https://contoso.sharepoint.com/sites/a-team --pageName page.aspx --standardWebPart Image --webPartData '{ "dataVersion": "1.8", "serverProcessedContent": {"htmlStrings":{},"searchablePlainTexts":{"captionText":""},"imageSources":{"imageSource":"/sites/team-a/SiteAssets/work-life-balance.png"},"links":{}}, "properties": {"imageSourceType":2,"altText":"a group of people on a beach","overlayText":"Work life balance","fileName":"48146-OFF12_Justice_01.png","siteId":"27664b85-067d-4be9-a7d7-89b2e804d09f","webId":"a7664b85-067d-4be9-a7d7-89b2e804d09f","listId":"37664b85-067d-4be9-a7d7-89b2e804d09f","uniqueId":"67664b85-067d-4be9-a7d7-89b2e804d09f","imgWidth":650,"imgHeight":433,"fixAspectRatio":false,"isOverlayTextEnabled":true}}'
+```
+
+Add the standard Bing Map web part to a modern page in the vertical section
+
+```sh
+m365 spo page clientsidewebpart add --webUrl https://contoso.sharepoint.com/sites/a-team --pageName page.aspx --standardWebPart BingMap --verticalSection
 ```
 
 ## Response

--- a/src/m365/spo/commands/page/page-clientsidewebpart-add.spec.ts
+++ b/src/m365/spo/commands/page/page-clientsidewebpart-add.spec.ts
@@ -92,7 +92,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
   it('checks out page if not checked out by the current user', async () => {
     let checkedOut = false;
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')`) {
         return {
           IsPageCheckedOutToCurrentUser: false,
           Title: "article",
@@ -109,7 +109,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -117,7 +117,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`) {
         checkedOut = true;
         return {
           Title: "article",
@@ -134,7 +134,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/SavePageAsDraft`) {
         return {};
       }
 
@@ -154,7 +154,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
   it('checks out page if not checked out by the current user (debug)', async () => {
     let checkedOut = false;
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')`) {
         return {
           IsPageCheckedOutToCurrentUser: false,
           Title: "article",
@@ -171,7 +171,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -179,7 +179,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`) {
         checkedOut = true;
         return {
           Title: "article",
@@ -196,7 +196,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/SavePageAsDraft`) {
         return {};
       }
 
@@ -217,7 +217,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
   it('doesn\'t check out page if checked out by the current user', async () => {
     let checkingOut = false;
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')`) {
         return {
           IsPageCheckedOutToCurrentUser: true,
           Title: "article",
@@ -234,7 +234,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -242,7 +242,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`) {
         checkingOut = true;
         return {
           Title: "article",
@@ -259,7 +259,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/SavePageAsDraft`) {
         return {};
       }
 
@@ -278,14 +278,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part to an empty column when no order specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"sectionFactor\":8,\"layoutIndex\":1},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -294,7 +294,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -363,14 +363,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part to an empty column when order 1 specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"sectionFactor\":8,\"layoutIndex\":1},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -379,7 +379,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -449,14 +449,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part to an empty column when order 5 specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"sectionFactor\":8,\"layoutIndex\":1},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -465,7 +465,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -535,14 +535,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part at the end of the column with one web part when no order specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -551,7 +551,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -661,14 +661,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part at the beginning of the column with one web part when order 1 specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -677,7 +677,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -788,14 +788,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part at the end of the column with one web part when order 2 specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -804,7 +804,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -915,14 +915,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part at the end of the column with multiple web part when no order specified (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"controlType\":3,\"displayMode\":2,\"id\":\"230b9699-d4ed-414b-8a83-9b251297c384\",\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"controlIndex\":1.5,\"layoutIndex\":1,\"sectionFactor\":8},\"webPartId\":\"62cac389-787f-495d-beca-e11786162ef4\",\"emphasis\":{},\"reservedHeight\":321,\"reservedWidth\":757,\"webPartData\":{\"id\":\"62cac389-787f-495d-beca-e11786162ef4\",\"instanceId\":\"230b9699-d4ed-414b-8a83-9b251297c384\",\"title\":\"Countdown Timer\",\"description\":\"This web part is used to allow a site admin to count down/up to an important event.\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{\"buttonURL\":null}},\"dataVersion\":\"2.1\",\"properties\":{\"showButton\":false,\"countDate\":\"Sun Apr 07 2019 22:00:00 GMT+0200 (Central European Summer Time)\",\"title\":\"\",\"description\":\"\",\"countDirection\":\"COUNT_DOWN\",\"dateDisplay\":\"DAY_HOUR_MINUTE_SECOND\",\"buttonText\":\"\"}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -931,7 +931,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -1082,14 +1082,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part at the beginning of the column with multiple web part when order 1 specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"controlType\":3,\"displayMode\":2,\"id\":\"230b9699-d4ed-414b-8a83-9b251297c384\",\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"controlIndex\":1.5,\"layoutIndex\":1,\"sectionFactor\":8},\"webPartId\":\"62cac389-787f-495d-beca-e11786162ef4\",\"emphasis\":{},\"reservedHeight\":321,\"reservedWidth\":757,\"webPartData\":{\"id\":\"62cac389-787f-495d-beca-e11786162ef4\",\"instanceId\":\"230b9699-d4ed-414b-8a83-9b251297c384\",\"title\":\"Countdown Timer\",\"description\":\"This web part is used to allow a site admin to count down/up to an important event.\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{\"buttonURL\":null}},\"dataVersion\":\"2.1\",\"properties\":{\"showButton\":false,\"countDate\":\"Sun Apr 07 2019 22:00:00 GMT+0200 (Central European Summer Time)\",\"title\":\"\",\"description\":\"\",\"countDirection\":\"COUNT_DOWN\",\"dateDisplay\":\"DAY_HOUR_MINUTE_SECOND\",\"buttonText\":\"\"}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -1098,7 +1098,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -1249,14 +1249,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part in the middle of the column with multiple web part when order 2 specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"controlType\":3,\"displayMode\":2,\"id\":\"230b9699-d4ed-414b-8a83-9b251297c384\",\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"controlIndex\":1.5,\"layoutIndex\":1,\"sectionFactor\":8},\"webPartId\":\"62cac389-787f-495d-beca-e11786162ef4\",\"emphasis\":{},\"reservedHeight\":321,\"reservedWidth\":757,\"webPartData\":{\"id\":\"62cac389-787f-495d-beca-e11786162ef4\",\"instanceId\":\"230b9699-d4ed-414b-8a83-9b251297c384\",\"title\":\"Countdown Timer\",\"description\":\"This web part is used to allow a site admin to count down/up to an important event.\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{\"buttonURL\":null}},\"dataVersion\":\"2.1\",\"properties\":{\"showButton\":false,\"countDate\":\"Sun Apr 07 2019 22:00:00 GMT+0200 (Central European Summer Time)\",\"title\":\"\",\"description\":\"\",\"countDirection\":\"COUNT_DOWN\",\"dateDisplay\":\"DAY_HOUR_MINUTE_SECOND\",\"buttonText\":\"\"}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -1265,7 +1265,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -1416,14 +1416,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds web part at the end of the column with multiple web part when order 5 specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"controlType\":3,\"displayMode\":2,\"id\":\"230b9699-d4ed-414b-8a83-9b251297c384\",\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"controlIndex\":1.5,\"layoutIndex\":1,\"sectionFactor\":8},\"webPartId\":\"62cac389-787f-495d-beca-e11786162ef4\",\"emphasis\":{},\"reservedHeight\":321,\"reservedWidth\":757,\"webPartData\":{\"id\":\"62cac389-787f-495d-beca-e11786162ef4\",\"instanceId\":\"230b9699-d4ed-414b-8a83-9b251297c384\",\"title\":\"Countdown Timer\",\"description\":\"This web part is used to allow a site admin to count down/up to an important event.\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{\"buttonURL\":null}},\"dataVersion\":\"2.1\",\"properties\":{\"showButton\":false,\"countDate\":\"Sun Apr 07 2019 22:00:00 GMT+0200 (Central European Summer Time)\",\"title\":\"\",\"description\":\"\",\"countDirection\":\"COUNT_DOWN\",\"dateDisplay\":\"DAY_HOUR_MINUTE_SECOND\",\"buttonText\":\"\"}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -1432,7 +1432,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -1583,14 +1583,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds a standard web part at the end of the column with one web part when no order specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -1599,7 +1599,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -1709,14 +1709,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds a standard web part in a default section when no section exists on page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -1725,7 +1725,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -1782,16 +1782,16 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
     }));
   });
 
-  it('adds a standard web part with properties at the end of the column with one web part when no order specified (debug)', async () => {
+  it('adds a standard web part in a vertical section when there is no vertical section on the page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
-          "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
+          "CanvasContent1": "[{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"sectionFactor\":12,\"layoutIndex\":1},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":12,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -1800,7 +1800,268 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        data = opts.data;
+        return {};
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          standardWebPart: 'BingMap',
+          verticalSection: true
+        }
+      });
+    assert.strictEqual(replaceId(JSON.stringify(data)), JSON.stringify({
+      CanvasContent1: JSON.stringify([
+        {
+          "controlType": 3,
+          "displayMode": 2,
+          "id": "89c644b3-f69c-4e84-85d7-dfa04c6163b5",
+          "position":
+          {
+            "controlIndex": 1,
+            "sectionIndex": 1,
+            "zoneIndex": 1,
+            "sectionFactor": 12,
+            "layoutIndex": 2
+          },
+          "webPartId": "e377ea37-9047-43b9-8cdb-a761be2f8e09",
+          "emphasis": {},
+          "webPartData":
+          {
+            "dataVersion": "1.0",
+            "description": "Display a key location on a map",
+            "id": "e377ea37-9047-43b9-8cdb-a761be2f8e09",
+            "instanceId": "89c644b3-f69c-4e84-85d7-dfa04c6163b5",
+            "properties":
+            {
+              "pushPins": [],
+              "maxNumberOfPushPins": 1,
+              "shouldShowPushPinTitle": true, "zoomLevel": 12, "mapType": "road"
+            }, "title": "Bing maps"
+          }
+        }, {
+          "displayMode": 2,
+          "position": {
+            "zoneIndex": 1,
+            "sectionIndex": 1,
+            "sectionFactor": 12,
+            "layoutIndex": 1
+          },
+          "emphasis": {}
+        },
+        {
+          "displayMode": 2,
+          "position":
+          {
+            "zoneIndex": 1,
+            "sectionIndex": 2,
+            "sectionFactor": 12,
+            "layoutIndex": 1
+          },
+          "emphasis": {}
+        },
+        {
+          "controlType": 0,
+          "pageSettingsSlice":
+          {
+            "isDefaultDescription": true,
+            "isDefaultThumbnail": true
+          }
+        }])
+    }));
+  });
+
+  it('adds a standard web part in a vertical section when there is no section on the page', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
+        return {
+          "IsPageCheckedOutToCurrentUser": true,
+          "CanvasContent1": "[{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
+        return clientSideWebParts;
+      }
+
+      throw 'Invalid request';
+    });
+
+    let data: string = '';
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        data = opts.data;
+        return {};
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          standardWebPart: 'BingMap',
+          verticalSection: true
+        }
+      });
+    assert.strictEqual(replaceId(JSON.stringify(data)), JSON.stringify({
+      CanvasContent1: JSON.stringify([
+        {
+          "controlType": 3,
+          "displayMode": 2,
+          "id": "89c644b3-f69c-4e84-85d7-dfa04c6163b5",
+          "position": {
+            "controlIndex": 1,
+            "sectionIndex": 1,
+            "zoneIndex": 1,
+            "sectionFactor": 12,
+            "layoutIndex": 2
+          },
+          "webPartId": "e377ea37-9047-43b9-8cdb-a761be2f8e09",
+          "emphasis": {},
+          "webPartData": {
+            "dataVersion": "1.0",
+            "description": "Display a key location on a map",
+            "id": "e377ea37-9047-43b9-8cdb-a761be2f8e09",
+            "instanceId": "89c644b3-f69c-4e84-85d7-dfa04c6163b5",
+            "properties": {
+              "pushPins": [],
+              "maxNumberOfPushPins": 1,
+              "shouldShowPushPinTitle": true,
+              "zoomLevel": 12,
+              "mapType": "road"
+            },
+            "title": "Bing maps"
+          }
+        },
+        {
+          "controlType": 0,
+          "pageSettingsSlice": {
+            "isDefaultDescription": true,
+            "isDefaultThumbnail": true
+          }
+        }
+      ])
+    }));
+  });
+
+  it('adds a standard web part in a vertical section when there is the existing verticalSection on the page', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
+        return {
+          "IsPageCheckedOutToCurrentUser": true,
+          "CanvasContent1": "[{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"sectionFactor\":12,\"layoutIndex\":2},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":12,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
+        return clientSideWebParts;
+      }
+
+      throw 'Invalid request';
+    });
+
+    let data: string = '';
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        data = opts.data;
+        return {};
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger,
+      {
+        options: {
+          pageName: 'page.aspx',
+          webUrl: 'https://contoso.sharepoint.com/sites/team-a',
+          standardWebPart: 'BingMap',
+          verticalSection: true
+        }
+      });
+    assert.strictEqual(replaceId(JSON.stringify(data)), JSON.stringify({
+      CanvasContent1: JSON.stringify([{
+        "controlType": 3,
+        "displayMode": 2,
+        "id": "89c644b3-f69c-4e84-85d7-dfa04c6163b5",
+        "position":
+        {
+          "zoneIndex": 1,
+          "sectionIndex": 1,
+          "sectionFactor": 12,
+          "layoutIndex": 2,
+          "controlIndex": 1
+        },
+        "webPartId": "e377ea37-9047-43b9-8cdb-a761be2f8e09",
+        "emphasis": {},
+        "webPartData":
+        {
+          "dataVersion": "1.0",
+          "description": "Display a key location on a map",
+          "id": "e377ea37-9047-43b9-8cdb-a761be2f8e09",
+          "instanceId": "89c644b3-f69c-4e84-85d7-dfa04c6163b5",
+          "properties":
+          {
+            "pushPins": [],
+            "maxNumberOfPushPins": 1,
+            "shouldShowPushPinTitle": true,
+            "zoomLevel": 12,
+            "mapType": "road"
+          },
+          "title": "Bing maps"
+        }
+      },
+      {
+        "displayMode": 2,
+        "position":
+        {
+          "zoneIndex": 1,
+          "sectionIndex": 2,
+          "sectionFactor": 12,
+          "layoutIndex": 1
+        },
+        "emphasis": {}
+      },
+      {
+        "controlType": 0,
+        "pageSettingsSlice":
+        {
+          "isDefaultDescription": true,
+          "isDefaultThumbnail": true
+        }
+      }])
+    }));
+  });
+
+  it('adds a standard web part with properties at the end of the column with one web part when no order specified (debug)', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
+        return {
+          "IsPageCheckedOutToCurrentUser": true,
+          "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
+        return clientSideWebParts;
+      }
+
+      throw 'Invalid request';
+    });
+
+    let data: string = '';
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -1913,7 +2174,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles OData error when adding Client Side Web Part to non-existing page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/foo.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/foo.aspx')`) {
         throw { error: { 'odata.error': { message: { value: 'The file /sites/team-a/sitepages/foo.aspx does not exist' } } } };
       }
 
@@ -1932,14 +2193,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles OData error if WebPart API does not respond properly', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"sectionFactor\":8,\"layoutIndex\":1},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         throw { error: { 'odata.error': { message: { value: 'An error has occurred' } } } };
       }
 
@@ -1958,14 +2219,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles OData error when adding Client Side Web Part to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -1988,14 +2249,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles WebPart properties error when adding Client Side Web Part to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -2004,7 +2265,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -2115,14 +2376,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles invalid specified WebPart Id error when adding Client Side Web Part to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -2130,7 +2391,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         return {};
       }
 
@@ -2149,7 +2410,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles error if target page is not a modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         throw {
           error: {
             "odata.error": {
@@ -2178,14 +2439,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles invalid section error when adding Client Side Web Part to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -2205,14 +2466,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles invalid column error when adding Client Side Web Part to modern page', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -2233,14 +2494,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds a web part using web part data', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -2249,7 +2510,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -2355,14 +2616,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds a web part using web part data (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -2371,7 +2632,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -2478,14 +2739,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('adds a web part with dynamicDataPaths and dynamicDataValues', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"controlType\":3,\"displayMode\":2,\"id\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"position\":{\"controlIndex\":0.5,\"sectionIndex\":1,\"sectionFactor\":8,\"zoneIndex\":1,\"layoutIndex\":1},\"webPartId\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"emphasis\":{},\"reservedHeight\":127,\"reservedWidth\":757,\"addedFromPersistedData\":true,\"webPartData\":{\"id\":\"868ac3c3-cad7-4bd6-9a1c-14dc5cc8e823\",\"instanceId\":\"4dae46b3-b059-4930-8495-0920cec4faa0\",\"title\":\"Weather\",\"description\":\"Show current weather conditions on your page\",\"serverProcessedContent\":{\"htmlStrings\":{},\"searchablePlainTexts\":{},\"imageSources\":{},\"links\":{}},\"dataVersion\":\"1.2\",\"properties\":{\"temperatureUnit\":\"F\",\"locations\":[{\"latitude\":47.604,\"longitude\":-122.329,\"name\":\"Seattle, United States\",\"showCustomizedDisplayName\":false}]}}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -2494,7 +2755,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -2607,14 +2868,14 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
   it('correctly handles sections in reverse order', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')`) {
         return {
           "IsPageCheckedOutToCurrentUser": true,
           "CanvasContent1": "[{\"displayMode\":2,\"position\":{\"zoneIndex\":2,\"sectionIndex\":1,\"sectionFactor\":8,\"layoutIndex\":1},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":2,\"sectionIndex\":2,\"sectionFactor\":4,\"layoutIndex\":1},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":1,\"sectionFactor\":6,\"layoutIndex\":1},\"emphasis\":{}},{\"displayMode\":2,\"position\":{\"zoneIndex\":1,\"sectionIndex\":2,\"sectionFactor\":6,\"layoutIndex\":1},\"emphasis\":{}},{\"controlType\":0,\"pageSettingsSlice\":{\"isDefaultDescription\":true,\"isDefaultThumbnail\":true}}]"
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/getclientsidewebparts()`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/web/getclientsidewebparts()`) {
         return clientSideWebParts;
       }
 
@@ -2623,7 +2884,7 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
 
     let data: string = '';
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/team-a/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
         data = opts.data;
         return {};
       }
@@ -2810,6 +3071,17 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
     assert(containsOption);
   });
 
+  it('supports specifying verticalSection', () => {
+    const options = command.options;
+    let containsOption = false;
+    options.forEach((o) => {
+      if (o.option.indexOf('--verticalSection') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
   it('fails validation if webUrl is not an absolute URL', async () => {
     const actual = await command.validate({
       options: { pageName: 'page.aspx', webUrl: 'foo', webPartId: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e1' }
@@ -2986,6 +3258,32 @@ describe(commands.PAGE_CLIENTSIDEWEBPART_ADD, () => {
         webUrl: 'https://contoso.sharepoint.com',
         webPartId: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e1',
         column: 'foobar'
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both the section and verticalSection parameters are specified', async () => {
+    const actual = await command.validate({
+      options: {
+        pageName: 'page.aspx',
+        webUrl: 'https://contoso.sharepoint.com',
+        webPartId: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e1',
+        section: 1,
+        verticalSection: true
+      }
+    }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('Fails validation if both the column and verticalSection parameters are specified.', async () => {
+    const actual = await command.validate({
+      options: {
+        pageName: 'page.aspx',
+        webUrl: 'https://contoso.sharepoint.com',
+        webPartId: '3ede60d3-dc2c-438b-b5bf-cc40bb2351e1',
+        column: 1,
+        verticalSection: true
       }
     }, commandInfo);
     assert.notStrictEqual(actual, true);

--- a/src/m365/spo/commands/page/page-clientsidewebpart-add.ts
+++ b/src/m365/spo/commands/page/page-clientsidewebpart-add.ts
@@ -25,6 +25,7 @@ interface Options extends GlobalOptions {
   section?: number;
   column?: number;
   order?: number;
+  verticalSection?: boolean;
 }
 
 class SpoPageClientSideWebPartAddCommand extends SpoCommand {
@@ -54,7 +55,8 @@ class SpoPageClientSideWebPartAddCommand extends SpoCommand {
         webPartProperties: typeof args.options.webPartProperties !== 'undefined',
         section: typeof args.options.section !== 'undefined',
         column: typeof args.options.column !== 'undefined',
-        order: typeof args.options.order !== 'undefined'
+        order: typeof args.options.order !== 'undefined',
+        verticalSection: !!args.options.verticalSection
       });
     });
   }
@@ -87,6 +89,9 @@ class SpoPageClientSideWebPartAddCommand extends SpoCommand {
       },
       {
         option: '--order [order]'
+      },
+      {
+        option: '--verticalSection'
       }
     );
   }
@@ -132,6 +137,14 @@ class SpoPageClientSideWebPartAddCommand extends SpoCommand {
 
         if (args.options.column && (!Number.isInteger(args.options.column) || args.options.column < 1)) {
           return 'The value of parameter column must be 1 or higher';
+        }
+
+        if (args.options.section && args.options.verticalSection) {
+          return 'Specify section or verticalSection but not both';
+        }
+
+        if (args.options.column && args.options.verticalSection) {
+          return 'Specify column or verticalSection but not both';
         }
 
         return validation.isValidSharePointUrl(args.options.webUrl);
@@ -213,57 +226,11 @@ class SpoPageClientSideWebPartAddCommand extends SpoCommand {
 
       await this.setWebPartProperties(webPart, logger, args);
 
-      // if no section exists (canvasContent array only has 1 default object), add a default section (1 col)
-      if (canvasContent.length === 1) {
-        const defaultSection: Control = {
-          position: {
-            controlIndex: 1,
-            sectionIndex: 1,
-            zoneIndex: 1,
-            sectionFactor: 12,
-            layoutIndex: 1
-          },
-          emphasis: {},
-          displayMode: 2
-        };
-        canvasContent.unshift(defaultSection);
-      }
+      const control: Control = this.getCorrectControl(canvasContent, args);
+      const controlIndex: number = canvasContent.indexOf(control);
+      const zoneIndex: number = control.position.zoneIndex;
+      const column: number = control.position.sectionIndex;
 
-      // get unique zoneIndex values given each section can have 1 or more
-      // columns each assigned to the zoneIndex of the corresponding section
-      const zoneIndices: number[] = canvasContent
-        .filter(c => c.position)
-        .map(c => c.position.zoneIndex)
-        .filter((value: number, index: number, array: number[]): boolean => {
-          return array.indexOf(value) === index;
-        })
-        .sort((a, b) => a - b);
-
-      // get section number. if not specified, get the last section
-      const section: number = args.options.section || zoneIndices.length;
-      if (section > zoneIndices.length) {
-        throw `Invalid section '${section}'`;
-      }
-
-      // zoneIndex that represents the section where the web part should be added
-      const zoneIndex: number = zoneIndices[section - 1];
-
-      const column: number = args.options.column || 1;
-      // we need the index of the control in the array so that we know which
-      // item to replace or where to add the web part
-      const controlIndex: number = canvasContent
-        .findIndex(c => c.position &&
-          c.position.zoneIndex === zoneIndex &&
-          c.position.sectionIndex === column);
-      if (controlIndex === -1) {
-        throw `Invalid column '${args.options.column}'`;
-      }
-
-      // get the first control that matches section and column
-      // if it's a empty column, it should be replaced with the web part
-      // if it's a web part, then we need to determine if there are other
-      // web parts and where in the array the new web part should be put
-      const control: Control = canvasContent[controlIndex];
       const webPartControl: Control = this.extend({
         controlType: 3,
         displayMode: 2,
@@ -450,6 +417,84 @@ class SpoPageClientSideWebPartAddCommand extends SpoCommand {
       (webPart as any).webPartData = this.extend((webPart as any).webPartData, webPartData);
       webPart.id = (webPart as any).webPartData.instanceId;
     }
+  }
+
+  private getCorrectControl(canvasContent: Control[], args: CommandArgs): Control {
+    // get Vertical section 
+    if (args.options.verticalSection) {
+      let verticalSection = canvasContent
+        .find(c => c.position?.layoutIndex === 2);
+
+      //if vertical section does not exist, create it
+      if (!verticalSection) {
+        verticalSection = {
+          position: {
+            controlIndex: 1,
+            sectionIndex: 1,
+            zoneIndex: 1,
+            sectionFactor: 12,
+            layoutIndex: 2
+          },
+          emphasis: {},
+          displayMode: 2
+        };
+        canvasContent.unshift(verticalSection);
+      }
+      return verticalSection;
+    }
+
+    // if no section exists (canvasContent array only has 1 default object), add a default section (1 col)
+    if (canvasContent.length === 1) {
+      const defaultSection: Control = {
+        position: {
+          controlIndex: 1,
+          sectionIndex: 1,
+          zoneIndex: 1,
+          sectionFactor: 12,
+          layoutIndex: 1
+        },
+        emphasis: {},
+        displayMode: 2
+      };
+      canvasContent.unshift(defaultSection);
+    }
+
+    // get unique zoneIndex values given each section can have 1 or more
+    // columns each assigned to the zoneIndex of the corresponding section
+    const zoneIndices: number[] = canvasContent
+      // Exclude the vertical section
+      .filter(c => c.position)
+      .map(c => c.position.zoneIndex)
+      .filter((value: number, index: number, array: number[]): boolean => {
+        return array.indexOf(value) === index;
+      })
+      .sort((a, b) => a - b);
+
+    // get section number. if not specified, get the last section
+    const section: number = args.options.section || zoneIndices.length;
+    if (section > zoneIndices.length) {
+      throw `Invalid section '${section}'`;
+    }
+
+    // zoneIndex that represents the section where the web part should be added
+    const zoneIndex: number = zoneIndices[section - 1];
+
+    const column: number = args.options.column || 1;
+    // we need the index of the control in the array so that we know which
+    // item to replace or where to add the web part
+    const controlIndex: number = canvasContent
+      .findIndex(c => c.position &&
+        c.position.zoneIndex === zoneIndex &&
+        c.position.sectionIndex === column);
+    if (controlIndex === -1) {
+      throw `Invalid column '${args.options.column}'`;
+    }
+
+    // get the first control that matches section and column
+    // if it's a empty column, it should be replaced with the web part
+    // if it's a web part, then we need to determine if there are other
+    // web parts and where in the array the new web part should be put
+    return canvasContent[controlIndex];
   }
 
   /**


### PR DESCRIPTION
Closes #6265

As mentioned in the title, this update allows adding a web part to the vertical section.

I have added a parameter named `--verticalSection` to handle this case.
Could you let me know if this is a good approach to resolve the issue?

I have also applied some recommendations from the previous tasks to this command's test file.

Some code from this command can be reused in the future implementation of `page section remove`.