### PR TITLE
Switches to Node@22. Closes #6604

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -54,10 +54,10 @@ jobs:
         nodeBuild: [22]
         include:
           - os: ubuntu-latest
-            nodeRun: 20
+            nodeRun: 18
             nodeBuild: 22
           - os: ubuntu-latest
-            nodeRun: 22
+            nodeRun: 20
             nodeBuild: 22
 
     steps:

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [20]
+        node: [22]
 
     steps:
       - uses: actions/checkout@v4
@@ -49,16 +49,16 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         # node versions to run tests on
-        nodeRun: [20]
+        nodeRun: [22]
         # node version on which code was built and should be tested
-        nodeBuild: [20]
+        nodeBuild: [22]
         include:
           - os: ubuntu-latest
-            nodeRun: 18
-            nodeBuild: 20
+            nodeRun: 20
+            nodeBuild: 22
           - os: ubuntu-latest
             nodeRun: 22
-            nodeBuild: 20
+            nodeBuild: 22
 
     steps:
       - name: Configure pagefile
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Cache node modules
         id: cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - name: Cache node modules
         id: cache
@@ -25,7 +25,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: node_modules-ubuntu-latest-20-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: node_modules-ubuntu-latest-22-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - name: Restore dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -49,10 +49,10 @@ jobs:
           name: build
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - name: Cache node modules
         id: cache
@@ -60,7 +60,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: node_modules-ubuntu-latest-20-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: node_modules-ubuntu-latest-22-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - name: Restore dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Cache node modules
         id: cache
@@ -123,10 +123,10 @@ jobs:
           name: build
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - name: Cache node modules
         id: cache
@@ -134,7 +134,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: node_modules-ubuntu-latest-20-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: node_modules-ubuntu-latest-22-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - name: Restore dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -153,10 +153,10 @@ jobs:
           name: build
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [20]
+        node: [22]
 
     steps:
       - uses: actions/checkout@v4
@@ -51,16 +51,16 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         # node versions to run tests on
-        nodeRun: [20]
+        nodeRun: [22]
         # node version on which code was built and should be tested
-        nodeBuild: [20]
+        nodeBuild: [22]
         include:
           - os: ubuntu-latest
-            nodeRun: 18
-            nodeBuild: 20
+            nodeRun: 20
+            nodeBuild: 22
           - os: ubuntu-latest
             nodeRun: 22
-            nodeBuild: 20
+            nodeBuild: 22
 
     steps:
       - name: Configure pagefile
@@ -133,7 +133,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Cache node modules
         id: cache
@@ -167,13 +167,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: build-ubuntu-latest-20
+          name: build-ubuntu-latest-22
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - name: Cache node modules
         id: cache
@@ -181,7 +181,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: node_modules-ubuntu-latest-20-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: node_modules-ubuntu-latest-22-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - name: Restore dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -196,7 +196,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-ubuntu-latest-20
+          name: build-ubuntu-latest-22
           path: build.tar
           overwrite: true
   deploy_docs:
@@ -224,13 +224,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: build-ubuntu-latest-20
+          name: build-ubuntu-latest-22
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -56,10 +56,10 @@ jobs:
         nodeBuild: [22]
         include:
           - os: ubuntu-latest
-            nodeRun: 20
+            nodeRun: 18
             nodeBuild: 22
           - os: ubuntu-latest
-            nodeRun: 22
+            nodeRun: 20
             nodeBuild: 22
 
     steps:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ m365 spo site get --url https://contoso.sharepoint.com --output text
 
 ## Build
 
-To build and run this CLI locally, you will need [`node`](https://nodejs.org) `>= 20.0.0` installed.
+To build and run this CLI locally, you will need [`node`](https://nodejs.org) `>= 22.0.0` installed.
 
 ```sh
 # Clone this repository

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -55,7 +55,7 @@
         "@types/json-schema": "^7.0.15",
         "@types/json-to-ast": "^2.1.4",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^20.17.16",
+        "@types/node": "^22.13.4",
         "@types/node-forge": "^1.3.11",
         "@types/omelette": "^0.4.4",
         "@types/semver": "^7.5.8",
@@ -1880,11 +1880,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
-      "integrity": "sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==",
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -5959,9 +5960,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
     },
     "node_modules/update-notifier": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -293,7 +293,7 @@
     "@types/json-schema": "^7.0.15",
     "@types/json-to-ast": "^2.1.4",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^20.17.16",
+    "@types/node": "^22.13.4",
     "@types/node-forge": "^1.3.11",
     "@types/omelette": "^0.4.4",
     "@types/semver": "^7.5.8",

--- a/scripts/check-version.js
+++ b/scripts/check-version.js
@@ -1,6 +1,6 @@
 const nodeVersion = process.versions.node.split('.')[0];
 
-if (nodeVersion !== "20") {
-  console.error("Node version must be 20");
+if (nodeVersion !== "22") {
+  console.error("Node version must be 22");
   process.exitCode = 1;
 }


### PR DESCRIPTION
Closes #6604

When installing the packages, you'll notice a few warnings, likely due to our use of `eslint` v8. We definitely need to keep in mind the migration from v8 to v9, as mentioned in #6350.