### PR TITLE
Fixes page header set for customizable headers. Closes #6542

### DIFF
--- a/src/m365/spo/commands/page/page-control-set.mock.ts
+++ b/src/m365/spo/commands/page/page-control-set.mock.ts
@@ -122,6 +122,87 @@ export const CanvasContent = {
   }
 };
 
+export const mockCanvasContentStringified = JSON.stringify([CanvasContent]);
+
+export const mockPageJsonCanvasContent = {
+  ListItemAllFields: {
+    "CommentsDisabled": false,
+    "FileSystemObjectType": 0,
+    "Id": 1,
+    "ServerRedirectedEmbedUri": null,
+    "ServerRedirectedEmbedUrl": "",
+    "ContentTypeId": "0x0101009D1CB255DA76424F860D91F20E6C41180062FDF2882AB3F745ACB63105A3C623C9",
+    "FileLeafRef": "Home.aspx",
+    "ComplianceAssetId": null,
+    "WikiField": null,
+    "Title": "Home",
+    "ClientSideApplicationId": "b6917cb1-93a0-4b97-a84d-7cf49975d4ec",
+    "PageLayoutType": "Home",
+    "CanvasContent1": mockCanvasContentStringified,
+    "BannerImageUrl": {
+      "Description": "/_layouts/15/images/sitepagethumbnail.png",
+      "Url": "https://contoso.sharepoint.com/_layouts/15/images/sitepagethumbnail.png"
+    },
+    "Description": "Lorem ipsum Dolor samet Lorem ipsum",
+    "PromotedState": null,
+    "FirstPublishedDate": null,
+    "LayoutWebpartsContent": [{
+      "id": "cbe7b0a9-3504-44dd-a3a3-0e5cacd07788",
+      "instanceId": "cbe7b0a9-3504-44dd-a3a3-0e5cacd07788",
+      "title": "Title Region",
+      "description": "Title Region Description",
+      "serverProcessedContent": {
+        "htmlStrings": {},
+        "searchablePlainTexts": {},
+        "imageSources": {},
+        "links": {}
+      },
+      "dataVersion": "1.4",
+      "properties": {
+        "title": "Page",
+        "imageSourceType": 4,
+        "layoutType": "FullWidthImage",
+        "textAlignment": "Left",
+        "showTopicHeader": false,
+        "showPublishDate": false,
+        "topicHeader": ""
+      }
+    }],
+    "AuthorsId": null,
+    "AuthorsStringId": null,
+    "OriginalSourceUrl": null,
+    "ID": 1,
+    "Created": "2018-01-20T09:54:41",
+    "AuthorId": 1073741823,
+    "Modified": "2018-04-12T12:42:47",
+    "EditorId": 12,
+    "OData__CopySource": null,
+    "CheckoutUserId": null,
+    "OData__UIVersionString": "7.0",
+    "GUID": "edaab907-e729-48dd-9e73-26487c0cf592"
+  },
+  "CheckInComment": "",
+  "CheckOutType": 2,
+  "ContentTag": "{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25,1",
+  "CustomizedPageStatus": 1,
+  "ETag": "\"{E82A21D1-CA2C-4854-98F2-012AC0E7FA09},25\"",
+  "Exists": true,
+  "IrmEnabled": false,
+  "Length": "805",
+  "Level": 1,
+  "LinkingUri": null,
+  "LinkingUrl": "",
+  "MajorVersion": 7,
+  "MinorVersion": 0,
+  "Name": "home.aspx",
+  "ServerRelativeUrl": "/sites/team-a/SitePages/home.aspx",
+  "TimeCreated": "2018-01-20T08:54:41Z",
+  "TimeLastModified": "2018-04-12T10:42:46Z",
+  "Title": "Home",
+  "UIVersion": 3584,
+  "UIVersionLabel": "7.0",
+  "UniqueId": "e82a21d1-ca2c-4854-98f2-012ac0e7fa09"
+};
 
 export const mockPageData = {
   "AuthorByline": "value",
@@ -130,7 +211,7 @@ export const mockPageData = {
   "Title": "value",
   "TopicHeader": "value",
   "LayoutWebpartsContent": "value",
-  "CanvasContent1": JSON.stringify([{ ...CanvasContent }])
+  "CanvasContent1": mockCanvasContentStringified
 };
 
 export const mockPageDataFail = {

--- a/src/m365/spo/commands/page/page-control-set.spec.ts
+++ b/src/m365/spo/commands/page/page-control-set.spec.ts
@@ -13,7 +13,7 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import { ClientSidePage } from './clientsidepages.js';
 import command from './page-control-set.js';
-import { CanvasContent, mockPageData, mockPageDataFail } from './page-control-set.mock.js';
+import { mockCanvasContentStringified, mockPageData, mockPageDataFail } from './page-control-set.mock.js';
 
 describe(commands.PAGE_CONTROL_SET, () => {
   let log: string[];
@@ -72,7 +72,7 @@ describe(commands.PAGE_CONTROL_SET, () => {
   it('correctly handles control not found', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/SitePages/Pages/GetByUrl('sitepages/home.aspx')`) > -1) {
-        return { CanvasContent1: JSON.stringify([CanvasContent]) };
+        return { CanvasContent1: mockCanvasContentStringified };
       }
 
       throw 'Invalid request';
@@ -96,7 +96,7 @@ describe(commands.PAGE_CONTROL_SET, () => {
   it('correctly handles control found and handles error on page checkout error', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/SitePages/Pages/GetByUrl('sitepages/home.aspx')`) > -1) {
-        return { CanvasContent1: JSON.stringify([CanvasContent]) };
+        return { CanvasContent1: mockCanvasContentStringified };
       }
 
       throw 'Invalid request';
@@ -112,7 +112,7 @@ describe(commands.PAGE_CONTROL_SET, () => {
   it('correctly handles control found and handles page checkout correctly when no data is provided', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/SitePages/Pages/GetByUrl('sitepages/home.aspx')`) > -1) {
-        return { CanvasContent1: JSON.stringify([CanvasContent]) };
+        return { CanvasContent1: mockCanvasContentStringified };
       }
 
       throw 'Invalid request';
@@ -134,7 +134,7 @@ describe(commands.PAGE_CONTROL_SET, () => {
   it('correctly handles control not found after the page has been checked out', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/SitePages/Pages/GetByUrl('sitepages/home.aspx')`) > -1) {
-        return { CanvasContent1: JSON.stringify([CanvasContent]) };
+        return { CanvasContent1: mockCanvasContentStringified };
       }
 
       throw 'Invalid request';
@@ -156,7 +156,7 @@ describe(commands.PAGE_CONTROL_SET, () => {
   it('correctly handles control found and handles page checkout', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/SitePages/Pages/GetByUrl('sitepages/home.aspx')`) > -1) {
-        return { CanvasContent1: JSON.stringify([CanvasContent]) };
+        return { CanvasContent1: mockCanvasContentStringified };
       }
 
       throw 'Invalid request';
@@ -182,7 +182,7 @@ describe(commands.PAGE_CONTROL_SET, () => {
   it('correctly page save with webPartData', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/SitePages/Pages/GetByUrl('sitepages/home.aspx')`) > -1) {
-        return { CanvasContent1: JSON.stringify([CanvasContent]) };
+        return { CanvasContent1: mockCanvasContentStringified };
       }
 
       throw 'Invalid request';
@@ -213,7 +213,7 @@ describe(commands.PAGE_CONTROL_SET, () => {
   it('correctly page save with webPartProperties', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/SitePages/Pages/GetByUrl('sitepages/home.aspx')`) > -1) {
-        return { CanvasContent1: JSON.stringify([CanvasContent]) };
+        return { CanvasContent1: mockCanvasContentStringified };
       }
 
       throw 'Invalid request';
@@ -244,7 +244,7 @@ describe(commands.PAGE_CONTROL_SET, () => {
   it('correctly page save when page extension is not provided', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/SitePages/Pages/GetByUrl('sitepages/home.aspx')`) > -1) {
-        return { CanvasContent1: JSON.stringify([CanvasContent]) };
+        return { CanvasContent1: mockCanvasContentStringified };
       }
 
       throw 'Invalid request';

--- a/src/m365/spo/commands/page/page-header-set.spec.ts
+++ b/src/m365/spo/commands/page/page-header-set.spec.ts
@@ -11,14 +11,13 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import { mockCanvasContent, mockPage } from './page-control-set.mock.js';
+import { mockCanvasContentStringified, mockPageJsonCanvasContent } from './page-control-set.mock.js';
 import command from './page-header-set.js';
 
 describe(commands.PAGE_HEADER_SET, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let data: string;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -42,30 +41,6 @@ describe(commands.PAGE_HEADER_SET, () => {
         log.push(msg);
       }
     };
-
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) > -1) {
-        return {
-          IsPageCheckedOutToCurrentUser: true,
-          Title: 'Page'
-        };
-      }
-
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) > -1) {
-        return { CanvasContent1: mockCanvasContent };
-      }
-
-      throw 'Invalid request';
-    });
-
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
-        data = opts.data;
-        return '';
-      }
-
-      throw 'Invalid request';
-    });
   });
 
   afterEach(() => {
@@ -73,7 +48,6 @@ describe(commands.PAGE_HEADER_SET, () => {
       request.get,
       request.post
     ]);
-    data = '';
   });
 
   after(() => {
@@ -94,27 +68,29 @@ describe(commands.PAGE_HEADER_SET, () => {
   });
 
   it('checks out page if not checked out by the current user', async () => {
-    sinonUtil.restore([request.get, request.post]);
-    let checkedOut = false;
+    sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
         return {
           IsPageCheckedOutToCurrentUser: false,
           Title: 'Page'
         };
       }
 
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockPageJsonCanvasContent.ListItemAllFields;
+      }
+
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`) > -1) {
-        checkedOut = true;
-        return mockPage.ListItemAllFields;
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/checkoutpage`) {
+        return mockPageJsonCanvasContent.ListItemAllFields;
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/SavePageAsDraft`) > -1) {
-        return {};
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
       }
 
       throw 'Invalid request';
@@ -123,39 +99,32 @@ describe(commands.PAGE_HEADER_SET, () => {
     await command.action(logger, {
       options: {
         debug: true,
-        pageName: 'home',
+        pageName: 'page',
         webUrl: 'https://contoso.sharepoint.com/sites/newsletter'
       }
     });
-    assert.strictEqual(checkedOut, true);
+    assert.strictEqual(postStub.firstCall.args[0].url, `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/checkoutpage`);
   });
 
-  it('doesn\'t check out page if not checked out by the current user', async () => {
-    sinonUtil.restore([request.get, request.post]);
-    let checkingOut = false;
+  it('doesn\'t check out page if page is checked out by the current user', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
         return {
           IsPageCheckedOutToCurrentUser: true,
           Title: 'Page'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')?$expand=ListItemAllFields`) > -1) {
-        return { CanvasContent1: mockCanvasContent };
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockPageJsonCanvasContent.ListItemAllFields;
       }
 
       throw 'Invalid request';
     });
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/checkoutpage`) > -1) {
-        checkingOut = true;
-        return {};
-      }
-
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/home.aspx')/SavePageAsDraft`) > -1) {
-        return {};
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) > -1) {
+        return;
       }
 
       throw 'Invalid request';
@@ -163,44 +132,113 @@ describe(commands.PAGE_HEADER_SET, () => {
 
     await command.action(logger, {
       options: {
-        pageName: 'home.aspx',
+        pageName: 'page.aspx',
         webUrl: 'https://contoso.sharepoint.com/sites/newsletter'
       }
     });
-    assert.deepStrictEqual(checkingOut, false);
+    assert.notStrictEqual(postStub.firstCall.args[0].url, `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/checkoutpage`);
   });
 
   it('sets page header to default when no type specified', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":""}}]',
-      CanvasContent1: '<div>just some test content</div>'
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    await command.action(logger, { options: { debug: true, pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a' } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { debug: true, pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('sets page header to default when default type specified', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":""}}]',
-      CanvasContent1: '<div>just some test content</div>'
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Default' } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Default' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('sets page header to none when none specified', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"imageSourceType":4,"layoutType":"NoImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":""}}]',
-      CanvasContent1: '<div>just some test content</div>'
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'None' } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'None' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
-  it('check when no CanvasContent1 is provided', async () => {
+  /*it('check when no CanvasContent1 is provided', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"title":"Page","imageSourceType":4,"layoutType":"NoImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":""}}]',
       Title: 'Page',
@@ -228,7 +266,7 @@ describe(commands.PAGE_HEADER_SET, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fnewsletter%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
         return {
           ListId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
           UniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
@@ -242,213 +280,443 @@ describe(commands.PAGE_HEADER_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'None' } });
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'None' } });
     assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
-  });
+  });*/
 
   it('sets page header to custom when custom type specified', async () => {
     const mockData = {
-      LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":"/sites/team-a/siteassets/hero.jpg"},"links":{},"customMetadata":{"imageSource":{"siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613"}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":"","authors":[],"altText":"","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613","translateX":42.3837520042758,"translateY":56.4285714285714}}]',
-      CanvasContent1: '<div>just some test content</div>'
+      LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":"/sites/newsletter/siteassets/hero.jpg"},"links":{},"customMetadata":{"imageSource":{"siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613"}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":"","authors":[],"altText":"","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613","translateX":42.3837520042758,"translateY":56.4285714285714}}]',
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
         return {
           IsPageCheckedOutToCurrentUser: true,
           Title: 'Page'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/site?`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/site?$select=Id`) {
         return {
           Id: 'c7678ab2-c9dc-454b-b2ee-7fcffb983d4e'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web?`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web?$select=Id`) {
         return {
           Id: '0df4d2d2-5ecf-45e9-94f5-c638106bfc65'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fnewsletter%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) {
         return {
           ListId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
           UniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) > -1) {
-        return { CanvasContent1: mockCanvasContent };
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
       }
 
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Custom', imageUrl: '/sites/team-a/siteassets/hero.jpg', translateX: 42.3837520042758, translateY: 56.4285714285714 } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Custom', imageUrl: '/sites/newsletter/siteassets/hero.jpg', translateX: 42.3837520042758, translateY: 56.4285714285714 } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('sets page header to custom when custom type specified (debug)', async () => {
     const mockData = {
-      LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":"/sites/team-a/siteassets/hero.jpg"},"links":{},"customMetadata":{"imageSource":{"siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613"}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":"","authors":[],"altText":"","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613","translateX":42.3837520042758,"translateY":56.4285714285714}}]',
-      CanvasContent1: '<div>just some test content</div>'
+      LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":"/sites/newsletter/siteassets/hero.jpg"},"links":{},"customMetadata":{"imageSource":{"siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613"}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":"","authors":[],"altText":"","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613","translateX":42.3837520042758,"translateY":56.4285714285714}}]',
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
         return {
           IsPageCheckedOutToCurrentUser: true,
           Title: 'Page'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/site?`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/site?$select=Id`) {
         return {
           Id: 'c7678ab2-c9dc-454b-b2ee-7fcffb983d4e'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web?`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web?$select=Id`) {
         return {
           Id: '0df4d2d2-5ecf-45e9-94f5-c638106bfc65'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fnewsletter%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) {
         return {
           ListId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
           UniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) > -1) {
-        return { CanvasContent1: mockCanvasContent };
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
       }
 
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Custom', imageUrl: '/sites/team-a/siteassets/hero.jpg', translateX: 42.3837520042758, translateY: 56.4285714285714 } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    await command.action(logger, { options: { debug: true, pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Custom', imageUrl: '/sites/newsletter/siteassets/hero.jpg', translateX: 42.3837520042758, translateY: 56.4285714285714 } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('sets image to empty when header set to custom and no image specified', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":""},"links":{},"customMetadata":{"imageSource":{"siteId":"","webId":"","listId":"","uniqueId":""}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":"","authors":[],"altText":"","webId":"","siteId":"","listId":"","uniqueId":"","translateX":0,"translateY":0}}]',
-      CanvasContent1: '<div>just some test content</div>'
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Custom' } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
-  });
-
-  it('sets focus coordinates to 0 0 if none specified', async () => {
-    const mockData = {
-      LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":"/sites/team-a/siteassets/hero.jpg"},"links":{},"customMetadata":{"imageSource":{"siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613"}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":"","authors":[],"altText":"","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613","translateX":0,"translateY":0}}]',
-      CanvasContent1: '<div>just some test content</div>'
-    };
-
-    sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
         return {
           IsPageCheckedOutToCurrentUser: true,
           Title: 'Page'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/site?`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Custom' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
+  });
+
+  it('sets focus coordinates to 0 0 if none specified', async () => {
+    const mockData = {
+      LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":"/sites/newsletter/siteassets/hero.jpg"},"links":{},"customMetadata":{"imageSource":{"siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613"}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":"","authors":[],"altText":"","webId":"0df4d2d2-5ecf-45e9-94f5-c638106bfc65","siteId":"c7678ab2-c9dc-454b-b2ee-7fcffb983d4e","listId":"e1557527-d333-49f2-9d60-ea8a3003fda8","uniqueId":"102f496d-23a2-415f-803a-232b8a6c7613","translateX":0,"translateY":0}}]',
+      CanvasContent1: mockCanvasContentStringified
+    };
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/site?$select=Id`) {
         return {
           Id: 'c7678ab2-c9dc-454b-b2ee-7fcffb983d4e'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web?`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web?$select=Id`) {
         return {
           Id: '0df4d2d2-5ecf-45e9-94f5-c638106bfc65'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fnewsletter%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) {
         return {
           ListId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
           UniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) > -1) {
-        return { CanvasContent1: mockCanvasContent };
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
       }
 
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Custom', imageUrl: '/sites/team-a/siteassets/hero.jpg' } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Custom', imageUrl: '/sites/newsletter/siteassets/hero.jpg' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('centers text when textAlignment set to Center', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Center","showTopicHeader":false,"showPublishDate":false,"topicHeader":""}}]',
-      CanvasContent1: '<div>just some test content</div>'
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Default', textAlignment: 'Center' } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Default', textAlignment: 'Center' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('shows topicHeader with the specified topicHeader text', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":true,"showPublishDate":false,"topicHeader":"Team Awesome"}}]',
       TopicHeader: 'Team Awesome',
-      CanvasContent1: '<div>just some test content</div>'
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Default', showTopicHeader: true, topicHeader: 'Team Awesome' } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Default', showTopicHeader: true, topicHeader: 'Team Awesome' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('shows publish date', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":true,"topicHeader":""}}]',
-      CanvasContent1: '<div>just some test content</div>'
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Default', showPublishDate: true } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Default', showPublishDate: true } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('shows page authors', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":""},"links":{},"customMetadata":{"imageSource":{"siteId":"","webId":"","listId":"","uniqueId":""}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":"","authors":[],"altText":"","webId":"","siteId":"","listId":"","uniqueId":"","translateX":0,"translateY":0}}]',
       AuthorByline: ['Joe Doe', 'Jane Doe'],
-      CanvasContent1: '<div>just some test content</div>'
+      CanvasContent1: mockCanvasContentStringified
     };
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Custom', authors: 'Joe Doe, Jane Doe' } });
-    assert.strictEqual(JSON.stringify(data), JSON.stringify(mockData));
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Custom', authors: 'Joe Doe, Jane Doe' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
   it('automatically appends the .aspx extension', async () => {
-    await command.action(logger, { options: { pageName: 'page', webUrl: 'https://contoso.sharepoint.com/sites/team-a' } } as any);
+    const getStub = sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockPageJsonCanvasContent.ListItemAllFields;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { pageName: 'page', webUrl: 'https://contoso.sharepoint.com/sites/newsletter' } } as any);
+    assert.deepStrictEqual(getStub.firstCall.args[0].url, `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`);
+  });
+
+  it('sets page header to default when no type specified without any header', async () => {
+    const mockData = {
+      LayoutWebpartsContent: '[]',
+      CanvasContent1: mockCanvasContentStringified
+    };
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { debug: true, pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      LayoutWebpartsContent: '[]',
+      CanvasContent1: '[{"controlType":3,"displayMode":2,"id":"ede2ee65-157d-4523-b4ed-87b9b64374a6","position":{"zoneIndex":1,"sectionIndex":2,"sectionFactor":12,"layoutIndex":1,"controlIndex":1},"webPartId":"ede2ee65-157d-4523-b4ed-87b9b64374a6","emphasis":{},"addedFromPersistedData":true,"reservedHeight":600,"reservedWidth":969,"webPartData":{"id":"ede2ee65-157d-4523-b4ed-87b9b64374a6","instanceId":"dcd01c36-24f9-42e5-8e03-76e4af572468","title":"valo-markdown","description":"Use markdown to add text, tables, links, and images to your page.","serverProcessedContent":{"htmlStrings":{"html":"<h2 id=\\"this-is-just-a-test\\">This is just a test</h2><p>Test for playbook 123</p><div class=\\"react-codemirror2\\"><div class=\\"CodeMirror cm-s-monokai CodeMirror-wrap\\"><div class=\\"CodeMirror-vscrollbar\\" tabindex=\\"-1\\" style=\\"bottom:0px;\\"><div style=\\"min-width:1px;height:0px;\\"></div></div><div class=\\"CodeMirror-hscrollbar\\" tabindex=\\"-1\\"><div style=\\"height:100%;min-height:1px;width:0px;\\"></div></div><div class=\\"CodeMirror-scrollbar-filler\\"></div><div class=\\"CodeMirror-gutter-filler\\"></div><div class=\\"CodeMirror-scroll\\" tabindex=\\"-1\\"><div class=\\"CodeMirror-sizer\\" style=\\"margin-left:0px;margin-bottom:-8px;border-right-width:22px;min-height:290px;padding-right:0px;padding-bottom:0px;\\"><div style=\\"position:relative;top:0px;\\"><div class=\\"CodeMirror-lines\\" role=\\"presentation\\"><div role=\\"presentation\\" style=\\"position:relative;outline:none;\\"><div class=\\"CodeMirror-measure\\"></div><div class=\\"CodeMirror-measure\\"></div><div style=\\"position:relative;z-index:1;\\"></div><div class=\\"CodeMirror-cursors\\"><div class=\\"CodeMirror-cursor\\" style=\\"left:55.0089px;top:260.571px;height:21.7143px;\\">&nbsp;</div></div><div class=\\"CodeMirror-code\\" role=\\"presentation\\"><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> { <span class=\\"cm-def\\">exec</span> } <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">child_process</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">fs</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">fs</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">path</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">path</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">parseMarkdown</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">frontmatter</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">valoWpTitle</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-string-2\\">`valo-markdown`</span>;</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">siteUrl</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-string-2\\">`https://contoso.sharepoint.com/sites/StaticPages`</span>;</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">(() <span class=\\"cm-operator\\">=&gt;</span> {</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"> &nbsp;<span class=\\"cm-keyword\\">if</span> (<span class=\\"cm-atom\\">true</span>) {</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">  }</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">})();</span></pre></div></div></div></div></div><div style=\\"position:absolute;height:22px;width:1px;border-bottom:0px solid transparent;top:290px;\\"></div><div class=\\"CodeMirror-gutters\\" style=\\"display:none;height:312px;\\"></div></div></div></div><p>!!! Warning\\n    This is a warning of mkdocs</p><p>&lt;p style=\\"color:red\\"&gt;This is a paragraph&lt;/p&gt;</p>"},"searchablePlainTexts":{"code":"\\n# This is just a test\\n\\nTest for playbook 123\\n\\n```typescript\\nconst { exec } = require(child_process);\\nconst fs = require(fs);\\nconst path = require(path);\\nconst parseMarkdown = require(frontmatter);\\n\\nconst valoWpTitle = `valo-markdown`;\\nconst siteUrl = `https://contoso.sharepoint.com/sites/StaticPages`;\\n\\n(() => {\\n  if (true) {\\n\\n  }\\n})();\\n```\\n\\n\\n!!! Warning\\n    This is a warning of mkdocs\\n\\n\\n<p style=\\"color:red\\">This is a paragraph</p>"},"imageSources":{},"links":{}},"dataVersion":"2.0","properties":{"displayPreview":true,"lineWrapping":true,"miniMap":{"enabled":false},"previewState":"Show","theme":"Monokai"}}},{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","controlType":3,"displayMode":2,"emphasis":{},"position":{"zoneIndex":1,"sectionFactor":0,"layoutIndex":1,"controlIndex":1,"sectionIndex":1},"webPartId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","webPartData":{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"title":"","imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":""}}}]'
+    });
+  });
+
+  it('sets page header to default when no type specified with Banner Webpart in first section', async () => {
+    const mockData = {
+      LayoutWebpartsContent: '[]',
+      CanvasContent1: '[{"controlType":3,"displayMode":2,"id":"ede2ee65-157d-4523-b4ed-87b9b64374a6","position":{"zoneIndex":1,"sectionIndex":2,"sectionFactor":12,"layoutIndex":1,"controlIndex":1},"webPartId":"ede2ee65-157d-4523-b4ed-87b9b64374a6","emphasis":{},"addedFromPersistedData":true,"reservedHeight":600,"reservedWidth":969,"webPartData":{"id":"ede2ee65-157d-4523-b4ed-87b9b64374a6","instanceId":"dcd01c36-24f9-42e5-8e03-76e4af572468","title":"valo-markdown","description":"Use markdown to add text, tables, links, and images to your page.","serverProcessedContent":{"htmlStrings":{"html":"<h2 id=\\"this-is-just-a-test\\">This is just a test</h2><p>Test for playbook 123</p><div class=\\"react-codemirror2\\"><div class=\\"CodeMirror cm-s-monokai CodeMirror-wrap\\"><div class=\\"CodeMirror-vscrollbar\\" tabindex=\\"-1\\" style=\\"bottom:0px;\\"><div style=\\"min-width:1px;height:0px;\\"></div></div><div class=\\"CodeMirror-hscrollbar\\" tabindex=\\"-1\\"><div style=\\"height:100%;min-height:1px;width:0px;\\"></div></div><div class=\\"CodeMirror-scrollbar-filler\\"></div><div class=\\"CodeMirror-gutter-filler\\"></div><div class=\\"CodeMirror-scroll\\" tabindex=\\"-1\\"><div class=\\"CodeMirror-sizer\\" style=\\"margin-left:0px;margin-bottom:-8px;border-right-width:22px;min-height:290px;padding-right:0px;padding-bottom:0px;\\"><div style=\\"position:relative;top:0px;\\"><div class=\\"CodeMirror-lines\\" role=\\"presentation\\"><div role=\\"presentation\\" style=\\"position:relative;outline:none;\\"><div class=\\"CodeMirror-measure\\"></div><div class=\\"CodeMirror-measure\\"></div><div style=\\"position:relative;z-index:1;\\"></div><div class=\\"CodeMirror-cursors\\"><div class=\\"CodeMirror-cursor\\" style=\\"left:55.0089px;top:260.571px;height:21.7143px;\\">&nbsp;</div></div><div class=\\"CodeMirror-code\\" role=\\"presentation\\"><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> { <span class=\\"cm-def\\">exec</span> } <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">child_process</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">fs</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">fs</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">path</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">path</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">parseMarkdown</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">frontmatter</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">valoWpTitle</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-string-2\\">`valo-markdown`</span>;</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">siteUrl</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-string-2\\">`https://contoso.sharepoint.com/sites/StaticPages`</span>;</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">(() <span class=\\"cm-operator\\">=&gt;</span> {</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"> &nbsp;<span class=\\"cm-keyword\\">if</span> (<span class=\\"cm-atom\\">true</span>) {</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">  }</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">})();</span></pre></div></div></div></div></div><div style=\\"position:absolute;height:22px;width:1px;border-bottom:0px solid transparent;top:290px;\\"></div><div class=\\"CodeMirror-gutters\\" style=\\"display:none;height:312px;\\"></div></div></div></div><p>!!! Warning\\n    This is a warning of mkdocs</p><p>&lt;p style=\\"color:red\\"&gt;This is a paragraph&lt;/p&gt;</p>"},"searchablePlainTexts":{"code":"\\n# This is just a test\\n\\nTest for playbook 123\\n\\n```typescript\\nconst { exec } = require(child_process);\\nconst fs = require(fs);\\nconst path = require(path);\\nconst parseMarkdown = require(frontmatter);\\n\\nconst valoWpTitle = `valo-markdown`;\\nconst siteUrl = `https://contoso.sharepoint.com/sites/StaticPages`;\\n\\n(() => {\\n  if (true) {\\n\\n  }\\n})();\\n```\\n\\n\\n!!! Warning\\n    This is a warning of mkdocs\\n\\n\\n<p style=\\"color:red\\">This is a paragraph</p>"},"imageSources":{},"links":{}},"dataVersion":"2.0","properties":{"displayPreview":true,"lineWrapping":true,"miniMap":{"enabled":false},"previewState":"Show","theme":"Monokai"}}},{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","controlType":3,"displayMode":2,"emphasis":{},"position":{"zoneIndex":1,"sectionFactor":0,"layoutIndex":1,"controlIndex":1,"sectionIndex":1},"webPartId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","webPartData":{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"title":"","imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":""}}}]'
+    };
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')/SavePageAsDraft`) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { debug: true, pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter' } });
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, {
+      LayoutWebpartsContent: '[]',
+      CanvasContent1: '[{"controlType":3,"displayMode":2,"id":"ede2ee65-157d-4523-b4ed-87b9b64374a6","position":{"zoneIndex":1,"sectionIndex":2,"sectionFactor":12,"layoutIndex":1,"controlIndex":1},"webPartId":"ede2ee65-157d-4523-b4ed-87b9b64374a6","emphasis":{},"addedFromPersistedData":true,"reservedHeight":600,"reservedWidth":969,"webPartData":{"id":"ede2ee65-157d-4523-b4ed-87b9b64374a6","instanceId":"dcd01c36-24f9-42e5-8e03-76e4af572468","title":"valo-markdown","description":"Use markdown to add text, tables, links, and images to your page.","serverProcessedContent":{"htmlStrings":{"html":"<h2 id=\\"this-is-just-a-test\\">This is just a test</h2><p>Test for playbook 123</p><div class=\\"react-codemirror2\\"><div class=\\"CodeMirror cm-s-monokai CodeMirror-wrap\\"><div class=\\"CodeMirror-vscrollbar\\" tabindex=\\"-1\\" style=\\"bottom:0px;\\"><div style=\\"min-width:1px;height:0px;\\"></div></div><div class=\\"CodeMirror-hscrollbar\\" tabindex=\\"-1\\"><div style=\\"height:100%;min-height:1px;width:0px;\\"></div></div><div class=\\"CodeMirror-scrollbar-filler\\"></div><div class=\\"CodeMirror-gutter-filler\\"></div><div class=\\"CodeMirror-scroll\\" tabindex=\\"-1\\"><div class=\\"CodeMirror-sizer\\" style=\\"margin-left:0px;margin-bottom:-8px;border-right-width:22px;min-height:290px;padding-right:0px;padding-bottom:0px;\\"><div style=\\"position:relative;top:0px;\\"><div class=\\"CodeMirror-lines\\" role=\\"presentation\\"><div role=\\"presentation\\" style=\\"position:relative;outline:none;\\"><div class=\\"CodeMirror-measure\\"></div><div class=\\"CodeMirror-measure\\"></div><div style=\\"position:relative;z-index:1;\\"></div><div class=\\"CodeMirror-cursors\\"><div class=\\"CodeMirror-cursor\\" style=\\"left:55.0089px;top:260.571px;height:21.7143px;\\">&nbsp;</div></div><div class=\\"CodeMirror-code\\" role=\\"presentation\\"><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> { <span class=\\"cm-def\\">exec</span> } <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">child_process</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">fs</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">fs</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">path</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">path</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">parseMarkdown</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-variable\\">require</span>(<span class=\\"cm-variable\\">frontmatter</span>);</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">valoWpTitle</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-string-2\\">`valo-markdown`</span>;</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span class=\\"cm-keyword\\">const</span> <span class=\\"cm-def\\">siteUrl</span> <span class=\\"cm-operator\\">=</span> <span class=\\"cm-string-2\\">`https://contoso.sharepoint.com/sites/StaticPages`</span>;</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">(() <span class=\\"cm-operator\\">=&gt;</span> {</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"> &nbsp;<span class=\\"cm-keyword\\">if</span> (<span class=\\"cm-atom\\">true</span>) {</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\"><span>&nbsp;</span></span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">  }</span></pre><pre class=\\" CodeMirror-line \\" role=\\"presentation\\"><span role=\\"presentation\\" style=\\"padding-right:0.1px;\\">})();</span></pre></div></div></div></div></div><div style=\\"position:absolute;height:22px;width:1px;border-bottom:0px solid transparent;top:290px;\\"></div><div class=\\"CodeMirror-gutters\\" style=\\"display:none;height:312px;\\"></div></div></div></div><p>!!! Warning\\n    This is a warning of mkdocs</p><p>&lt;p style=\\"color:red\\"&gt;This is a paragraph&lt;/p&gt;</p>"},"searchablePlainTexts":{"code":"\\n# This is just a test\\n\\nTest for playbook 123\\n\\n```typescript\\nconst { exec } = require(child_process);\\nconst fs = require(fs);\\nconst path = require(path);\\nconst parseMarkdown = require(frontmatter);\\n\\nconst valoWpTitle = `valo-markdown`;\\nconst siteUrl = `https://contoso.sharepoint.com/sites/StaticPages`;\\n\\n(() => {\\n  if (true) {\\n\\n  }\\n})();\\n```\\n\\n\\n!!! Warning\\n    This is a warning of mkdocs\\n\\n\\n<p style=\\"color:red\\">This is a paragraph</p>"},"imageSources":{},"links":{}},"dataVersion":"2.0","properties":{"displayPreview":true,"lineWrapping":true,"miniMap":{"enabled":false},"previewState":"Show","theme":"Monokai"}}},{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","controlType":3,"displayMode":2,"emphasis":{},"position":{"zoneIndex":1,"sectionFactor":0,"layoutIndex":1,"controlIndex":1,"sectionIndex":1},"webPartId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","webPartData":{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"title":"","imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"topicHeader":""}}}]'
+    });
   });
 
   it('correctly handles OData error when retrieving modern page', async () => {
-    sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(() => {
       throw { error: { 'odata.error': { message: { value: 'An error has occurred' } } } };
     });
 
-    await assert.rejects(command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a' } } as any),
+    await assert.rejects(command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter' } } as any),
       new CommandError('An error has occurred'));
   });
 
   it('correctly handles error when the specified image doesn\'t exist', async () => {
-    sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) > -1) {
         return {
@@ -457,30 +725,30 @@ describe(commands.PAGE_HEADER_SET, () => {
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/site?`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/site?$select=Id`) {
         return {
           Id: 'c7678ab2-c9dc-454b-b2ee-7fcffb983d4e'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web?`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web?$select=Id`) {
         return {
           Id: '0df4d2d2-5ecf-45e9-94f5-c638106bfc65'
         };
       }
 
-      if ((opts.url as string).indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fteam-a%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) > -1) {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/web/GetFileByServerRelativePath(DecodedUrl='%2Fsites%2Fnewsletter%2Fsiteassets%2Fhero.jpg')?$select=ListId,UniqueId`) {
         throw { error: { 'odata.error': { message: { value: 'An error has occurred' } } } };
       }
 
-      if ((opts.url as string).indexOf(`/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) > -1) {
-        return { CanvasContent1: mockCanvasContent };
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockPageJsonCanvasContent.ListItemAllFields;
       }
 
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/team-a', type: 'Custom', imageUrl: '/sites/team-a/siteassets/hero.jpg', translateX: 42.3837520042758, translateY: 56.4285714285714 } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Custom', imageUrl: '/sites/newsletter/siteassets/hero.jpg', translateX: 42.3837520042758, translateY: 56.4285714285714 } } as any), new CommandError('An error has occurred'));
   });
 
   it('fails validation if webUrl is not an absolute URL', async () => {

--- a/src/m365/spo/commands/page/page-header-set.ts
+++ b/src/m365/spo/commands/page/page-header-set.ts
@@ -6,6 +6,7 @@ import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
 import { ClientSidePageProperties } from './ClientSidePageProperties.js';
+import { PageControl } from './PageControl.js';
 import { CustomPageHeader, CustomPageHeaderProperties, CustomPageHeaderServerProcessedContent, PageHeader } from './PageHeader.js';
 
 interface CommandArgs {
@@ -27,6 +28,8 @@ interface Options extends GlobalOptions {
   type?: string;
   webUrl: string;
 }
+
+const BannerWebPartId: string = 'cbe7b0a9-3504-44dd-a3a3-0e5cacd07788';
 
 class SpoPageHeaderSetCommand extends SpoCommand {
   public get name(): string {
@@ -153,8 +156,8 @@ class SpoPageHeaderSetCommand extends SpoCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     const noPageHeader: PageHeader = {
-      "id": "cbe7b0a9-3504-44dd-a3a3-0e5cacd07788",
-      "instanceId": "cbe7b0a9-3504-44dd-a3a3-0e5cacd07788",
+      "id": BannerWebPartId,
+      "instanceId": BannerWebPartId,
       "title": "Title Region",
       "description": "Title Region Description",
       "serverProcessedContent": {
@@ -175,8 +178,8 @@ class SpoPageHeaderSetCommand extends SpoCommand {
       }
     };
     const defaultPageHeader: PageHeader = {
-      "id": "cbe7b0a9-3504-44dd-a3a3-0e5cacd07788",
-      "instanceId": "cbe7b0a9-3504-44dd-a3a3-0e5cacd07788",
+      "id": BannerWebPartId,
+      "instanceId": BannerWebPartId,
       "title": "Title Region",
       "description": "Title Region Description",
       "serverProcessedContent": {
@@ -197,8 +200,8 @@ class SpoPageHeaderSetCommand extends SpoCommand {
       }
     };
     const customPageHeader: CustomPageHeader = {
-      "id": "cbe7b0a9-3504-44dd-a3a3-0e5cacd07788",
-      "instanceId": "cbe7b0a9-3504-44dd-a3a3-0e5cacd07788",
+      "id": BannerWebPartId,
+      "instanceId": BannerWebPartId,
       "title": "Title Region",
       "description": "Title Region Description",
       "serverProcessedContent": {
@@ -312,6 +315,16 @@ class SpoPageHeaderSetCommand extends SpoCommand {
         topicHeader = topicHeader || pageData.TopicHeader || "";
       }
 
+      const pageControls: PageControl[] = JSON.parse(pageData.CanvasContent1);
+      //In the new design page header is is a configurable Banner webpart in the first full-width section
+      const headerControl: PageControl | undefined = pageControls.find(control => control?.position?.zoneIndex === 1 && control?.position?.sectionFactor === 0 && control?.webPartId === BannerWebPartId);
+      const isStandardPageHeader: boolean = pageData.LayoutWebpartsContent !== '[]';
+
+      //LayoutWebpartsContent represents standard page header
+      if (!isStandardPageHeader) {
+        header = headerControl?.webPartData as any || header;
+      }
+
       header.properties.title = title;
       header.properties.textAlignment = args.options.textAlignment as any || 'Left';
       header.properties.showTopicHeader = args.options.showTopicHeader || false;
@@ -372,8 +385,41 @@ class SpoPageHeaderSetCommand extends SpoCommand {
       }
 
       const requestBody: any = {
-        LayoutWebpartsContent: JSON.stringify([header])
+        LayoutWebpartsContent: JSON.stringify([header]),
+        CanvasContent1: canvasContent
       };
+
+      if (!isStandardPageHeader) {
+        requestBody.LayoutWebpartsContent = '[]';
+        header.properties.title = topicHeader;
+        if (headerControl) {
+          headerControl.webPartData = header as any;
+        }
+        else {
+          for (const pageControl of pageControls) {
+            if (pageControl?.position?.sectionIndex) {
+              pageControl.position.sectionIndex += pageControl.position.sectionIndex;
+            }
+          }
+
+          pageControls.push({
+            id: BannerWebPartId,
+            controlType: 3,
+            displayMode: 2,
+            emphasis: {},
+            position: {
+              zoneIndex: 1,
+              sectionFactor: 0,
+              layoutIndex: 1,
+              controlIndex: 1,
+              sectionIndex: 1
+            },
+            webPartId: BannerWebPartId,
+            webPartData: header as any
+          });
+        }
+        requestBody.CanvasContent1 = JSON.stringify(pageControls);
+      }
 
       if (title) {
         requestBody.Title = title;
@@ -389,9 +435,6 @@ class SpoPageHeaderSetCommand extends SpoCommand {
       }
       if (bannerImageUrl) {
         requestBody.BannerImageUrl = bannerImageUrl;
-      }
-      if (canvasContent) {
-        requestBody.CanvasContent1 = canvasContent;
       }
 
       requestOptions = {


### PR DESCRIPTION
The change includes fixes for the issue mentioned in #6542.

Currently, there are two methods to add a header to the page:
1. Using the `LayoutWebpartsContent` property (the old method used in the command).
2. Updating the `CanvasContent1` property of the page.

I have just added the second method without making changes to the first one. Potentially, we could remove the old method in the future, as it seems that page editing is now handled solely by the `CanvasContent1` property.

Interestingly, the 'header' object provided in both methods is the same but has a slightly different effect.

Do you think we should allow users to provide the `--headerText to update the page name (.2 in the screenshot)?

![image](https://github.com/user-attachments/assets/b4e47f46-8601-4c1c-82d9-2f57d8a299e4)

I have also edited the tests according to some comments from previous PRs. One change I had to make in the mock file was updating the `CanvasContent` value. It was originally set to HTML, but in my case, it returns the correct JSON value.