### PR TITLE
Fixed "graph directoryextension get" examples. Closes #6658

### DIFF
--- a/docs/docs/cmd/graph/directoryextension/directoryextension-get.mdx
+++ b/docs/docs/cmd/graph/directoryextension/directoryextension-get.mdx
@@ -38,15 +38,14 @@ m365 graph directoryextension get [options]
 Get directory extension by id registered for an application specified by app id.
 
 ```sh
-m365 directoryextension get --id 1f0f15e3-925d-40f0-8fc8-9d3ad135bce0 --appId fd918e4b-c821-4efb-b50a-5eddd23afc6f
+m365 graph directoryextension get --id 1f0f15e3-925d-40f0-8fc8-9d3ad135bce0 --appId fd918e4b-c821-4efb-b50a-5eddd23afc6f
 ```
 
 Get directory extension by name registered for an application specified by name.
 
 ```sh
-m365 directoryextension get --name extension_105be60b603845fea385e58772d9d630_GitHubWorkAccount --appName ContosoApp
+m365 graph directoryextension get --name extension_105be60b603845fea385e58772d9d630_GitHubWorkAccount --appName ContosoApp
 ```
-
 
 ## Response
 


### PR DESCRIPTION
Fixed `graph directoryextension get` examples by adding missing `graph` to the command. Closes #6658