### PR TITLE
Fixes undefined in verbose logs. Closes #6619

### DIFF
--- a/src/m365/flow/commands/flow-list.ts
+++ b/src/m365/flow/commands/flow-list.ts
@@ -100,7 +100,7 @@ class FlowListCommand extends PowerAutomateCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (this.verbose) {
-      await logger.logToStderr(`Getting Power Automate flows${args.options.asAdmin && ' as admin'} in environment '${args.options.environmentName}'...`);
+      await logger.logToStderr(`Getting Power Automate flows${args.options.asAdmin ? ' as admin' : ''} in environment '${args.options.environmentName}'...`);
     }
 
     try {


### PR DESCRIPTION
Closes #6619
This PR replaces the && operator with a ternary operator to prevent `undefined` from appearing in verbose logs.