### PR TITLE
🚀 Refactor app commands to use `getAppRegistrationByAppId` util. Closes #5234

### DIFF
--- a/src/m365/app/commands/app-get.spec.ts
+++ b/src/m365/app/commands/app-get.spec.ts
@@ -11,12 +11,12 @@ import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
 import command from './app-get.js';
+import { entraApp } from '../../../utils/entraApp.js';
 
 describe(commands.GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
-  let loggerLogToStderrSpy: sinon.SinonSpy;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -49,12 +49,12 @@ describe(commands.GET, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
   });
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get
+      request.get,
+      entraApp.getAppRegistrationByAppId
     ]);
   });
 
@@ -72,59 +72,30 @@ describe(commands.GET, () => {
   });
 
   it('handles error when the app specified with the appId not found', async () => {
-    sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
-        return { value: [] };
-      }
-
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
+    const error = `App with appId '9b1b1e42-794b-4c71-93ac-5ed92488b67f' not found in Microsoft Entra ID`;
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').rejects(new Error(error));
 
     await assert.rejects(command.action(logger, {
       options: {
         appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f'
       }
-    }), new CommandError(`No Microsoft Entra application registration with ID 9b1b1e42-794b-4c71-93ac-5ed92488b67f found`));
-  });
-
-  it('handles error when retrieving information about app through appId failed', async () => {
-    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f'
-      }
-    }), new CommandError(`An error has occurred`));
+    }), new CommandError(`App with appId '9b1b1e42-794b-4c71-93ac-5ed92488b67f' not found in Microsoft Entra ID`));
   });
 
   it(`gets an Microsoft Entra app registration by its app (client) ID.`, async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
-        return {
-          value: [
-            {
-              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
-              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
-              "createdDateTime": "2019-10-29T17:46:55Z",
-              "displayName": "My App",
-              "description": null
-            }
-          ]
-        };
-      }
-
-      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
-        return {
+    const appResponse = {
+      value: [
+        {
           "id": "340a4aa3-1af6-43ac-87d8-189819003952",
           "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
           "createdDateTime": "2019-10-29T17:46:55Z",
           "displayName": "My App",
           "description": null
-        };
-      }
+        }
+      ]
+    };
 
-      throw 'Invalid request';
-    });
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
     await command.action(logger, {
       options: {
@@ -135,44 +106,5 @@ describe(commands.GET, () => {
     assert.strictEqual(call.args[0].id, '340a4aa3-1af6-43ac-87d8-189819003952');
     assert.strictEqual(call.args[0].appId, '9b1b1e42-794b-4c71-93ac-5ed92488b67f');
     assert.strictEqual(call.args[0].displayName, 'My App');
-  });
-
-  it(`shows underlying debug information in debug mode`, async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
-        return {
-          value: [
-            {
-              "id": "340a4aa3-1af6-43ac-87d8-189819003952",
-              "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
-              "createdDateTime": "2019-10-29T17:46:55Z",
-              "displayName": "My App",
-              "description": null
-            }
-          ]
-        };
-      }
-
-      if ((opts.url as string).indexOf('/v1.0/myorganization/applications/') > -1) {
-        return {
-          "id": "340a4aa3-1af6-43ac-87d8-189819003952",
-          "appId": "9b1b1e42-794b-4c71-93ac-5ed92488b67f",
-          "createdDateTime": "2019-10-29T17:46:55Z",
-          "displayName": "My App",
-          "description": null
-        };
-      }
-
-      throw 'Invalid request';
-    });
-
-    await command.action(logger, {
-      options: {
-        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
-        debug: true
-      }
-    });
-    const call: sinon.SinonSpyCall = loggerLogToStderrSpy.firstCall;
-    assert(call.args[0].includes('Executing command entra app get with options'));
   });
 });

--- a/src/m365/app/commands/app-get.ts
+++ b/src/m365/app/commands/app-get.ts
@@ -1,9 +1,7 @@
-import { cli } from '../../../cli/cli.js';
 import { Logger } from '../../../cli/Logger.js';
-import Command from '../../../Command.js';
-import entraAppGetCommand, { Options as EntraAppGetCommandOptions } from '../../entra/commands/app/app-get.js';
 import AppCommand, { AppCommandArgs } from '../../base/AppCommand.js';
 import commands from '../commands.js';
+import { entraApp } from '../../../utils/entraApp.js';
 
 class AppGetCommand extends AppCommand {
   public get name(): string {
@@ -15,20 +13,9 @@ class AppGetCommand extends AppCommand {
   }
 
   public async commandAction(logger: Logger, args: AppCommandArgs): Promise<void> {
-    const options: EntraAppGetCommandOptions = {
-      appId: this.appId,
-      output: 'json',
-      debug: args.options.debug,
-      verbose: args.options.verbose
-    };
-
     try {
-      const appGetOutput = await cli.executeCommandWithOutput(entraAppGetCommand as Command, { options: { ...options, _: [] } });
-      if (this.verbose) {
-        await logger.logToStderr(appGetOutput.stderr);
-      }
-
-      await logger.log(JSON.parse(appGetOutput.stdout));
+      const app = await entraApp.getAppRegistrationByAppId(args.options.appId!);
+      await logger.log(app);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);

--- a/src/m365/app/commands/permission/permission-list.ts
+++ b/src/m365/app/commands/permission/permission-list.ts
@@ -1,11 +1,9 @@
 import { Application, AppRole, AppRoleAssignment, OAuth2PermissionGrant, PermissionScope, RequiredResourceAccess, ResourceAccess, ServicePrincipal } from '@microsoft/microsoft-graph-types';
-import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import Command from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import appGetCommand, { Options as AppGetCommandOptions } from '../../../entra/commands/app/app-get.js';
 import AppCommand from '../../../base/AppCommand.js';
 import commands from '../../commands.js';
+import { entraApp } from '../../../../utils/entraApp.js';
 
 interface ApiPermission {
   resource: string;
@@ -221,23 +219,12 @@ class AppPermissionListCommand extends AppCommand {
 
   private async getAppRegistration(appId: string, logger: Logger): Promise<Application> {
     if (this.verbose) {
-      await logger.logToStderr(`Retrieving Microsoft Entra application registration ${appId}`);
+      await logger.logToStderr(`Retrieving the Entra application registration with appId '${appId}'`);
     }
 
-    const options: AppGetCommandOptions = {
-      appId: appId,
-      output: 'json',
-      debug: this.debug,
-      verbose: this.verbose
-    };
+    const app: Application = await entraApp.getAppRegistrationByAppId(appId);
 
-    const output = await cli.executeCommandWithOutput(appGetCommand as Command, { options: { ...options, _: [] } });
-
-    if (this.debug) {
-      await logger.logToStderr(output.stderr);
-    }
-
-    return JSON.parse(output.stdout) as Application;
+    return app;
   }
 
   private async getAppRegPermissions(appId: string, logger: Logger): Promise<ApiPermission[]> {

--- a/src/m365/entra/commands/app/app-remove.ts
+++ b/src/m365/entra/commands/app/app-remove.ts
@@ -2,6 +2,7 @@ import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
+import { entraApp } from '../../../../utils/entraApp.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
@@ -123,32 +124,33 @@ class EntraAppRemoveCommand extends GraphCommand {
       await logger.logToStderr(`Retrieving information about Microsoft Entra app ${appId ? appId : name}...`);
     }
 
-    const filter: string = appId ?
-      `appId eq '${formatting.encodeQueryParameter(appId)}'` :
-      `displayName eq '${formatting.encodeQueryParameter(name as string)}'`;
-
-    const requestOptions: CliRequestOptions = {
-      url: `${this.resource}/v1.0/myorganization/applications?$filter=${filter}&$select=id`,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
-
-    const res = await request.get<{ value: { id: string }[] }>(requestOptions);
-
-    if (res.value.length === 1) {
-      return res.value[0].id;
+    if (appId) {
+      const app = await entraApp.getAppRegistrationByAppId(appId, ['id']);
+      return app.id!;
     }
+    else {
+      const requestOptions: CliRequestOptions = {
+        url: `${this.resource}/v1.0/myorganization/applications?$filter=displayName eq '${formatting.encodeQueryParameter(name as string)}'&$select=id`,
+        headers: {
+          accept: 'application/json;odata.metadata=none'
+        },
+        responseType: 'json'
+      };
 
-    if (res.value.length === 0) {
-      const applicationIdentifier = appId ? `ID ${appId}` : `name ${name}`;
-      throw `No Microsoft Entra application registration with ${applicationIdentifier} found`;
+      const res = await request.get<{ value: { id: string }[] }>(requestOptions);
+
+      if (res.value.length === 1) {
+        return res.value[0].id;
+      }
+
+      if (res.value.length === 0) {
+        throw `No Microsoft Entra application registration with name ${name} found`;
+      }
+
+      const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', res.value);
+      const result = await cli.handleMultipleResultsFound<{ id: string }>(`Multiple Microsoft Entra application registration with name '${name}' found.`, resultAsKeyValuePair);
+      return result.id;
     }
-
-    const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', res.value);
-    const result = await cli.handleMultipleResultsFound<{ id: string }>(`Multiple Microsoft Entra application registration with name '${name}' found.`, resultAsKeyValuePair);
-    return result.id;
   }
 }
 

--- a/src/m365/entra/commands/app/app-role-list.spec.ts
+++ b/src/m365/entra/commands/app/app-role-list.spec.ts
@@ -13,12 +13,23 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './app-role-list.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { entraApp } from '../../../../utils/entraApp.js';
 
 describe(commands.APP_ROLE_LIST, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+
+  //#region Mocked Responses 
+  const appResponse = {
+    value: [
+      {
+        "id": "5b31c38c-2584-42f0-aa47-657fb3a84230"
+      }
+    ]
+  };
+  //#endregion
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -50,7 +61,8 @@ describe(commands.APP_ROLE_LIST, () => {
     sinonUtil.restore([
       request.get,
       cli.getSettingWithDefaultValue,
-      cli.handleMultipleResultsFound
+      cli.handleMultipleResultsFound,
+      entraApp.getAppRegistrationByAppId
     ]);
   });
 
@@ -72,15 +84,9 @@ describe(commands.APP_ROLE_LIST, () => {
   });
 
   it('lists roles for the specified appId (debug)', async () => {
-    sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq 'bc724b77-da87-43a9-b385-6ebaaf969db8'&$select=id`) {
-        return {
-          value: [{
-            id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-          }]
-        };
-      }
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
+    sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230/appRoles`) {
         return {
           value: [
@@ -310,19 +316,14 @@ describe(commands.APP_ROLE_LIST, () => {
   });
 
   it('handles error when the app specified with the appId not found', async () => {
-    sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
-        return { value: [] };
-      }
-
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
+    const error = `App with appId '9b1b1e42-794b-4c71-93ac-5ed92488b67f' not found in Microsoft Entra ID`;
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').rejects(new Error(error));
 
     await assert.rejects(command.action(logger, {
       options: {
         appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f'
       }
-    }), new CommandError(`No Microsoft Entra application registration with ID 9b1b1e42-794b-4c71-93ac-5ed92488b67f found`));
+    }), new CommandError(`App with appId '9b1b1e42-794b-4c71-93ac-5ed92488b67f' not found in Microsoft Entra ID`));
   });
 
   it('handles error when the app specified with appName not found', async () => {
@@ -440,16 +441,6 @@ describe(commands.APP_ROLE_LIST, () => {
         "value": "writers"
       }
     ]));
-  });
-
-  it('handles error when retrieving information about app through appId failed', async () => {
-    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f'
-      }
-    } as any), new CommandError('An error has occurred'));
   });
 
   it('handles error when retrieving information about app through appName failed', async () => {

--- a/src/m365/entra/commands/app/app-role-list.ts
+++ b/src/m365/entra/commands/app/app-role-list.ts
@@ -7,6 +7,7 @@ import { odata } from '../../../../utils/odata.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 import { cli } from '../../../../cli/cli.js';
+import { entraApp } from '../../../../utils/entraApp.js';
 
 interface CommandArgs {
   options: Options;
@@ -83,32 +84,33 @@ class EntraAppRoleListCommand extends GraphCommand {
       await logger.logToStderr(`Retrieving information about Microsoft Entra app ${appId ? appId : appName}...`);
     }
 
-    const filter: string = appId ?
-      `appId eq '${formatting.encodeQueryParameter(appId)}'` :
-      `displayName eq '${formatting.encodeQueryParameter(appName as string)}'`;
-
-    const requestOptions: CliRequestOptions = {
-      url: `${this.resource}/v1.0/myorganization/applications?$filter=${filter}&$select=id`,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
-
-    const res = await request.get<{ value: { id: string }[] }>(requestOptions);
-
-    if (res.value.length === 1) {
-      return res.value[0].id;
+    if (appId) {
+      const app = await entraApp.getAppRegistrationByAppId(appId, ["id"]);
+      return app.id!;
     }
+    else {
+      const requestOptions: CliRequestOptions = {
+        url: `${this.resource}/v1.0/myorganization/applications?$filter=displayName eq '${formatting.encodeQueryParameter(appName as string)}'&$select=id`,
+        headers: {
+          accept: 'application/json;odata.metadata=none'
+        },
+        responseType: 'json'
+      };
 
-    if (res.value.length === 0) {
-      const applicationIdentifier = appId ? `ID ${appId}` : `name ${appName}`;
-      throw `No Microsoft Entra application registration with ${applicationIdentifier} found`;
+      const res = await request.get<{ value: { id: string }[] }>(requestOptions);
+
+      if (res.value.length === 1) {
+        return res.value[0].id;
+      }
+
+      if (res.value.length === 0) {
+        throw `No Microsoft Entra application registration with name ${appName} found`;
+      }
+
+      const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', res.value);
+      const result = await cli.handleMultipleResultsFound<{ id: string }>(`Multiple Microsoft Entra application registrations with name '${appName}' found.`, resultAsKeyValuePair);
+      return result.id;
     }
-
-    const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', res.value);
-    const result = await cli.handleMultipleResultsFound<{ id: string }>(`Multiple Microsoft Entra application registrations with name '${appName}' found.`, resultAsKeyValuePair);
-    return result.id;
   }
 }
 

--- a/src/m365/entra/commands/app/app-role-remove.spec.ts
+++ b/src/m365/entra/commands/app/app-role-remove.spec.ts
@@ -13,12 +13,23 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './app-role-remove.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { entraApp } from '../../../../utils/entraApp.js';
 
 describe(commands.APP_ROLE_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
   let promptIssued: boolean = false;
+
+  //#region Mocked Responses 
+  const appResponse = {
+    value: [
+      {
+        "id": "5b31c38c-2584-42f0-aa47-657fb3a84230"
+      }
+    ]
+  };
+  //#endregion
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -56,7 +67,8 @@ describe(commands.APP_ROLE_REMOVE, () => {
       request.patch,
       cli.promptForConfirmation,
       cli.getSettingWithDefaultValue,
-      cli.handleMultipleResultsFound
+      cli.handleMultipleResultsFound,
+      entraApp.getAppRegistrationByAppId
     ]);
   });
 
@@ -299,24 +311,9 @@ describe(commands.APP_ROLE_REMOVE, () => {
   });
 
   it('deletes an app role when the role is in enabled state and valid appId, role claim and --force option specified', async () => {
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-    const getRequestStub = sinon.stub(request, 'get');
-
-    getRequestStub.onFirstCall().callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '53788d97-dc06-460c-8bd6-5cfbc7e3b0f7'&$select=id`) {
-        return {
-          "value": [
-            {
-              id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-            }
-          ]
-        };
-      }
-
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
-
-    getRequestStub.onSecondCall().callsFake(async opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230?$select=id,appRoles') {
         return {
           id: '5b31c38c-2584-42f0-aa47-657fb3a84230',
@@ -390,24 +387,9 @@ describe(commands.APP_ROLE_REMOVE, () => {
   });
 
   it('deletes an app role when the role is in enabled state and valid appId, role name and --force option specified', async () => {
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-    const getRequestStub = sinon.stub(request, 'get');
-
-    getRequestStub.onFirstCall().callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '53788d97-dc06-460c-8bd6-5cfbc7e3b0f7'&$select=id`) {
-        return {
-          "value": [
-            {
-              id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-            }
-          ]
-        };
-      }
-
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
-
-    getRequestStub.onSecondCall().callsFake(async opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230?$select=id,appRoles') {
         return {
           id: '5b31c38c-2584-42f0-aa47-657fb3a84230',
@@ -482,23 +464,9 @@ describe(commands.APP_ROLE_REMOVE, () => {
   });
 
   it('deletes an app role when the role is in enabled state and valid appId, role id and --force option specified', async () => {
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-    const getRequestStub = sinon.stub(request, 'get');
-
-    getRequestStub.onFirstCall().callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '53788d97-dc06-460c-8bd6-5cfbc7e3b0f7'&$select=id`) {
-        return {
-          "value": [
-            {
-              id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-            }
-          ]
-        };
-      }
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
-
-    getRequestStub.onSecondCall().callsFake(async opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230?$select=id,appRoles') {
         return {
           id: '5b31c38c-2584-42f0-aa47-657fb3a84230',
@@ -648,24 +616,9 @@ describe(commands.APP_ROLE_REMOVE, () => {
   });
 
   it('deletes an app role when the role is in enabled state and valid appId, role name and --force option specified (debug)', async () => {
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-    const getRequestStub = sinon.stub(request, 'get');
-
-    getRequestStub.onFirstCall().callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '53788d97-dc06-460c-8bd6-5cfbc7e3b0f7'&$select=id`) {
-        return {
-          "value": [
-            {
-              id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-            }
-          ]
-        };
-      }
-
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
-
-    getRequestStub.onSecondCall().callsFake(async opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230?$select=id,appRoles') {
         return {
           id: '5b31c38c-2584-42f0-aa47-657fb3a84230',
@@ -741,23 +694,9 @@ describe(commands.APP_ROLE_REMOVE, () => {
   });
 
   it('deletes an app role when the role is in enabled state and valid appId, role id and --force option specified (debug)', async () => {
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-    const getRequestStub = sinon.stub(request, 'get');
-
-    getRequestStub.onFirstCall().callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '53788d97-dc06-460c-8bd6-5cfbc7e3b0f7'&$select=id`) {
-        return {
-          "value": [
-            {
-              id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-            }
-          ]
-        };
-      }
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
-
-    getRequestStub.onSecondCall().callsFake(async opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230?$select=id,appRoles') {
         return {
           id: '5b31c38c-2584-42f0-aa47-657fb3a84230',
@@ -1792,27 +1731,12 @@ describe(commands.APP_ROLE_REMOVE, () => {
   });
 
   it('deletes an app role when the role is in enabled state and valid appId, role name and prompt is confirmed', async () => {
-
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    const getRequestStub = sinon.stub(request, 'get');
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-    getRequestStub.onFirstCall().callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '53788d97-dc06-460c-8bd6-5cfbc7e3b0f7'&$select=id`) {
-        return {
-          "value": [
-            {
-              id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-            }
-          ]
-        };
-      }
-
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
-
-    getRequestStub.onSecondCall().callsFake(async opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230?$select=id,appRoles') {
         return {
           id: '5b31c38c-2584-42f0-aa47-657fb3a84230',
@@ -1886,26 +1810,12 @@ describe(commands.APP_ROLE_REMOVE, () => {
   });
 
   it('deletes an app role when the role is in enabled state and valid appId, role id and prompt is confirmed (debug)', async () => {
-
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    const getRequestStub = sinon.stub(request, 'get');
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-    getRequestStub.onFirstCall().callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '53788d97-dc06-460c-8bd6-5cfbc7e3b0f7'&$select=id`) {
-        return {
-          "value": [
-            {
-              id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-            }
-          ]
-        };
-      }
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
-
-    getRequestStub.onSecondCall().callsFake(async opts => {
+    sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230?$select=id,appRoles') {
         return {
           id: '5b31c38c-2584-42f0-aa47-657fb3a84230',
@@ -2028,13 +1938,8 @@ describe(commands.APP_ROLE_REMOVE, () => {
   });
 
   it('handles error when the app specified with the appId not found', async () => {
-    sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
-        return { value: [] };
-      }
-
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
+    const error = `App with appId '9b1b1e42-794b-4c71-93ac-5ed92488b67f' not found in Microsoft Entra ID`;
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').rejects(new Error(error));
 
     await assert.rejects(command.action(logger, {
       options: {
@@ -2042,7 +1947,7 @@ describe(commands.APP_ROLE_REMOVE, () => {
         name: 'App-Role',
         force: true
       }
-    }), new CommandError(`No Microsoft Entra application registration with ID 9b1b1e42-794b-4c71-93ac-5ed92488b67f found`));
+    }), new CommandError(`App with appId '9b1b1e42-794b-4c71-93ac-5ed92488b67f' not found in Microsoft Entra ID`));
   });
 
   it('handles error when the app specified with appName not found', async () => {

--- a/src/m365/entra/commands/app/app-set.spec.ts
+++ b/src/m365/entra/commands/app/app-set.spec.ts
@@ -14,11 +14,20 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './app-set.js';
 import { settingsNames } from '../../../../settingsNames.js';
+import { entraApp } from '../../../../utils/entraApp.js';
 
 describe(commands.APP_SET, () => {
 
   //#region Mocked Responses  
   const appDetailsResponse: any = { "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity", "id": "95cfe30d-ed44-4f9d-b73d-c66560f72e83", "deletedDateTime": null, "appId": "ff254847-12c7-44cf-921e-8883dbd622a7", "applicationTemplateId": null, "disabledByMicrosoftStatus": null, "createdDateTime": "2022-02-07T08:51:18Z", "displayName": "Angular Teams app", "description": null, "groupMembershipClaims": null, "identifierUris": ["api://244e-2001-1c00-80c-d00-e5da-977c-7c52-5193.ngrok.io/ff254847-12c7-44cf-921e-8883dbd622a7"], "isDeviceOnlyAuthSupported": null, "isFallbackPublicClient": null, "notes": null, "publisherDomain": "contoso.onmicrosoft.com", "serviceManagementReference": null, "signInAudience": "AzureADMyOrg", "tags": [], "tokenEncryptionKeyId": null, "defaultRedirectUri": null, "certification": null, "optionalClaims": null, "addIns": [], "api": { "acceptMappedClaims": null, "knownClientApplications": [], "requestedAccessTokenVersion": null, "oauth2PermissionScopes": [{ "adminConsentDescription": "Access as a user", "adminConsentDisplayName": "Access as a user", "id": "cf38eb5b-8fcd-4697-9bd5-d80b7f98dfc5", "isEnabled": true, "type": "User", "userConsentDescription": null, "userConsentDisplayName": null, "value": "access_as_user" }], "preAuthorizedApplications": [{ "appId": "5e3ce6c0-2b1f-4285-8d4b-75ee78787346", "delegatedPermissionIds": ["cf38eb5b-8fcd-4697-9bd5-d80b7f98dfc5"] }, { "appId": "1fec8e78-bce4-4aaf-ab1b-5451cc387264", "delegatedPermissionIds": ["cf38eb5b-8fcd-4697-9bd5-d80b7f98dfc5"] }] }, "appRoles": [], "info": { "logoUrl": null, "marketingUrl": null, "privacyStatementUrl": null, "supportUrl": null, "termsOfServiceUrl": null }, "keyCredentials": [], "parentalControlSettings": { "countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow" }, "passwordCredentials": [], "publicClient": { "redirectUris": [] }, "requiredResourceAccess": [{ "resourceAppId": "00000003-0000-0000-c000-000000000000", "resourceAccess": [{ "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d", "type": "Scope" }] }], "verifiedPublisher": { "displayName": null, "verifiedPublisherId": null, "addedDateTime": null }, "web": { "homePageUrl": null, "logoutUrl": null, "redirectUris": [], "implicitGrantSettings": { "enableAccessTokenIssuance": false, "enableIdTokenIssuance": false } }, "spa": { "redirectUris": [] } };
+
+  const appResponse = {
+    value: [
+      {
+        "id": "5b31c38c-2584-42f0-aa47-657fb3a84230"
+      }
+    ]
+  };
   //#endregion
 
   let log: string[];
@@ -56,7 +65,8 @@ describe(commands.APP_SET, () => {
       fs.existsSync,
       fs.readFileSync,
       cli.getSettingWithDefaultValue,
-      cli.handleMultipleResultsFound
+      cli.handleMultipleResultsFound,
+      entraApp.getAppRegistrationByAppId
     ]);
   });
 
@@ -78,17 +88,8 @@ describe(commands.APP_SET, () => {
   });
 
   it('updates uris for the specified appId', async () => {
-    sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq 'bc724b77-da87-43a9-b385-6ebaaf969db8'&$select=id`) {
-        return {
-          value: [{
-            id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-          }]
-        };
-      }
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
     sinon.stub(request, 'patch').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230' &&
         opts.data &&
@@ -109,17 +110,8 @@ describe(commands.APP_SET, () => {
   });
 
   it('updates unknown options for the specified appId', async () => {
-    sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq 'bc724b77-da87-43a9-b385-6ebaaf969db8'&$select=id`) {
-        return {
-          value: [{
-            id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-          }]
-        };
-      }
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
     sinon.stub(request, 'patch').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230' &&
         opts.data &&
@@ -149,17 +141,8 @@ describe(commands.APP_SET, () => {
   });
 
   it('updates multiple URIs for the specified appId', async () => {
-    sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq 'bc724b77-da87-43a9-b385-6ebaaf969db8'&$select=id`) {
-        return {
-          value: [{
-            id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-          }]
-        };
-      }
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
     sinon.stub(request, 'patch').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230' &&
         opts.data &&
@@ -998,17 +981,8 @@ describe(commands.APP_SET, () => {
   });
 
   it('updates allowPublicClientFlows value for the specified appId', async () => {
-    sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq 'bc724b77-da87-43a9-b385-6ebaaf969db8'&$select=id`) {
-        return {
-          value: [{
-            id: '5b31c38c-2584-42f0-aa47-657fb3a84230'
-          }]
-        };
-      }
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').resolves(appResponse.value[0]);
 
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
     sinon.stub(request, 'patch').callsFake(async opts => {
       if (opts.url === 'https://graph.microsoft.com/v1.0/myorganization/applications/5b31c38c-2584-42f0-aa47-657fb3a84230' &&
         opts.data &&
@@ -1062,13 +1036,9 @@ describe(commands.APP_SET, () => {
   });
 
   it('handles error when the app specified with the appId not found', async () => {
-    sinon.stub(request, 'get').callsFake(async opts => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/myorganization/applications?$filter=appId eq '9b1b1e42-794b-4c71-93ac-5ed92488b67f'&$select=id`) {
-        return { value: [] };
-      }
+    const error = `App with appId '9b1b1e42-794b-4c71-93ac-5ed92488b67f' not found in Microsoft Entra ID`;
+    sinon.stub(entraApp, 'getAppRegistrationByAppId').rejects(new Error(error));
 
-      throw `Invalid request ${JSON.stringify(opts)}`;
-    });
     sinon.stub(request, 'patch').rejects('PATCH request executed');
 
     await assert.rejects(command.action(logger, {
@@ -1076,7 +1046,7 @@ describe(commands.APP_SET, () => {
         appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
         uris: 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8'
       }
-    }), new CommandError(`No Microsoft Entra application registration with ID 9b1b1e42-794b-4c71-93ac-5ed92488b67f found`));
+    }), new CommandError(`App with appId '9b1b1e42-794b-4c71-93ac-5ed92488b67f' not found in Microsoft Entra ID`));
   });
 
   it('handles error when the app specified with name not found', async () => {
@@ -1273,17 +1243,6 @@ describe(commands.APP_SET, () => {
       }
     });
     assert(updateRequestIssued);
-  });
-
-  it('handles error when retrieving information about app through appId failed', async () => {
-    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        appId: '9b1b1e42-794b-4c71-93ac-5ed92488b67f',
-        uris: 'https://contoso.com/bc724b77-da87-43a9-b385-6ebaaf969db8'
-      }
-    }), new CommandError(`An error has occurred`));
   });
 
   it('handles error when retrieving information about app through name failed', async () => {

--- a/src/m365/entra/commands/app/app-set.ts
+++ b/src/m365/entra/commands/app/app-set.ts
@@ -8,6 +8,7 @@ import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 import { cli } from '../../../../cli/cli.js';
 import { optionsUtils } from '../../../../utils/optionsUtils.js';
+import { entraApp } from '../../../../utils/entraApp.js';
 
 interface CommandArgs {
   options: Options;
@@ -155,32 +156,33 @@ class EntraAppSetCommand extends GraphCommand {
       await logger.logToStderr(`Retrieving information about Microsoft Entra app ${appId ? appId : name}...`);
     }
 
-    const filter: string = appId ?
-      `appId eq '${formatting.encodeQueryParameter(appId)}'` :
-      `displayName eq '${formatting.encodeQueryParameter(name as string)}'`;
-
-    const requestOptions: CliRequestOptions = {
-      url: `${this.resource}/v1.0/myorganization/applications?$filter=${filter}&$select=id`,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      responseType: 'json'
-    };
-
-    const res = await request.get<{ value: { id: string }[] }>(requestOptions);
-
-    if (res.value.length === 1) {
-      return res.value[0].id;
+    if (appId) {
+      const app = await entraApp.getAppRegistrationByAppId(appId, ['id']);
+      return app.id!;
     }
+    else {
+      const requestOptions: CliRequestOptions = {
+        url: `${this.resource}/v1.0/myorganization/applications?$filter=displayName eq '${formatting.encodeQueryParameter(name as string)}'&$select=id`,
+        headers: {
+          accept: 'application/json;odata.metadata=none'
+        },
+        responseType: 'json'
+      };
 
-    if (res.value.length === 0) {
-      const applicationIdentifier = appId ? `ID ${appId}` : `name ${name}`;
-      throw `No Microsoft Entra application registration with ${applicationIdentifier} found`;
+      const res = await request.get<{ value: { id: string }[] }>(requestOptions);
+
+      if (res.value.length === 1) {
+        return res.value[0].id;
+      }
+
+      if (res.value.length === 0) {
+        throw `No Microsoft Entra application registration with name ${name} found`;
+      }
+
+      const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', res.value);
+      const result = await cli.handleMultipleResultsFound<{ id: string }>(`Multiple Microsoft Entra application registration with name '${name}' found.`, resultAsKeyValuePair);
+      return result.id;
     }
-
-    const resultAsKeyValuePair = formatting.convertArrayToHashTable('id', res.value);
-    const result = await cli.handleMultipleResultsFound<{ id: string }>(`Multiple Microsoft Entra application registration with name '${name}' found.`, resultAsKeyValuePair);
-    return result.id;
   }
 
   private async updateUnknownOptions(args: CommandArgs, objectId: string): Promise<string> {


### PR DESCRIPTION
As requested [here](https://github.com/pnp/cli-microsoft365/issues/4531#issuecomment-2774863945), this PR uses the `getById` util function to get a Microsoft Entra ID app by ID. This util function is then implemented in these commands:
- `m365 app get`
- `m365 app permission list`
- `m365 entra app permission list`
- `m365 entra app remove`
- `m365 entra app role add`
- `m365 entra app role list`
- `m365 entra app role remove`
- `m365 entra app app set`

Closes #5234 & #5232