### PR TITLE
Fixes issue link to office hours form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,5 +3,8 @@ contact_links:
   - name: Need help?
     url: https://aka.ms/cli-m365/discord
     about: Ask a question in our community Discord server.
+  - name: Request office hours
+    url: https://forms.office.com/r/F7nUDGFNBB
+    about: Request a call with CLI for Microsoft 365 maintainer to recheck your case or provide support with CLI for Microsoft 365.
 
 

--- a/.github/ISSUE_TEMPLATE/office-hours.yml
+++ b/.github/ISSUE_TEMPLATE/office-hours.yml
@@ -1,7 +1,0 @@
-blank_issues_enabled: true
-contact_links:
-  - name: Request office hours
-    url: https://forms.office.com/r/F7nUDGFNBB
-    about: Request a call with CLI for Microsoft 365 maintainer to recheck your case or provide support with CLI for Microsoft 365.
-
-


### PR DESCRIPTION
The office hours link does not show up. After checking the docs apperently all link type issues should be kept in the same file which I did not know. 