### PR TITLE
Fixes wrong syntax in 'spo field get'

### DIFF
--- a/docs/docs/cmd/spo/field/field-get.mdx
+++ b/docs/docs/cmd/spo/field/field-get.mdx
@@ -32,7 +32,6 @@ m365 spo field get [options]
 
 `-t, --title [title]`
 : The display name (case-sensitive) of the field to retrieve. Specify either `id`, `title` or `internalName`.
-```
 
 `--internalName [internalName]`
 : The internal name (case-sensitive) of the field to retrieve. Specify either `id`, `title` or `internalName`.


### PR DESCRIPTION
This fixes a small syntax typo on the page of `spo field get`

Ref: https://pnp.github.io/cli-microsoft365/cmd/spo/field/field-get