### PR TITLE
Adds minimal permissions to docs pages

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -247,7 +247,7 @@ module.exports = {
         ]
       }
     ],
-    "@typescript-eslint/explicit-function-return-type": ["error", { "allowExpressions": true }],
+    "@typescript-eslint/explicit-function-return-type": ["error", { "allowExpressions": true }, ],
     "mocha/no-identical-title": "error",
     "@typescript-eslint/no-floating-promises": "error"
   },
@@ -270,6 +270,14 @@ module.exports = {
       ],
       "rules": {
         "camelcase": "off"
+      }
+    },
+    {
+      "files": [
+        "*.mjs"
+      ],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off"
       }
     }
   ]

--- a/docs/docs/cmd/_global.mdx
+++ b/docs/docs/cmd/_global.mdx
@@ -1,6 +1,6 @@
 ```md definition-list
 `-h, --help [help]`
-: Output usage information. Optionally, specify which section of command's help you want to see. Allowed values are `options`, `examples`, `remarks`, `response`, `full`. Default is `options`.
+: Output usage information. Optionally, specify which section of command's help you want to see. Allowed values are `options`, `examples`, `remarks`, `permissions`, `response`, `full`. Default is `options`.
 
 `--query [query]`
 : JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples.

--- a/docs/docs/cmd/planner/bucket/bucket-add.mdx
+++ b/docs/docs/cmd/planner/bucket/bucket-add.mdx
@@ -47,6 +47,25 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                           |
+  |-----------------|---------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                               |
+  |-----------------|-------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Adds a Microsoft Planner bucket for a plan based on its ID with an order hint

--- a/docs/docs/cmd/planner/bucket/bucket-get.mdx
+++ b/docs/docs/cmd/planner/bucket/bucket-get.mdx
@@ -47,6 +47,25 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                      |
+  |-----------------|----------------------------------|
+  | Microsoft Graph | Tasks.Read, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                          |
+  |-----------------|--------------------------------------|
+  | Microsoft Graph | Tasks.Read.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Gets the specified Microsoft Planner bucket 

--- a/docs/docs/cmd/planner/bucket/bucket-list.mdx
+++ b/docs/docs/cmd/planner/bucket/bucket-list.mdx
@@ -41,6 +41,25 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                      |
+  |-----------------|----------------------------------|
+  | Microsoft Graph | Tasks.Read, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                          |
+  |-----------------|--------------------------------------|
+  | Microsoft Graph | Tasks.Read.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Lists the Microsoft Planner buckets based on its plan ID

--- a/docs/docs/cmd/planner/bucket/bucket-remove.mdx
+++ b/docs/docs/cmd/planner/bucket/bucket-remove.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # planner bucket remove
 
@@ -47,6 +49,25 @@ m365 planner bucket remove [options]
 When using `rosterId`, the command is based on an API that is currently in preview and is subject to change once the API reached general availability.
 
 :::
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                           |
+  |-----------------|---------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                               |
+  |-----------------|-------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 

--- a/docs/docs/cmd/planner/bucket/bucket-set.mdx
+++ b/docs/docs/cmd/planner/bucket/bucket-set.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # planner bucket set
 
@@ -50,6 +52,25 @@ m365 planner bucket set [options]
 When using `rosterId`, the command is based on an API that is currently in preview and is subject to change once the API reached general availability.
 
 :::
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                           |
+  |-----------------|---------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                               |
+  |-----------------|-------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 

--- a/docs/docs/cmd/planner/plan/plan-add.mdx
+++ b/docs/docs/cmd/planner/plan/plan-add.mdx
@@ -42,6 +42,25 @@ m365 planner plan add [options]
 
 - Hint: Unlike for groups, a Planner Roster can contain only 1 plan.
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                           |
+  |-----------------|---------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                               |
+  |-----------------|-------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Adds a Microsoft Planner plan with a Group by id.

--- a/docs/docs/cmd/planner/plan/plan-get.mdx
+++ b/docs/docs/cmd/planner/plan/plan-get.mdx
@@ -41,6 +41,25 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                      |
+  |-----------------|----------------------------------|
+  | Microsoft Graph | Tasks.Read, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                          |
+  |-----------------|--------------------------------------|
+  | Microsoft Graph | Tasks.Read.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Returns the Microsoft Planner plan by id.

--- a/docs/docs/cmd/planner/plan/plan-list.mdx
+++ b/docs/docs/cmd/planner/plan/plan-list.mdx
@@ -35,6 +35,25 @@ When using rosterId, the command is based on an API that is currently in preview
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                      |
+  |-----------------|----------------------------------|
+  | Microsoft Graph | Tasks.Read, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                          |
+  |-----------------|--------------------------------------|
+  | Microsoft Graph | Tasks.Read.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Returns a list of Microsoft Planner plans for the specified Group by id.

--- a/docs/docs/cmd/planner/plan/plan-remove.mdx
+++ b/docs/docs/cmd/planner/plan/plan-remove.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # planner plan remove
 
@@ -34,6 +36,25 @@ m365 planner plan remove [options]
 ## Remarks
 
 If you wish to delete a Planner plan contained within a Planner Roster, you'll have to remove the roster using [planner roster remove](../roster/roster-remove.mdx).
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                           |
+  |-----------------|---------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                               |
+  |-----------------|-------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 

--- a/docs/docs/cmd/planner/plan/plan-set.mdx
+++ b/docs/docs/cmd/planner/plan/plan-set.mdx
@@ -57,6 +57,25 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                           |
+  |-----------------|---------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                               |
+  |-----------------|-------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Updates a Microsoft Planner plan title.

--- a/docs/docs/cmd/planner/roster/roster-add.mdx
+++ b/docs/docs/cmd/planner/roster/roster-add.mdx
@@ -36,6 +36,25 @@ To be able to create a new Roster, the Planner Roster creation tenant setting sh
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions     |
+  |-----------------|-----------------|
+  | Microsoft Graph | Tasks.ReadWrite |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Creates a new Microsoft Planner Roster

--- a/docs/docs/cmd/planner/roster/roster-get.mdx
+++ b/docs/docs/cmd/planner/roster/roster-get.mdx
@@ -29,6 +29,25 @@ This command is based on an API that is currently in preview and is subject to c
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions |
+  |-----------------|-------------|
+  | Microsoft Graph | Tasks.Read  |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions    |
+  |-----------------|----------------|
+  | Microsoft Graph | Tasks.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Gets information about a specific Planner Roster.

--- a/docs/docs/cmd/planner/roster/roster-member-add.mdx
+++ b/docs/docs/cmd/planner/roster/roster-member-add.mdx
@@ -35,6 +35,25 @@ This command is based on an API that is currently in preview and is subject to c
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions     |
+  |-----------------|-----------------|
+  | Microsoft Graph | Tasks.ReadWrite |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Adds a specific user by user name as member of the Planner Roster.

--- a/docs/docs/cmd/planner/roster/roster-member-get.mdx
+++ b/docs/docs/cmd/planner/roster/roster-member-get.mdx
@@ -35,6 +35,25 @@ This command is based on an API that is currently in preview and is subject to c
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions |
+  |-----------------|-------------|
+  | Microsoft Graph | Tasks.Read  |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions    |
+  |-----------------|----------------|
+  | Microsoft Graph | Tasks.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Gets a specific user by user name as member of the Planner Roster.

--- a/docs/docs/cmd/planner/roster/roster-member-list.mdx
+++ b/docs/docs/cmd/planner/roster/roster-member-list.mdx
@@ -29,6 +29,25 @@ This command is based on an API that is currently in preview and is subject to c
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions |
+  |-----------------|-------------|
+  | Microsoft Graph | Tasks.Read  |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions    |
+  |-----------------|----------------|
+  | Microsoft Graph | Tasks.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Lists members of the specified Microsoft Planner Roster.

--- a/docs/docs/cmd/planner/roster/roster-member-remove.mdx
+++ b/docs/docs/cmd/planner/roster/roster-member-remove.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # planner roster member remove
 
@@ -41,6 +43,25 @@ This command is based on an API that is currently in preview and is subject to c
 The Planner Roster will be deleted when it doesn't have any users remaining in the membership list because the last user removed themselves. Roster, its plan and all contained tasks will be deleted within 30 days of this operation. We will show an extra prompt when this happens. This prompt is also suppressed when specifying `-f, --force`.
 
 :::
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions     |
+  |-----------------|-----------------|
+  | Microsoft Graph | Tasks.ReadWrite |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All |
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 

--- a/docs/docs/cmd/planner/roster/roster-plan-list.mdx
+++ b/docs/docs/cmd/planner/roster/roster-plan-list.mdx
@@ -32,6 +32,25 @@ This command is based on an API that is currently in preview and is subject to c
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions |
+  |-----------------|-------------|
+  | Microsoft Graph | Tasks.Read  |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions    |
+  |-----------------|----------------|
+  | Microsoft Graph | Tasks.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 List all Planner plans contained in a Roster where the current logged in user is member of.

--- a/docs/docs/cmd/planner/roster/roster-remove.mdx
+++ b/docs/docs/cmd/planner/roster/roster-remove.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # planner roster remove
 
@@ -35,6 +37,25 @@ Deleting a Planner Roster will also delete the plan within the Roster.
 This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
 
 :::
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions     |
+  |-----------------|-----------------|
+  | Microsoft Graph | Tasks.ReadWrite |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All |
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 

--- a/docs/docs/cmd/planner/task/task-add.mdx
+++ b/docs/docs/cmd/planner/task/task-add.mdx
@@ -98,6 +98,25 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                                      |
+  |-----------------|--------------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All, User.Read |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                                              |
+  |-----------------|----------------------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All, User.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Adds a Microsoft Planner task with the name for plan with the specified ID and specified bucket with the ID.

--- a/docs/docs/cmd/planner/task/task-checklistitem-add.mdx
+++ b/docs/docs/cmd/planner/task/task-checklistitem-add.mdx
@@ -27,6 +27,25 @@ m365 planner task checklistitem add [options]
 
 <Global />
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions     |
+  |-----------------|-----------------|
+  | Microsoft Graph | Tasks.ReadWrite |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Adds an unchecked checklist item with the specified title to a Microsoft Planner task with the specified ID.

--- a/docs/docs/cmd/planner/task/task-checklistitem-list.mdx
+++ b/docs/docs/cmd/planner/task/task-checklistitem-list.mdx
@@ -21,6 +21,25 @@ m365 planner task checklistitem list [options]
 
 <Global />
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions |
+  |-----------------|-------------|
+  | Microsoft Graph | Tasks.Read  |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions    |
+  |-----------------|----------------|
+  | Microsoft Graph | Tasks.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Lists the checklist items of a Planner task.

--- a/docs/docs/cmd/planner/task/task-checklistitem-remove.mdx
+++ b/docs/docs/cmd/planner/task/task-checklistitem-remove.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # planner task checklistitem remove
 
@@ -24,6 +26,25 @@ m365 planner task checklistitem remove [options]
 ```
 
 <Global />
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions     |
+  |-----------------|-----------------|
+  | Microsoft Graph | Tasks.ReadWrite |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All |
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 

--- a/docs/docs/cmd/planner/task/task-get.mdx
+++ b/docs/docs/cmd/planner/task/task-get.mdx
@@ -45,6 +45,33 @@ m365 planner task get [options]
 
 <Global />
 
+## Remarks
+
+:::warning
+
+When using `rosterId`, the command is based on an API that is currently in preview and is subject to change once the API reached general availability.
+
+:::
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                      |
+  |-----------------|----------------------------------|
+  | Microsoft Graph | Tasks.Read, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                          |
+  |-----------------|--------------------------------------|
+  | Microsoft Graph | Tasks.Read.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Returns the Microsoft Planner task by id.

--- a/docs/docs/cmd/planner/task/task-list.mdx
+++ b/docs/docs/cmd/planner/task/task-list.mdx
@@ -53,6 +53,25 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                      |
+  |-----------------|----------------------------------|
+  | Microsoft Graph | Tasks.Read, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                          |
+  |-----------------|--------------------------------------|
+  | Microsoft Graph | Tasks.Read.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 List tasks for the currently logged in user.

--- a/docs/docs/cmd/planner/task/task-reference-add.mdx
+++ b/docs/docs/cmd/planner/task/task-reference-add.mdx
@@ -30,6 +30,25 @@ m365 planner task reference add [options]
 
 <Global />
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions     |
+  |-----------------|-----------------|
+  | Microsoft Graph | Tasks.ReadWrite |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Add a new reference with the url _https://www.microsoft.com_ to a Planner task with the id _2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2_

--- a/docs/docs/cmd/planner/task/task-reference-list.mdx
+++ b/docs/docs/cmd/planner/task/task-reference-list.mdx
@@ -21,6 +21,25 @@ m365 planner task reference list [options]
 
 <Global />
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions |
+  |-----------------|-------------|
+  | Microsoft Graph | Tasks.Read  |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions    |
+  |-----------------|----------------|
+  | Microsoft Graph | Tasks.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Retrieve the references of the specified planner task

--- a/docs/docs/cmd/planner/task/task-reference-remove.mdx
+++ b/docs/docs/cmd/planner/task/task-reference-remove.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # planner task reference remove
 
@@ -27,6 +29,25 @@ m365 planner task reference remove [options]
 ```
 
 <Global />
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions     |
+  |-----------------|-----------------|
+  | Microsoft Graph | Tasks.ReadWrite |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All |
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 

--- a/docs/docs/cmd/planner/task/task-remove.mdx
+++ b/docs/docs/cmd/planner/task/task-remove.mdx
@@ -1,4 +1,6 @@
 import Global from '/docs/cmd/_global.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # planner task remove
 
@@ -53,6 +55,25 @@ m365 planner task remove [options]
 When using `rosterId`, the command is based on an API that is currently in preview and is subject to change once the API reached general availability.
 
 :::
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                           |
+  |-----------------|---------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                               |
+  |-----------------|-------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All |
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 

--- a/docs/docs/cmd/planner/task/task-set.mdx
+++ b/docs/docs/cmd/planner/task/task-set.mdx
@@ -100,6 +100,25 @@ When using `rosterId`, the command is based on an API that is currently in previ
 
 :::
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                                      |
+  |-----------------|--------------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite, GroupMember.Read.All, User.Read |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                                              |
+  |-----------------|----------------------------------------------------------|
+  | Microsoft Graph | Tasks.ReadWrite.All, GroupMember.Read.All, User.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 Updates a Microsoft Planner task name of the specified task by ID.

--- a/docs/docs/cmd/planner/tenant/tenant-settings-list.mdx
+++ b/docs/docs/cmd/planner/tenant/tenant-settings-list.mdx
@@ -18,13 +18,30 @@ m365 planner tenant settings list [options]
 
 ## Remarks
 
-:::info
-
-To use this command you must be a global administrator.
-
-:::
-
 After executing the command `planner tenant settings set`, it can take some time for all changes to propagate across the tenant. Because of this, executing this command right away can return some unexpected results.
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions |
+  |-----------------|-------------|
+  | Microsoft Graph | email       |
+
+  :::info
+
+  To use this command you must be a **global administrator**.
+
+  :::
+
+  </TabItem>
+  <TabItem value="Application">
+
+  This command does not support application permissions.
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 
@@ -47,7 +64,17 @@ m365 planner tenant settings list
     "allowTenantMoveWithDataLoss": false,
     "allowTenantMoveWithDataMigration": false,
     "allowRosterCreation": true,
-    "allowPlannerMobilePushNotifications": true
+    "allowPlannerMobilePushNotifications": true,
+    "allowFileRecommendations": true,
+    "enforceClientLicenseCheck": false,
+    "allowDataFlowToDataverse": true,
+    "allowPlannerCopilot": true,
+    "disallowedSharedWithContainerTypes": [
+      {
+        "hostContainerType": "group",
+        "sharedWithContainerType": "roster"
+      }
+    ]
   }
   ```
 
@@ -56,10 +83,16 @@ m365 planner tenant settings list
 
   ```txt
   allowCalendarSharing               : true
+  allowDataFlowToDataverse           : true
+  allowFileRecommendations           : true
+  allowPlannerCopilot                : true
   allowPlannerMobilePushNotifications: true
   allowRosterCreation                : true
   allowTenantMoveWithDataLoss        : false
   allowTenantMoveWithDataMigration   : false
+  disallowedSharedWithContainerTypes : [{"hostContainerType":"group","sharedWithContainerType":"roster"}]
+  enforceClientLicenseCheck          : false
+  id                                 : 1
   isPlannerAllowed                   : true
   ```
 
@@ -67,8 +100,8 @@ m365 planner tenant settings list
   <TabItem value="CSV">
 
   ```csv
-  isPlannerAllowed,allowCalendarSharing,allowTenantMoveWithDataLoss,allowTenantMoveWithDataMigration,allowRosterCreation,allowPlannerMobilePushNotifications
-  1,1,,,1,1
+  id,isPlannerAllowed,allowCalendarSharing,allowTenantMoveWithDataLoss,allowTenantMoveWithDataMigration,allowRosterCreation,allowPlannerMobilePushNotifications,allowFileRecommendations,enforceClientLicenseCheck,allowDataFlowToDataverse,allowPlannerCopilot
+  1,1,1,0,0,1,1,1,0,1,1
   ```
 
   </TabItem>
@@ -90,6 +123,10 @@ m365 planner tenant settings list
   allowTenantMoveWithDataMigration | false
   allowRosterCreation | true
   allowPlannerMobilePushNotifications | true
+  allowFileRecommendations | true
+  enforceClientLicenseCheck | false
+  allowDataFlowToDataverse | true
+  allowPlannerCopilot | true
   ```
 
   </TabItem>

--- a/docs/docs/cmd/planner/tenant/tenant-settings-set.mdx
+++ b/docs/docs/cmd/planner/tenant/tenant-settings-set.mdx
@@ -36,13 +36,28 @@ m365 planner tenant settings set [options]
 
 <Global />
 
-## Remarks
+## Permissions
 
-:::info
+<Tabs>
+  <TabItem value="Delegated">
 
-To use this command you must be a global administrator.
+  | Resource        | Permissions |
+  |-----------------|-------------|
+  | Microsoft Graph | email       |
 
-:::
+  :::info
+
+  To use this command you must be a **global administrator**.
+
+  :::
+
+  </TabItem>
+  <TabItem value="Application">
+
+  This command does not support application permissions.
+
+  </TabItem>
+</Tabs>
 
 ## Examples
 
@@ -77,7 +92,17 @@ m365 planner tenant settings set --isPlannerAllowed true --allowRosterCreation f
     "allowTenantMoveWithDataLoss": false,
     "allowTenantMoveWithDataMigration": false,
     "allowRosterCreation": true,
-    "allowPlannerMobilePushNotifications": true
+    "allowPlannerMobilePushNotifications": true,
+    "allowFileRecommendations": true,
+    "enforceClientLicenseCheck": false,
+    "allowDataFlowToDataverse": true,
+    "allowPlannerCopilot": true,
+    "disallowedSharedWithContainerTypes": [
+      {
+        "hostContainerType": "group",
+        "sharedWithContainerType": "roster"
+      }
+    ]
   }
   ```
 
@@ -86,10 +111,16 @@ m365 planner tenant settings set --isPlannerAllowed true --allowRosterCreation f
 
   ```txt
   allowCalendarSharing               : true
+  allowDataFlowToDataverse           : true
+  allowFileRecommendations           : true
+  allowPlannerCopilot                : true
   allowPlannerMobilePushNotifications: true
   allowRosterCreation                : true
   allowTenantMoveWithDataLoss        : false
   allowTenantMoveWithDataMigration   : false
+  disallowedSharedWithContainerTypes : [{"hostContainerType":"group","sharedWithContainerType":"roster"}]
+  enforceClientLicenseCheck          : false
+  id                                 : 1
   isPlannerAllowed                   : true
   ```
 
@@ -97,15 +128,15 @@ m365 planner tenant settings set --isPlannerAllowed true --allowRosterCreation f
   <TabItem value="CSV">
 
   ```csv
-  isPlannerAllowed,allowCalendarSharing,allowTenantMoveWithDataLoss,allowTenantMoveWithDataMigration,allowRosterCreation,allowPlannerMobilePushNotifications
-  1,1,,,1,1
+  id,isPlannerAllowed,allowCalendarSharing,allowTenantMoveWithDataLoss,allowTenantMoveWithDataMigration,allowRosterCreation,allowPlannerMobilePushNotifications,allowFileRecommendations,enforceClientLicenseCheck,allowDataFlowToDataverse,allowPlannerCopilot
+  1,1,1,0,0,1,1,1,0,1,1
   ```
 
   </TabItem>
   <TabItem value="Markdown">
 
   ```md
-  # planner tenant settings list
+  # planner tenant settings set --isPlannerAllowed true
 
   Date: 4/2/2023
 
@@ -120,6 +151,10 @@ m365 planner tenant settings set --isPlannerAllowed true --allowRosterCreation f
   allowTenantMoveWithDataMigration | false
   allowRosterCreation | true
   allowPlannerMobilePushNotifications | true
+  allowFileRecommendations | true
+  enforceClientLicenseCheck | false
+  allowDataFlowToDataverse | true
+  allowPlannerCopilot | true
   ```
 
   </TabItem>

--- a/docs/docs/contribute/environment-setup.mdx
+++ b/docs/docs/contribute/environment-setup.mdx
@@ -4,7 +4,7 @@ Setting up your local copy of the project for development and testing is essenti
 
 :::info[Install prerequisites]
 
-Before you start contributing to this project, you will need **node@20** and **npm@10** installed.
+Before you start contributing to this project, you will need the latest LTS version of **Node.js** and **npm** installed.
 
 :::
 

--- a/docs/docs/contribute/new-command/writing-the-docs.mdx
+++ b/docs/docs/contribute/new-command/writing-the-docs.mdx
@@ -1,4 +1,4 @@
-# Write the command specs
+# Writing docs page
 
 Each command has a corresponding documentation page. The contents of this page are almost identical to the help implemented in the command itself. This way, users working with the CLI can get help directly inside the CLI, while users interested in the capabilities of the CLI, can browse through the help pages published in our documentation. In the CLI for Microsoft 365, we extend this basic information with additional remarks and examples to help users work with the CLI. This will also be published in the terminal when users execute your command with the `--help` flag. 
 
@@ -73,6 +73,44 @@ import Global from '/docs/cmd/_global.mdx';
 When listing available options for the particular command, CLI for Microsoft 365 follows the naming convention where required options are wrapped in angle brackets (`< >`) while optional options are wrapped in square brackets (`[ ]`).
 
 :::
+
+### Permissions
+
+Each command should list the minimum required permissions. If the user grants all the permissions specified in the documentation, they should be able to run the command successfully with any combination of options.
+To make your life easier, we encourage you to use a tool to help discover the minimal permissions needed to run a command. Check out the [documenting minimal permissions guide](https://link-to-guide-of-waldek.com) to learn how.
+After you've discovered the permissions required to run your command, you can generate the permissions section by using the script that can be found at `scripts/generate-docs-permissions.mjs`. This script will generate the markdown section for you, ensuring that the permissions are formatted correctly. You can run the script by executing the following command in your terminal:
+
+```sh
+node ./scripts/generate-docs-permissions.mjs
+```
+
+The script above will output the permissions section, you can find an example below.
+
+```md title="docs\docs\cmd\spo\group\group-get.mdx"
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<!-- ... -->
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource    | Permissions   |
+  |-------------|---------------|
+  | SharePoint  | AllSites.Read |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource    | Permissions    |
+  |-------------|----------------|
+  | SharePoint  | Sites.Read.All |
+
+  </TabItem>
+</Tabs>
+```
 
 ### Examples
 

--- a/docs/src/config/sidebars.ts
+++ b/docs/src/config/sidebars.ts
@@ -4924,7 +4924,7 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'doc',
-          label: 'Help page',
+          label: 'Docs page',
           id: 'contribute/new-command/writing-the-docs'
         }
       ]

--- a/scripts/generate-docs-permissions.mjs
+++ b/scripts/generate-docs-permissions.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import confirm from '@inquirer/confirm';
+import select from '@inquirer/select';
+import input from '@inquirer/input';
+import clipboardy from 'clipboardy';
+
+const RESOURCE_CHOICES = [
+  { value: 'Azure Service Management', name: 'Azure Service Management' },
+  { value: 'Dynamics CRM', name: 'Dynamics CRM' },
+  { value: 'Microsoft Graph', name: 'Microsoft Graph' },
+  { value: 'Office 365 Management APIs', name: 'Office 365 Management APIs' },
+  { value: 'Power BI Service', name: 'Power BI Service' },
+  { value: 'PowerApps Service', name: 'PowerApps Service' },
+  { value: 'SharePoint', name: 'SharePoint' },
+  { value: '_other', name: 'Other - specify…' },
+  { value: '_done', name: '✓  Done adding services' }
+];
+
+async function pickResource(message) {
+  let resource = await select({ message, choices: RESOURCE_CHOICES, pageSize: RESOURCE_CHOICES.length });
+  if (resource === '_done') {
+    return null;
+  }
+  if (resource === '_other') {
+    resource = await input({ message: 'Specify the resource name:' });
+  }
+  return resource;
+}
+
+async function collectPermissions(kind /* 'delegated' | 'application' */) {
+  const list = [];
+  while (true) {
+    console.log('');
+    const resource = await pickResource(`Choose a resource to add ${kind} permissions for:`);
+    if (!resource){
+      break;
+    }
+    let permissions = await input({ message: `Enter the ${kind} permissions for ${resource}:` });
+    permissions = permissions.split(',').map(p => p.trim()).join(', ');
+    list.push({ resource, permissions });
+  }
+  return list;
+}
+
+function constructMarkdownTable(list) {
+  const COLS = ['resource', 'permissions'];
+
+  // Get longest piece of text per column, headers included
+  const widths = COLS.map(key =>
+    Math.max(
+      key.length,
+      ...list.map(r => r[key].length)
+    )
+  );
+
+  // Ensure that cells start with a capital letter and are padded
+  const cell = (text, col) => ` ${(text.charAt(0).toUpperCase() + text.slice(1)).padEnd(widths[col])} `;
+
+  const header   = `|${COLS.map((h, i) => cell(h, i)).join('|')}|`;
+  const divider  = `  |${widths.map(w => '-'.repeat(w + 2)).join('|')}|`;
+  const dataRows = list.map(r => `  |${cell(r.resource, 0)}|${cell(r.permissions, 1)}|`);
+
+  return [header, divider, ...dataRows].join('\n');
+}
+
+async function main() {
+  console.log('\nThis tool will build a well-formatted Markdown permissions section.\n');
+
+  const permissions = {
+    delegated: [],
+    application: []
+  };
+
+  if (await confirm({ message: 'Does the command support delegated permissions?', default: true })) {
+    permissions.delegated = await collectPermissions('delegated');
+  }
+
+  if (await confirm({ message: 'Does the command support application permissions?', default: true })) {
+    if (permissions.delegated.length) {
+      // Re-use the same resource first
+      for (const { resource } of permissions.delegated) {
+        let scopes = await input({ message: `Enter the application permission for ${resource}:` });
+        scopes = scopes.split(',').map(p => p.trim()).join(', ');
+        permissions.application.push({ resource, permissions: scopes });
+      }
+    }
+    else {
+      // Allow adding extra app-only resources
+      permissions.application.push(...await collectPermissions('application'));
+    }
+  }
+
+  // Generate the Markdown output
+  let delegatedTable = '';
+  if (permissions.delegated.length === 0) {
+    delegatedTable = 'This command does not support delegated permissions.';
+  }
+  else {
+    permissions.delegated.sort((a, b) => a.resource.toLowerCase().localeCompare(b.resource.toLowerCase()));
+    delegatedTable = constructMarkdownTable(permissions.delegated);
+  }
+
+  let applicationTable = '';
+  if (permissions.application.length === 0) {
+    applicationTable = 'This command does not support application permissions.';
+  }
+  else {
+    permissions.application.sort((a, b) => a.resource.toLowerCase().localeCompare(b.resource.toLowerCase()));
+    applicationTable = constructMarkdownTable(permissions.application);
+  }
+
+  const output = `import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  ${delegatedTable}
+
+  </TabItem>
+  <TabItem value="Application">
+
+  ${applicationTable}
+
+  </TabItem>
+</Tabs>`;
+
+  console.log('Your permissions section:\n');
+  console.log(output + '\n');
+  const copyOutput = await confirm({ message: 'Do you want to copy the output to the clipboard?', default: true });
+  if (copyOutput) {
+    await clipboardy.write(output);
+    console.log('✅ Copied to clipboard!');
+  }
+}
+
+main()
+  .catch(err => {
+    console.error('❌  Unexpected error:', err);
+    process.exitCode = 1;
+  });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -46,7 +46,7 @@ let currentCommandName: string | undefined;
 let optionsFromArgs: { options: yargs.Arguments } | undefined;
 const defaultHelpMode = 'options';
 const defaultHelpTarget = 'console';
-const helpModes: string[] = ['options', 'examples', 'remarks', 'response', 'full'];
+const helpModes: string[] = ['options', 'examples', 'remarks', 'permissions', 'response', 'full'];
 const helpTargets: string[] = ['console', 'web'];
 const yargsConfiguration: Partial<yargs.Configuration> = {
   'parse-numbers': true,

--- a/src/m365/planner/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-list.spec.ts
@@ -69,10 +69,6 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('defines correct properties for the default output', () => {
-    assert.deepStrictEqual(command.defaultProperties(), ['isPlannerAllowed', 'allowCalendarSharing', 'allowTenantMoveWithDataLoss', 'allowTenantMoveWithDataMigration', 'allowRosterCreation', 'allowPlannerMobilePushNotifications']);
-  });
-
   it('successfully lists tenant planner settings', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === 'https://tasks.office.com/taskAPI/tenantAdminSettings/Settings') {

--- a/src/m365/planner/commands/tenant/tenant-settings-list.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-list.ts
@@ -12,10 +12,6 @@ class PlannerTenantSettingsListCommand extends PlannerCommand {
     return 'Lists the Microsoft Planner configuration of the tenant';
   }
 
-  public defaultProperties(): string[] | undefined {
-    return ['isPlannerAllowed', 'allowCalendarSharing', 'allowTenantMoveWithDataLoss', 'allowTenantMoveWithDataMigration', 'allowRosterCreation', 'allowPlannerMobilePushNotifications'];
-  }
-
   public async commandAction(logger: Logger): Promise<void> {
     const requestOptions: CliRequestOptions = {
       url: `${this.resource}/taskAPI/tenantAdminSettings/Settings`,

--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -16,9 +16,9 @@ function convertHeadings(md: string): string {
 }
 
 function convertAdmonitions(md: string): string {
-  const regex = new RegExp(/^:::(\w+)(?:\[([^\]]+)\])?([\s\S]*?):::$/, 'gm');
-  return md.replace(regex, (_, label: string, title: string | undefined, content: string) =>
-    label.toLocaleUpperCase() + (title ? EOL + EOL + title : '') + EOL + EOL + content.trim());
+  const regex = new RegExp(/^([ \t]*):::(\w+)(?:\[([^\]]+)\])?([\s\S]*?)^\1:::$/, 'gm');
+  return md.replace(regex, (_, indent: string | undefined, label: string, title: string | undefined, content: string) =>
+    indent + label.toLocaleUpperCase() + (title ? EOL + EOL + indent + title : '') + EOL + EOL + indent + content.trim());
 }
 
 function includeContent(md: string, rootFolder: string): string {
@@ -63,7 +63,7 @@ function convertHyperlinks(md: string): string {
 function convertContentTabs(md: string): string {
   return md
     .replace(/<TabItem value="([^"]+)">/gm, '$1')
-    .replace(/.*<\/?(Tabs|TabItem)>.*\n?/g, '')
+    .replace(/.*\n?<\/?(Tabs|TabItem)>.*\n?/g, '')
     .replace(/```(?:\w+)?\s*([\s\S]*?)\s*```/g, '$1')
     .trim();
 }


### PR DESCRIPTION
Closes #4399

----

In this PR:

* I've added the response section to all Planner commands.
* Created a script to generate the permissions section in the docs.
* Updated the contributing page on how to correctly document command permissions, in this section, there should be a link to @waldekmastykarz's page about documenting minimal permissions (#6705), but that page doesn't exist yet.
* On the side, I've also updated the Planner tenant settings list command's output since it was out of date.