### PR TITLE
fix: m365 spo homesite remove fails. Closes #6491

### DIFF
--- a/docs/docs/cmd/spo/homesite/homesite-remove.mdx
+++ b/docs/docs/cmd/spo/homesite/homesite-remove.mdx
@@ -17,6 +17,9 @@ m365 spo homesite remove [options]
 ```md definition-list
 `-f, --force`
 : Do not prompt for confirmation before removing the Home Site.
+
+`-u, --url [url]`
+: URL of the home site to remove.
 ```
 
 <Global />
@@ -31,10 +34,16 @@ To use this command you must be either **SharePoint Administrator** or **Global 
 
 ## Examples
 
-Removes the current Home Site without confirmation.
+Removes the first Home Site without confirmation.
 
 ```sh
 m365 spo homesite remove --force
+```
+
+Removes a Home site specified by URL without confirmation.
+
+```sh
+m365 spo homesite remove -url "https://contoso.sharepoint.com/sites/testcomms" --force
 ```
 
 ## Response

--- a/src/m365/spo/commands/homesite/homesite-remove.spec.ts
+++ b/src/m365/spo/commands/homesite/homesite-remove.spec.ts
@@ -13,11 +13,53 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
 import command from './homesite-remove.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
+import { z } from 'zod';
 
 describe(commands.HOMESITE_REMOVE, () => {
   let log: any[];
   let logger: Logger;
   let promptIssued: boolean = false;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodTypeAny;
+  const siteId = '00000000-0000-0000-0000-000000000010';
+  const homeSites = {
+    "value": [
+      {
+        "Audiences": [
+          {
+            "Email": "ColumnSearchable@contoso.onmicrosoft.com",
+            "Id": "978b5280-4f80-47ea-a1db-b0d1d2fb1ba4",
+            "Title": "ColumnSearchable Members"
+          },
+          {
+            "Email": "contosoteam@contoso.onmicrosoft.com",
+            "Id": "21af775d-17b3-4637-94a4-2ba8625277cb",
+            "Title": "Contoso TeamR Members"
+          }
+        ],
+        "IsInDraftMode": false,
+        "IsVivaBackendSite": false,
+        "SiteId": "431d7819-4aaf-49a1-b664-b2fe9e609b63",
+        "TargetedLicenseType": 2,
+        "Title": "The Landing",
+        "Url": "https://contoso.sharepoint.com/sites/TheLanding",
+        "VivaConnectionsDefaultStart": true,
+        "WebId": "626c1724-8ac8-45d5-af87-c07c752fab75"
+      },
+      {
+        "Audiences": [],
+        "IsInDraftMode": false,
+        "IsVivaBackendSite": false,
+        "SiteId": "45d4a135-40e4-4571-8340-61d17fdfd58a",
+        "TargetedLicenseType": 0,
+        "Title": "Contoso Electronics",
+        "Url": "https://contoso.sharepoint.com/sites/contosoportal",
+        "VivaConnectionsDefaultStart": true,
+        "WebId": "9418e2a1-855c-4752-8dd4-48693f43b10a"
+      }
+    ]
+  };
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -32,6 +74,8 @@ describe(commands.HOMESITE_REMOVE, () => {
     });
     auth.connection.active = true;
     auth.connection.spoUrl = 'https://contoso.sharepoint.com';
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
   });
 
   beforeEach(() => {
@@ -57,8 +101,10 @@ describe(commands.HOMESITE_REMOVE, () => {
 
   afterEach(() => {
     sinonUtil.restore([
+      request.get,
       request.post,
-      cli.promptForConfirmation
+      cli.promptForConfirmation,
+      spo.getSiteAdminPropertiesByUrl
     ]);
   });
 
@@ -92,7 +138,22 @@ describe(commands.HOMESITE_REMOVE, () => {
     assert(postSpy.notCalled);
   });
 
-  it('removes the Home Site when prompt confirmed', async () => {
+  it('fails validation if the url is not a valid SharePoint url', async () => {
+    const actual = commandOptionsSchema.safeParse({ url: 'invalid' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('removes the Home Site using legacy method when only one Home Site exists and prompt is confirmed', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetTargetedSitesDetails`) {
+        return { value: [homeSites.value[0]] };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(spo, 'getSiteAdminPropertiesByUrl').resolves({ SiteId: siteId } as any);
+
     let homeSiteRemoveCallIssued = false;
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -121,14 +182,24 @@ describe(commands.HOMESITE_REMOVE, () => {
     assert(homeSiteRemoveCallIssued);
   });
 
-  it('removes the Home Site whithout confirm prompt', async () => {
-    let homeSiteRemoveCallIssued = false;
+  it('removes the first Home Site when multiple Home Sites exist and url is not specified', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetTargetedSitesDetails`) {
+        return homeSites;
+      }
 
-    sinon.stub(request, 'post').callsFake(async (opts) => {
+      throw 'Invalid request';
+    });
+
+    sinon.stub(spo, 'getSiteAdminPropertiesByUrl').resolves({ SiteId: siteId } as any);
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RemoveTargetedSite` &&
+        opts.data.siteId === siteId) {
+        return {};
+      }
+
       if (opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="28" ObjectPathId="27" /><Method Name="RemoveSPHSite" Id="29" ObjectPathId="27" /></Actions><ObjectPaths><Constructor Id="27" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /></ObjectPaths></Request>`) {
-
-        homeSiteRemoveCallIssued = true;
-
         return JSON.stringify(
           [
             {
@@ -144,10 +215,59 @@ describe(commands.HOMESITE_REMOVE, () => {
     });
 
     await command.action(logger, { options: { force: true } });
-    assert(homeSiteRemoveCallIssued);
+    assert(postStub.calledOnce);
+    assert.deepStrictEqual(postStub.lastCall.args[0].url, "https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RemoveTargetedSite");
+  });
+
+  it('removes the Home Site specified by URL', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetTargetedSitesDetails`) {
+        return homeSites;
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(spo, 'getSiteAdminPropertiesByUrl').resolves({ SiteId: siteId } as any);
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RemoveTargetedSite` &&
+        opts.data?.siteId === siteId) {
+        return {};
+      }
+
+      if (opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="28" ObjectPathId="27" /><Method Name="RemoveSPHSite" Id="29" ObjectPathId="27" /></Actions><ObjectPaths><Constructor Id="27" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /></ObjectPaths></Request>`) {
+        return JSON.stringify(
+          [
+            {
+              "SchemaVersion": "15.0.0.0", "LibraryVersion": "16.0.8929.1227", "ErrorInfo": null, "TraceCorrelationId": "e4f2e59e-c0a9-0000-3dd0-1d8ef12cc742"
+            }, 57, {
+              "IsNull": false
+            }, 58, "The Home site has been removed."
+          ]
+        );
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinonUtil.restore(cli.promptForConfirmation);
+    sinon.stub(cli, 'promptForConfirmation').resolves(true);
+
+    await command.action(logger, { options: { url: 'https://contoso.sharepoint.com' } });
+    assert(postStub.calledOnce);
   });
 
   it('correctly handles error when removing the Home Site (debug)', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetTargetedSitesDetails`) {
+        return { value: [homeSites.value[0]] };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(spo, 'getSiteAdminPropertiesByUrl').resolves({ SiteId: siteId } as any);
+
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.data === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="28" ObjectPathId="27" /><Method Name="RemoveSPHSite" Id="29" ObjectPathId="27" /></Actions><ObjectPaths><Constructor Id="27" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /></ObjectPaths></Request>`) {
         return JSON.stringify(
@@ -166,26 +286,5 @@ describe(commands.HOMESITE_REMOVE, () => {
 
     await assert.rejects(command.action(logger, { options: { debug: true, force: true } } as any),
       new CommandError(`The requested operation is part of an experimental feature that is not supported in the current environment.`));
-  });
-
-  it('correctly handles random API error', async () => {
-    const error = {
-      error: {
-        'odata.error': {
-          code: '-1, Microsoft.SharePoint.Client.InvalidOperationException',
-          message: {
-            value: 'An error has occurred'
-          }
-        }
-      }
-    };
-
-    sinon.stub(request, 'post').rejects(error);
-
-    await assert.rejects(command.action(logger, {
-      options: {
-        force: true
-      }
-    } as any), new CommandError(error.error['odata.error'].message.value));
   });
 });

--- a/src/m365/spo/commands/homesite/homesite-remove.ts
+++ b/src/m365/spo/commands/homesite/homesite-remove.ts
@@ -1,18 +1,30 @@
+import { z } from 'zod';
+import { zod } from '../../../../utils/zod.js';
+import { globalOptionsZod } from '../../../../Command.js';
+import { validation } from '../../../../utils/validation.js';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { odata } from '../../../../utils/odata.js';
 import config from '../../../../config.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { ClientSvcResponse, ClientSvcResponseContents, spo } from '../../../../utils/spo.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
 
+const options = globalOptionsZod
+  .extend({
+    url: zod.alias('u', z.string()
+      .refine((url: string) => validation.isValidSharePointUrl(url) === true, url => ({
+        message: `'${url}' is not a valid SharePoint Online site URL.`
+      }))
+    ).optional(),
+    force: zod.alias('f', z.boolean().optional())
+  })
+  .strict();
+
+declare type Options = z.infer<typeof options>;
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  force?: boolean;
 }
 
 class SpoHomeSiteRemoveCommand extends SpoCommand {
@@ -21,30 +33,11 @@ class SpoHomeSiteRemoveCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Removes the current Home Site';
+    return 'Removes a Home Site';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        force: args.options.force || false
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-f, --force'
-      }
-    );
+  public get schema(): z.ZodTypeAny {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -54,23 +47,41 @@ class SpoHomeSiteRemoveCommand extends SpoCommand {
         const spoAdminUrl = await spo.getSpoAdminUrl(logger, this.debug);
         const reqDigest = await spo.getRequestDigest(spoAdminUrl);
 
-        const requestOptions: CliRequestOptions = {
-          url: `${spoAdminUrl}/_vti_bin/client.svc/ProcessQuery`,
-          headers: {
-            'X-RequestDigest': reqDigest.FormDigestValue
-          },
-          data: `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="28" ObjectPathId="27" /><Method Name="RemoveSPHSite" Id="29" ObjectPathId="27" /></Actions><ObjectPaths><Constructor Id="27" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /></ObjectPaths></Request>`
-        };
-
-        const res = await request.post<string>(requestOptions);
-
-        const json: ClientSvcResponse = JSON.parse(res);
-        const response: ClientSvcResponseContents = json[0];
-        if (response.ErrorInfo) {
-          throw response.ErrorInfo.ErrorMessage;
+        if (args.options.url) {
+          await this.removeHomeSiteByUrl(args.options.url, spoAdminUrl, logger);
         }
         else {
-          await logger.log(json[json.length - 1]);
+          await this.showDeprecationWarning(
+            logger,
+            commands.HOMESITE_REMOVE,
+            `${commands.HOMESITE_REMOVE} --url <url>`
+          );
+
+          const homeSites = await this.getHomeSites(spoAdminUrl);
+
+          if (homeSites.length > 1) {
+            await this.removeHomeSiteByUrl(homeSites[0].Url, spoAdminUrl, logger);
+          }
+          else {
+            const requestOptions: CliRequestOptions = {
+              url: `${spoAdminUrl}/_vti_bin/client.svc/ProcessQuery`,
+              headers: {
+                'X-RequestDigest': reqDigest.FormDigestValue
+              },
+              data: `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="28" ObjectPathId="27" /><Method Name="RemoveSPHSite" Id="29" ObjectPathId="27" /></Actions><ObjectPaths><Constructor Id="27" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /></ObjectPaths></Request>`
+            };
+
+            const res = await request.post<string>(requestOptions);
+
+            const json: ClientSvcResponse = JSON.parse(res);
+            const response: ClientSvcResponseContents = json[0];
+            if (response.ErrorInfo) {
+              throw response.ErrorInfo.ErrorMessage;
+            }
+            else {
+              await logger.log(json[json.length - 1]);
+            }
+          }
         }
       }
       catch (err: any) {
@@ -83,12 +94,46 @@ class SpoHomeSiteRemoveCommand extends SpoCommand {
       await removeHomeSite();
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to remove the Home Site?` });
+      const result = await cli.promptForConfirmation({
+        message: args.options.url
+          ? `Are you sure you want to remove the Home Site at ${args.options.url}?`
+          : `Are you sure you want to remove the primary Home Site?`
+      });
 
       if (result) {
         await removeHomeSite();
       }
     }
+  }
+
+  private async removeHomeSiteByUrl(siteUrl: string, spoAdminUrl: string, logger: Logger): Promise<void> {
+    const siteAdminProperties = await spo.getSiteAdminPropertiesByUrl(siteUrl, false, logger, this.verbose);
+
+    const requestOptions: CliRequestOptions = {
+      url: `${spoAdminUrl}/_api/SPO.Tenant/RemoveTargetedSite`,
+      headers: {
+        'Accept': 'application/json;odata=nometadata'
+      },
+      data: {
+        siteId: siteAdminProperties.SiteId
+      }
+    };
+
+    await request.post(requestOptions);
+
+    await logger.log(`${siteUrl} has been removed as a Home Site. It may take some time for the change to apply. Check aka.ms/homesites for details.`);
+  }
+
+  private async getHomeSites(spoAdminUrl: string): Promise<any[]> {
+    const requestOptions: CliRequestOptions = {
+      url: `${spoAdminUrl}/_api/SPO.Tenant/GetTargetedSitesDetails`,
+      headers: {
+        accept: 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    return await odata.getAllItems(requestOptions);
   }
 }
 


### PR DESCRIPTION
Supports removing a Home Site by URL. When multiple Home Sites are configured, the command shows a deprecation message and removes the first one from the list. Closes #6491