### PR TITLE
Updates 'spo tenant site unarchive' warning prompt

### DIFF
--- a/docs/docs/cmd/spo/tenant/tenant-site-unarchive.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-site-unarchive.mdx
@@ -34,7 +34,7 @@ To use this command, you must be a Global or SharePoint administrator.
 
 :::warning
 
-If a site remains archived for more than **seven days**, the reactivation fee will be calculated based on the entire storage capacity of the site.
+If a site has been archived for more than **seven days**, reactivating it triggers a 120-day cooldown period during which you can't archive the site again.
 
 :::
 

--- a/src/m365/spo/commands/tenant/tenant-site-unarchive.ts
+++ b/src/m365/spo/commands/tenant/tenant-site-unarchive.ts
@@ -70,7 +70,7 @@ class SpoTenantSiteUnarchiveCommand extends SpoCommand {
       await this.unarchiveSite(logger, args.options.url);
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to unarchive site '${args.options.url}'? This may cause additional billing costs.` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to unarchive site '${args.options.url}'? You won't be able to rearchive this site for 120 days.` });
 
       if (result) {
         await this.unarchiveSite(logger, args.options.url);


### PR DESCRIPTION
Reactivating an archived SharePoint site doesn't charge a fee anymore.

Source: https://techcommunity.microsoft.com/blog/microsoft_365_archive_blog/microsoft-365-archive-eliminates-reactivation-fees-by-march-31-2025/4383215