### PR TITLE
Fixes docs styling

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -40,7 +40,8 @@ const config: Config = {
   future: {
     v4: {
       removeLegacyPostBuildHeadAttribute: true,
-      useCssCascadeLayers: true,
+      // This flag is disabled because it causes issues with the styling of admonitions, tabs, tables, collapsible sections, and other components
+      useCssCascadeLayers: false
     },
     experimental_faster: true
   },


### PR DESCRIPTION
Closes #6762

---

Since this is a setting that will be enabled by default in v4, we'll have to investigate what is causing this.