### PR TITLE
Fixes `external item add` with custom properties. Closes #6792

### DIFF
--- a/src/m365/external/commands/item/item-add.spec.ts
+++ b/src/m365/external/commands/item/item-add.spec.ts
@@ -71,12 +71,11 @@ describe(commands.ITEM_ADD, () => {
       "content": {
         "value": "Something went wrong",
         "type": "text"
-      },
-      "activities": []
+      }
     };
-    sinon.stub(request, 'put').callsFake(async (opts: any) => {
+    const putStub = sinon.stub(request, 'put').callsFake(async (opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections/connection/items/ticket1`) {
-        return externalItem;
+        return;
       }
       throw 'Invalid request';
     });
@@ -91,7 +90,7 @@ describe(commands.ITEM_ADD, () => {
       assignee: 'Steve'
     };
     await command.action(logger, { options } as any);
-    assert(loggerLogSpy.calledWith(externalItem));
+    assert.deepStrictEqual(putStub.lastCall.args[0].data, externalItem);
   });
 
   it('adds an external item with a collection properties', async () => {
@@ -113,12 +112,11 @@ describe(commands.ITEM_ADD, () => {
       "content": {
         "value": "Something went wrong",
         "type": "text"
-      },
-      "activities": []
+      }
     };
-    sinon.stub(request, 'put').callsFake(async (opts: any) => {
+    const putStub = sinon.stub(request, 'put').callsFake(async (opts: any) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/external/connections/connection/items/ticket1`) {
-        return externalItem;
+        return;
       }
       throw 'Invalid request';
     });
@@ -133,7 +131,7 @@ describe(commands.ITEM_ADD, () => {
       assignee: 'Steve;#Brian'
     };
     await command.action(logger, { options } as any);
-    assert(loggerLogSpy.calledWith(externalItem));
+    assert.deepStrictEqual(putStub.lastCall.args[0].data, externalItem);
   });
 
   it('outputs properties in csv output', async () => {

--- a/src/m365/external/commands/item/item-add.ts
+++ b/src/m365/external/commands/item/item-add.ts
@@ -128,7 +128,7 @@ class ExternalItemAddCommand extends GraphCommand {
     // we need to rewrite the @odata properties to the correct format
     // to extract multiple values for collections into arrays
     this.rewriteCollectionProperties(args.options);
-    this.addUnknownOptionsToPayload(requestBody, args.options);
+    this.addUnknownOptionsToPayload(requestBody.properties, args.options);
 
     const requestOptions: CliRequestOptions = {
       url: `${this.resource}/v1.0/external/connections/${args.options.externalConnectionId}/items/${args.options.id}`,


### PR DESCRIPTION
Quick fix for the `external item add` command. Closes #6792 