### PR TITLE
Fixes dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,48 +1,50 @@
 version: 2
 updates:
   # Monthly dependency updates
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: monthly
     labels:
       - pr-priority
     ignore:
       - dependency-name: "*"
         update-types:
-          - "version-update:semver-major"
+          - version-update:semver-major
     groups:
       update-dependencies:
         patterns:
           - "*"
+    versioning-strategy: increase
     open-pull-requests-limit: 1
 
   # Monthly docs dependency updates
-  - package-ecosystem: "npm"
-    directory: "/docs"
+  - package-ecosystem: npm
+    directory: /docs
     schedule:
-      interval: "monthly"
+      interval: monthly
     labels:
       - pr-priority
     ignore:
       - dependency-name: "*"
         update-types:
-          - "version-update:semver-major"
+          - version-update:semver-major
     groups:
       update-dependencies:
         patterns:
           - "*"
+    versioning-strategy: increase
     open-pull-requests-limit: 1
 
   # Monthly GitHub Actions dependency updates
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: monthly
     ignore:
       - dependency-name: "*"
         update-types:
-          - "version-update:semver-major"
+          - version-update:semver-major
     groups:
       update-dependencies:
         patterns:
@@ -50,16 +52,16 @@ updates:
     open-pull-requests-limit: 1
 
   # Monthly Docker dependency updates
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: docker
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: monthly
     labels:
       - pr-priority
     ignore:
       - dependency-name: "*"
         update-types:
-          - "version-update:semver-major"
+          - version-update:semver-major
     groups:
       update-dependencies:
         patterns:


### PR DESCRIPTION
Fixes Dependabot updates where it doesn't update the `package.json` file if the updated version already falls within the defined range.
Example: #6873