### PR TITLE
Fix 6941-Added minimal permissions for 'entra m365group recyclebin' commands

### DIFF
--- a/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-clear.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-clear.mdx
@@ -26,16 +26,9 @@ m365 entra m365group recyclebinitem clear [options]
 <Tabs>
   <TabItem value="Delegated">
 
-  | Resource        | Permissions                 |
-  |-----------------|-----------------------------|
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
   | Microsoft Graph | Group.ReadWrite.All |
-
-  </TabItem>
-  <TabItem value="Application">
-
-  | Resource        | Permissions                 |
-  |-----------------|-----------------------------|
-  | Microsoft Graph | Group.Read.All |
 
   </TabItem>
 </Tabs>

--- a/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-list.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-list.mdx
@@ -29,15 +29,15 @@ m365 entra m365group recyclebinitem list [options]
 <Tabs>
   <TabItem value="Delegated">
 
-  | Resource        | Permissions                 |
-  |-----------------|-----------------------------|
+  | Resource        | Permissions    |
+  |-----------------|----------------|
   | Microsoft Graph | Group.Read.All |
 
   </TabItem>
   <TabItem value="Application">
 
-  | Resource        | Permissions                 |
-  |-----------------|-----------------------------|
+  | Resource        | Permissions    |
+  |-----------------|----------------|
   | Microsoft Graph | Group.Read.All |
 
   </TabItem>

--- a/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-remove.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-remove.mdx
@@ -35,8 +35,8 @@ m365 entra m365group recyclebinitem remove [options]
 <Tabs>
   <TabItem value="Delegated">
 
-  | Resource        | Permissions                 |
-  |-----------------|-----------------------------|
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
   | Microsoft Graph | Group.ReadWrite.All |
 
   </TabItem>

--- a/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-restore.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-recyclebinitem-restore.mdx
@@ -32,16 +32,16 @@ m365 entra m365group recyclebinitem restore [options]
 <Tabs>
   <TabItem value="Delegated">
 
-  | Resource        | Permissions                 |
-  |-----------------|-----------------------------|
-  | Microsoft Graph | User.DeleteRestore.All |
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Group.ReadWrite.All |
 
   </TabItem>
   <TabItem value="Application">
 
-  | Resource        | Permissions                 |
-  |-----------------|-----------------------------|
-  | Microsoft Graph | User.DeleteRestore.All |
+  | Resource        | Permissions         |
+  |-----------------|---------------------|
+  | Microsoft Graph | Group.ReadWrite.All |
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
### Added minimal permissions for 'entra m365group recyclebin' commands
Added minimal permissions for 'entra m365group recyclebin' commands. 

### Screenshots

- recyclebinitem list ```m365 entra m365group recyclebinitem list```

<img width="1239" height="344" alt="image" src="https://github.com/user-attachments/assets/bccab6f2-2bee-4209-b4c5-696e6d5a35fd" />


- recyclebinitem restore ```m365 entra m365group recyclebinitem restore --id 87casd23-4xxx-4as0-b23d-a1234561dbd8```

<img width="1051" height="307" alt="image" src="https://github.com/user-attachments/assets/f35241f4-c529-421d-8cf6-7cc6a0583ff2" />


- recyclebinitem clear ```m365 entra m365group recyclebinitem clear```

<img width="1244" height="344" alt="image" src="https://github.com/user-attachments/assets/cafc5b41-d6d5-40cf-9f1a-258854d58130" />



- recyclebinitem remove ```m365 entra m365group recyclebinitem remove --id 87casd23-4xxx-4as0-b23d-a1234561dbd8```

<img width="1240" height="332" alt="image" src="https://github.com/user-attachments/assets/e5e95001-b3db-48d6-b121-4737daa41deb" />


Closes #6941 

Thanks,
Nish
