### PR TITLE
Extends 'spe container permission list' command. Closes #6726

### DIFF
--- a/docs/docs/cmd/spe/container/container-get.mdx
+++ b/docs/docs/cmd/spe/container/container-get.mdx
@@ -22,10 +22,10 @@ m365 spe container get [options]
 : Display name of the container. Specify either `id` or `name` but not both.
 
 `--containerTypeId [containerTypeId]`
-: The container type ID of the container instance. Use either `containerTypeId` or `containerTypeName` but not both.
+: The container type ID of the container instance. Specify either `containerTypeId` or `containerTypeName` when using `name` but not both.
 
 `--containerTypeName [containerTypeName]`
-: The container type name of the container instance. Use either `containerTypeId` or `containerTypeName` but not both.
+: The container type name of the container instance. Specify either `containerTypeId` or `containerTypeName` when using `name` but not both.
 ```
 
 <Global />

--- a/docs/docs/cmd/spe/container/container-get.mdx
+++ b/docs/docs/cmd/spe/container/container-get.mdx
@@ -20,6 +20,12 @@ m365 spe container get [options]
 
 `-n, --name [name]`
 : Display name of the container. Specify either `id` or `name` but not both.
+
+`--containerTypeId [containerTypeId]`
+: The container type ID of the container instance. Use either `containerTypeId` or `containerTypeName` but not both.
+
+`--containerTypeName [containerTypeName]`
+: The container type name of the container instance. Use either `containerTypeId` or `containerTypeName` but not both.
 ```
 
 <Global />
@@ -54,7 +60,13 @@ m365 spe container get --id "b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDE
 Gets a container of a specific type by display name.
 
 ```sh
-m365 spe container get --name "My Application Storage Container"
+m365 spe container get --name "My Application Storage Container" --containerTypeId "91710488-5756-407f-9046-fbe5f0b4de73"
+```
+
+Gets container by using its name and container type name.
+
+```sh
+m365 spe container get --name "Invoices" --containerTypeName "My container type name"
 ```
 
 ## Response

--- a/docs/docs/cmd/spe/container/container-permission-list.mdx
+++ b/docs/docs/cmd/spe/container/container-permission-list.mdx
@@ -15,8 +15,17 @@ m365 spe container permission list [options]
 ## Options
 
 ```md definition-list
-`-i, --containerId <id>`
-: The ID of the SharePoint Embedded Container.
+`-i, --containerId [id]`
+: The ID of the SharePoint Embedded Container. Specify either `containerId` or `containerName` but not both.
+
+`-n, --containerName [containerName]`
+: Display name of the SharePoint Embedded Container. Specify either `containerId` or `containerName` but not both.
+
+`--containerTypeId [containerTypeId]`
+: The container type ID of the container instance. Use either `containerTypeId` or `containerTypeName` but not both.
+
+`--containerTypeName [containerTypeName]`
+: The container type name of the container instance. Use either `containerTypeId` or `containerTypeName` but not both.
 ```
 
 <Global />
@@ -42,10 +51,22 @@ m365 spe container permission list [options]
 
 ## Examples
 
-Lists Container permissions.
+Lists Container permissions by id.
 
 ```sh
 m365 spe container permission list --containerId "b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z"
+```
+
+Lists Container permissions by display name.
+
+```sh
+m365 spe container permission list --containerName "My Application Storage Container" --containerTypeId "91710488-5756-407f-9046-fbe5f0b4de73"
+```
+
+Lists Container permissions by display name and container type name.
+
+```sh
+m365 spe container permission list --containerName "My Application Storage Container"  --containerTypeName "My container type name"
 ```
 
 ## Response

--- a/docs/docs/cmd/spe/container/container-permission-list.mdx
+++ b/docs/docs/cmd/spe/container/container-permission-list.mdx
@@ -22,10 +22,10 @@ m365 spe container permission list [options]
 : Display name of the SharePoint Embedded Container. Specify either `containerId` or `containerName` but not both.
 
 `--containerTypeId [containerTypeId]`
-: The container type ID of the container instance. Use either `containerTypeId` or `containerTypeName` but not both.
+: The container type ID of the container instance. Specify either `containerTypeId` or `containerTypeName` when using `containerName` but not both.
 
 `--containerTypeName [containerTypeName]`
-: The container type name of the container instance. Use either `containerTypeId` or `containerTypeName` but not both.
+: The container type name of the container instance. Specify either `containerTypeId` or `containerTypeName` when using `containerName` but not both.
 ```
 
 <Global />

--- a/src/m365/spe/commands/container/container-permission-list.spec.ts
+++ b/src/m365/spe/commands/container/container-permission-list.spec.ts
@@ -22,6 +22,7 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
 
   const containerId = "b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z";
   const containerName = 'My Application Storage Container';
+  const containerTypeId = 'b2e2cef4-9ac1-4b3b-b4a5-2a2e3a2e2a2e';
   const containerPermissionResponse = {
     "value": [
       {
@@ -94,6 +95,7 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
   afterEach(() => {
     sinonUtil.restore([
       spe.getContainerIdByName,
+      spe.getContainerTypeIdByName,
       odata.getAllItems,
       cli.handleMultipleResultsFound
     ]);
@@ -156,6 +158,7 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
     await command.action(logger, {
       options: {
         containerName,
+        containerTypeId,
         debug: true
       }
     });
@@ -174,6 +177,7 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
     await command.action(logger, {
       options: {
         containerName,
+        containerTypeId,
         verbose: true
       }
     });
@@ -187,7 +191,8 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
     await assert.rejects(
       command.action(logger, {
         options: {
-          containerName
+          containerName,
+          containerTypeId
         }
       }),
       new CommandError(`The specified container '${containerName}' does not exist.`)
@@ -211,7 +216,8 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
 
     await command.action(logger, {
       options: {
-        containerName
+        containerName,
+        containerTypeId
       }
     });
 
@@ -231,9 +237,20 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
 
     await assert.rejects(command.action(logger, {
       options: {
-        containerName
+        containerName,
+        containerTypeId
       }
     }), new CommandError('unexpected error'));
+  });
+
+  it('rethrows CommandError thrown during command execution', async () => {
+    sinon.stub(odata, 'getAllItems').rejects(new CommandError('command error'));
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        containerId
+      }
+    }), new CommandError('command error'));
   });
 
   it('correctly handles error when SharePoint Embedded Container is not found', async () => {
@@ -259,7 +276,7 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
   it('fails validation when neither containerId nor containerName is specified', () => {
     const result = schema.safeParse({});
     assert.strictEqual(result.success, false);
-    assert(result.error?.issues.some(issue => issue.message.includes('Specify either containerId or containerName')));
+    assert(result.error?.issues.some(issue => issue.message.includes('Specify either id or name')));
   });
 
   it('fails validation when both containerId and containerName are specified', () => {
@@ -268,7 +285,7 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
       containerName
     });
     assert.strictEqual(result.success, false);
-    assert(result.error?.issues.some(issue => issue.message.includes('Specify either containerId or containerName')));
+    assert(result.error?.issues.some(issue => issue.message.includes('Specify either id or name')));
   });
 
   it('passes validation when only containerId is specified', () => {
@@ -276,8 +293,49 @@ describe(commands.CONTAINER_PERMISSION_LIST, () => {
     assert.strictEqual(result.success, true);
   });
 
-  it('passes validation when only containerName is specified', () => {
-    const result = schema.safeParse({ containerName });
+  it('passes validation when containerName and containerTypeId are specified', () => {
+    const result = schema.safeParse({ containerName, containerTypeId });
     assert.strictEqual(result.success, true);
+  });
+
+  it('correctly lists permissions of a SharePoint Embedded Container by containerTypeName', async () => {
+    const containerTypeName = 'My Container Type';
+    sinon.stub(spe, 'getContainerTypeIdByName').resolves(containerTypeId);
+    sinon.stub(odata, 'getAllItems').onFirstCall().resolves([
+      {
+        id: containerId,
+        displayName: containerName
+      }
+    ]).onSecondCall().resolves(containerPermissionResponse.value);
+
+    await command.action(logger, {
+      options: {
+        containerName,
+        containerTypeName
+      }
+    });
+
+    assert(loggerLogSpy.calledWith(containerPermissionResponse.value));
+  });
+
+  it('logs progress when getting container type by name in verbose mode', async () => {
+    const containerTypeName = 'My Container Type';
+    sinon.stub(spe, 'getContainerTypeIdByName').resolves(containerTypeId);
+    sinon.stub(odata, 'getAllItems').onFirstCall().resolves([
+      {
+        id: containerId,
+        displayName: containerName
+      }
+    ]).onSecondCall().resolves(containerPermissionResponse.value);
+
+    await command.action(logger, {
+      options: {
+        containerName,
+        containerTypeName,
+        verbose: true
+      }
+    });
+
+    assert(loggerLogToStderrSpy.calledWith(`Getting container type with name '${containerTypeName}'...`));
   });
 });

--- a/src/m365/spe/commands/container/container-permission-list.ts
+++ b/src/m365/spe/commands/container/container-permission-list.ts
@@ -6,11 +6,14 @@ import commands from '../../commands.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import { odata } from '../../../../utils/odata.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { spe } from '../../../../utils/spe.js';
 
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
   containerId: z.string().alias('i').optional(),
-  containerName: z.string().alias('n').optional()
+  containerName: z.string().alias('n').optional(),
+  containerTypeId: z.uuid().optional(),
+  containerTypeName: z.string().optional()
 });
 
 declare type Options = z.infer<typeof options>;
@@ -39,7 +42,13 @@ class SpeContainerPermissionListCommand extends GraphCommand {
   public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
     return schema
       .refine((opts: Options) => [opts.containerId, opts.containerName].filter(value => value !== undefined).length === 1, {
-        message: 'Specify either containerId or containerName, but not both.'
+        message: 'Specify either id or name, but not both.'
+      })
+      .refine((options: Options) => !options.containerName || [options.containerTypeId, options.containerTypeName].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options when specifying the container name: containerTypeId or containerTypeName.'
+      })
+      .refine((options: Options) => options.containerName || [options.containerTypeId, options.containerTypeName].filter(o => o !== undefined).length === 0, {
+        error: 'Options containerTypeId and containerTypeName are only required when retrieving a container by name.'
       });
   }
 
@@ -83,20 +92,20 @@ class SpeContainerPermissionListCommand extends GraphCommand {
       await logger.logToStderr(`Resolving container id from name '${options.containerName}'...`);
     }
 
-    const containers = await odata.getAllItems<{ id: string; displayName: string }>(`${this.resource}/v1.0/storage/fileStorage/containers?$select=id,displayName`);
-    const matchingContainers = containers.filter(c => c.displayName.toLowerCase() === options.containerName!.toLowerCase());
+    const containerTypeId = await this.getContainerTypeId(options, logger);
+    return spe.getContainerIdByName(containerTypeId, options.containerName!);
+  }
 
-    if (matchingContainers.length === 0) {
-      throw new CommandError(`The specified container '${options.containerName}' does not exist.`);
+  private async getContainerTypeId(options: Options, logger: Logger): Promise<string> {
+    if (options.containerTypeId) {
+      return options.containerTypeId;
     }
 
-    if (matchingContainers.length > 1) {
-      const containerKeyValuePair = formatting.convertArrayToHashTable('id', matchingContainers);
-      const container = await cli.handleMultipleResultsFound<{ id: string; displayName: string }>(`Multiple containers with name '${options.containerName}' found.`, containerKeyValuePair);
-      return container.id;
+    if (this.verbose) {
+      await logger.logToStderr(`Getting container type with name '${options.containerTypeName}'...`);
     }
 
-    return matchingContainers[0].id;
+    return spe.getContainerTypeIdByName(options.containerTypeName!);
   }
 }
 

--- a/src/m365/spe/commands/container/container-permission-list.ts
+++ b/src/m365/spe/commands/container/container-permission-list.ts
@@ -1,7 +1,7 @@
 import { cli } from '../../../../cli/cli.js';
 import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import { globalOptionsZod } from '../../../../Command.js';
+import { CommandError, globalOptionsZod } from '../../../../Command.js';
 import commands from '../../commands.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import { odata } from '../../../../utils/odata.js';
@@ -9,8 +9,10 @@ import { formatting } from '../../../../utils/formatting.js';
 
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
-  containerId: z.string().alias('i')
+  containerId: z.string().alias('i').optional(),
+  containerName: z.string().alias('n').optional()
 });
+
 declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
@@ -34,13 +36,22 @@ class SpeContainerPermissionListCommand extends GraphCommand {
     return options;
   }
 
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine((opts: Options) => [opts.containerId, opts.containerName].filter(value => value !== undefined).length === 1, {
+        message: 'Specify either containerId or containerName, but not both.'
+      });
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
+      const containerId = await this.resolveContainerId(args.options, logger);
+
       if (this.verbose) {
-        await logger.logToStderr(`Retrieving permissions of a SharePoint Embedded Container with id '${args.options.containerId}'...`);
+        await logger.logToStderr(`Retrieving permissions of a SharePoint Embedded Container with id '${containerId}'...`);
       }
 
-      const containerPermission = await odata.getAllItems<any>(`${this.resource}/v1.0/storage/fileStorage/containers/${formatting.encodeQueryParameter(args.options.containerId)}/permissions`);
+      const containerPermission = await odata.getAllItems<any>(`${this.resource}/v1.0/storage/fileStorage/containers/${formatting.encodeQueryParameter(containerId)}/permissions`);
 
       if (!cli.shouldTrimOutput(args.options.output)) {
         await logger.log(containerPermission);
@@ -56,8 +67,36 @@ class SpeContainerPermissionListCommand extends GraphCommand {
       }
     }
     catch (err: any) {
+      if (err instanceof CommandError) {
+        throw err;
+      }
       this.handleRejectedODataJsonPromise(err);
     }
+  }
+
+  private async resolveContainerId(options: Options, logger: Logger): Promise<string> {
+    if (options.containerId) {
+      return options.containerId;
+    }
+
+    if (this.verbose) {
+      await logger.logToStderr(`Resolving container id from name '${options.containerName}'...`);
+    }
+
+    const containers = await odata.getAllItems<{ id: string; displayName: string }>(`${this.resource}/v1.0/storage/fileStorage/containers?$select=id,displayName`);
+    const matchingContainers = containers.filter(c => c.displayName.toLowerCase() === options.containerName!.toLowerCase());
+
+    if (matchingContainers.length === 0) {
+      throw new CommandError(`The specified container '${options.containerName}' does not exist.`);
+    }
+
+    if (matchingContainers.length > 1) {
+      const containerKeyValuePair = formatting.convertArrayToHashTable('id', matchingContainers);
+      const container = await cli.handleMultipleResultsFound<{ id: string; displayName: string }>(`Multiple containers with name '${options.containerName}' found.`, containerKeyValuePair);
+      return container.id;
+    }
+
+    return matchingContainers[0].id;
   }
 }
 


### PR DESCRIPTION
Closes #6726

Additionally, it performs a fixup in the `container get` command, in which we forgot to add the new options to the doc