### PR TITLE
Add workflow to close stale issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -2,7 +2,7 @@ name: Close stale issues
 
 on:
   schedule:
-    - cron: '0 0 * * 0' # runs weekly on Sunday at midnight
+    - cron: '0 0 * * *' # runs every night at midnight
 
 
 jobs:
@@ -13,8 +13,8 @@ jobs:
         with:
             days-before-stale: 335
             days-before-close: 30
-            stale-issue-message: 'This issue has been automatically marked as stale due to inactivity.'
+            stale-issue-message: 'This issue has been automatically marked as stale due to inactivity, and will be closed in 30 days if no further activity occurs. If you believe this issue should remain open, please comment on it to let us know. Any activity will reset the stale timer.'
             stale-issue-label: 'stale'
-            close-issue-message: 'Close as not planned'
+            close-issue-message: 'Close as not planned, feel free to reopen if new information arises.'
             close-issue-label: 'stale-closed'
             exempt-issue-labels: 'keep-open,epic'


### PR DESCRIPTION
## Add workflow to close stale issues

Flag issues that are not updated for 11 months as stale and close issue after 1 more month of inactivity. 

Discussed during a catch-up call to clean up the repo of some of our 'older' issues as we have over 151 open issues that are not updated for the last year. You can run `is:issue state:open updated:<@today-1y` to see the results. 

The goal is to run once a week and close out issues older than a year. Exclusions are there for `epics` so we can keep working on them and we can add a label `keep-open` in case we need to keep something open and ignored from this run. 

To keep track of everything stale issues are flagged with `stale` and closed issues flagged with `stale-closed` so we can quickly identify things that are automatically processed. 

Ambition is to have a bit shorter timeframe and close issues within 6 months and ~ 7 days of inactivity, but let's start with this 🧽