### PR TITLE
Updates dependabot gh-actions and docker strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,10 +41,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-major
     groups:
       update-dependencies:
         patterns:
@@ -58,10 +54,6 @@ updates:
       interval: monthly
     labels:
       - pr-priority
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-major
     groups:
       update-dependencies:
         patterns:


### PR DESCRIPTION
Curently Depandabot only updates GitHub workflows when there is a new minor version, ignoring major versions.
Since the large majority of the actions used in our workflows target a specific major version, the workflow almost never creates a PR with a new version. By including major versions as well, we will be notified when a new version of a specific action is published.