### PR TITLE
Fixes docs announcement bar close button

### DIFF
--- a/docs/src/scss/Global.module.scss
+++ b/docs/src/scss/Global.module.scss
@@ -72,6 +72,13 @@
       }
     }
   }
+
+  // Modify announcement bar close button color
+  .theme-announcement-bar {
+    button.close {
+      color: #f5f5f5;
+    }
+  }
 }
 
 //* Definition list


### PR DESCRIPTION
Noticed that the close button of the docs announcement bar was barely visible.

<img width="1815" height="183" alt="image" src="https://github.com/user-attachments/assets/04a2ce0f-2577-4742-8121-4940c65bedde" />
