### PR TITLE
Fixes workflow caching

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -2,6 +2,9 @@ name: Check PR
 
 on: pull_request
 
+env:
+  NODE_VERSION: &node_version 24
+
 jobs:
   build:
     if: github.repository_owner == 'pnp'
@@ -9,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [24]
+        node: [*node_version]
 
     steps:
       - uses: actions/checkout@v4
@@ -49,19 +52,19 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         # node versions to run tests on
-        nodeRun: [24]
+        nodeRun: [*node_version]
         # node version on which code was built and should be tested
-        nodeBuild: [24]
+        nodeBuild: [*node_version]
         include:
           - os: ubuntu-latest
             nodeRun: 20
-            nodeBuild: 24
+            nodeBuild: *node_version
           - os: ubuntu-latest
             nodeRun: 22
-            nodeBuild: 24
+            nodeBuild: *node_version
           - os: ubuntu-latest
             nodeRun: 25
-            nodeBuild: 24
+            nodeBuild: *node_version
 
     steps:
       - name: Configure pagefile
@@ -101,7 +104,7 @@ jobs:
         with:
           path: |
             .eslintcache
-          key: eslintcache-${{ matrix.os }}-${{ hashFiles('npm-shrinkwrap.json', '.eslintrc.cjs') }}
+          key: eslintcache-${{ matrix.os }}-${{ hashFiles('npm-shrinkwrap.json', 'eslint.config.mjs') }}
       - name: Test with coverage
         # we run coverage only on Node that was used to build
         if: matrix.nodeRun == matrix.nodeBuild
@@ -131,7 +134,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache node modules
         id: cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+env:
+  NODE_VERSION: &node_version 24
+
 jobs:
   build:
     if: github.repository_owner == 'pnp'
@@ -14,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
       - name: Cache node modules
         id: cache
@@ -25,7 +28,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: node_modules-ubuntu-latest-24-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: node_modules-ubuntu-latest-${{ env.NODE_VERSION }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - name: Restore dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -49,10 +52,10 @@ jobs:
           name: build
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
       - name: Cache node modules
         id: cache
@@ -60,7 +63,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: node_modules-ubuntu-latest-24-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: node_modules-ubuntu-latest-${{ env.NODE_VERSION }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - name: Restore dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -70,7 +73,7 @@ jobs:
         with:
           path: |
             .eslintcache
-          key: eslintcache-${{ matrix.os }}-${{ hashFiles('npm-shrinkwrap.json', '.eslintrc.cjs') }}
+          key: eslintcache-ubuntu-latest-${{ env.NODE_VERSION }}-${{ hashFiles('npm-shrinkwrap.json', 'eslint.config.mjs') }}
       - name: Test
         run: npm test
         env:
@@ -91,7 +94,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache node modules
         id: cache
@@ -123,10 +126,10 @@ jobs:
           name: build
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
       - name: Cache node modules
         id: cache
@@ -134,7 +137,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: node_modules-ubuntu-latest-24-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: node_modules-ubuntu-latest-${{ env.NODE_VERSION }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - name: Restore dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -153,10 +156,10 @@ jobs:
           name: build
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -2,6 +2,9 @@ name: Release next
 
 on:
   workflow_dispatch:        
+
+env:
+  NODE_VERSION: &node_version 24
       
 jobs:
   build:
@@ -10,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [24]
+        node: [*node_version]
 
     steps:
       - uses: actions/checkout@v4
@@ -50,19 +53,19 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         # node versions to run tests on
-        nodeRun: [24]
+        nodeRun: [*node_version]
         # node version on which code was built and should be tested
-        nodeBuild: [24]
+        nodeBuild: [*node_version]
         include:
           - os: ubuntu-latest
             nodeRun: 20
-            nodeBuild: 24
+            nodeBuild: *node_version
           - os: ubuntu-latest
             nodeRun: 22
-            nodeBuild: 24
+            nodeBuild: *node_version
           - os: ubuntu-latest
             nodeRun: 25
-            nodeBuild: 24
+            nodeBuild: *node_version
 
     steps:
       - name: Configure pagefile
@@ -102,7 +105,7 @@ jobs:
         with:
           path: |
             .eslintcache
-          key: eslintcache-${{ matrix.os }}-${{ hashFiles('npm-shrinkwrap.json', '.eslintrc.cjs') }}
+          key: eslintcache-${{ matrix.os }}-${{ hashFiles('npm-shrinkwrap.json', 'eslint.config.mjs') }}
       - name: Test with coverage
         # we run coverage only on Node that was used to build
         if: matrix.nodeRun == matrix.nodeBuild
@@ -135,7 +138,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache node modules
         id: cache
@@ -169,13 +172,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: build-ubuntu-latest-24
+          name: build-ubuntu-latest-${{ env.NODE_VERSION }}
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
       - name: Cache node modules
         id: cache
@@ -183,7 +186,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: node_modules-ubuntu-latest-24-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: node_modules-ubuntu-latest-${{ env.NODE_VERSION }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - name: Restore dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -198,7 +201,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-ubuntu-latest-24
+          name: build-ubuntu-latest-${{ env.NODE_VERSION }}
           path: build.tar
           overwrite: true
   deploy_docs:
@@ -226,13 +229,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: build-ubuntu-latest-24
+          name: build-ubuntu-latest-${{ env.NODE_VERSION }}
       - name: Unpack build artifact
         run: tar -xvf build.tar && rm build.tar
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
In the aftermath of #6350, we transformed the `.eslintrc.cjs` file to `eslint.config.mjs`, but our workflow is still referencing the old file to identify the correct cache.

Additionally, I centralized the definition of the Node version, making it easier to update it in the future.