### PR TITLE
Extends `spo site add` with BrandCenter option. Closes #6668

### DIFF
--- a/docs/docs/cmd/spo/site/site-add.mdx
+++ b/docs/docs/cmd/spo/site/site-add.mdx
@@ -16,7 +16,7 @@ m365 spo site add [options]
 
 ```md definition-list
 `--type [type]`
-: Type of sites to add. Allowed values `TeamSite`, `CommunicationSite`, `ClassicSite`, default `TeamSite`
+: Type of sites to add. Allowed values `TeamSite`, `CommunicationSite`, `ClassicSite`, `BrandCenter`, default `TeamSite`
 
 `-t, --title <title>`
 : Site title
@@ -25,7 +25,7 @@ m365 spo site add [options]
 : Site alias, used in the URL and in the team site group e-mail (applies to type TeamSite)
 
 `-u, --url [url]`
-: Site URL  (applies to type CommunicationSite, ClassicSite)
+: Site URL  (applies to type CommunicationSite, ClassicSite, BrandCenter)
 
 `-z, --timeZone [timeZone]`
 : Integer representing time zone to use for the site (applies to type ClassicSite)
@@ -43,7 +43,7 @@ m365 spo site add [options]
 : Determines if the associated group is public or not (applies to type TeamSite)
 
 `-c, --classification [classification]`
-: Site classification (applies to type TeamSite, CommunicationSite)
+: Site classification (applies to type TeamSite, CommunicationSite, BrandCenter)
 
 `--siteDesign [siteDesign]`
 : Type of communication site to create. Allowed values `Topic`, `Showcase`, `Blank`, default `Topic`. When creating a communication site, specify either `siteDesign` or `siteDesignId` (applies to type CommunicationSite)
@@ -52,7 +52,7 @@ m365 spo site add [options]
 : Id of the custom site design to use to create the site. When creating a communication site, specify either `siteDesign` or `siteDesignId` (applies to type CommunicationSite)
 
 `--shareByEmailEnabled`
-: Determines whether it's allowed to share file with guests (applies to type CommunicationSite)
+: Determines whether it's allowed to share file with guests (applies to type CommunicationSite, BrandCenter)
 
 `-w, --webTemplate [webTemplate]`
 : Template to use for creating the site. Default `STS#0`  (applies to type ClassicSite)
@@ -77,6 +77,9 @@ m365 spo site add [options]
 
 `--wait`
 : Wait for the site to be provisioned before completing the command  (applies to type ClassicSite)
+
+`-f, --force`
+: Don't prompt for confirmation to create BrandCenter
 ```
 
 <Global />
@@ -99,7 +102,7 @@ Deleting and creating classic site collections is by default asynchronous and de
 
 ## Remarks for modern sites
 
-The `--owners` option is mandatory for creating `CommunicationSite` sites with app-only permissions.
+The `--owners` option is mandatory for creating `CommunicationSite or `BrandCenter` sites with app-only permissions.
 
 When trying to create a team site using app-only permissions, you will get an _Insufficient privileges to complete the operation._ error. As a workaround, you can use the [`entra m365group add`](../../entra/m365group/m365group-add.mdx) command, followed by [`spo site set`](./site-set.mdx) to further configure the Team site.
 
@@ -199,6 +202,12 @@ Create a new classic site and enable the site collection app catalog
 
 ```sh
 m365 spo site add --type ClassicSite --url https://contoso.sharepoint.com/sites/team --title Team --owners admin@contoso.onmicrosoft.com --timeZone 4 --webTemplate STS#0 --withAppCatalog
+```
+
+Create a brand center site
+
+```sh
+m365 spo site add --type BrandCenter --url https://contoso.sharepoint.com/sites/brandcenter --title Branding
 ```
 
 ## Response

--- a/src/m365/spo/commands/site/site-add.spec.ts
+++ b/src/m365/spo/commands/site/site-add.spec.ts
@@ -15,6 +15,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { spo } from '../../../../utils/spo.js';
 import commands from '../../commands.js';
+import { brandCenter, type BrandCenterConfiguration } from '../../../../utils/brandCenter.js';
 import command from './site-add.js';
 
 describe(commands.SITE_ADD, () => {
@@ -24,6 +25,30 @@ describe(commands.SITE_ADD, () => {
   let commandInfo: CommandInfo;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let waitUntilFinishedStub: sinon.SinonStub;
+
+  const brandCenterConfigurationBase: Omit<BrandCenterConfiguration, 'IsBrandCenterSiteFeatureEnabled'> = {
+    BrandColorsListId: '',
+    BrandColorsListUrl: null,
+    BrandFontLibraryId: '',
+    BrandFontLibraryUrl: null,
+    IsPublicCdnEnabled: false,
+    OrgAssets: {
+      Domain: {
+        DecodedUrl: ''
+      },
+      OrgAssetsLibraries: {
+        OrgAssetsLibraries: [],
+        Items: []
+      },
+      SiteId: '',
+      Url: {
+        DecodedUrl: ''
+      },
+      WebId: ''
+    },
+    SiteId: '',
+    SiteUrl: ''
+  };
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -62,7 +87,10 @@ describe(commands.SITE_ADD, () => {
     sinonUtil.restore([
       request.post,
       spo.ensureFormDigest,
-      spo.waitUntilFinished
+      spo.waitUntilFinished,
+      spo.getSpoAdminUrl,
+      brandCenter.getBrandCenterConfiguration,
+      cli.promptForConfirmation
     ]);
   });
 
@@ -2385,6 +2413,108 @@ describe(commands.SITE_ADD, () => {
 
     await command.action(logger, { options: { type: 'ClassicSite', url: 'https://contoso.sharepoint.com/sites/team', title: 'Team', timeZone: 4, owners: 'admin@contoso.com', wait: true, removeDeletedSite: true } });
     assert(loggerLogSpy.calledWithExactly('https://contoso.sharepoint.com/sites/team'));
+  });
+
+  it('creates a brand center site using the correct endpoint', async () => {
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(brandCenter, 'getBrandCenterConfiguration').resolves({
+      ...brandCenterConfigurationBase,
+      IsBrandCenterSiteFeatureEnabled: false
+    });
+    sinon.stub(cli, 'promptForConfirmation').resolves(true);
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/SPSiteManager/Create`) > -1) {
+        return { SiteStatus: 2, SiteUrl: "https://contoso.sharepoint.com/sites/BrandCenter" };
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { type: 'BrandCenter', url: 'https://contoso.sharepoint.com/sites/brandcenter', title: 'Brand Center' } });
+
+    assert.deepStrictEqual(postStub.lastCall.args[0].data.request.AdditionalSiteFeatureIds, ["99cd6e8b-189b-4611-ae89-f89105876e43"]);
+  });
+
+  it('creates a brand center site with --force flag without user confirmation', async () => {
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(brandCenter, 'getBrandCenterConfiguration').resolves({
+      ...brandCenterConfigurationBase,
+      IsBrandCenterSiteFeatureEnabled: false
+    });
+
+    const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/SPSiteManager/Create`) > -1) {
+        return { SiteStatus: 2, SiteUrl: "https://contoso.sharepoint.com/sites/BrandCenter" };
+      }
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { type: 'BrandCenter', url: 'https://contoso.sharepoint.com/sites/brandcenter', title: 'Brand Center', force: true } });
+
+    assert.deepStrictEqual(postStub.lastCall.args[0].data.request.AdditionalSiteFeatureIds, ["99cd6e8b-189b-4611-ae89-f89105876e43"]);
+  });
+
+  it('does not activate brand center feature when user declines confirmation', async () => {
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(brandCenter, 'getBrandCenterConfiguration').resolves({
+      ...brandCenterConfigurationBase,
+      IsBrandCenterSiteFeatureEnabled: false
+    });
+    sinon.stub(cli, 'promptForConfirmation').resolves(false);
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/SPSiteManager/Create`) > -1) {
+        return { SiteStatus: 2, SiteUrl: "https://contoso.sharepoint.com/sites/BrandCenter" };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { type: 'BrandCenter', url: 'https://contoso.sharepoint.com/sites/brandcenter', title: 'Brand Center' } }), new CommandError('Operation cancelled by the user.'));
+  });
+
+  it('does not activate brand center feature when already enabled', async () => {
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(brandCenter, 'getBrandCenterConfiguration').resolves({
+      ...brandCenterConfigurationBase,
+      IsBrandCenterSiteFeatureEnabled: true
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/SPSiteManager/Create`) > -1) {
+        return { SiteStatus: 2, SiteUrl: "https://contoso.sharepoint.com/sites/BrandCenter" };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { type: 'BrandCenter', url: 'https://contoso.sharepoint.com/sites/brandcenter', title: 'Brand Center' } }), new CommandError('Brand center site is already created in the tenant.'));
+  });
+
+  it('logs warning message when brand center feature is already enabled', async () => {
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(brandCenter, 'getBrandCenterConfiguration').resolves({
+      ...brandCenterConfigurationBase,
+      IsBrandCenterSiteFeatureEnabled: true
+    });
+
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/SPSiteManager/Create`) > -1) {
+        return { SiteStatus: 2, SiteUrl: "https://contoso.sharepoint.com/sites/BrandCenter" };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, { options: { type: 'BrandCenter', url: 'https://contoso.sharepoint.com/sites/brandcenter', title: 'Brand Center' } }), new CommandError('Brand center site is already created in the tenant.'));
+  });
+
+  it('passes validation when BrandCenter type is specified', async () => {
+    const actual = await command.validate({
+      options: {
+        type: 'BrandCenter',
+        title: 'Brand Center',
+        url: 'https://contoso.sharepoint.com/sites/brandcenter'
+      }
+    }, commandInfo);
+    assert.strictEqual(actual, true);
   });
 
   it('escapes XML in the request', async () => {

--- a/src/utils/brandCenter.spec.ts
+++ b/src/utils/brandCenter.spec.ts
@@ -1,0 +1,139 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import { Logger } from '../cli/Logger.js';
+import request from '../request.js';
+import { sinonUtil } from './sinonUtil.js';
+import { spo } from './spo.js';
+import { brandCenter, BrandCenterConfiguration } from './brandCenter.js';
+
+describe('utils/brandCenter', () => {
+  let log: string[];
+  let logger: Logger;
+  let loggerLogToStderrSpy: sinon.SinonSpy;
+
+  const mockBrandCenterConfiguration: BrandCenterConfiguration = {
+    BrandColorsListId: 'mock-colors-list-id',
+    BrandColorsListUrl: 'https://contoso.sharepoint.com/sites/brandcenter/Lists/BrandColors',
+    BrandFontLibraryId: 'mock-fonts-library-id',
+    BrandFontLibraryUrl: 'https://contoso.sharepoint.com/sites/brandcenter/BrandFonts',
+    IsBrandCenterSiteFeatureEnabled: true,
+    IsPublicCdnEnabled: true,
+    OrgAssets: {
+      CentralAssetRepositoryLibraries: {
+        OrgAssetsLibraries: [],
+        Items: []
+      },
+      Domain: {
+        DecodedUrl: 'https://contoso.sharepoint.com'
+      },
+      OrgAssetsLibraries: {
+        OrgAssetsLibraries: [{
+          DisplayName: 'Brand Assets',
+          FileType: 'Image',
+          LibraryUrl: {
+            DecodedUrl: 'https://contoso.sharepoint.com/sites/brandcenter/BrandAssets'
+          },
+          ListId: 'mock-list-id',
+          OrgAssetFlags: 1,
+          OrgAssetType: 1,
+          ThumbnailUrl: {
+            DecodedUrl: 'https://contoso.sharepoint.com/sites/brandcenter/BrandAssets/thumbnail.jpg'
+          },
+          UniqueId: 'mock-unique-id'
+        }],
+        Items: []
+      },
+      SiteId: 'mock-site-id',
+      Url: {
+        DecodedUrl: 'https://contoso.sharepoint.com/sites/brandcenter'
+      },
+      WebId: 'mock-web-id'
+    },
+    SiteId: 'mock-site-id',
+    SiteUrl: 'https://contoso.sharepoint.com/sites/brandcenter'
+  };
+
+  beforeEach(() => {
+    log = [];
+    logger = {
+      log: async (msg: string) => {
+        log.push(msg);
+      },
+      logRaw: async (msg: string) => {
+        log.push(msg);
+      },
+      logToStderr: async (msg: string) => {
+        log.push(msg);
+      }
+    };
+    loggerLogToStderrSpy = sinon.spy(logger, 'logToStderr');
+  });
+
+  afterEach(() => {
+    sinonUtil.restore([
+      request.get,
+      spo.getSpoAdminUrl
+    ]);
+  });
+
+  it('retrieves brand center configuration successfully', async () => {
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(request, 'get').resolves(mockBrandCenterConfiguration);
+
+    const result = await brandCenter.getBrandCenterConfiguration(logger, false);
+
+    assert.deepStrictEqual(result, mockBrandCenterConfiguration);
+  });
+
+  it('retrieves brand center configuration with debug logging', async () => {
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(request, 'get').resolves(mockBrandCenterConfiguration);
+
+    await brandCenter.getBrandCenterConfiguration(logger, true);
+
+    assert(loggerLogToStderrSpy.calledWith('Retrieving brand center configuration...'));
+    assert(loggerLogToStderrSpy.calledWith('Successfully retrieved brand center configuration'));
+  });
+
+  it('handles errors without debug logging when debug is false', async () => {
+    const errorMessage = 'Access denied';
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(request, 'get').rejects(new Error(errorMessage));
+
+    await assert.rejects(
+      brandCenter.getBrandCenterConfiguration(logger, false),
+      { message: errorMessage }
+    );
+
+    assert(loggerLogToStderrSpy.notCalled);
+  });
+
+  it('returns configuration with IsBrandCenterSiteFeatureEnabled false when feature is disabled', async () => {
+    const disabledConfig: BrandCenterConfiguration = {
+      ...mockBrandCenterConfiguration,
+      IsBrandCenterSiteFeatureEnabled: false
+    };
+
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(request, 'get').resolves(disabledConfig);
+
+    const result = await brandCenter.getBrandCenterConfiguration(logger, false);
+
+    assert.deepStrictEqual(result, disabledConfig);
+  });
+
+  it('handles response with null values', async () => {
+    const configWithNulls: BrandCenterConfiguration = {
+      ...mockBrandCenterConfiguration,
+      BrandColorsListUrl: null,
+      BrandFontLibraryUrl: null
+    };
+
+    sinon.stub(spo, 'getSpoAdminUrl').resolves('https://contoso-admin.sharepoint.com');
+    sinon.stub(request, 'get').resolves(configWithNulls);
+
+    const result = await brandCenter.getBrandCenterConfiguration(logger, false);
+
+    assert.deepStrictEqual(result, configWithNulls);
+  });
+});

--- a/src/utils/brandCenter.ts
+++ b/src/utils/brandCenter.ts
@@ -1,0 +1,77 @@
+import { Logger } from '../cli/Logger.js';
+import request, { CliRequestOptions } from '../request.js';
+import { spo } from './spo.js';
+
+interface OrgAssetsLibrary {
+  DisplayName: string;
+  FileType: string;
+  LibraryUrl: {
+    DecodedUrl: string;
+  };
+  ListId: string;
+  OrgAssetFlags: number;
+  OrgAssetType: number;
+  ThumbnailUrl: {
+    DecodedUrl: string;
+  };
+  UniqueId: string;
+}
+
+interface OrgAssetsLibraryCollection {
+  OrgAssetsLibraries: OrgAssetsLibrary[];
+  Items: OrgAssetsLibrary[];
+}
+
+export interface BrandCenterConfiguration {
+  BrandColorsListId: string;
+  BrandColorsListUrl: string | null;
+  BrandFontLibraryId: string;
+  BrandFontLibraryUrl: string | null;
+  IsBrandCenterSiteFeatureEnabled: boolean;
+  IsPublicCdnEnabled: boolean;
+  OrgAssets: {
+    CentralAssetRepositoryLibraries?: OrgAssetsLibraryCollection;
+    Domain: {
+      DecodedUrl: string;
+    };
+    OrgAssetsLibraries: OrgAssetsLibraryCollection;
+    SiteId: string;
+    Url: {
+      DecodedUrl: string;
+    };
+    WebId: string;
+  };
+  SiteId: string;
+  SiteUrl: string;
+}
+
+export const brandCenter = {
+  /**
+   * Gets the brand center configuration for the specified site
+   * @param logger Logger instance for verbose output
+   * @param debug Debug flag for detailed logging
+   * @returns Promise<BrandCenterConfiguration> Brand center configuration object
+   */
+  async getBrandCenterConfiguration(logger: Logger, debug: boolean = false): Promise<BrandCenterConfiguration> {
+    if (debug) {
+      await logger.logToStderr(`Retrieving brand center configuration...`);
+    }
+
+    const spoAdminUrl = await spo.getSpoAdminUrl(logger, debug);
+    const brandConfigRequestOptions: CliRequestOptions = {
+      url: `${spoAdminUrl}/_api/SPO.Tenant/GetBrandCenterConfiguration`,
+      headers: {
+        'accept': 'application/json;odata=nometadata'
+      },
+      responseType: 'json'
+    };
+
+    const brandConfig = await request.get<BrandCenterConfiguration>(brandConfigRequestOptions);
+
+    if (debug) {
+      await logger.logToStderr(`Successfully retrieved brand center configuration`);
+    }
+
+    return brandConfig;
+  }
+};


### PR DESCRIPTION
Extends `spo site add` with BrandCenter option. Closes #6668

To test it, you can remove the Brand Center feature using this command. Then a site can be deleted `m365 spo feature disable --webUrl https://contoso.sharepoint.com/sites/brandcenter --id 99cd6e8b-189b-4611-ae89-f89105876e43 --scope Site --force`

I have included a utility file to be used for other Branding Center commands.

