### PR TITLE
Improves error when retrieving app by objectId, Closes #6884

### DIFF
--- a/src/utils/entraApp.spec.ts
+++ b/src/utils/entraApp.spec.ts
@@ -91,6 +91,14 @@ describe('utils/entraApp', () => {
     assert.deepStrictEqual(actual.displayName, appName);
   });
 
+  it('throws error message when no application was found using getAppRegistrationByObjectId', async () => {
+    const error = { response: { status: 404 } };
+    sinon.stub(request, 'get').rejects(error);
+
+    await assert.rejects(entraApp.getAppRegistrationByObjectId(appObjectId),
+      new Error(`App with objectId '${appObjectId}' not found in Microsoft Entra ID.`));
+  });
+
   it('handles selecting single application when multiple applications with the specified name found using getAppRegistrationByAppName and cli is set to prompt', async () => {
     sinon.stub(request, 'get').callsFake(async opts => {
       if (opts.url === `https://graph.microsoft.com/v1.0/applications?$filter=displayName eq '${formatting.encodeQueryParameter(appName)}'&$select=id`) {

--- a/src/utils/entraApp.ts
+++ b/src/utils/entraApp.ts
@@ -485,8 +485,15 @@ export const entraApp = {
       responseType: 'json'
     };
 
-    const app = await request.get<Application>(requestOptions);
+    try {
+      return await request.get<Application>(requestOptions);
+    }
+    catch (error: any) {
+      if (error?.response?.status === 404) {
+        throw Error(`App with objectId '${objectId}' not found in Microsoft Entra ID.`);
+      }
 
-    return app;
+      throw error;
+    }
   }
 };


### PR DESCRIPTION
## Summary

`getAppRegistrationByObjectId` now returns a clear error message when the objectId doesn't match any application, consistent with `getAppRegistrationByAppId` and `getAppRegistrationByAppName`.

Before: `Resource 'xxx' does not exist or one of its queried reference-property objects are not present.`
After: `App with objectId 'xxx' not found in Microsoft Entra ID.`

## Changes

- `src/utils/entraApp.ts`: Wrapped `request.get` in try/catch that intercepts 404 responses and throws a descriptive error. Non-404 errors are re-thrown unchanged.
- `src/utils/entraApp.spec.ts`: Added test for the 404 error path.

## Testing

- 9/9 entraApp tests passing (added 1 new test)
- managementapp-add tests passing (non-404 errors still propagate correctly)

Closes #6884

This contribution was developed with AI assistance (Claude Code).