### PR TITLE
Guard against undefined verificationUri and userCode in device code flow

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -462,7 +462,7 @@ export class Auth {
       await logger.logToStderr(`🌶️  ${response.message}`);
     }
 
-    if (cli.getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false)) {
+    if (cli.getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) && response.verificationUri) {
       await browserUtil.open(response.verificationUri);
     }
 
@@ -475,7 +475,9 @@ export class Auth {
         this._clipboardy = (await import('clipboardy')).default;
       }
 
-      this._clipboardy.writeSync(response.userCode);
+      if (response.userCode) {
+        this._clipboardy.writeSync(response.userCode);
+      }
     }
   }
 

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -462,7 +462,7 @@ export class Auth {
       await logger.logToStderr(`🌶️  ${response.message}`);
     }
 
-    if (cli.getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) && response.verificationUri) {
+    if (cli.getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) && response.verificationUri != null) {
       await browserUtil.open(response.verificationUri);
     }
 
@@ -475,7 +475,7 @@ export class Auth {
         this._clipboardy = (await import('clipboardy')).default;
       }
 
-      if (response.userCode) {
+      if (response.userCode != null) {
         this._clipboardy.writeSync(response.userCode);
       }
     }

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -462,7 +462,7 @@ export class Auth {
       await logger.logToStderr(`🌶️  ${response.message}`);
     }
 
-    if (cli.getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) && response.verificationUri != null) {
+    if (cli.getSettingWithDefaultValue<boolean>(settingsNames.autoOpenLinksInBrowser, false) && response.verificationUri !== undefined) {
       await browserUtil.open(response.verificationUri);
     }
 
@@ -475,7 +475,7 @@ export class Auth {
         this._clipboardy = (await import('clipboardy')).default;
       }
 
-      if (response.userCode != null) {
+      if (response.userCode !== undefined) {
         this._clipboardy.writeSync(response.userCode);
       }
     }


### PR DESCRIPTION
## Summary

- Add null check on `response.verificationUri` before calling `browserUtil.open()` in `processDeviceCodeCallback`
- Add null check on `response.userCode` before calling `clipboardy.writeSync()`

Both crash with `TypeError` when the MSAL `DeviceCodeResponse` does not populate these fields and `autoOpenLinksInBrowser` or `copyDeviceCodeToClipboard` are enabled.

Closes #7167