### PR TITLE
Added Permissions section for `entra license` commands. Closes #6939

### DIFF
--- a/docs/docs/cmd/entra/license/license-list.mdx
+++ b/docs/docs/cmd/entra/license/license-list.mdx
@@ -16,6 +16,25 @@ m365 entra license list [options]
 
 <Global />
 
+## Permissions
+
+<Tabs>
+  <TabItem value="Delegated">
+
+  | Resource        | Permissions                |
+  |-----------------|----------------------------|
+  | Microsoft Graph | LicenseAssignment.Read.All |
+
+  </TabItem>
+  <TabItem value="Application">
+
+  | Resource        | Permissions                |
+  |-----------------|----------------------------|
+  | Microsoft Graph | LicenseAssignment.Read.All |
+
+  </TabItem>
+</Tabs>
+
 ## Examples
 
 List all licenses within the tenant.


### PR DESCRIPTION
Added Permissions section for `entra license` commands. Closes #6939

`entra user license` commands already have the Permissions section.