### PR TITLE
Enhances `tenant settings set`. Closes #6458

### DIFF
--- a/docs/docs/cmd/spo/tenant/tenant-settings-set.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-settings-set.mdx
@@ -267,6 +267,9 @@ m365 spo tenant settings set [options]
 
 `--SyncAadB2BManagementPolicy [SyncAadB2BManagementPolicy]`
 : Syncs Azure B2B Management Policies. Allowed values `true`, `false`. For more information, see [SharePoint and OneDrive integration with Microsoft Entra B2B](https://aka.ms/spo-b2b-integration).
+
+`--AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled [AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled]`
+: Enables or disables web property bag updates when DenyAddAndCustomizePages is enabled. Allowed values `true`, `false`.
 ```
 
 <Global />

--- a/src/m365/spo/commands/tenant/tenant-settings-set.spec.ts
+++ b/src/m365/spo/commands/tenant/tenant-settings-set.spec.ts
@@ -320,4 +320,16 @@ describe(commands.TENANT_SETTINGS_SET, () => {
     });
     assert.strictEqual(loggerStderrLogSpy.calledWith(chalk.yellow("WARNING: Make sure to also enable the Microsoft Entra one-time passcode authentication preview. If it is not enabled then SharePoint will not use Microsoft Entra B2B even if EnableAzureADB2BIntegration is set to true. Learn more at http://aka.ms/spo-b2b-integration.")), true);
   });
+
+  it('sets AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled to true', async () => {
+    const stubRequest = defaultRequestsSuccessStub();
+
+    await command.action(logger, {
+      options: {
+        AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled: true
+      }
+    });
+
+    assert.strictEqual(stubRequest.lastCall.args[0].data, `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><SetProperty Id="42" ObjectPathId="7" Name="AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled"><Parameter Type="String">true</Parameter></SetProperty></Actions><ObjectPaths><Identity Id="7" Name="6648899e-a042-6000-ee90-5bfa05d08b79|908bed80-a04a-4433-b4a0-883d9847d11d:ea1787c6-7ce2-4e71-be47-5e0deb30f9ee&#xA;Tenant" /></ObjectPaths></Request>`);
+  });
 });

--- a/src/m365/spo/commands/tenant/tenant-settings-set.ts
+++ b/src/m365/spo/commands/tenant/tenant-settings-set.ts
@@ -98,6 +98,7 @@ interface Options extends GlobalOptions {
   CommentsOnListItemsDisabled?: boolean;
   EnableAzureADB2BIntegration?: boolean;
   SyncAadB2BManagementPolicy?: boolean;
+  AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled?: boolean;
 }
 
 class SpoTenantSettingsSetCommand extends SpoCommand {
@@ -156,7 +157,8 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
     'DisableCustomAppAuthentication',
     'CommentsOnListItemsDisabled',
     'EnableAzureADB2BIntegration',
-    'SyncAadB2BManagementPolicy'
+    'SyncAadB2BManagementPolicy',
+    'AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled'
   ];
 
   public get name(): string {
@@ -545,6 +547,10 @@ class SpoTenantSettingsSetCommand extends SpoCommand {
       },
       {
         option: '--SyncAadB2BManagementPolicy [SyncAadB2BManagementPolicy]',
+        autocomplete: ['true', 'false']
+      },
+      {
+        option: '--AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled [AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled]',
         autocomplete: ['true', 'false']
       }
     );


### PR DESCRIPTION
Closes #6458 

It would be best to merge this one together with #7206 , as otherwise the  `spo propertybag set` would keep throwing the error, as the NoScript does not get set yet the command would succeed (tested locally)