### PR TITLE
fix(spfx): use cmd resolution for FN021009 rushstack/heft override

### DIFF
--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021009_PKG_overrides_rushstack_heft.spec.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021009_PKG_overrides_rushstack_heft.spec.ts
@@ -53,21 +53,24 @@ describe('FN021009_PKG_overrides_rushstack_heft', () => {
     assert.strictEqual(findings.length, 1);
   });
 
-  it(`returns correct node when overrides.@rushstack/heft is set to a string`, () => {
+  it(`doesn't return notification if overrides.@rushstack/heft is already set to expected version`, () => {
     const project: Project = {
       path: '/usr/tmp',
       packageJson: {
         overrides: {
-          '@rushstack/heft': '0.0.1'
-        },
-        source: JSON.stringify({
-          overrides: {
-            '@rushstack/heft': '0.0.1'
-          }
-        }, null, 2)
+          '@rushstack/heft': '0.7.36'
+        }
       }
     };
     rule.visit(project, findings);
-    assert.strictEqual(findings[0].occurrences[0].position?.line, 3);
+    assert.strictEqual(findings.length, 0);
+  });
+
+  it(`returns cmd resolution type`, () => {
+    assert.strictEqual(rule.resolutionType, 'cmd');
+  });
+
+  it(`returns npm pkg set resolution command with version`, () => {
+    assert.strictEqual(rule.resolution, 'npm pkg set overrides.@rushstack/heft="0.7.36"');
   });
 });

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021009_PKG_overrides_rushstack_heft.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021009_PKG_overrides_rushstack_heft.ts
@@ -1,8 +1,8 @@
-import { JsonRule } from "../../JsonRule.js";
+import { Rule } from "../../Rule.js";
 import { Project } from "../../project-model/index.js";
 import { Finding } from "../../report-model/index.js";
 
-export class FN021009_PKG_overrides_rushstack_heft extends JsonRule {
+export class FN021009_PKG_overrides_rushstack_heft extends Rule {
   constructor(private version: string) {
     super();
   }
@@ -20,15 +20,11 @@ export class FN021009_PKG_overrides_rushstack_heft extends JsonRule {
   }
 
   get resolution(): string {
-    return `{
-  "overrides": {
-    "@rushstack/heft": "${this.version}"
-  }
-}`;
+    return `npm pkg set overrides.@rushstack/heft="${this.version}"`;
   }
 
   get resolutionType(): string {
-    return 'json';
+    return 'cmd';
   }
 
   get severity(): string {
@@ -48,8 +44,7 @@ export class FN021009_PKG_overrides_rushstack_heft extends JsonRule {
       typeof project.packageJson.overrides !== 'object' ||
       !project.packageJson.overrides['@rushstack/heft'] ||
       project.packageJson.overrides['@rushstack/heft'] !== this.version) {
-      const node = this.getAstNodeFromFile(project.packageJson, 'overrides.@rushstack/heft');
-      this.addFindingWithPosition(findings, node);
+      this.addFinding(findings);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #7208

The `FN021009_PKG_overrides_rushstack_heft` rule currently uses `resolutionType: 'json'`, which asks users to manually edit their `package.json` to set the `overrides.@rushstack/heft` entry. This is problematic because the upgrade guide is read top-to-bottom, so `npm install` (which appears earlier) fails before the override is ever set.

This PR changes the rule to use `resolutionType: 'cmd'` with the resolution:

```
npm pkg set overrides.@rushstack/heft="<version>"
```

This allows the CLI to run the command automatically (or surface it as a runnable step), setting the override _before_ `npm install` so the install succeeds without manual intervention.

### Changes

- `FN021009_PKG_overrides_rushstack_heft.ts`: extend `Rule` instead of `JsonRule`; switch `resolutionType` from `'json'` to `'cmd'`; update `resolution` to `npm pkg set overrides.@rushstack/heft="<version>"`; use `addFinding` instead of `addFindingWithPosition`
- `FN021009_PKG_overrides_rushstack_heft.spec.ts`: remove AST position test (no longer applicable); add tests for the new `resolutionType` and resolution command string; add a passing-case test for when the version is already correct

## Test plan

- [ ] Run `npm test` for the `spfx project upgrade` suite and confirm FN021009 tests pass
- [ ] Run `m365 spfx project upgrade` against an SPFx 1.21.x project and verify the upgrade output shows a `cmd` step for `npm pkg set overrides.@rushstack/heft=...` instead of a JSON block
- [ ] Confirm the generated command can be executed directly in a terminal to set the override correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)