### PR TITLE
Adds Docker build check to PR workflow. Closes #5033

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -158,3 +158,15 @@ jobs:
       - name: Build docs
         run: npm run build
         working-directory: docs
+  docker_build:
+    if: github.repository_owner == 'pnp'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV 0="/bin/bash" \
 
 RUN bash -c 'echo "export PATH=$PATH:/home/cli-microsoft365/.npm-global/bin:/home/.local/bin" >> ~/.bash_profile' \
   && bash -c 'echo "export CLIMICROSOFT365_ENV=\"docker\"" >> ~/.bash_profile' \
-  && bash -c 'npm i -g @pnp/cli-microsoft365@${CLI_VERSION} --omit=dev --quiet --no-progress' \ 
+  && bash -c 'npm i -g @pnp/cli-microsoft365@${CLI_VERSION} --omit=dev --quiet --no-progress' \
   && bash -c 'echo "source /etc/bash/bash_completion.sh" >> ~/.bash_profile' \
   && bash -c 'echo "alias \"m365?\"=\"m365_chili\"" >> ~/.bash_profile' \
   && bash -c 'echo ". .bashrc" >> ~/.bash_profile' \


### PR DESCRIPTION
Closes #5033

## Summary
- Adds a Docker image build job to the PR check workflow.
- Fixes the Dockerfile line continuation so the new PR build succeeds.

## Validation
- docker build -t cli-microsoft365-pr-check-test:local .