### PR TITLE
Migrates context commands to Zod. Closes #7293

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -902,6 +902,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1750,6 +1751,7 @@
     "node_modules/@types/node": {
       "version": "24.12.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1859,6 +1861,7 @@
       "version": "8.59.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2388,6 +2391,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3144,6 +3148,7 @@
     "node_modules/diagnostic-channel": {
       "version": "1.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -3302,6 +3307,7 @@
       "version": "10.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5900,6 +5906,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/m365/context/commands/context-init.spec.ts
+++ b/src/m365/context/commands/context-init.spec.ts
@@ -1,19 +1,25 @@
 import assert from 'assert';
 import fs from 'fs';
 import sinon from 'sinon';
+import { cli } from '../../../cli/cli.js';
+import { CommandInfo } from '../../../cli/CommandInfo.js';
 import { Logger } from '../../../cli/Logger.js';
 import { telemetry } from '../../../telemetry.js';
 import { CommandError } from '../../../Command.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
-import command from './context-init.js';
+import command, { options } from './context-init.js';
 
 describe(commands.INIT, () => {
   let log: any[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(telemetry, 'trackEvent').resolves();
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -51,6 +57,16 @@ describe(commands.INIT, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation with no options', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ option: "value" });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('logs an error if an error occurred while reading the .m365rc.json', async () => {
     const originalFsExistsSync = fs.existsSync;
     const originalFsReadFileSync = fs.readFileSync;
@@ -72,7 +88,7 @@ describe(commands.INIT, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { verbose: true } }), new CommandError('Error reading .m365rc.json: Error: An error has occurred. Please add context info to .m365rc.json manually.'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) }), new CommandError('Error reading .m365rc.json: Error: An error has occurred. Please add context info to .m365rc.json manually.'));
   });
 
   it(`logs an error if the .m365rc.json file contents couldn't be parsed`, async () => {
@@ -104,7 +120,7 @@ describe(commands.INIT, () => {
       errorMessage = err;
     }
 
-    await assert.rejects(command.action(logger, { options: { verbose: true } }), new CommandError(`Error reading .m365rc.json: ${errorMessage}. Please add context info to .m365rc.json manually.`));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) }), new CommandError(`Error reading .m365rc.json: ${errorMessage}. Please add context info to .m365rc.json manually.`));
   });
 
   it(`logs an error if the content can't be written to the .m365rc.json file`, async () => {
@@ -131,7 +147,7 @@ describe(commands.INIT, () => {
     });
     sinon.stub(fs, 'writeFileSync').callsFake(_ => { throw new Error('An error has occurred'); });
 
-    await assert.rejects(() => command.action(logger, { options: { verbose: true } }), new CommandError('Error writing .m365rc.json: Error: An error has occurred. Please add context info to .m365rc.json manually.'));
+    await assert.rejects(() => command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) }), new CommandError('Error writing .m365rc.json: Error: An error has occurred. Please add context info to .m365rc.json manually.'));
   });
 
   it(`creates the .m365rc.json file if it doesn't exist and saves context info`, async () => {
@@ -147,7 +163,7 @@ describe(commands.INIT, () => {
     });
     const fsWriteFileSyncStub = sinon.stub(fs, 'writeFileSync').callsFake(() => { });
 
-    await command.action(logger, { options: { verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) });
 
     assert(fsWriteFileSyncStub.calledWith('.m365rc.json', JSON.stringify({
       context: {}
@@ -176,7 +192,7 @@ describe(commands.INIT, () => {
     });
     const fsWriteFileSyncStub = sinon.stub(fs, 'writeFileSync').callsFake(() => { });
 
-    await command.action(logger, { options: { verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) });
 
     assert(fsWriteFileSyncStub.calledWith('.m365rc.json', JSON.stringify({
       context: {}
@@ -207,7 +223,7 @@ describe(commands.INIT, () => {
     });
     const fsWriteFileSyncSpy = sinon.spy(fs, 'writeFileSync');
 
-    await command.action(logger, { options: { verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) });
 
     assert(fsWriteFileSyncSpy.notCalled);
   });
@@ -235,7 +251,7 @@ describe(commands.INIT, () => {
     });
     const fsWriteFileSyncSpy = sinon.spy(fs, 'writeFileSync');
 
-    await assert.rejects(command.action(logger, { options: { verbose: true } }), new CommandError('Error reading .m365rc.json: Error: An error has occurred. Please add context info to .m365rc.json manually.'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) }), new CommandError('Error reading .m365rc.json: Error: An error has occurred. Please add context info to .m365rc.json manually.'));
     assert(fsWriteFileSyncSpy.notCalled);
   });
 
@@ -251,6 +267,6 @@ describe(commands.INIT, () => {
     });
     sinon.stub(fs, 'writeFileSync').callsFake(_ => { throw new Error('An error has occurred'); });
 
-    await assert.rejects(command.action(logger, { options: { verbose: true } }), new CommandError('Error writing .m365rc.json: Error: An error has occurred. Please add context info to .m365rc.json manually.'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) }), new CommandError('Error writing .m365rc.json: Error: An error has occurred. Please add context info to .m365rc.json manually.'));
   });
 });

--- a/src/m365/context/commands/context-init.ts
+++ b/src/m365/context/commands/context-init.ts
@@ -1,5 +1,9 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../Command.js';
 import ContextCommand from '../../base/ContextCommand.js';
 import commands from '../commands.js';
+
+export const options = z.strictObject({ ...globalOptionsZod.shape });
 
 class ContextInitCommand extends ContextCommand {
   public get name(): string {
@@ -8,6 +12,10 @@ class ContextInitCommand extends ContextCommand {
 
   public get description(): string {
     return 'Initiates CLI for Microsoft 365 context in the current working folder';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(): Promise<void> {

--- a/src/m365/context/commands/option/option-set.spec.ts
+++ b/src/m365/context/commands/option/option-set.spec.ts
@@ -1,19 +1,25 @@
 import assert from 'assert';
 import fs from 'fs';
 import sinon from 'sinon';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import { telemetry } from '../../../../telemetry.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './option-set.js';
+import command, { options } from './option-set.js';
 
 describe(commands.OPTION_SET, () => {
   let log: any[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(telemetry, 'trackEvent').resolves();
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -51,11 +57,42 @@ describe(commands.OPTION_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation when name and value are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: 'listName',
+      value: 'testList'
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation when name is not specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      value: 'testList'
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation when value is not specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: 'listName'
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: 'listName',
+      value: 'testList',
+      unknown: 'option'
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('handles an error when reading file contents fails', async () => {
     sinon.stub(fs, 'existsSync').callsFake(_ => true);
     sinon.stub(fs, 'readFileSync').callsFake(_ => { throw new Error('An error has occurred'); });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, name: 'listName', value: 'testList' } }), new CommandError(`Error reading .m365rc.json: Error: An error has occurred. Please add listName to .m365rc.json manually.`));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, name: 'listName', value: 'testList' }) }), new CommandError(`Error reading .m365rc.json: Error: An error has occurred. Please add listName to .m365rc.json manually.`));
   });
 
   it('handles an error when writing file contents fails', async () => {
@@ -71,7 +108,7 @@ describe(commands.OPTION_SET, () => {
     }));
     sinon.stub(fs, 'writeFileSync').callsFake(_ => { throw new Error('An error has occurred'); });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, name: 'listName', value: 'testList' } }), new CommandError(`Error writing .m365rc.json: Error: An error has occurred. Please add listName to .m365rc.json manually.`));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, name: 'listName', value: 'testList' }) }), new CommandError(`Error writing .m365rc.json: Error: An error has occurred. Please add listName to .m365rc.json manually.`));
   });
 
   it('adds a new key with value when context is present', async () => {
@@ -85,7 +122,7 @@ describe(commands.OPTION_SET, () => {
       fileContents = contents as string;
     });
 
-    await command.action(logger, { options: { verbose: true, name: 'listName', value: 'testList' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, name: 'listName', value: 'testList' }) });
     assert.strictEqual(filePath, '.m365rc.json');
     assert.strictEqual(fileContents, JSON.stringify({
       context: { listName: 'testList' }
@@ -101,7 +138,7 @@ describe(commands.OPTION_SET, () => {
       filePath = _.toString();
       fileContents = contents as string;
     });
-    await assert.doesNotReject(command.action(logger, { options: { debug: true, name: 'listName', value: 'testList' } }));
+    await assert.doesNotReject(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, name: 'listName', value: 'testList' }) }));
     assert.strictEqual(filePath, '.m365rc.json');
     assert.strictEqual(fileContents, JSON.stringify({
       context: { listName: 'testList' }
@@ -129,7 +166,7 @@ describe(commands.OPTION_SET, () => {
       fileContents = contents as string;
     });
 
-    await command.action(logger, { options: { verbose: true, name: 'listName', value: 'testList' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, name: 'listName', value: 'testList' }) });
     assert.strictEqual(filePath, '.m365rc.json');
     assert.strictEqual(fileContents, JSON.stringify({
       "apps": [

--- a/src/m365/context/commands/option/option-set.ts
+++ b/src/m365/context/commands/option/option-set.ts
@@ -1,18 +1,21 @@
 import fs from 'fs';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import { CommandError } from '../../../../Command.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { CommandError, globalOptionsZod } from '../../../../Command.js';
 import ContextCommand from '../../../base/ContextCommand.js';
 import { M365RcJson } from '../../../base/M365RcJson.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.string().alias('n'),
+  value: z.string().alias('v')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  name: string;
-  value: string;
 }
 
 class ContextOptionSetCommand extends ContextCommand {
@@ -24,21 +27,8 @@ class ContextOptionSetCommand extends ContextCommand {
     return 'Allows to add a new name for the option and value to the local context file.';
   }
 
-  constructor() {
-    super();
-
-    this.#initOptions();
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '-v, --value <value>'
-      }
-    );
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {


### PR DESCRIPTION
Closes #7293

Completes the Zod migration for the two remaining `context` commands that still used the old `#initOptions()` pattern:

- **`context-init`**: Added a Zod schema with global options and the `get schema()` getter. This command has no custom options, so the schema only spreads `globalOptionsZod`.
- **`option-set`**: Replaced the constructor-based `#initOptions()` and `GlobalOptions` interface with a Zod `strictObject` schema defining `name` (alias `n`) and `value` (alias `v`) as required strings.

Updated both test files to import the exported `options` schema, set up `commandOptionsSchema` via `getSchemaToParse()`, use `commandOptionsSchema.parse()` in all `command.action()` calls, and added schema validation tests (required fields, unknown options).

The other three context commands (`context-remove`, `option-list`, `option-remove`) were already migrated.