### PR TITLE
Migrate entra approleassignment and enterpriseapp commands to Zod

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -902,6 +902,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1750,6 +1751,7 @@
     "node_modules/@types/node": {
       "version": "24.12.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1859,6 +1861,7 @@
       "version": "8.59.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2388,6 +2391,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3144,6 +3148,7 @@
     "node_modules/diagnostic-channel": {
       "version": "1.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -3302,6 +3307,7 @@
       "version": "10.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5900,6 +5906,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/m365/entra/commands/approleassignment/approleassignment-add.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-add.spec.ts
@@ -49,7 +49,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -94,7 +94,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
     getRequestStub();
     postRequestStub();
 
-    await command.action(logger, { options: { appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All' }) });
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].objectId, 'nI5EJPrQ0UOh3eJ5cglpoLL3KmM12wZPom8Zw6AEypw');
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].principalDisplayName, 'myapp');
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].resourceDisplayName, 'Office 365 SharePoint Online');
@@ -104,7 +104,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
     getRequestStub();
     postRequestStub();
 
-    await command.action(logger, { options: { appObjectId: '24448e9c-d0fa-43d1-a1dd-e279720969a0', resource: 'SharePoint', scopes: 'Sites.Read.All,Sites.ReadWrite.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ appObjectId: '24448e9c-d0fa-43d1-a1dd-e279720969a0', resource: 'SharePoint', scopes: 'Sites.Read.All,Sites.ReadWrite.All' }) });
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].objectId, 'nI5EJPrQ0UOh3eJ5cglpoLL3KmM12wZPom8Zw6AEypw');
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].principalDisplayName, 'myapp');
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].resourceDisplayName, 'Office 365 SharePoint Online');
@@ -117,7 +117,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
     getRequestStub();
     postRequestStub();
 
-    await command.action(logger, { options: { appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All', output: 'json' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All', output: 'json' }) });
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].id, 'nI5EJPrQ0UOh3eJ5cglpoLL3KmM12wZPom8Zw6AEypw');
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].principalDisplayName, 'myapp');
     assert.strictEqual(loggerLogSpy.lastCall.args[0][0].resourceDisplayName, 'Office 365 SharePoint Online');
@@ -130,28 +130,28 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
     getRequestStub();
     postRequestStub();
 
-    await command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' }) });
   });
 
   it('handles intune alias for the resource option value', async () => {
     getRequestStub();
     postRequestStub();
 
-    await command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'intune', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'intune', scopes: 'Sites.Read.All' }) });
   });
 
   it('handles exchange alias for the resource option value', async () => {
     getRequestStub();
     postRequestStub();
 
-    await command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'exchange', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'exchange', scopes: 'Sites.Read.All' }) });
   });
 
   it('handles appId for the resource option value', async () => {
     getRequestStub();
     postRequestStub();
 
-    await command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'fff194f1-7dce-4428-8301-1badb5518201', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'fff194f1-7dce-4428-8301-1badb5518201', scopes: 'Sites.Read.All' }) });
   });
 
   it('rejects if app roles are not found for the specified resource option value', async () => {
@@ -168,7 +168,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' }) }),
       new CommandError(`The resource 'SharePoint' does not have any application permissions available.`));
   });
 
@@ -186,7 +186,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' }) }),
       new CommandError(`The scope value 'Sites.Read.All' you have specified does not exist for SharePoint. ${os.EOL}Available scopes (application permissions) are: ${os.EOL}Scope1${os.EOL}Scope2`));
   });
 
@@ -204,7 +204,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' }) }),
       new CommandError("The specified service principal doesn't exist"));
   });
 
@@ -230,7 +230,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '26e49d05-4227-4ace-ae52-9b8f08f37184', resource: 'SharePoint', scopes: 'Sites.Read.All' }) }),
       new CommandError("Multiple service principal found. Found: 24448e9c-d0fa-43d1-a1dd-e279720969a0."));
   });
 
@@ -250,7 +250,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
 
     sinon.stub(cli, 'handleMultipleResultsFound').resolves({ id: '24448e9c-d0fa-43d1-a1dd-e279720969a0' });
 
-    await command.action(logger, { options: { debug: true, appDisplayName: 'test', resource: 'SharePoint', scopes: 'Scope1' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appDisplayName: 'test', resource: 'SharePoint', scopes: 'Scope1' }) });
     assert.deepEqual(loggerLogSpy.lastCall.args[0][0], {
       objectId: 'nI5EJPrQ0UOh3eJ5cglpoLL3KmM12wZPom8Zw6AEypw',
       principalDisplayName: 'myapp',

--- a/src/m365/entra/commands/approleassignment/approleassignment-add.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-add.spec.ts
@@ -276,7 +276,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
       new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`));
   });
 
-  it('fails validation if neither appId, objectId nor displayName are not specified', () => {
+  it('fails validation if neither appId, appObjectId, nor appDisplayName are specified', () => {
     const actual = commandOptionsSchema.safeParse({ resource: 'abc', scopes: 'abc' });
     assert.strictEqual(actual.success, false);
   });

--- a/src/m365/entra/commands/approleassignment/approleassignment-add.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-add.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './approleassignment-add.js';
+import command, { options } from './approleassignment-add.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.APPROLEASSIGNMENT_ADD, () => {
@@ -20,6 +20,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   const getRequestStub = (): sinon.SinonStub => {
     return sinon.stub(request, 'get').callsFake(async (opts: any) => {
@@ -48,6 +49,7 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
   });
 
   beforeEach(() => {
@@ -274,93 +276,39 @@ describe(commands.APPROLEASSIGNMENT_ADD, () => {
       new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`));
   });
 
-  it('fails validation if neither appId, objectId nor displayName are not specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither appId, objectId nor displayName are not specified', () => {
+    const actual = commandOptionsSchema.safeParse({ resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the appId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appId: '123', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the appId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '123', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the objectId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appObjectId: '123', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the objectId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ appObjectId: '123', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both appId and appDisplayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { appId: '123', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both appId and appDisplayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both appObjectId and appDisplayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { appObjectId: '123', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both appObjectId and appDisplayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appObjectId: '57907bf8-73fa-43a6-89a5-1f603e29e452', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both appObjectId, appId and appDisplayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { appId: '123', appObjectId: '123', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both appObjectId, appId and appDisplayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', appObjectId: '57907bf8-73fa-43a6-89a5-1f603e29e452', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when the appId option specified', async () => {
-    const actual = await command.validate({ options: { appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.strictEqual(actual, true);
-  });
-
-  it('supports specifying appId', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--appId') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying appDisplayName', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--appDisplayName') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
+  it('passes validation when the appId option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, true);
   });
 });
 

--- a/src/m365/entra/commands/approleassignment/approleassignment-add.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-add.ts
@@ -1,6 +1,7 @@
 import os from 'os';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
@@ -15,16 +16,19 @@ interface AppRole {
   resourceId: string;
 }
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  appId: z.uuid().optional(),
+  appObjectId: z.uuid().optional(),
+  appDisplayName: z.string().optional(),
+  resource: z.string().alias('r'),
+  scopes: z.string().alias('s')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  appId?: string;
-  appObjectId?: string;
-  appDisplayName?: string;
-  resource: string;
-  scopes: string;
 }
 
 class EntraAppRoleAssignmentAddCommand extends GraphCommand {
@@ -36,64 +40,19 @@ class EntraAppRoleAssignmentAddCommand extends GraphCommand {
     return 'Adds service principal permissions also known as scopes and app role assignments for specified Microsoft Entra application registration';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        appId: typeof args.options.appId !== 'undefined',
-        appObjectId: typeof args.options.appObjectId !== 'undefined',
-        appDisplayName: typeof args.options.appDisplayName !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.appId, options.appObjectId, options.appDisplayName].filter(o => o !== undefined).length === 1, {
+        error: 'Specify either appId, appObjectId, or appDisplayName',
+        params: {
+          customCode: 'optionSet',
+          options: ['appId', 'appObjectId', 'appDisplayName']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--appId [appId]'
-      },
-      {
-        option: '--appObjectId [appObjectId]'
-      },
-      {
-        option: '--appDisplayName [appDisplayName]'
-      },
-      {
-        option: '-r, --resource <resource>',
-        autocomplete: ['Microsoft Graph', 'SharePoint', 'OneNote', 'Exchange', 'Microsoft Forms', 'Azure Active Directory Graph', 'Skype for Business']
-      },
-      {
-        option: '-s, --scopes <scopes>'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.appId && !validation.isValidGuid(args.options.appId)) {
-          return `${args.options.appId} is not a valid GUID`;
-        }
-
-        if (args.options.appObjectId && !validation.isValidGuid(args.options.appObjectId)) {
-          return `${args.options.appObjectId} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['appId', 'appObjectId', 'appDisplayName'] });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/approleassignment/approleassignment-add.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-add.ts
@@ -22,7 +22,7 @@ export const options = z.strictObject({
   appObjectId: z.uuid().optional(),
   appDisplayName: z.string().optional(),
   resource: z.string().alias('r'),
-  scopes: z.string().alias('s')
+  scopes: z.string().transform((value) => value.split(',').map(String)).alias('s')
 });
 
 declare type Options = z.infer<typeof options>;
@@ -144,7 +144,7 @@ class EntraAppRoleAssignmentAddCommand extends GraphCommand {
       }
 
       // search for match between the found app roles and the specified scopes option value
-      for (const scope of args.options.scopes.split(',')) {
+      for (const scope of args.options.scopes) {
         const existingRoles = appRolesFound.filter((role: AppRole) => {
           return role.value.toLocaleLowerCase() === scope.toLocaleLowerCase().trim();
         });

--- a/src/m365/entra/commands/approleassignment/approleassignment-list.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-list.spec.ts
@@ -443,7 +443,7 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -489,28 +489,28 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
   it('retrieves App Role assignments for the specified appDisplayName', async () => {
     sinon.stub(request, 'get').callsFake(RequestStub.retrieveAppRoles);
 
-    await command.action(logger, { options: { output: 'json', appDisplayName: CommandActionParameters.appNameWithRoleAssignments } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ output: 'json', appDisplayName: CommandActionParameters.appNameWithRoleAssignments }) });
     assert(loggerLogSpy.calledWith(jsonOutput));
   });
 
   it('retrieves App Role assignments for the specified appId', async () => {
     sinon.stub(request, 'get').callsFake(RequestStub.retrieveAppRoles);
 
-    await command.action(logger, { options: { output: 'json', appId: CommandActionParameters.appIdWithRoleAssignments } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ output: 'json', appId: CommandActionParameters.appIdWithRoleAssignments }) });
     assert(loggerLogSpy.calledWith(jsonOutput));
   });
 
   it('retrieves App Role assignments for the specified appId and outputs text', async () => {
     sinon.stub(request, 'get').callsFake(RequestStub.retrieveAppRoles);
 
-    await command.action(logger, { options: { output: 'text', appId: CommandActionParameters.appIdWithRoleAssignments } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ output: 'text', appId: CommandActionParameters.appIdWithRoleAssignments }) });
     assert(loggerLogSpy.calledWith(jsonOutput));
   });
 
   it('retrieves App Role assignments for the specified appObjectId and outputs text', async () => {
     sinon.stub(request, 'get').callsFake(RequestStub.retrieveAppRoles);
 
-    await command.action(logger, { options: { output: 'text', appObjectId: CommandActionParameters.objectIdWithRoleAssignments } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ output: 'text', appObjectId: CommandActionParameters.objectIdWithRoleAssignments }) });
     assert(loggerLogSpy.calledWith(jsonOutput));
   });
 
@@ -523,13 +523,13 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
   it('correctly handles a service principal that does not have any app role assignments', async () => {
     sinon.stub(request, 'get').callsFake(RequestStub.retrieveAppRoles);
 
-    await assert.rejects(command.action(logger, { options: { appObjectId: CommandActionParameters.objectIdNoRoleAssignments } } as any), new CommandError('no app role assignments found'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ appObjectId: CommandActionParameters.objectIdNoRoleAssignments }) }), new CommandError('no app role assignments found'));
   });
 
   it('correctly handles no app role assignments for the specified app', async () => {
     sinon.stub(request, 'get').callsFake(RequestStub.retrieveAppRoles);
 
-    await assert.rejects(command.action(logger, { options: { appId: CommandActionParameters.appIdWithNoRoleAssignments } } as any), new CommandError('app registration not found'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ appId: CommandActionParameters.appIdWithNoRoleAssignments }) }), new CommandError('app registration not found'));
   });
 
   it('correctly handles API OData error', async () => {
@@ -544,7 +544,7 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { appObjectId: '021d971f-779d-439b-8006-9f084423f344' } } as any), new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ appObjectId: '021d971f-779d-439b-8006-9f084423f344' }) }), new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`));
   });
 
   it('fails validation if neither appId, appObjectId, nor appDisplayName are specified', () => {

--- a/src/m365/entra/commands/approleassignment/approleassignment-list.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-list.spec.ts
@@ -547,7 +547,7 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
     await assert.rejects(command.action(logger, { options: { appObjectId: '021d971f-779d-439b-8006-9f084423f344' } } as any), new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`));
   });
 
-  it('fails validation if neither appId nor appDisplayName are not specified', () => {
+  it('fails validation if neither appId, appObjectId, nor appDisplayName are specified', () => {
     const actual = commandOptionsSchema.safeParse({});
     assert.strictEqual(actual.success, false);
   });

--- a/src/m365/entra/commands/approleassignment/approleassignment-list.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-list.spec.ts
@@ -12,8 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './approleassignment-list.js';
-import { settingsNames } from '../../../../settingsNames.js';
+import command, { options } from './approleassignment-list.js';
 
 class ServicePrincipalAppRoleAssignments {
   private static AppRoleAssignments: any = {
@@ -414,6 +413,7 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   const jsonOutput = [
     {
@@ -443,6 +443,7 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
   });
 
   beforeEach(() => {
@@ -546,80 +547,34 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
     await assert.rejects(command.action(logger, { options: { appObjectId: '021d971f-779d-439b-8006-9f084423f344' } } as any), new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`));
   });
 
-  it('fails validation if neither appId nor appDisplayName are not specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither appId nor appDisplayName are not specified', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the appId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the appId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the appObjectId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appObjectId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the appObjectId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ appObjectId: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both appId and appDisplayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { appId: CommandActionParameters.appIdWithNoRoleAssignments, appDisplayName: CommandActionParameters.appNameWithRoleAssignments } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both appId and appDisplayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: CommandActionParameters.appIdWithNoRoleAssignments, appDisplayName: CommandActionParameters.appNameWithRoleAssignments });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if appObjectId and appDisplayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { appDisplayName: CommandActionParameters.appNameWithRoleAssignments, appObjectId: CommandActionParameters.objectIdWithRoleAssignments } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if appObjectId and appDisplayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appDisplayName: CommandActionParameters.appNameWithRoleAssignments, appObjectId: CommandActionParameters.objectIdWithRoleAssignments });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when the appId option specified', async () => {
-    const actual = await command.validate({ options: { appId: CommandActionParameters.appIdWithNoRoleAssignments } }, commandInfo);
-    assert.strictEqual(actual, true);
-  });
-
-  it('supports specifying appId', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--appId') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying appDisplayName', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--appDisplayName') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
+  it('passes validation when the appId option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: CommandActionParameters.appIdWithNoRoleAssignments });
+    assert.strictEqual(actual.success, true);
   });
 });
 

--- a/src/m365/entra/commands/approleassignment/approleassignment-list.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-list.ts
@@ -1,20 +1,23 @@
 import { AppRole, AppRoleAssignment, ServicePrincipal } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
-import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  appId: z.uuid().optional().alias('i'),
+  appDisplayName: z.string().optional().alias('n'),
+  appObjectId: z.uuid().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  appId?: string;
-  appDisplayName?: string;
-  appObjectId?: string;
 }
 
 class EntraAppRoleAssignmentListCommand extends GraphCommand {
@@ -26,57 +29,19 @@ class EntraAppRoleAssignmentListCommand extends GraphCommand {
     return 'Lists app role assignments for the specified application registration';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        appId: typeof args.options.appId !== 'undefined',
-        appDisplayName: typeof args.options.appDisplayName !== 'undefined',
-        appObjectId: typeof args.options.appObjectId !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.appId, options.appObjectId, options.appDisplayName].filter(o => o !== undefined).length === 1, {
+        error: 'Specify either appId, appObjectId, or appDisplayName',
+        params: {
+          customCode: 'optionSet',
+          options: ['appId', 'appObjectId', 'appDisplayName']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --appId [appId]'
-      },
-      {
-        option: '-n, --appDisplayName [appDisplayName]'
-      },
-      {
-        option: '--appObjectId [appObjectId]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.appId && !validation.isValidGuid(args.options.appId)) {
-          return `${args.options.appId} is not a valid GUID`;
-        }
-
-        if (args.options.appObjectId && !validation.isValidGuid(args.options.appObjectId)) {
-          return `${args.options.appObjectId} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['appId', 'appObjectId', 'appDisplayName'] });
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/entra/commands/approleassignment/approleassignment-remove.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-remove.spec.ts
@@ -244,7 +244,7 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
       new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`));
   });
 
-  it('fails validation if neither appId, appObjectId nor appDisplayName are not specified', () => {
+  it('fails validation if neither appId, appObjectId, nor appDisplayName are specified', () => {
     const actual = commandOptionsSchema.safeParse({ resource: 'abc', scopes: 'abc' });
     assert.strictEqual(actual.success, false);
   });

--- a/src/m365/entra/commands/approleassignment/approleassignment-remove.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-remove.spec.ts
@@ -12,13 +12,13 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './approleassignment-remove.js';
-import { settingsNames } from '../../../../settingsNames.js';
+import command, { options } from './approleassignment-remove.js';
 
 describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let promptIssued: boolean = false;
   let deleteRequestStub: sinon.SinonStub;
 
@@ -29,6 +29,7 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
   });
 
   beforeEach(() => {
@@ -243,104 +244,39 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
       new CommandError(`Resource '' does not exist or one of its queried reference-property objects are not present`));
   });
 
-  it('fails validation if neither appId, appObjectId nor appDisplayName are not specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither appId, appObjectId nor appDisplayName are not specified', () => {
+    const actual = commandOptionsSchema.safeParse({ resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the appId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appId: '123', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the appId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '123', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the appObjectId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { appObjectId: '123', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the appObjectId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ appObjectId: '123', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both appId and appDisplayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { appId: '123', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both appId and appDisplayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both appObjectId and appDisplayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { appObjectId: '123', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both appObjectId and appDisplayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appObjectId: '57907bf8-73fa-43a6-89a5-1f603e29e452', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both appObjectId, appId and appDisplayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { appId: '123', appObjectId: '123', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both appObjectId, appId and appDisplayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', appObjectId: '57907bf8-73fa-43a6-89a5-1f603e29e452', appDisplayName: 'abc', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when the appId option specified', async () => {
-    const actual = await command.validate({ options: { appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', resource: 'abc', scopes: 'abc' } }, commandInfo);
-    assert.strictEqual(actual, true);
-  });
-
-  it('supports specifying appId', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--appId') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying appDisplayName', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--appDisplayName') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying confirmation flag', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--force') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
+  it('passes validation when the appId option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ appId: '57907bf8-73fa-43a6-89a5-1f603e29e452', resource: 'abc', scopes: 'abc' });
+    assert.strictEqual(actual.success, true);
   });
 });
 

--- a/src/m365/entra/commands/approleassignment/approleassignment-remove.spec.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-remove.spec.ts
@@ -29,7 +29,7 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -93,13 +93,13 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
   });
 
   it('prompts before removing the app role assignment when force option not passed', async () => {
-    await command.action(logger, { options: { appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scopes: 'Sites.Read.All' }) });
 
     assert(promptIssued);
   });
 
   it('prompts before removing the app role assignment when force option not passed (debug)', async () => {
-    await command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scopes: 'Sites.Read.All' }) });
 
     assert(promptIssued);
   });
@@ -108,7 +108,7 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    await command.action(logger, { options: { appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All' }) });
     assert(deleteRequestStub.notCalled);
   });
 
@@ -116,37 +116,37 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { debug: true, appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All' }) });
     assert(deleteRequestStub.called);
   });
 
   it('deletes app role assignments for service principal with specified displayName', async () => {
-    await command.action(logger, { options: { appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ appDisplayName: 'myapp', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true }) });
     assert(deleteRequestStub.called);
   });
 
   it('deletes app role assignments for service principal with specified objectId and multiple scopes', async () => {
-    await command.action(logger, { options: { appObjectId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All,Sites.FullControl.All', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ appObjectId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All,Sites.FullControl.All', force: true }) });
     assert(deleteRequestStub.calledTwice);
   });
 
   it('deletes app role assignments for service principal with specified appId (debug)', async () => {
-    await command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true }) });
     assert(deleteRequestStub.called);
   });
 
   it('handles intune alias for the resource option value', async () => {
-    await command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'intune', scopes: 'Sites.Read.All', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'intune', scopes: 'Sites.Read.All', force: true }) });
     assert(deleteRequestStub.called);
   });
 
   it('handles exchange alias for the resource option value', async () => {
-    await command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'exchange', scopes: 'Sites.Read.All', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'exchange', scopes: 'Sites.Read.All', force: true }) });
     assert(deleteRequestStub.called);
   });
 
   it('handles appId for the resource option value', async () => {
-    await command.action(logger, { options: { debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'fff194f1-7dce-4428-8301-1badb5518201', scopes: 'Sites.Read.All', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: 'dc311e81-e099-4c64-bd66-c7183465f3f2', resource: 'fff194f1-7dce-4428-8301-1badb5518201', scopes: 'Sites.Read.All', force: true }) });
     assert(deleteRequestStub.called);
   });
 
@@ -164,7 +164,7 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true }) }),
       new CommandError(`Resource not found`));
   });
 
@@ -182,7 +182,7 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true }) }),
       new CommandError(`The resource 'SharePoint' does not have any application permissions available.`));
   });
 
@@ -200,7 +200,7 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true }) }),
       new CommandError(`The scope value 'Sites.Read.All' you have specified does not exist for SharePoint. ${os.EOL}Available scopes (application permissions) are: ${os.EOL}Scope1${os.EOL}Scope2`));
   });
 
@@ -218,12 +218,12 @@ describe(commands.APPROLEASSIGNMENT_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.Read.All', force: true }) }),
       new CommandError("app registration not found"));
   });
 
   it('rejects if app role assignment is not found', async () => {
-    await assert.rejects(command.action(logger, { options: { debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.ReadWrite.All', force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, appId: '3e64c22f-3f14-4bce-a267-cb44c9a08e17', resource: 'SharePoint', scopes: 'Sites.ReadWrite.All', force: true }) }),
       new CommandError("App role assignment not found"));
   });
 

--- a/src/m365/entra/commands/approleassignment/approleassignment-remove.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-remove.ts
@@ -16,7 +16,7 @@ export const options = z.strictObject({
   appObjectId: z.uuid().optional(),
   appDisplayName: z.string().optional(),
   resource: z.string().alias('r'),
-  scopes: z.string().alias('s'),
+  scopes: z.string().transform((value) => value.split(',').map(String)).alias('s'),
   force: z.boolean().optional().alias('f')
 });
 
@@ -115,7 +115,7 @@ class EntraAppRoleAssignmentRemoveCommand extends GraphCommand {
           throw `The resource '${args.options.resource}' does not have any application permissions available.`;
         }
 
-        for (const scope of args.options.scopes.split(',')) {
+        for (const scope of args.options.scopes) {
           const existingRoles = appRolesFound.filter((role: AppRole) => {
             return role.value!.toLocaleLowerCase() === scope.toLocaleLowerCase().trim();
           });

--- a/src/m365/entra/commands/approleassignment/approleassignment-remove.ts
+++ b/src/m365/entra/commands/approleassignment/approleassignment-remove.ts
@@ -1,7 +1,8 @@
 import os from 'os';
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { validation } from '../../../../utils/validation.js';
@@ -9,17 +10,20 @@ import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 import { AppRole, AppRoleAssignment, ServicePrincipal } from '@microsoft/microsoft-graph-types';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  appId: z.uuid().optional(),
+  appObjectId: z.uuid().optional(),
+  appDisplayName: z.string().optional(),
+  resource: z.string().alias('r'),
+  scopes: z.string().alias('s'),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  appId?: string;
-  appDisplayName?: string;
-  appObjectId?: string;
-  resource: string;
-  scopes: string;
-  force?: boolean;
 }
 
 class EntraAppRoleAssignmentRemoveCommand extends GraphCommand {
@@ -31,68 +35,19 @@ class EntraAppRoleAssignmentRemoveCommand extends GraphCommand {
     return 'Deletes an app role assignment for the specified Entra Application Registration';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        appId: typeof args.options.appId !== 'undefined',
-        appDisplayName: typeof args.options.appDisplayName !== 'undefined',
-        appObjectId: typeof args.options.appObjectId !== 'undefined',
-        force: (!!args.options.force).toString()
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.appId, options.appObjectId, options.appDisplayName].filter(o => o !== undefined).length === 1, {
+        error: 'Specify either appId, appObjectId, or appDisplayName',
+        params: {
+          customCode: 'optionSet',
+          options: ['appId', 'appObjectId', 'appDisplayName']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--appId [appId]'
-      },
-      {
-        option: '--appObjectId [appObjectId]'
-      },
-      {
-        option: '--appDisplayName [appDisplayName]'
-      },
-      {
-        option: '-r, --resource <resource>',
-        autocomplete: ['Microsoft Graph', 'SharePoint', 'OneNote', 'Exchange', 'Microsoft Forms', 'Azure Active Directory Graph', 'Skype for Business']
-      },
-      {
-        option: '-s, --scopes <scopes>'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.appId && !validation.isValidGuid(args.options.appId)) {
-          return `${args.options.appId} is not a valid GUID`;
-        }
-
-        if (args.options.appObjectId && !validation.isValidGuid(args.options.appObjectId)) {
-          return `${args.options.appObjectId} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['appId', 'appObjectId', 'appDisplayName'] });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './enterpriseapp-add.js';
+import command, { options } from './enterpriseapp-add.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.ENTERPRISEAPP_ADD, () => {
@@ -19,6 +19,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -27,6 +28,7 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
   });
 
   beforeEach(() => {
@@ -73,114 +75,49 @@ describe(commands.ENTERPRISEAPP_ADD, () => {
     assert.deepStrictEqual(alias, [commands.SP_ADD]);
   });
 
-  it('fails validation if neither the id, displayName, nor objectId option specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither the id, displayName, nor objectId option specified', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the id is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the objectId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { objectId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the objectId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ objectId: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both id and displayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { id: '00000000-0000-0000-0000-000000000000', displayName: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both id and displayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '00000000-0000-0000-0000-000000000000', displayName: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both displayName and objectId are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { displayName: 'abc', objectId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both displayName and objectId are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ displayName: 'abc', objectId: '00000000-0000-0000-0000-000000000000' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both id and objectId are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { id: '00000000-0000-0000-0000-000000000000', objectId: '00000000-0000-0000-0000-000000000000' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both id and objectId are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '00000000-0000-0000-0000-000000000000', objectId: '00000000-0000-0000-0000-000000000000' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when the id option specified', async () => {
-    const actual = await command.validate({ options: { id: '00000000-0000-0000-0000-000000000000' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when the id option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '00000000-0000-0000-0000-000000000000' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when the displayName option specified', async () => {
-    const actual = await command.validate({ options: { displayName: 'abc' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when the displayName option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ displayName: 'abc' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when the objectId option specified', async () => {
-    const actual = await command.validate({ options: { objectId: '00000000-0000-0000-0000-000000000000' } }, commandInfo);
-    assert.strictEqual(actual, true);
-  });
-
-  it('supports specifying id', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--id') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying displayName', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--displayName') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying objectId', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--objectId') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
+  it('passes validation when the objectId option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ objectId: '00000000-0000-0000-0000-000000000000' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('correctly handles API OData error', async () => {

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-add.ts
@@ -1,20 +1,23 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
-import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 import { cli } from '../../../../cli/cli.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.uuid().optional().alias('i'),
+  displayName: z.string().optional().alias('n'),
+  objectId: z.uuid().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  displayName?: string;
-  objectId?: string;
 }
 
 class EntraEnterpriseAppAddCommand extends GraphCommand {
@@ -30,57 +33,19 @@ class EntraEnterpriseAppAddCommand extends GraphCommand {
     return [commands.SP_ADD];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: (!(!args.options.id)).toString(),
-        displayName: (!(!args.options.displayName)).toString(),
-        objectId: (!(!args.options.objectId)).toString()
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.id, options.displayName, options.objectId].filter(o => o !== undefined).length === 1, {
+        error: 'Specify either id, displayName, or objectId',
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'displayName', 'objectId']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-n, --displayName [displayName]'
-      },
-      {
-        option: '--objectId [objectId]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
-          return `${args.options.id} is not a valid GUID`;
-        }
-
-        if (args.options.objectId && !validation.isValidGuid(args.options.objectId)) {
-          return `${args.options.objectId} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['id', 'displayName', 'objectId'] });
   }
 
   private async getAppId(args: CommandArgs): Promise<string> {

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
@@ -272,7 +272,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
     }), new CommandError(`The specified Entra app does not exist`));
   });
 
-  it('fails validation if neither the id nor the displayName option specified', () => {
+  it('fails validation if neither the id, displayName, nor objectId option specified', () => {
     const actual = commandOptionsSchema.safeParse({});
     assert.strictEqual(actual.success, false);
   });

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
@@ -44,7 +44,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -102,7 +102,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, displayName: 'foo' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, displayName: 'foo' }) });
     assert(loggerLogSpy.calledWith(spAppInfo));
   });
 
@@ -119,7 +119,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: '65415bb1-9267-4313-bbf5-ae259732ee12' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: '65415bb1-9267-4313-bbf5-ae259732ee12' }) });
     assert(loggerLogSpy.calledWith(spAppInfo));
   });
 
@@ -136,7 +136,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { objectId: '59e617e5-e447-4adc-8b88-00af644d7c92' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ objectId: '59e617e5-e447-4adc-8b88-00af644d7c92' }) });
     assert(loggerLogSpy.calledWith(spAppInfo));
   });
 
@@ -152,7 +152,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: 'b2307a39-e878-458b-bc90-03bc578531d6' }) }),
       new CommandError('An error has occurred'));
   });
 
@@ -248,7 +248,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
 
     sinon.stub(cli, 'handleMultipleResultsFound').resolves(spAppInfo.value[0]);
 
-    await command.action(logger, { options: { debug: true, displayName: 'foo' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, displayName: 'foo' }) });
     assert(loggerLogSpy.calledWith(spAppInfo));
   });
 
@@ -309,6 +309,11 @@ describe(commands.ENTERPRISEAPP_GET, () => {
 
   it('fails validation if objectId and displayName are specified', () => {
     const actual = commandOptionsSchema.safeParse({ displayName: 'abc', objectId: '6a7b1395-d313-4682-8ed4-65a6265a6320' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if both id and objectId are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '6a7b1395-d313-4682-8ed4-65a6265a6320', objectId: '6a7b1395-d313-4682-8ed4-65a6265a6320' });
     assert.strictEqual(actual.success, false);
   });
 });

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './enterpriseapp-get.js';
+import command, { options } from './enterpriseapp-get.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.ENTERPRISEAPP_GET, () => {
@@ -19,6 +19,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   const spAppInfo = {
     "value": [
@@ -43,6 +44,7 @@ describe(commands.ENTERPRISEAPP_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
   });
 
   beforeEach(() => {
@@ -270,97 +272,43 @@ describe(commands.ENTERPRISEAPP_GET, () => {
     }), new CommandError(`The specified Entra app does not exist`));
   });
 
-  it('fails validation if neither the id nor the displayName option specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither the id nor the displayName option specified', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the id is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when the id option specified', async () => {
-    const actual = await command.validate({ options: { id: '6a7b1395-d313-4682-8ed4-65a6265a6320' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when the id option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '6a7b1395-d313-4682-8ed4-65a6265a6320' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when the displayName option specified', async () => {
-    const actual = await command.validate({ options: { displayName: 'Microsoft Graph' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when the displayName option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Microsoft Graph' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation when both the id and displayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { id: '6a7b1395-d313-4682-8ed4-65a6265a6320', displayName: 'Microsoft Graph' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when both the id and displayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '6a7b1395-d313-4682-8ed4-65a6265a6320', displayName: 'Microsoft Graph' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the objectId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { objectId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the objectId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ objectId: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both id and displayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { id: '123', displayName: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both id and displayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '6a7b1395-d313-4682-8ed4-65a6265a6320', displayName: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if objectId and displayName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { displayName: 'abc', objectId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('supports specifying id', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--id') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying displayName', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--displayName') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
+  it('fails validation if objectId and displayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ displayName: 'abc', objectId: '6a7b1395-d313-4682-8ed4-65a6265a6320' });
+    assert.strictEqual(actual.success, false);
   });
 });

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-get.ts
@@ -1,20 +1,23 @@
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
-import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.uuid().optional().alias('i'),
+  displayName: z.string().optional().alias('n'),
+  objectId: z.uuid().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  displayName?: string;
-  objectId?: string;
 }
 
 class EntraEnterpriseAppGetCommand extends GraphCommand {
@@ -30,57 +33,19 @@ class EntraEnterpriseAppGetCommand extends GraphCommand {
     return [commands.SP_GET];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: (!(!args.options.id)).toString(),
-        displayName: (!(!args.options.displayName)).toString(),
-        objectId: (!(!args.options.objectId)).toString()
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.id, options.displayName, options.objectId].filter(o => o !== undefined).length === 1, {
+        error: 'Specify either id, displayName, or objectId',
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'displayName', 'objectId']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-n, --displayName [displayName]'
-      },
-      {
-        option: '--objectId [objectId]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
-          return `${args.options.id} is not a valid GUID`;
-        }
-
-        if (args.options.objectId && !validation.isValidGuid(args.options.objectId)) {
-          return `${args.options.objectId} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['id', 'displayName', 'objectId'] });
   }
 
   private async getSpId(args: CommandArgs): Promise<string> {

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,12 +10,14 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './enterpriseapp-list.js';
+import command, { options } from './enterpriseapp-list.js';
 
 describe(commands.ENTERPRISEAPP_LIST, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   const displayName = "My custom enterprise application";
   const tag = "WindowsAzureActiveDirectoryIntegratedApp";
@@ -97,6 +101,8 @@ describe(commands.ENTERPRISEAPP_LIST, () => {
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
     sinon.stub(session, 'getId').callsFake(() => '');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -152,7 +158,7 @@ describe(commands.ENTERPRISEAPP_LIST, () => {
       return 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) });
     assert(loggerLogSpy.calledWith(servicePrincipalResponse.value));
   });
 
@@ -165,7 +171,7 @@ describe(commands.ENTERPRISEAPP_LIST, () => {
       return 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: displayName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: displayName }) });
     assert(loggerLogSpy.calledWith(servicePrincipalResponse.value));
   });
 
@@ -178,7 +184,7 @@ describe(commands.ENTERPRISEAPP_LIST, () => {
       return 'Invalid request';
     });
 
-    await command.action(logger, { options: { tag: tag } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ tag: tag }) });
     assert(loggerLogSpy.calledWith(servicePrincipalResponse.value));
   });
 
@@ -195,6 +201,6 @@ describe(commands.ENTERPRISEAPP_LIST, () => {
       throw error;
     });
 
-    await assert.rejects(command.action(logger, { options: {} } as any), error['odata.error'].message.value);
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({}) }), error['odata.error'].message.value);
   });
 });

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-list.ts
@@ -1,16 +1,20 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import { odata } from '../../../../utils/odata.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  displayName: z.string().optional().alias('n'),
+  tag: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  displayName?: string;
-  tag?: string;
 }
 
 class EntraEnterpriseAppListCommand extends GraphCommand {
@@ -30,31 +34,8 @@ class EntraEnterpriseAppListCommand extends GraphCommand {
     return [commands.SP_LIST];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        displayName: typeof args.options.displayName !== 'undefined',
-        tag: typeof args.options.tag !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --displayName [displayName]'
-      },
-      {
-        option: '--tag [tag]'
-      }
-    );
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-remove.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-remove.spec.ts
@@ -56,7 +56,7 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => settingName === settingsNames.prompt ? false : defaultValue);
   });
 
@@ -169,14 +169,14 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
   });
 
   it('prompts before removing the enterprise application when force option not passed', async () => {
-    await command.action(logger, { options: { id: '65415bb1-9267-4313-bbf5-ae259732ee12' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: '65415bb1-9267-4313-bbf5-ae259732ee12' }) });
 
     assert(promptIssued);
   });
 
   it('aborts removing the enterprise application when prompt not confirmed', async () => {
     const deleteCallsSpy = sinon.stub(request, 'delete').resolves();
-    await command.action(logger, { options: { id: '65415bb1-9267-4313-bbf5-ae259732ee12' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: '65415bb1-9267-4313-bbf5-ae259732ee12' }) });
     assert(deleteCallsSpy.notCalled);
   });
 
@@ -190,13 +190,13 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
     });
 
     const deleteCallsSpy: sinon.SinonStub = deleteRequestStub();
-    await command.action(logger, { options: { verbose: true, displayName: 'foo', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, displayName: 'foo', force: true }) });
     assert(deleteCallsSpy.calledOnce);
   });
 
   it('deletes the specified enterprise application using its id', async () => {
     const deleteCallsSpy: sinon.SinonStub = deleteRequestStub();
-    await command.action(logger, { options: { id: '65415bb1-9267-4313-bbf5-ae259732ee12', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: '65415bb1-9267-4313-bbf5-ae259732ee12', force: true }) });
     assert(deleteCallsSpy.calledOnce);
   });
 
@@ -205,7 +205,7 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     const deleteCallsSpy: sinon.SinonStub = deleteRequestStub();
-    await command.action(logger, { options: { objectId: '59e617e5-e447-4adc-8b88-00af644d7c92', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ objectId: '59e617e5-e447-4adc-8b88-00af644d7c92', verbose: true }) });
     assert(deleteCallsSpy.calledOnce);
   });
 
@@ -221,7 +221,7 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { displayName: 'foo', force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'foo', force: true }) }),
       new CommandError('An error has occurred'));
   });
 
@@ -304,7 +304,7 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
 
     sinon.stub(cli, 'handleMultipleResultsFound').resolves(spAppInfo.value[0]);
     const deleteCallsSpy: sinon.SinonStub = deleteRequestStub();
-    await command.action(logger, { options: { verbose: true, displayName: 'foo', force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, displayName: 'foo', force: true }) });
     assert(deleteCallsSpy.calledOnce);
   });
 });

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-remove.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-remove.spec.ts
@@ -11,13 +11,14 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './enterpriseapp-remove.js';
+import command, { options } from './enterpriseapp-remove.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.ENTERPRISEAPP_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let promptIssued: boolean = false;
 
   const spAppInfo = {
@@ -55,6 +56,7 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()! as typeof options;
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => settingName === settingsNames.prompt ? false : defaultValue);
   });
 
@@ -126,44 +128,44 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
     }), new CommandError(`The specified enterprise application does not exist.`));
   });
 
-  it('fails validation if neither the id nor the displayName option is specified', async () => {
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither the id nor the displayName option is specified', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the id is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when the id option is specified', async () => {
-    const actual = await command.validate({ options: { id: '6a7b1395-d313-4682-8ed4-65a6265a6320' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when the id option is specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '6a7b1395-d313-4682-8ed4-65a6265a6320' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when the displayName option is specified', async () => {
-    const actual = await command.validate({ options: { displayName: 'Contoso app' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when the displayName option is specified', () => {
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Contoso app' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation when both the id and displayName are specified', async () => {
-    const actual = await command.validate({ options: { id: '6a7b1395-d313-4682-8ed4-65a6265a6320', displayName: 'Contoso app' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when both the id and displayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '6a7b1395-d313-4682-8ed4-65a6265a6320', displayName: 'Contoso app' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the objectId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { objectId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the objectId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ objectId: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if both id and displayName are specified', async () => {
-    const actual = await command.validate({ options: { id: '123', displayName: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both id and displayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: '6a7b1395-d313-4682-8ed4-65a6265a6320', displayName: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if objectId and displayName are specified', async () => {
-    const actual = await command.validate({ options: { displayName: 'abc', objectId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if objectId and displayName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ displayName: 'abc', objectId: '6a7b1395-d313-4682-8ed4-65a6265a6320' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('prompts before removing the enterprise application when force option not passed', async () => {

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-remove.spec.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-remove.spec.ts
@@ -128,7 +128,7 @@ describe(commands.ENTERPRISEAPP_REMOVE, () => {
     }), new CommandError(`The specified enterprise application does not exist.`));
   });
 
-  it('fails validation if neither the id nor the displayName option is specified', () => {
+  it('fails validation if neither the id, displayName, nor objectId option is specified', () => {
     const actual = commandOptionsSchema.safeParse({});
     assert.strictEqual(actual.success, false);
   });

--- a/src/m365/entra/commands/enterpriseapp/enterpriseapp-remove.ts
+++ b/src/m365/entra/commands/enterpriseapp/enterpriseapp-remove.ts
@@ -1,22 +1,25 @@
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { odata } from '../../../../utils/odata.js';
 import { formatting } from '../../../../utils/formatting.js';
-import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.uuid().optional().alias('i'),
+  displayName: z.string().optional().alias('n'),
+  objectId: z.uuid().optional(),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  displayName?: string;
-  objectId?: string;
-  force?: boolean;
 }
 
 class EntraEnterpriseAppRemoveCommand extends GraphCommand {
@@ -32,67 +35,19 @@ class EntraEnterpriseAppRemoveCommand extends GraphCommand {
     return [commands.SP_REMOVE];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        displayName: typeof args.options.displayName !== 'undefined',
-        objectId: typeof args.options.objectId !== 'undefined',
-        force: !!args.options.force
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.id, options.displayName, options.objectId].filter(o => o !== undefined).length === 1, {
+        error: 'Specify either id, displayName, or objectId',
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'displayName', 'objectId']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-n, --displayName [displayName]'
-      },
-      {
-        option: '--objectId [objectId]'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
-          return `The option 'id' with value '${args.options.id}' is not a valid GUID.`;
-        }
-
-        if (args.options.objectId && !validation.isValidGuid(args.options.objectId)) {
-          return `The option 'objectId' with value '${args.options.objectId}' is not a valid GUID.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['id', 'displayName', 'objectId'] });
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'displayName', 'objectId');
-    this.types.boolean.push('force');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {


### PR DESCRIPTION
## Summary

Migrates the following commands from legacy options/validators to Zod schemas:

- `entra approleassignment add`
- `entra approleassignment list`
- `entra approleassignment remove`
- `entra enterpriseapp add`
- `entra enterpriseapp get`
- `entra enterpriseapp list`
- `entra enterpriseapp remove`

### Changes per command

- Replaced `interface Options extends GlobalOptions` with `export const options = z.strictObject({...globalOptionsZod.shape, ...})`
- Replaced GUID validation (`validation.isValidGuid()`) with `z.uuid()`
- Replaced `#initOptions()`, `#initValidators()`, `#initOptionSets()`, `#initTelemetry()`, `#initTypes()` with declarative Zod schema + `getRefinedSchema()` for option sets
- Added `get schema()` method
- Removed constructors

### Test changes

- Validation tests now use `commandOptionsSchema.safeParse()` instead of `command.validate()`
- Removed redundant "supports specifying" tests
- Tests are synchronous (no more `async` for validation)

Closes #7295