### PR TITLE
Migrate `file` commands to Zod

### DIFF
--- a/src/m365/file/commands/convert/convert-pdf.spec.ts
+++ b/src/m365/file/commands/convert/convert-pdf.spec.ts
@@ -12,15 +12,14 @@ import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
-import { z } from 'zod';
 import commands from '../../commands.js';
-import command from './convert-pdf.js';
+import command, { options } from './convert-pdf.js';
 
 describe(commands.CONVERT_PDF, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let commandOptionsSchema: z.ZodTypeAny;
+  let commandOptionsSchema: typeof options;
   let unlinkSyncStub: sinon.SinonStub;
   const mockPdfFile = 'pdf';
   let pdfConvertResponseStream: PassThrough;
@@ -34,7 +33,7 @@ describe(commands.CONVERT_PDF, () => {
     auth.connection.active = true;
     unlinkSyncStub = sinon.stub(fs, 'unlinkSync').returns();
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -157,10 +156,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -225,11 +224,11 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -294,10 +293,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/Shared%20Documents/Demo%20Files/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -362,10 +361,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/DemoDocs/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -422,10 +421,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/subsite/Shared%20Documents/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -482,10 +481,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/subsite/Shared%20Documents/Folder/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -542,10 +541,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/subsite/DocLib/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -598,10 +597,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso-my.sharepoint.com/personal/steve_contoso_com/Documents/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -654,10 +653,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso-my.sharepoint.com/personal/steve_contoso_com/Documents/Folder/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -710,10 +709,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/sites/Contoso/Shared%20Documents/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -766,10 +765,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/sites/Contoso/Shared%20Documents/Folder/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -826,10 +825,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/sites/Contoso/site/Shared%20Documents/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -886,13 +885,14 @@ describe(commands.CONVERT_PDF, () => {
       });
 
       sinon.stub(fs, 'readFileSync').returns('abc');
+      sinon.stub(fs, 'existsSync').callsFake((filePath: fs.PathLike) => filePath === 'file.docx');
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -1009,13 +1009,14 @@ describe(commands.CONVERT_PDF, () => {
       });
 
       sinon.stub(fs, 'readFileSync').returns('abc');
+      sinon.stub(fs, 'existsSync').callsFake((filePath: fs.PathLike) => filePath === 'file.docx');
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'file.docx',
           targetFile: 'https://contoso.sharepoint.com/Shared Documents/file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.calledOnce, 'Did not remove local file');
@@ -1076,11 +1077,11 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await assert.rejects(command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'https://contoso.sharepoint.com/Docs/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       }), new CommandError('Drive not found'));
       assert(unlinkSyncStub.notCalled, 'Removed local file');
     });
@@ -1142,11 +1143,11 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await assert.rejects(command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       }), new CommandError('Error: Request failed with status code 404'));
       assert(unlinkSyncStub.notCalled, 'Removed local file');
     });
@@ -1217,11 +1218,11 @@ describe(commands.CONVERT_PDF, () => {
       }, 5);
 
       await assert.rejects(command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx',
           targetFile: './foo/file.pdf'
-        }
+        })
       }), new CommandError("Error: ENOENT: no such file or directory, open './foo/file.pdf'"));
       assert(unlinkSyncStub.notCalled, 'Removed local file');
     });
@@ -1296,10 +1297,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await assert.rejects(command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx',
           targetFile: 'https://contoso.sharepoint.com/Shared Documents/file.pdf'
-        }
+        })
       }), new CommandError('An error has occurred'));
 
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
@@ -1369,10 +1370,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(request, 'delete').rejects(new Error('Issue DELETE request'));
 
       await assert.rejects(command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx',
           targetFile: 'https://contoso.sharepoint.com/Shared Documents/file.pdf'
-        }
+        })
       }), new CommandError('An error has occurred'));
 
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
@@ -1467,10 +1468,10 @@ describe(commands.CONVERT_PDF, () => {
       sinon.stub(fs, 'readFileSync').returns('abc');
 
       await assert.rejects(command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx',
           targetFile: 'https://contoso.sharepoint.com/Shared Documents/file.pdf'
-        }
+        })
       }), new CommandError('An error has occurred'));
 
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
@@ -1525,13 +1526,14 @@ describe(commands.CONVERT_PDF, () => {
         }
       });
       sinon.stub(fs, 'readFileSync').returns('abc');
+      sinon.stub(fs, 'existsSync').callsFake((filePath: fs.PathLike) => filePath === 'file.docx');
 
       await assert.rejects(command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       }), new CommandError('An error has occurred'));
 
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
@@ -1649,15 +1651,16 @@ describe(commands.CONVERT_PDF, () => {
       });
 
       sinon.stub(fs, 'readFileSync').returns('abc');
+      sinon.stub(fs, 'existsSync').callsFake((filePath: fs.PathLike) => filePath === 'file.docx');
       sinonUtil.restore(fs.unlinkSync);
       unlinkSyncStub = sinon.stub(fs, 'unlinkSync').throws(new Error('An error has occurred'));
 
       await assert.rejects(command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'file.docx',
           targetFile: 'https://contoso.sharepoint.com/Shared Documents/file.pdf'
-        }
+        })
       }), new CommandError('An error has occurred'));
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.calledOnce, 'Did not remove local file');
@@ -1723,13 +1726,14 @@ describe(commands.CONVERT_PDF, () => {
       });
 
       sinon.stub(fs, 'readFileSync').returns('abc');
+      sinon.stub(fs, 'existsSync').callsFake((filePath: fs.PathLike) => filePath === 'file.docx');
 
       await command.action(logger, {
-        options: {
+        options: commandOptionsSchema.parse({
           debug: true,
           sourceFile: 'file.docx',
           targetFile: 'file.pdf'
-        }
+        })
       });
       assert.strictEqual(Buffer.from(pdfConvertWriteStream.read()).toString(), mockPdfFile, 'Invalid PDF contents');
       assert(unlinkSyncStub.notCalled, 'Removed local file');
@@ -1741,12 +1745,13 @@ describe(commands.CONVERT_PDF, () => {
       expiresOn: '123',
       accessToken: '123.YQ==.456' // 'a' simulating invalid token
     };
+    sinon.stub(fs, 'existsSync').callsFake((filePath: fs.PathLike) => filePath === 'file.docx');
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         sourceFile: 'file.docx',
         targetFile: 'file.pdf'
-      }
+      })
     }), new CommandError('Unable to determine authentication type'));
   });
 

--- a/src/m365/file/commands/convert/convert-pdf.spec.ts
+++ b/src/m365/file/commands/convert/convert-pdf.spec.ts
@@ -12,6 +12,7 @@ import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
+import { z } from 'zod';
 import commands from '../../commands.js';
 import command from './convert-pdf.js';
 
@@ -19,6 +20,7 @@ describe(commands.CONVERT_PDF, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodTypeAny;
   let unlinkSyncStub: sinon.SinonStub;
   const mockPdfFile = 'pdf';
   let pdfConvertResponseStream: PassThrough;
@@ -32,6 +34,7 @@ describe(commands.CONVERT_PDF, () => {
     auth.connection.active = true;
     unlinkSyncStub = sinon.stub(fs, 'unlinkSync').returns();
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
   });
 
   beforeEach(() => {
@@ -1749,25 +1752,25 @@ describe(commands.CONVERT_PDF, () => {
 
   it(`fails validation if the specified local source file doesn't exist`, async () => {
     sinon.stub(fs, 'existsSync').callsFake(() => false);
-    const actual = await command.validate({ options: { sourceFile: 'file.docx', targetFile: 'file.pdf' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ sourceFile: 'file.docx', targetFile: 'file.pdf' });
+    assert.strictEqual(actual.success, false);
   });
 
   it(`fails validation if another file exists at the path specified in the target file`, async () => {
     sinon.stub(fs, 'existsSync').callsFake(() => true);
-    const actual = await command.validate({ options: { sourceFile: 'file.docx', targetFile: 'file.pdf' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ sourceFile: 'file.docx', targetFile: 'file.pdf' });
+    assert.strictEqual(actual.success, false);
   });
 
   it(`passes validation if the source file is a URL`, async () => {
     sinon.stub(fs, 'existsSync').callsFake(() => false);
-    const actual = await command.validate({ options: { sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx', targetFile: 'file.pdf' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ sourceFile: 'https://contoso.sharepoint.com/Shared Documents/file.docx', targetFile: 'file.pdf' });
+    assert.strictEqual(actual.success, true);
   });
 
   it(`passes validation if the target file is a URL`, async () => {
     sinon.stub(fs, 'existsSync').callsFake(() => true);
-    const actual = await command.validate({ options: { sourceFile: 'file.docx', targetFile: 'https://contoso.sharepoint.com/Shared Documents/file.pdf' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ sourceFile: 'file.docx', targetFile: 'https://contoso.sharepoint.com/Shared Documents/file.pdf' });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/file/commands/convert/convert-pdf.ts
+++ b/src/m365/file/commands/convert/convert-pdf.ts
@@ -3,22 +3,25 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { v4 } from 'uuid';
+import { z } from 'zod';
 import auth from '../../../../Auth.js';
 import { Logger } from '../../../../cli/Logger.js';
-import { CommandError } from '../../../../Command.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { CommandError, globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  sourceFile: z.string().alias('s'),
+  targetFile: z.string().alias('t')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  sourceFile: string;
-  targetFile: string;
 }
 
 class FileConvertPdfCommand extends GraphCommand {
@@ -33,42 +36,18 @@ class FileConvertPdfCommand extends GraphCommand {
     return 'Converts the specified file to PDF using Microsoft Graph';
   }
 
-  constructor() {
-    super();
-
-    this.#initOptions();
-    this.#initValidators();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-s, --sourceFile <sourceFile>'
-      },
-      {
-        option: '-t, --targetFile <targetFile>'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!args.options.sourceFile.toLowerCase().startsWith('https://') &&
-          !fs.existsSync(args.options.sourceFile)) {
-          // assume local path
-          return `Specified source file ${args.options.sourceFile} doesn't exist`;
-        }
-
-        if (!args.options.targetFile.toLowerCase().startsWith('https://') &&
-          fs.existsSync(args.options.targetFile)) {
-          // assume local path
-          return `Another file found at ${args.options.targetFile}`;
-        }
-
-        return true;
-      }
-    );
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => options.sourceFile.toLowerCase().startsWith('https://') || fs.existsSync(options.sourceFile), {
+        error: e => `Specified source file ${(e.input as Options).sourceFile} doesn't exist`
+      })
+      .refine(options => options.targetFile.toLowerCase().startsWith('https://') || !fs.existsSync(options.targetFile), {
+        error: e => `Another file found at ${(e.input as Options).targetFile}`
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/file/commands/file-add.spec.ts
+++ b/src/m365/file/commands/file-add.spec.ts
@@ -950,6 +950,12 @@ describe(commands.ADD, () => {
     assert.strictEqual(actual.success, false);
   });
 
+  it(`fails validation if the specified folderUrl is invalid`, async () => {
+    sinon.stub(fs, 'existsSync').returns(true);
+    const actual = commandOptionsSchema.safeParse({ filePath: 'file.pdf', folderUrl: '/' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it(`fails validation if the specified siteUrl is invalid`, async () => {
     sinon.stub(fs, 'existsSync').returns(true);
     const actual = commandOptionsSchema.safeParse({

--- a/src/m365/file/commands/file-add.spec.ts
+++ b/src/m365/file/commands/file-add.spec.ts
@@ -11,6 +11,7 @@ import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
+import { z } from 'zod';
 import commands from '../commands.js';
 import command from './file-add.js';
 
@@ -18,6 +19,7 @@ describe(commands.ADD, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodTypeAny;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -26,6 +28,7 @@ describe(commands.ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
   });
 
   beforeEach(() => {
@@ -943,25 +946,23 @@ describe(commands.ADD, () => {
 
   it(`fails validation if the specified local source file doesn't exist`, async () => {
     sinon.stub(fs, 'existsSync').returns(false);
-    const actual = await command.validate({ options: { filePath: 'file.pdf', folderUrl: 'https://contoso.sharepoint.com/Shared Documents' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ filePath: 'file.pdf', folderUrl: 'https://contoso.sharepoint.com/Shared Documents' });
+    assert.strictEqual(actual.success, false);
   });
 
   it(`fails validation if the specified siteUrl is invalid`, async () => {
     sinon.stub(fs, 'existsSync').returns(true);
-    const actual = await command.validate({
-      options: {
-        filePath: 'file.pdf',
-        folderUrl: 'https://contoso.sharepoint.com/Shared Documents',
-        siteUrl: '/'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      filePath: 'file.pdf',
+      folderUrl: 'https://contoso.sharepoint.com/Shared Documents',
+      siteUrl: '/'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it(`passes validation if the target file is a URL`, async () => {
     sinon.stub(fs, 'existsSync').returns(true);
-    const actual = await command.validate({ options: { filePath: 'file.pdf', folderUrl: 'https://contoso.sharepoint.com/Shared Documents' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ filePath: 'file.pdf', folderUrl: 'https://contoso.sharepoint.com/Shared Documents' });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/file/commands/file-add.spec.ts
+++ b/src/m365/file/commands/file-add.spec.ts
@@ -11,15 +11,14 @@ import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
-import { z } from 'zod';
 import commands from '../commands.js';
-import command from './file-add.js';
+import command, { options } from './file-add.js';
 
 describe(commands.ADD, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let commandOptionsSchema: z.ZodTypeAny;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -28,7 +27,7 @@ describe(commands.ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -45,6 +44,7 @@ describe(commands.ADD, () => {
       }
     };
     (command as any).items = [];
+    sinon.stub(fs, 'existsSync').returns(true);
   });
 
   afterEach(() => {
@@ -150,11 +150,11 @@ describe(commands.ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/Shared Documents'
-      }
+      })
     });
   });
 
@@ -222,11 +222,11 @@ describe(commands.ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/Shared Documents'
-      }
+      })
     });
   });
 
@@ -309,11 +309,11 @@ describe(commands.ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/Shared Documents/'
-      }
+      })
     });
   });
 
@@ -396,11 +396,11 @@ describe(commands.ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/Shared Documents/Folder'
-      }
+      })
     });
   });
 
@@ -483,11 +483,11 @@ describe(commands.ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/DemoDocs'
-      }
+      })
     });
   });
 
@@ -558,10 +558,10 @@ describe(commands.ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         filePath: 'file.pdf',
         folderUrl: 'https://contoso-my.sharepoint.com/personal/steve_contoso_com/Documents'
-      }
+      })
     });
   });
 
@@ -632,10 +632,10 @@ describe(commands.ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/sites/Contoso/Shared Documents'
-      }
+      })
     });
   });
 
@@ -690,11 +690,11 @@ describe(commands.ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/sites/Contoso/Shared Documents',
         siteUrl: 'https://contoso.sharepoint.com/sites/Contoso'
-      }
+      })
     });
   });
 
@@ -753,11 +753,11 @@ describe(commands.ADD, () => {
     sinon.stub(request, 'put').rejects(new Error('Issued PUT request'));
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/Docs'
-      }
+      })
     }), new CommandError('Drive not found'));
   });
 
@@ -781,10 +781,10 @@ describe(commands.ADD, () => {
     sinon.stub(request, 'put').rejects(new Error('Issued PUT request'));
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/Shared Documents'
-      }
+      })
     }), new CommandError('An error has occurred'));
   });
 
@@ -847,10 +847,10 @@ describe(commands.ADD, () => {
     sinon.stub(request, 'put').rejects(new Error('Issued PUT request'));
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         filePath: 'https://contoso.sharepoint.com/Shared Documents/file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/Shared Documents/file.pdf'
-      }
+      })
     }), new CommandError('An error has occurred'));
   });
 
@@ -937,27 +937,26 @@ describe(commands.ADD, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         filePath: 'file.pdf',
         folderUrl: 'https://contoso.sharepoint.com/Shared Documents'
-      }
+      })
     }), new CommandError('An error has occurred'));
   });
 
   it(`fails validation if the specified local source file doesn't exist`, async () => {
+    sinonUtil.restore(fs.existsSync);
     sinon.stub(fs, 'existsSync').returns(false);
     const actual = commandOptionsSchema.safeParse({ filePath: 'file.pdf', folderUrl: 'https://contoso.sharepoint.com/Shared Documents' });
     assert.strictEqual(actual.success, false);
   });
 
   it(`fails validation if the specified folderUrl is invalid`, async () => {
-    sinon.stub(fs, 'existsSync').returns(true);
     const actual = commandOptionsSchema.safeParse({ filePath: 'file.pdf', folderUrl: '/' });
     assert.strictEqual(actual.success, false);
   });
 
   it(`fails validation if the specified siteUrl is invalid`, async () => {
-    sinon.stub(fs, 'existsSync').returns(true);
     const actual = commandOptionsSchema.safeParse({
       filePath: 'file.pdf',
       folderUrl: 'https://contoso.sharepoint.com/Shared Documents',
@@ -967,7 +966,6 @@ describe(commands.ADD, () => {
   });
 
   it(`passes validation if the target file is a URL`, async () => {
-    sinon.stub(fs, 'existsSync').returns(true);
     const actual = commandOptionsSchema.safeParse({ filePath: 'file.pdf', folderUrl: 'https://contoso.sharepoint.com/Shared Documents' });
     assert.strictEqual(actual.success, true);
   });

--- a/src/m365/file/commands/file-add.ts
+++ b/src/m365/file/commands/file-add.ts
@@ -12,7 +12,7 @@ export const options = z.strictObject({
   ...globalOptionsZod.shape,
   folderUrl: z.string()
     .refine(url => validation.isValidSharePointUrl(url) === true, {
-      error: e => `'${e.input}' is not a valid SharePoint Online site URL.`
+      error: e => `'${e.input}' is not a valid SharePoint Online folder URL.`
     })
     .alias('u'),
   filePath: z.string().alias('p'),

--- a/src/m365/file/commands/file-add.ts
+++ b/src/m365/file/commands/file-add.ts
@@ -1,20 +1,28 @@
 import fs from 'fs';
 import path from 'path';
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import request, { CliRequestOptions } from '../../../request.js';
 import { validation } from '../../../utils/validation.js';
 import GraphCommand from '../../base/GraphCommand.js';
 import commands from '../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  folderUrl: z.string()
+    .refine(url => validation.isValidSharePointUrl(url) === true, {
+      error: e => `'${e.input}' is not a valid SharePoint Online site URL.`
+    })
+    .alias('u'),
+  filePath: z.string().alias('p'),
+  siteUrl: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  folderUrl: string;
-  filePath: string;
-  siteUrl?: string;
 }
 
 class FileAddCommand extends GraphCommand {
@@ -26,47 +34,24 @@ class FileAddCommand extends GraphCommand {
     return 'Uploads file to the specified site';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        siteUrl: typeof args.options.siteUrl !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => fs.existsSync(options.filePath), {
+        error: e => `Specified source file ${(e.input as Options).filePath} doesn't exist`
+      })
+      .refine(options => {
+        if (options.siteUrl) {
+          return validation.isValidSharePointUrl(options.siteUrl) === true;
+        }
+
+        return true;
+      }, {
+        error: e => `'${(e.input as Options).siteUrl}' is not a valid SharePoint Online site URL.`
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      { option: '-u, --folderUrl <folderUrl>' },
-      { option: '-p, --filePath <filePath>' },
-      { option: '--siteUrl [siteUrl]' }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!fs.existsSync(args.options.filePath)) {
-          return `Specified source file ${args.options.sourceFile} doesn't exist`;
-        }
-
-        if (args.options.siteUrl) {
-          const isValidSiteUrl = validation.isValidSharePointUrl(args.options.siteUrl);
-          if (isValidSiteUrl !== true) {
-            return isValidSiteUrl;
-          }
-        }
-
-        return validation.isValidSharePointUrl(args.options.folderUrl);
-      }
-    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/file/commands/file-copy.spec.ts
+++ b/src/m365/file/commands/file-copy.spec.ts
@@ -11,6 +11,7 @@ import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
+import { z } from 'zod';
 import commands from '../commands.js';
 import command from './file-copy.js';
 
@@ -18,6 +19,7 @@ describe(commands.COPY, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodTypeAny;
 
   const defaultPostStub = (): sinon.SinonStub => {
     return sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -123,6 +125,7 @@ describe(commands.COPY, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
   });
 
   beforeEach(() => {
@@ -165,39 +168,33 @@ describe(commands.COPY, () => {
   });
 
   it('fails validation if nameConflictBehavior is not a valid option', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: '/Shared Documents/file.pdf',
-        targetUrl: '/teams/finance/Shared Documents',
-        nameConflictBehavior: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      webUrl: 'https://contoso.sharepoint.com',
+      sourceUrl: '/Shared Documents/file.pdf',
+      targetUrl: '/teams/finance/Shared Documents',
+      nameConflictBehavior: 'invalid'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: 'foo',
-        sourceUrl: '/Shared Documents/file.pdf',
-        targetUrl: '/teams/finance/Shared Documents'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      webUrl: 'foo',
+      sourceUrl: '/Shared Documents/file.pdf',
+      targetUrl: '/teams/finance/Shared Documents'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('passes validation with valid options', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: '/Shared Documents/file.pdf',
-        targetUrl: '/teams/finance/Shared Documents',
-        newName: 'file1',
-        nameConflictBehavior: 'rename'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      webUrl: 'https://contoso.sharepoint.com',
+      sourceUrl: '/Shared Documents/file.pdf',
+      targetUrl: '/teams/finance/Shared Documents',
+      newName: 'file1',
+      nameConflictBehavior: 'rename'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('copies file from source to target', async () => {

--- a/src/m365/file/commands/file-copy.spec.ts
+++ b/src/m365/file/commands/file-copy.spec.ts
@@ -11,15 +11,14 @@ import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
-import { z } from 'zod';
 import commands from '../commands.js';
-import command from './file-copy.js';
+import command, { options } from './file-copy.js';
 
 describe(commands.COPY, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let commandOptionsSchema: z.ZodTypeAny;
+  let commandOptionsSchema: typeof options;
 
   const defaultPostStub = (): sinon.SinonStub => {
     return sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -125,7 +124,7 @@ describe(commands.COPY, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -202,12 +201,12 @@ describe(commands.COPY, () => {
     const postStub: sinon.SinonStub = defaultPostStub();
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/file.pdf',
         targetUrl: '/teams/finance/Shared Documents',
         verbose: true
-      }
+      })
     });
 
     assert(getStub.called);
@@ -219,12 +218,12 @@ describe(commands.COPY, () => {
     defaultPostStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: 'https://contoso.sharepoint.com/Shared Documents/file.pdf',
         targetUrl: 'https://contoso.sharepoint.com/teams/finance/Shared Documents',
         verbose: true
-      }
+      })
     }));
   });
 
@@ -233,12 +232,12 @@ describe(commands.COPY, () => {
     defaultPostStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/teams/finance',
         sourceUrl: '/teams/finance/Shared Documents/file.pdf',
         targetUrl: '/Shared Documents',
         debug: true
-      }
+      })
     }));
   });
 
@@ -247,12 +246,12 @@ describe(commands.COPY, () => {
     defaultPostStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/file.pdf',
         targetUrl: '/teams/finance/Shared Documents',
         nameConflictBehavior: 'replace'
-      }
+      })
     }));
   });
 
@@ -261,13 +260,13 @@ describe(commands.COPY, () => {
     defaultPostStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/file.pdf',
         targetUrl: '/teams/finance/Shared Documents',
         nameConflictBehavior: 'rename',
         newName: 'file1.pdf'
-      }
+      })
     }));
   });
 
@@ -276,13 +275,13 @@ describe(commands.COPY, () => {
     defaultPostStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/file.pdf',
         targetUrl: '/teams/finance/Shared Documents',
         nameConflictBehavior: 'rename',
         newName: 'file2_renamed.docx'
-      }
+      })
     }));
   });
 
@@ -291,13 +290,13 @@ describe(commands.COPY, () => {
     defaultPostStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/file.pdf',
         targetUrl: '/teams/finance/Shared Documents',
         nameConflictBehavior: 'rename',
         newName: 'file3_renamed'
-      }
+      })
     }));
   });
 
@@ -306,13 +305,13 @@ describe(commands.COPY, () => {
     defaultPostStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/folder1',
         targetUrl: '/teams/finance/Shared Documents',
         nameConflictBehavior: 'rename',
         newName: 'folder1_renamed'
-      }
+      })
     }));
   });
 
@@ -320,11 +319,11 @@ describe(commands.COPY, () => {
     defaultGetStub();
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/invalid/file.pdf',
         targetUrl: '/teams/finance/Shared Documents'
-      }
+      })
     }), new CommandError(`Document library '/invalid/file.pdf' not found`));
   });
 });

--- a/src/m365/file/commands/file-copy.ts
+++ b/src/m365/file/commands/file-copy.ts
@@ -1,6 +1,7 @@
 import { Drive, DriveItem } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import request, { CliRequestOptions } from '../../../request.js';
 import { urlUtil } from '../../../utils/urlUtil.js';
 import { spo } from '../../../utils/spo.js';
@@ -8,21 +9,28 @@ import { validation } from '../../../utils/validation.js';
 import GraphCommand from '../../base/GraphCommand.js';
 import commands from '../commands.js';
 
+const nameConflictBehaviorOptions = ['fail', 'replace', 'rename'] as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  webUrl: z.string()
+    .refine(url => validation.isValidSharePointUrl(url) === true, {
+      error: e => `'${e.input}' is not a valid SharePoint Online site URL.`
+    })
+    .alias('u'),
+  sourceUrl: z.string().alias('s'),
+  targetUrl: z.string().alias('t'),
+  newName: z.string().optional(),
+  nameConflictBehavior: z.enum(nameConflictBehaviorOptions).optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  webUrl: string;
-  sourceUrl: string;
-  targetUrl: string;
-  newName?: string;
-  nameConflictBehavior?: string;
-}
-
 class FileCopyCommand extends GraphCommand {
-  private readonly nameConflictBehaviorOptions = ['fail', 'replace', 'rename'];
-
   public get name(): string {
     return commands.COPY;
   }
@@ -31,46 +39,8 @@ class FileCopyCommand extends GraphCommand {
     return 'Copies a file to another location using the Microsoft Graph';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        webUrl: typeof args.options.webUrl !== 'undefined',
-        sourceUrl: typeof args.options.sourceUrl !== 'undefined',
-        targetUrl: typeof args.options.targetUrl !== 'undefined',
-        newName: typeof args.options.newName !== 'undefined',
-        nameConflictBehavior: typeof args.options.nameConflictBehavior !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      { option: '-u, --webUrl <webUrl>' },
-      { option: '-s, --sourceUrl <sourceUrl>' },
-      { option: '-t, --targetUrl <targetUrl>' },
-      { option: '--newName [newName]' },
-      { option: '--nameConflictBehavior [nameConflictBehavior]', autocomplete: this.nameConflictBehaviorOptions }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.nameConflictBehavior && this.nameConflictBehaviorOptions.indexOf(args.options.nameConflictBehavior) === -1) {
-          return `${args.options.nameConflictBehavior} is not a valid nameConflictBehavior value. Allowed values: ${this.nameConflictBehaviorOptions.join(', ')}.`;
-        }
-
-        return validation.isValidSharePointUrl(args.options.webUrl);
-      }
-    );
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -106,7 +76,7 @@ class FileCopyCommand extends GraphCommand {
         const sourceFileExtension = sourceFileName.includes('.') ? sourceFileName.substring(sourceFileName.lastIndexOf('.')) : '';
         const newNameExtension = newName.includes('.') ? newName.substring(newName.lastIndexOf('.')) : '';
 
-        requestOptions.data.name = newNameExtension ? `${newName.replace(newNameExtension, "")}${sourceFileExtension}` : `${newName}${sourceFileExtension}`;
+        requestOptions.data.name = newNameExtension ? `${newName.replace(newNameExtension, '')}${sourceFileExtension}` : `${newName}${sourceFileExtension}`;
       }
 
       await request.post(requestOptions);

--- a/src/m365/file/commands/file-list.spec.ts
+++ b/src/m365/file/commands/file-list.spec.ts
@@ -10,6 +10,7 @@ import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
+import { z } from 'zod';
 import commands from '../commands.js';
 import command from './file-list.js';
 
@@ -18,6 +19,7 @@ describe(commands.LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodTypeAny;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -26,6 +28,7 @@ describe(commands.LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
   });
 
   beforeEach(() => {
@@ -9778,22 +9781,18 @@ describe(commands.LIST, () => {
   });
 
   it(`fails validation if the specified webUrl is invalid`, async () => {
-    const actual = await command.validate({
-      options: {
-        folderUrl: '/Shared Documents',
-        webUrl: '/'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      folderUrl: '/Shared Documents',
+      webUrl: '/'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it(`passes validation if the target file is a URL`, async () => {
-    const actual = await command.validate({
-      options: {
-        folderUrl: 'Shared Documents',
-        webUrl: 'https://contoso.sharepoint.com/Shared Documents'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      folderUrl: 'Shared Documents',
+      webUrl: 'https://contoso.sharepoint.com/Shared Documents'
+    });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/file/commands/file-list.spec.ts
+++ b/src/m365/file/commands/file-list.spec.ts
@@ -10,16 +10,15 @@ import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
-import { z } from 'zod';
 import commands from '../commands.js';
-import command from './file-list.js';
+import command, { options } from './file-list.js';
 
 describe(commands.LIST, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
-  let commandOptionsSchema: z.ZodTypeAny;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -28,7 +27,7 @@ describe(commands.LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -463,10 +462,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'DemoDocs'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -1170,11 +1169,11 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'DemoDocs',
         debug: true
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -1878,10 +1877,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/',
         folderUrl: 'DemoDocs/'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -2585,10 +2584,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/',
         folderUrl: '/DemoDocs'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -3292,10 +3291,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'demodocs'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -3999,10 +3998,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'Demo Docs'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -4405,10 +4404,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'DemoDocs/Folder'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([{
       "@microsoft.graph.downloadUrl": "https://contoso.sharepoint.com/_layouts/15/download.aspx?UniqueId=a05f5fb4-6ac7-4ce2-ba39-47376af92b81&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDAvbTM2NXg5NTQ4MTAuc2hhcmVwb2ludC5jb21AMWIxMWY1MDItOWViMC00MDFhLWIxNjQtNjg5MzNlNmU5NDQzIiwiaXNzIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwIiwibmJmIjoiMTYzNjI5Njc4NCIsImV4cCI6IjE2MzYzMDAzODQiLCJlbmRwb2ludHVybCI6ImhaRjR2ZzFOVXZ0cFJ3QmNlUnArMXJZaTVEcVA3SWNUUTVuOHA4aWY2K289IiwiZW5kcG9pbnR1cmxMZW5ndGgiOiIxMjIiLCJpc2xvb3BiYWNrIjoiVHJ1ZSIsImNpZCI6IlpHWm1Nakl3WkdRdE5HVXpOeTAwT1RCaExXRm1NVEl0WWpWallXSTJPVEkxWXpBMSIsInZlciI6Imhhc2hlZHByb29mdG9rZW4iLCJzaXRlaWQiOiJORFkxWXprM05UZ3RNREpsWXkwME9UbGxMVGhrTXpJdFptTmhPV0V6TURSaE1UazAiLCJhcHBfZGlzcGxheW5hbWUiOiJQblAgTWFuYWdlbWVudCBTaGVsbCIsImdpdmVuX25hbWUiOiJNT0QiLCJmYW1pbHlfbmFtZSI6IkFkbWluaXN0cmF0b3IiLCJzaWduaW5fc3RhdGUiOiJbXCJrbXNpXCJdIiwiYXBwaWQiOiIzMTM1OWM3Zi1iZDdlLTQ3NWMtODZkYi1mZGI4YzkzNzU0OGUiLCJ0aWQiOiIxYjExZjUwMi05ZWIwLTQwMWEtYjE2NC02ODkzM2U2ZTk0NDMiLCJ1cG4iOiJhZG1pbkBtMzY1eDk1NDgxMC5vbm1pY3Jvc29mdC5jb20iLCJwdWlkIjoiMTAwMzIwMDE1M0Y5NjFBMiIsImNhY2hla2V5IjoiMGguZnxtZW1iZXJzaGlwfDEwMDMyMDAxNTNmOTYxYTJAbGl2ZS5jb20iLCJzY3AiOiJhbGxzaXRlcy5mdWxsY29udHJvbCBncm91cC53cml0ZSBhbGxwcm9maWxlcy53cml0ZSB0ZXJtc3RvcmUud3JpdGUiLCJ0dCI6IjIiLCJ1c2VQZXJzaXN0ZW50Q29va2llIjpudWxsLCJpcGFkZHIiOiIyMC4xOTAuMTYwLjE2NCJ9.VzM1N0l1azFQVWhJSVU5MDJncDBDM29RTFY4RmYySGs5VG02cEdRQUw2RT0&ApiVersion=2.0",
@@ -4577,10 +4576,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: `DemoDocs/Fo'lde'r`
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([{
       "@microsoft.graph.downloadUrl": "https://contoso.sharepoint.com/_layouts/15/download.aspx?UniqueId=88fa8bc8-0eca-40e5-84c6-8d3974384803&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDAvbTM2NXg5NTQ4MTAuc2hhcmVwb2ludC5jb21AMWIxMWY1MDItOWViMC00MDFhLWIxNjQtNjg5MzNlNmU5NDQzIiwiaXNzIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwIiwibmJmIjoiMTYzNjI5NzIzOSIsImV4cCI6IjE2MzYzMDA4MzkiLCJlbmRwb2ludHVybCI6ImJUNlVod0k3TDQ5UEsyY3kxTisvWFlaUm5Ra25ZWGlMeEdxcFhmSk11QzA9IiwiZW5kcG9pbnR1cmxMZW5ndGgiOiIxMjIiLCJpc2xvb3BiYWNrIjoiVHJ1ZSIsImNpZCI6IlkyUTBZekE1TlRrdE1HRTVaQzAwT1RNMUxXRmxZek10TjJObU5tTXdOamRtT1dVeCIsInZlciI6Imhhc2hlZHByb29mdG9rZW4iLCJzaXRlaWQiOiJORFkxWXprM05UZ3RNREpsWXkwME9UbGxMVGhrTXpJdFptTmhPV0V6TURSaE1UazAiLCJhcHBfZGlzcGxheW5hbWUiOiJQblAgTWFuYWdlbWVudCBTaGVsbCIsImdpdmVuX25hbWUiOiJNT0QiLCJmYW1pbHlfbmFtZSI6IkFkbWluaXN0cmF0b3IiLCJzaWduaW5fc3RhdGUiOiJbXCJrbXNpXCJdIiwiYXBwaWQiOiIzMTM1OWM3Zi1iZDdlLTQ3NWMtODZkYi1mZGI4YzkzNzU0OGUiLCJ0aWQiOiIxYjExZjUwMi05ZWIwLTQwMWEtYjE2NC02ODkzM2U2ZTk0NDMiLCJ1cG4iOiJhZG1pbkBtMzY1eDk1NDgxMC5vbm1pY3Jvc29mdC5jb20iLCJwdWlkIjoiMTAwMzIwMDE1M0Y5NjFBMiIsImNhY2hla2V5IjoiMGguZnxtZW1iZXJzaGlwfDEwMDMyMDAxNTNmOTYxYTJAbGl2ZS5jb20iLCJzY3AiOiJhbGxzaXRlcy5mdWxsY29udHJvbCBncm91cC53cml0ZSBhbGxwcm9maWxlcy53cml0ZSB0ZXJtc3RvcmUud3JpdGUiLCJ0dCI6IjIiLCJ1c2VQZXJzaXN0ZW50Q29va2llIjpudWxsLCJpcGFkZHIiOiIyMC4xOTAuMTYwLjk2In0.T0VCSjFjOU1OS05FR2cvUkNrRXdlenhIckxVWDFiRVFxM2VuT2VhdGhMbz0&ApiVersion=2.0",
@@ -4984,10 +4983,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/sites/design',
         folderUrl: 'DemoDocs'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([{
       "@microsoft.graph.downloadUrl": "https://contoso.sharepoint.com/sites/Design/_layouts/15/download.aspx?UniqueId=1bc151a6-beb8-4034-be93-6e9a18aa6cdc&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDAvbTM2NXg5NjcwNTIuc2hhcmVwb2ludC5jb21ANzRhNTJiNGEtYTc5Ny00OGFkLTlkMGItMjQxYzliNjk1ZDFlIiwiaXNzIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwIiwibmJmIjoiMTYzNjgyMDgzOSIsImV4cCI6IjE2MzY4MjQ0MzkiLCJlbmRwb2ludHVybCI6Ik5PNFErS3pZSFBwMTJpZUhiZjdobmUrQ1E0em0yZVVvbnZCczI4RHdZVGs9IiwiZW5kcG9pbnR1cmxMZW5ndGgiOiIxMzUiLCJpc2xvb3BiYWNrIjoiVHJ1ZSIsImNpZCI6IlpEWmlZamszT0RFdFpEZ3lOeTAwWXpjd0xXSXlabUl0TjJVeE9XRmtOemszTTJOaSIsInZlciI6Imhhc2hlZHByb29mdG9rZW4iLCJzaXRlaWQiOiJZemc0WW1Fd09HWXROR1V4TnkwME9XTXhMV0V6TkdZdFkyRTROV1E1TURoak1qUmoiLCJhcHBfZGlzcGxheW5hbWUiOiJQblAgTWFuYWdlbWVudCBTaGVsbCIsImdpdmVuX25hbWUiOiJNT0QiLCJmYW1pbHlfbmFtZSI6IkFkbWluaXN0cmF0b3IiLCJhcHBpZCI6IjMxMzU5YzdmLWJkN2UtNDc1Yy04NmRiLWZkYjhjOTM3NTQ4ZSIsInRpZCI6Ijc0YTUyYjRhLWE3OTctNDhhZC05ZDBiLTI0MWM5YjY5NWQxZSIsInVwbiI6ImFkbWluQG0zNjV4OTY3MDUyLm9ubWljcm9zb2Z0LmNvbSIsInB1aWQiOiIxMDAzMjAwMUEyQ0I4QjA1IiwiY2FjaGVrZXkiOiIwaC5mfG1lbWJlcnNoaXB8MTAwMzIwMDFhMmNiOGIwNUBsaXZlLmNvbSIsInNjcCI6ImFsbHNpdGVzLmZ1bGxjb250cm9sIGdyb3VwLndyaXRlIGFsbHByb2ZpbGVzLndyaXRlIHRlcm1zdG9yZS53cml0ZSIsInR0IjoiMiIsInVzZVBlcnNpc3RlbnRDb29raWUiOm51bGwsImlwYWRkciI6IjIwLjE5MC4xNjAuMjQifQ.d0hGUFpuMVhJbGZGSVFzcEhPSjJyS1FIUStXbEtLL3RURW9qVUhwZWNKWT0&ApiVersion=2.0",
@@ -5688,10 +5687,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/sites/design/',
         folderUrl: 'DemoDocs'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([{
       "@microsoft.graph.downloadUrl": "https://contoso.sharepoint.com/sites/Design/_layouts/15/download.aspx?UniqueId=1bc151a6-beb8-4034-be93-6e9a18aa6cdc&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDAvbTM2NXg5NjcwNTIuc2hhcmVwb2ludC5jb21ANzRhNTJiNGEtYTc5Ny00OGFkLTlkMGItMjQxYzliNjk1ZDFlIiwiaXNzIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwIiwibmJmIjoiMTYzNjgyMDgzOSIsImV4cCI6IjE2MzY4MjQ0MzkiLCJlbmRwb2ludHVybCI6Ik5PNFErS3pZSFBwMTJpZUhiZjdobmUrQ1E0em0yZVVvbnZCczI4RHdZVGs9IiwiZW5kcG9pbnR1cmxMZW5ndGgiOiIxMzUiLCJpc2xvb3BiYWNrIjoiVHJ1ZSIsImNpZCI6IlpEWmlZamszT0RFdFpEZ3lOeTAwWXpjd0xXSXlabUl0TjJVeE9XRmtOemszTTJOaSIsInZlciI6Imhhc2hlZHByb29mdG9rZW4iLCJzaXRlaWQiOiJZemc0WW1Fd09HWXROR1V4TnkwME9XTXhMV0V6TkdZdFkyRTROV1E1TURoak1qUmoiLCJhcHBfZGlzcGxheW5hbWUiOiJQblAgTWFuYWdlbWVudCBTaGVsbCIsImdpdmVuX25hbWUiOiJNT0QiLCJmYW1pbHlfbmFtZSI6IkFkbWluaXN0cmF0b3IiLCJhcHBpZCI6IjMxMzU5YzdmLWJkN2UtNDc1Yy04NmRiLWZkYjhjOTM3NTQ4ZSIsInRpZCI6Ijc0YTUyYjRhLWE3OTctNDhhZC05ZDBiLTI0MWM5YjY5NWQxZSIsInVwbiI6ImFkbWluQG0zNjV4OTY3MDUyLm9ubWljcm9zb2Z0LmNvbSIsInB1aWQiOiIxMDAzMjAwMUEyQ0I4QjA1IiwiY2FjaGVrZXkiOiIwaC5mfG1lbWJlcnNoaXB8MTAwMzIwMDFhMmNiOGIwNUBsaXZlLmNvbSIsInNjcCI6ImFsbHNpdGVzLmZ1bGxjb250cm9sIGdyb3VwLndyaXRlIGFsbHByb2ZpbGVzLndyaXRlIHRlcm1zdG9yZS53cml0ZSIsInR0IjoiMiIsInVzZVBlcnNpc3RlbnRDb29raWUiOm51bGwsImlwYWRkciI6IjIwLjE5MC4xNjAuMjQifQ.d0hGUFpuMVhJbGZGSVFzcEhPSjJyS1FIUStXbEtLL3RURW9qVUhwZWNKWT0&ApiVersion=2.0",
@@ -6102,10 +6101,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/sites/design',
         folderUrl: 'DemoDocs/Folder'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([{
       "@microsoft.graph.downloadUrl": "https://contoso.sharepoint.com/sites/Design/_layouts/15/download.aspx?UniqueId=77e5e9f4-4731-478e-82ae-6eece079ae8b&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDAvbTM2NXg5NjcwNTIuc2hhcmVwb2ludC5jb21ANzRhNTJiNGEtYTc5Ny00OGFkLTlkMGItMjQxYzliNjk1ZDFlIiwiaXNzIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwIiwibmJmIjoiMTYzNjgyMTY1MiIsImV4cCI6IjE2MzY4MjUyNTIiLCJlbmRwb2ludHVybCI6IlFWaVJuSEVIRWRHNW5vSHhrOUFwQ3lXS3JKa05uL3pFVFhqT3NGWGpmQkE9IiwiZW5kcG9pbnR1cmxMZW5ndGgiOiIxMzUiLCJpc2xvb3BiYWNrIjoiVHJ1ZSIsImNpZCI6Ik1EZzRNV1UyTnpjdE1EUmpOeTAwWVdOaExXRXpZV1V0TWpNeE56WTJaR0UzTkdZeSIsInZlciI6Imhhc2hlZHByb29mdG9rZW4iLCJzaXRlaWQiOiJZemc0WW1Fd09HWXROR1V4TnkwME9XTXhMV0V6TkdZdFkyRTROV1E1TURoak1qUmoiLCJhcHBfZGlzcGxheW5hbWUiOiJQblAgTWFuYWdlbWVudCBTaGVsbCIsImdpdmVuX25hbWUiOiJNT0QiLCJmYW1pbHlfbmFtZSI6IkFkbWluaXN0cmF0b3IiLCJhcHBpZCI6IjMxMzU5YzdmLWJkN2UtNDc1Yy04NmRiLWZkYjhjOTM3NTQ4ZSIsInRpZCI6Ijc0YTUyYjRhLWE3OTctNDhhZC05ZDBiLTI0MWM5YjY5NWQxZSIsInVwbiI6ImFkbWluQG0zNjV4OTY3MDUyLm9ubWljcm9zb2Z0LmNvbSIsInB1aWQiOiIxMDAzMjAwMUEyQ0I4QjA1IiwiY2FjaGVrZXkiOiIwaC5mfG1lbWJlcnNoaXB8MTAwMzIwMDFhMmNiOGIwNUBsaXZlLmNvbSIsInNjcCI6ImFsbHNpdGVzLmZ1bGxjb250cm9sIGdyb3VwLndyaXRlIGFsbHByb2ZpbGVzLndyaXRlIHRlcm1zdG9yZS53cml0ZSIsInR0IjoiMiIsInVzZVBlcnNpc3RlbnRDb29raWUiOm51bGwsImlwYWRkciI6IjIwLjE5MC4xNjAuMjQifQ.M0xocUpuM3V6RStHbU5NRnBsQTBVK09SU3Jya3o5SmZZU0UyeE9sNTR6cz0&ApiVersion=2.0",
@@ -6542,11 +6541,11 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/',
         folderUrl: '/DemoDocs',
         recursive: true
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -7321,11 +7320,11 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/sites/design',
         folderUrl: 'DemoDocs',
         recursive: true
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -8259,11 +8258,11 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/sites/design',
         folderUrl: 'DemoDocs',
         recursive: true
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -9052,10 +9051,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/sites/design',
         folderUrl: 'DemoDocs'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([{
       "@microsoft.graph.downloadUrl": "https://contoso.sharepoint.com/sites/Design/_layouts/15/download.aspx?UniqueId=1bc151a6-beb8-4034-be93-6e9a18aa6cdc&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDAvbTM2NXg5NjcwNTIuc2hhcmVwb2ludC5jb21ANzRhNTJiNGEtYTc5Ny00OGFkLTlkMGItMjQxYzliNjk1ZDFlIiwiaXNzIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwIiwibmJmIjoiMTYzNjgyMDgzOSIsImV4cCI6IjE2MzY4MjQ0MzkiLCJlbmRwb2ludHVybCI6Ik5PNFErS3pZSFBwMTJpZUhiZjdobmUrQ1E0em0yZVVvbnZCczI4RHdZVGs9IiwiZW5kcG9pbnR1cmxMZW5ndGgiOiIxMzUiLCJpc2xvb3BiYWNrIjoiVHJ1ZSIsImNpZCI6IlpEWmlZamszT0RFdFpEZ3lOeTAwWXpjd0xXSXlabUl0TjJVeE9XRmtOemszTTJOaSIsInZlciI6Imhhc2hlZHByb29mdG9rZW4iLCJzaXRlaWQiOiJZemc0WW1Fd09HWXROR1V4TnkwME9XTXhMV0V6TkdZdFkyRTROV1E1TURoak1qUmoiLCJhcHBfZGlzcGxheW5hbWUiOiJQblAgTWFuYWdlbWVudCBTaGVsbCIsImdpdmVuX25hbWUiOiJNT0QiLCJmYW1pbHlfbmFtZSI6IkFkbWluaXN0cmF0b3IiLCJhcHBpZCI6IjMxMzU5YzdmLWJkN2UtNDc1Yy04NmRiLWZkYjhjOTM3NTQ4ZSIsInRpZCI6Ijc0YTUyYjRhLWE3OTctNDhhZC05ZDBiLTI0MWM5YjY5NWQxZSIsInVwbiI6ImFkbWluQG0zNjV4OTY3MDUyLm9ubWljcm9zb2Z0LmNvbSIsInB1aWQiOiIxMDAzMjAwMUEyQ0I4QjA1IiwiY2FjaGVrZXkiOiIwaC5mfG1lbWJlcnNoaXB8MTAwMzIwMDFhMmNiOGIwNUBsaXZlLmNvbSIsInNjcCI6ImFsbHNpdGVzLmZ1bGxjb250cm9sIGdyb3VwLndyaXRlIGFsbHByb2ZpbGVzLndyaXRlIHRlcm1zdG9yZS53cml0ZSIsInR0IjoiMiIsInVzZVBlcnNpc3RlbnRDb29raWUiOm51bGwsImlwYWRkciI6IjIwLjE5MC4xNjAuMjQifQ.d0hGUFpuMVhJbGZGSVFzcEhPSjJyS1FIUStXbEtLL3RURW9qVUhwZWNKWT0&ApiVersion=2.0",
@@ -9480,10 +9479,10 @@ describe(commands.LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'DemoDocs'
-      }
+      })
     });
     assert(loggerLogSpy.calledWith([
       {
@@ -9545,10 +9544,10 @@ describe(commands.LIST, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/sites/design',
         folderUrl: 'DemoDocs'
-      }
+      })
     }), new CommandError('Requested site could not be found'));
   });
 
@@ -9596,10 +9595,10 @@ describe(commands.LIST, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'DemoDocs'
-      }
+      })
     }), new CommandError(`Document library 'DemoDocs' not found`));
   });
 
@@ -9647,10 +9646,10 @@ describe(commands.LIST, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/',
         folderUrl: 'DemoDocs'
-      }
+      })
     }), new CommandError(`Document library 'DemoDocs' not found`));
   });
 
@@ -9710,10 +9709,10 @@ describe(commands.LIST, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'DemoDocs/Fodler'
-      }
+      })
     }), new CommandError('The resource could not be found.'));
   });
 
@@ -9773,10 +9772,10 @@ describe(commands.LIST, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         folderUrl: 'DemoDocs/Folder/Subfolder'
-      }
+      })
     }), new CommandError('The resource could not be found.'));
   });
 

--- a/src/m365/file/commands/file-list.ts
+++ b/src/m365/file/commands/file-list.ts
@@ -1,6 +1,7 @@
 import { Drive, DriveItem, Site } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import request, { CliRequestOptions } from '../../../request.js';
 import { formatting } from '../../../utils/formatting.js';
 import { odata } from '../../../utils/odata.js';
@@ -8,14 +9,21 @@ import { validation } from '../../../utils/validation.js';
 import GraphCommand from '../../base/GraphCommand.js';
 import commands from '../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  webUrl: z.string()
+    .refine(url => validation.isValidSharePointUrl(url) === true, {
+      error: e => `'${e.input}' is not a valid SharePoint Online site URL.`
+    })
+    .alias('u'),
+  folderUrl: z.string(),
+  recursive: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  webUrl: string;
-  folderUrl: string;
-  recursive?: boolean;
 }
 
 class FileListCommand extends GraphCommand {
@@ -33,34 +41,8 @@ class FileListCommand extends GraphCommand {
     return ['name', 'lastModifiedByUser'];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        recursive: !!args.options.recursive
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      { option: '-u, --webUrl <webUrl>' },
-      { option: '--folderUrl <folderUrl>' },
-      { option: '--recursive' }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => validation.isValidSharePointUrl(args.options.webUrl)
-    );
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/file/commands/file-move.spec.ts
+++ b/src/m365/file/commands/file-move.spec.ts
@@ -11,6 +11,7 @@ import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
+import { z } from 'zod';
 import commands from '../commands.js';
 import command from './file-move.js';
 
@@ -18,6 +19,7 @@ describe(commands.MOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodTypeAny;
 
   const defaultPostStub = (): sinon.SinonStub => {
     return sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -176,6 +178,7 @@ describe(commands.MOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
   });
 
   beforeEach(() => {
@@ -219,39 +222,33 @@ describe(commands.MOVE, () => {
   });
 
   it('fails validation if nameConflictBehavior is not a valid option', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: '/Shared Documents/file.pdf',
-        targetUrl: '/teams/finance/Shared Documents',
-        nameConflictBehavior: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      webUrl: 'https://contoso.sharepoint.com',
+      sourceUrl: '/Shared Documents/file.pdf',
+      targetUrl: '/teams/finance/Shared Documents',
+      nameConflictBehavior: 'invalid'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if the webUrl option is not a valid SharePoint site URL', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: 'foo',
-        sourceUrl: '/Shared Documents/file.pdf',
-        targetUrl: '/teams/finance/Shared Documents'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      webUrl: 'foo',
+      sourceUrl: '/Shared Documents/file.pdf',
+      targetUrl: '/teams/finance/Shared Documents'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('passes validation with valid options', async () => {
-    const actual = await command.validate({
-      options: {
-        webUrl: 'https://contoso.sharepoint.com',
-        sourceUrl: '/Shared Documents/file.pdf',
-        targetUrl: '/teams/finance/Shared Documents',
-        newName: 'file1',
-        nameConflictBehavior: 'rename'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      webUrl: 'https://contoso.sharepoint.com',
+      sourceUrl: '/Shared Documents/file.pdf',
+      targetUrl: '/teams/finance/Shared Documents',
+      newName: 'file1',
+      nameConflictBehavior: 'rename'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('moves a file by renaming when the same name already exists.', async () => {

--- a/src/m365/file/commands/file-move.spec.ts
+++ b/src/m365/file/commands/file-move.spec.ts
@@ -11,15 +11,14 @@ import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
-import { z } from 'zod';
 import commands from '../commands.js';
-import command from './file-move.js';
+import command, { options } from './file-move.js';
 
 describe(commands.MOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let commandOptionsSchema: z.ZodTypeAny;
+  let commandOptionsSchema: typeof options;
 
   const defaultPostStub = (): sinon.SinonStub => {
     return sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -178,7 +177,7 @@ describe(commands.MOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -256,13 +255,13 @@ describe(commands.MOVE, () => {
     defaultPatchStub();
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/file.pdf',
         targetUrl: '/Shared Documents/NewFolder',
         nameConflictBehavior: 'rename',
         newName: 'file_renamed.pdf'
-      }
+      })
     });
   });
 
@@ -271,13 +270,13 @@ describe(commands.MOVE, () => {
     defaultPatchStub();
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/file.pdf',
         targetUrl: '/Shared Documents/NewFolder',
         nameConflictBehavior: 'rename',
         newName: 'file_renamed'
-      }
+      })
     });
   });
 
@@ -287,12 +286,12 @@ describe(commands.MOVE, () => {
     const deleteStub: sinon.SinonStub = defaultDeleteStub();
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/file.pdf',
         targetUrl: '/teams/finance/Shared Documents',
         verbose: true
-      }
+      })
     });
 
     assert(getStub.called);
@@ -375,12 +374,12 @@ describe(commands.MOVE, () => {
     const deleteStub: sinon.SinonStub = defaultDeleteStub();
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/',
         sourceUrl: '/shared documents/file.pdf',
         targetUrl: '/teams/finance/Shared Documents',
         verbose: true
-      }
+      })
     });
 
     assert(deleteStub.called);
@@ -391,11 +390,11 @@ describe(commands.MOVE, () => {
     defaultPostStub();
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com/teams/finance',
         sourceUrl: '/teams/finance/shared documents/file.pdf',
         targetUrl: '/Shared Documents'
-      }
+      })
     }), new CommandError(`Name already exists`));
   });
 
@@ -405,13 +404,13 @@ describe(commands.MOVE, () => {
     defaultDeleteStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/Shared Documents/folder1',
         targetUrl: '/teams/finance/Shared Documents',
         nameConflictBehavior: 'rename',
         newName: 'folder1_renamed'
-      }
+      })
     }));
   });
 
@@ -421,12 +420,12 @@ describe(commands.MOVE, () => {
     defaultDeleteStub();
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: 'https://contoso.sharepoint.com/Shared Documents/file.pdf',
         targetUrl: 'https://contoso.sharepoint.com/teams/finance/Shared Documents',
         verbose: true
-      }
+      })
     }));
   });
 
@@ -434,11 +433,11 @@ describe(commands.MOVE, () => {
     defaultGetStub();
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         webUrl: 'https://contoso.sharepoint.com',
         sourceUrl: '/invalid/file.pdf',
         targetUrl: '/teams/finance/Shared Documents'
-      }
+      })
     }), new CommandError(`Drive 'https://contoso.sharepoint.com/invalid/file.pdf' not found`));
   });
 });

--- a/src/m365/file/commands/file-move.ts
+++ b/src/m365/file/commands/file-move.ts
@@ -1,6 +1,7 @@
 import { Drive } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import GraphCommand from '../../base/GraphCommand.js';
 import { setTimeout } from 'timers/promises';
 import commands from '../commands.js';
@@ -10,21 +11,29 @@ import { urlUtil } from '../../../utils/urlUtil.js';
 import { drive } from '../../../utils/drive.js';
 import { validation } from '../../../utils/validation.js';
 
+const nameConflictBehaviorOptions = ['fail', 'replace', 'rename'] as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  webUrl: z.string()
+    .refine(url => validation.isValidSharePointUrl(url) === true, {
+      error: e => `'${e.input}' is not a valid SharePoint Online site URL.`
+    })
+    .alias('u'),
+  sourceUrl: z.string().alias('s'),
+  targetUrl: z.string().alias('t'),
+  newName: z.string().optional(),
+  nameConflictBehavior: z.enum(nameConflictBehaviorOptions).optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  webUrl: string;
-  sourceUrl: string;
-  targetUrl: string;
-  newName?: string;
-  nameConflictBehavior?: string;
-}
-
 class FileMoveCommand extends GraphCommand {
   private pollingInterval: number = 10_000;
-  private readonly nameConflictBehaviorOptions = ['fail', 'replace', 'rename'];
 
   public get name(): string {
     return commands.MOVE;
@@ -34,46 +43,8 @@ class FileMoveCommand extends GraphCommand {
     return 'Moves a file to another location using the Microsoft Graph';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        webUrl: typeof args.options.webUrl !== 'undefined',
-        sourceUrl: typeof args.options.sourceUrl !== 'undefined',
-        targetUrl: typeof args.options.targetUrl !== 'undefined',
-        newName: typeof args.options.newName !== 'undefined',
-        nameConflictBehavior: typeof args.options.nameConflictBehavior !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      { option: '-u, --webUrl <webUrl>' },
-      { option: '-s, --sourceUrl <sourceUrl>' },
-      { option: '-t, --targetUrl <targetUrl>' },
-      { option: '--newName [newName]' },
-      { option: '--nameConflictBehavior [nameConflictBehavior]', autocomplete: this.nameConflictBehaviorOptions }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.nameConflictBehavior && this.nameConflictBehaviorOptions.indexOf(args.options.nameConflictBehavior) === -1) {
-          return `${args.options.nameConflictBehavior} is not a valid nameConflictBehavior value. Allowed values: ${this.nameConflictBehaviorOptions.join(', ')}.`;
-        }
-
-        return validation.isValidSharePointUrl(args.options.webUrl);
-      }
-    );
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -143,7 +114,7 @@ class FileMoveCommand extends GraphCommand {
       const sourceFileName = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
       const sourceFileExtension = sourceFileName.includes('.') ? sourceFileName.substring(sourceFileName.lastIndexOf('.')) : '';
       const newNameExtension = newName.includes('.') ? newName.substring(newName.lastIndexOf('.')) : '';
-      requestOptions.data.name = newNameExtension ? `${newName.replace(newNameExtension, "")}${sourceFileExtension}` : `${newName}${sourceFileExtension}`;
+      requestOptions.data.name = newNameExtension ? `${newName.replace(newNameExtension, '')}${sourceFileExtension}` : `${newName}${sourceFileExtension}`;
     }
 
     return requestOptions;


### PR DESCRIPTION
## Summary

Migrates all 5 `file` commands to use Zod schemas for option definitions and validation, replacing the old `#initTelemetry`, `#initOptions`, and `#initValidators` pattern.

### Commands migrated

| Command | Key changes |
|---------|-------------|
| `file add` | `folderUrl`/`siteUrl` SharePoint URL validation via Zod refine; `filePath` existence check via `getRefinedSchema` |
| `file copy` | `webUrl` SharePoint URL validation; `nameConflictBehavior` as `z.enum` |
| `file list` | `webUrl` SharePoint URL validation; `recursive` as optional boolean |
| `file move` | `webUrl` SharePoint URL validation; `nameConflictBehavior` as `z.enum` |
| `file convert pdf` | `sourceFile`/`targetFile` existence checks via `getRefinedSchema` |

### Changes per file

- **Command files**: Removed constructors, `#initTelemetry`, `#initOptions`, `#initValidators`; added exported `z.strictObject` schema with `globalOptionsZod.shape` spread and `get schema()` getter
- **Spec files**: Updated validation tests to use `commandOptionsSchema.safeParse()` instead of `command.validate()`

Closes #7303