### PR TITLE
Migrates flow commands to Zod

### DIFF
--- a/src/m365/flow/commands/flow-disable.spec.ts
+++ b/src/m365/flow/commands/flow-disable.spec.ts
@@ -7,6 +7,7 @@ import request from '../../../request.js';
 import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
+import { accessToken } from '../../../utils/accessToken.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
 import command from './flow-disable.js';
@@ -20,6 +21,7 @@ describe(commands.DISABLE, () => {
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
   });
 

--- a/src/m365/flow/commands/flow-disable.spec.ts
+++ b/src/m365/flow/commands/flow-disable.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../Auth.js';
+import { cli } from '../../../cli/cli.js';
+import { CommandInfo } from '../../../cli/CommandInfo.js';
 import { Logger } from '../../../cli/Logger.js';
 import { CommandError } from '../../../Command.js';
 import request from '../../../request.js';
@@ -10,11 +12,13 @@ import { session } from '../../../utils/session.js';
 import { accessToken } from '../../../utils/accessToken.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
-import command from './flow-disable.js';
+import command, { options } from './flow-disable.js';
 
 describe(commands.DISABLE, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -23,6 +27,8 @@ describe(commands.DISABLE, () => {
     sinon.stub(session, 'getId').returns('');
     sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -68,7 +74,7 @@ describe(commands.DISABLE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' }) });
     assert.strictEqual(postStub.lastCall.args[0].url, 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/3989cb59-ce1a-4a5c-bb78-257c5c39381d/stop?api-version=2016-11-01');
   });
 
@@ -82,7 +88,7 @@ describe(commands.DISABLE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', asAdmin: true } }));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', asAdmin: true }) }));
     assert.strictEqual(postStub.lastCall.args[0].url, 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/scopes/admin/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/3989cb59-ce1a-4a5c-bb78-257c5c39381d/stop?api-version=2016-11-01');
   });
 
@@ -94,7 +100,7 @@ describe(commands.DISABLE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' }) } as any),
       new CommandError(`Access to the environment 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6' is denied.`));
   });
 
@@ -106,7 +112,7 @@ describe(commands.DISABLE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12' }) } as any),
       new CommandError(`The caller with object id 'da8f7aea-cf43-497f-ad62-c2feae89a194' does not have permission for connection '1c6ee23a-a835-44bc-a4f5-462b658efc12' under Api 'shared_logicflows'.`));
   });
 
@@ -118,7 +124,7 @@ describe(commands.DISABLE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12', asAdmin: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12', asAdmin: true }) } as any),
       new CommandError(`Could not find flow '1c6ee23a-a835-44bc-a4f5-462b658efc12'.`));
   });
 
@@ -134,7 +140,7 @@ describe(commands.DISABLE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' }) } as any),
       new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/flow/commands/flow-disable.ts
+++ b/src/m365/flow/commands/flow-disable.ts
@@ -1,18 +1,22 @@
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import request, { CliRequestOptions } from '../../../request.js';
 import { formatting } from '../../../utils/formatting.js';
 import PowerAutomateCommand from '../../base/PowerAutomateCommand.js';
 import commands from '../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.string().alias('n'),
+  environmentName: z.string().alias('e'),
+  asAdmin: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  name: string;
-  environmentName: string;
-  asAdmin: boolean;
 }
 
 class FlowDisableCommand extends PowerAutomateCommand {
@@ -24,33 +28,8 @@ class FlowDisableCommand extends PowerAutomateCommand {
     return 'Disables specified Microsoft Flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        asAdmin: !!args.options.asAdmin
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--asAdmin'
-      }
-    );
+  public get schema(): z.ZodType {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/flow-enable.spec.ts
+++ b/src/m365/flow/commands/flow-enable.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../Auth.js';
+import { cli } from '../../../cli/cli.js';
+import { CommandInfo } from '../../../cli/CommandInfo.js';
 import { Logger } from '../../../cli/Logger.js';
 import { CommandError } from '../../../Command.js';
 import request from '../../../request.js';
@@ -10,11 +12,13 @@ import { session } from '../../../utils/session.js';
 import { accessToken } from '../../../utils/accessToken.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
-import command from './flow-enable.js';
+import command, { options } from './flow-enable.js';
 
 describe(commands.ENABLE, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -23,6 +27,8 @@ describe(commands.ENABLE, () => {
     sinon.stub(session, 'getId').returns('');
     sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -69,7 +75,7 @@ describe(commands.ENABLE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' }) });
     assert.strictEqual(postStub.lastCall.args[0].url, 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/3989cb59-ce1a-4a5c-bb78-257c5c39381d/start?api-version=2016-11-01');
   });
 
@@ -83,7 +89,7 @@ describe(commands.ENABLE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', asAdmin: true } }));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', asAdmin: true }) }));
     assert.strictEqual(postStub.lastCall.args[0].url, 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/scopes/admin/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c5/flows/3989cb59-ce1a-4a5c-bb78-257c5c39381d/start?api-version=2016-11-01');
   });
 
@@ -95,7 +101,7 @@ describe(commands.ENABLE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' }) } as any),
       new CommandError(`Access to the environment 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6' is denied.`));
   });
 
@@ -107,7 +113,7 @@ describe(commands.ENABLE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12' }) } as any),
       new CommandError(`The caller with object id 'da8f7aea-cf43-497f-ad62-c2feae89a194' does not have permission for connection '1c6ee23a-a835-44bc-a4f5-462b658efc12' under Api 'shared_logicflows'.`));
   });
 
@@ -119,7 +125,7 @@ describe(commands.ENABLE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12', asAdmin: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12', asAdmin: true }) } as any),
       new CommandError(`Could not find flow '1c6ee23a-a835-44bc-a4f5-462b658efc12'.`));
   });
 
@@ -135,7 +141,7 @@ describe(commands.ENABLE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' }) } as any),
       new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/flow/commands/flow-enable.spec.ts
+++ b/src/m365/flow/commands/flow-enable.spec.ts
@@ -7,6 +7,7 @@ import request from '../../../request.js';
 import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
+import { accessToken } from '../../../utils/accessToken.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
 import command from './flow-enable.js';
@@ -20,6 +21,7 @@ describe(commands.ENABLE, () => {
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
   });
 

--- a/src/m365/flow/commands/flow-enable.ts
+++ b/src/m365/flow/commands/flow-enable.ts
@@ -1,18 +1,22 @@
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import request, { CliRequestOptions } from '../../../request.js';
 import { formatting } from '../../../utils/formatting.js';
 import PowerAutomateCommand from '../../base/PowerAutomateCommand.js';
 import commands from '../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.string().alias('n'),
+  environmentName: z.string().alias('e'),
+  asAdmin: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  name: string;
-  environmentName: string;
-  asAdmin: boolean;
 }
 
 class FlowEnableCommand extends PowerAutomateCommand {
@@ -24,33 +28,8 @@ class FlowEnableCommand extends PowerAutomateCommand {
     return 'Enables specified Microsoft Flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        asAdmin: !!args.options.asAdmin
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--asAdmin'
-      }
-    );
+  public get schema(): z.ZodType {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/flow-export.spec.ts
+++ b/src/m365/flow/commands/flow-export.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
-import command from './flow-export.js';
+import command, { options } from './flow-export.js';
 import { formatting } from '../../../utils/formatting.js';
 import { accessToken } from '../../../utils/accessToken.js';
 
@@ -21,6 +21,7 @@ describe(commands.EXPORT, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let loggerLogToStderrSpy: sinon.SinonSpy;
 
   const actualFilename = `20180916t000000zba9d7134cc81499e9884bf70642afac7_20180916042428.zip`;
@@ -120,6 +121,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
     sinon.stub(accessToken, 'assertAccessTokenType').returns();
   });
 
@@ -292,49 +294,49 @@ describe(commands.EXPORT, () => {
   });
 
   it('fails validation if the id is not a GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if format is specified as neither JSON nor ZIP', async () => {
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'text' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'text' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if format is specified as JSON and packageCreatedBy parameter is specified', async () => {
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json', packageCreatedBy: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json', packageCreatedBy: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if format is specified as JSON and packageDescription parameter is specified', async () => {
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json', packageDescription: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json', packageDescription: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if format is specified as JSON and packageDisplayName parameter is specified', async () => {
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json', packageDisplayName: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json', packageDisplayName: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if format is specified as JSON and packageSourceEnvironment parameter is specified', async () => {
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json', packageSourceEnvironment: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json', packageSourceEnvironment: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if specified path doesn\'t exist', async () => {
     sinon.stub(fs, 'existsSync').callsFake(() => false);
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: `${foundFlowName}`, path: '/path/not/found.zip' } }, commandInfo);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: `${foundFlowName}`, path: '/path/not/found.zip' });
     sinonUtil.restore(fs.existsSync);
-    assert.notStrictEqual(actual, true);
+    assert.strictEqual(actual.success, false);
   });
 
   it('passes validation when the id and environment specified', async () => {
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: `${foundFlowName}` } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: `${foundFlowName}` });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when the id and environment specified and format set to JSON', async () => {
-    const actual = await command.validate({ options: { environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: foundEnvironmentId, name: `${foundFlowName}`, format: 'json' });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/flow/commands/flow-export.spec.ts
+++ b/src/m365/flow/commands/flow-export.spec.ts
@@ -168,7 +168,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { verbose: true, name: foundFlowName, environmentName: foundEnvironmentId, format: 'zip' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, name: foundFlowName, environmentName: foundEnvironmentId, format: 'zip' }) });
     assert(loggerLogToStderrSpy.calledWith(`File saved to path './${actualFilename}'.`));
   });
 
@@ -177,7 +177,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { verbose: true, name: foundFlowName, environmentName: foundEnvironmentId, format: 'zip' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, name: foundFlowName, environmentName: foundEnvironmentId, format: 'zip' }) });
     assert.strictEqual(getRequestsStub.lastCall.args[0].headers['x-anonymous'], true);
   });
 
@@ -186,7 +186,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { verbose: true, name: nonZipFileFlowId, environmentName: foundEnvironmentId, format: 'zip', path: './output.zip' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, name: nonZipFileFlowId, environmentName: foundEnvironmentId, format: 'zip', path: './output.zip' }) });
     assert(loggerLogToStderrSpy.calledWith(`File saved to path './output.zip'.`));
   });
 
@@ -195,7 +195,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { name: foundFlowName, environmentName: foundEnvironmentId, format: 'json' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: foundFlowName, environmentName: foundEnvironmentId, format: 'json' }) });
     assert(loggerLogSpy.calledWith(`./${flowDisplayName}.json`));
   });
 
@@ -215,7 +215,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'json' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'json' }) });
     assert(loggerLogSpy.calledWith('./_Flow __name_ _ with_ Illegal _ characters__.json'));
   });
 
@@ -224,7 +224,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { verbose: true, name: foundFlowName, environmentName: foundEnvironmentId, format: 'json' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, name: foundFlowName, environmentName: foundEnvironmentId, format: 'json' }) });
     assert(loggerLogToStderrSpy.calledWith(`File saved to path './${flowDisplayName}.json'.`));
   });
 
@@ -233,7 +233,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip' }) });
     assert(loggerLogSpy.calledWith(`./${actualFilename}`));
   });
 
@@ -242,7 +242,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip' }) });
     assert.strictEqual(getRequestsStub.lastCall.args[0].headers['x-anonymous'], true);
   });
 
@@ -251,7 +251,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip', path: './output.zip' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip', path: './output.zip' }) });
     assert(loggerLogSpy.notCalled);
   });
 
@@ -260,7 +260,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'post').callsFake(postFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip', path: './output.zip' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip', path: './output.zip' }) });
     assert.strictEqual(getRequestsStub.lastCall.args[0].headers['x-anonymous'], true);
   });
 
@@ -270,7 +270,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'get').callsFake(getFakes);
     sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
 
-    await command.action(logger, { options: { name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip', path: './output.zip' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: `${foundFlowName}`, environmentName: foundEnvironmentId, format: 'zip', path: './output.zip' }) });
     assert.strictEqual(postRequestsStub.lastCall.args[0].data.resources["L1BST1ZJREVSUy9NSUNST1NPRlQuRkxPVy9GTE9XUy9GMkVCOEIzNy1GNjI0LTRCMjItOTk1NC1CNUQwQ0JCMjhGOEI="].suggestedCreationType, 'Update');
     resourceIds.forEach((id) => {
       assert.strictEqual(postRequestsStub.lastCall.args[0].data.resources[id].suggestedCreationType, 'Existing');
@@ -281,7 +281,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'get').callsFake(getFakes);
     sinon.stub(request, 'post').callsFake(postFakes);
 
-    await assert.rejects(command.action(logger, { options: { environmentName: notFoundEnvironmentId, name: `${foundFlowName}` } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: notFoundEnvironmentId, name: `${foundFlowName}` }) } as any),
       new CommandError(`Access to the environment '${notFoundEnvironmentId}' is denied.`));
   });
 
@@ -289,7 +289,7 @@ describe(commands.EXPORT, () => {
     sinon.stub(request, 'get').callsFake(getFakes);
     sinon.stub(request, 'post').callsFake(postFakes);
 
-    await assert.rejects(command.action(logger, { options: { environmentName: foundEnvironmentId, name: notFoundFlowName } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: foundEnvironmentId, name: notFoundFlowName }) } as any),
       new CommandError(`The caller with object id '${foundEnvironmentId}' does not have permission for connection '${notFoundFlowName}' under Api 'shared_logicflows'.`));
   });
 

--- a/src/m365/flow/commands/flow-export.ts
+++ b/src/m365/flow/commands/flow-export.ts
@@ -1,27 +1,32 @@
 import fs from 'fs';
 import path from 'path';
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import request, { CliRequestOptions } from '../../../request.js';
 import { formatting } from '../../../utils/formatting.js';
-import { validation } from '../../../utils/validation.js';
 import PowerPlatformCommand from '../../base/PowerPlatformCommand.js';
 import commands from '../commands.js';
 import PowerAutomateCommand from '../../base/PowerAutomateCommand.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  environmentName: z.string().alias('e'),
+  name: z.uuid().alias('n'),
+  packageDisplayName: z.string().optional().alias('d'),
+  packageDescription: z.string().optional(),
+  packageCreatedBy: z.string().optional().alias('c'),
+  packageSourceEnvironment: z.string().optional().alias('s'),
+  format: z.string().transform(v => v.toLowerCase()).pipe(z.enum(['json', 'zip'], {
+    error: 'Option format must be json or zip. Default is zip'
+  })).optional().alias('f'),
+  path: z.string().optional().alias('p')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  environmentName: string;
-  name: string;
-  packageDisplayName?: string;
-  packageDescription?: string;
-  packageCreatedBy?: string;
-  packageSourceEnvironment?: string;
-  format?: string;
-  path?: string;
 }
 
 class FlowExportCommand extends PowerPlatformCommand {
@@ -33,94 +38,38 @@ class FlowExportCommand extends PowerPlatformCommand {
     return 'Exports the specified Microsoft Flow as a file';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
+  public get schema(): z.ZodType {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        packageDisplayName: typeof args.options.packageDisplayName !== 'undefined',
-        packageDescription: typeof args.options.packageDescription !== 'undefined',
-        packageCreatedBy: typeof args.options.packageCreatedBy !== 'undefined',
-        packageSourceEnvironment: typeof args.options.packageSourceEnvironment !== 'undefined',
-        format: args.options.format,
-        path: typeof args.options.path !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '-d, --packageDisplayName [packageDisplayName]'
-      },
-      {
-        option: '--packageDescription [packageDescription]'
-      },
-      {
-        option: '-c, --packageCreatedBy [packageCreatedBy]'
-      },
-      {
-        option: '-s, --packageSourceEnvironment [packageSourceEnvironment]'
-      },
-      {
-        option: '-f, --format [format]'
-      },
-      {
-        option: '-p, --path [path]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        const lowerCaseFormat = args.options.format ? args.options.format.toLowerCase() : '';
-
-        if (!validation.isValidGuid(args.options.name)) {
-          return `${args.options.name} is not a valid GUID`;
-        }
-
-        if (args.options.format && (lowerCaseFormat !== 'json' && lowerCaseFormat !== 'zip')) {
-          return 'Option format must be json or zip. Default is zip';
-        }
-
-        if (lowerCaseFormat === 'json') {
-          if (args.options.packageCreatedBy) {
-            return 'packageCreatedBy cannot be specified with output of json';
-          }
-
-          if (args.options.packageDescription) {
-            return 'packageDescription cannot be specified with output of json';
-          }
-
-          if (args.options.packageDisplayName) {
-            return 'packageDisplayName cannot be specified with output of json';
-          }
-
-          if (args.options.packageSourceEnvironment) {
-            return 'packageSourceEnvironment cannot be specified with output of json';
-          }
-        }
-
-        if (args.options.path && !fs.existsSync(path.dirname(args.options.path))) {
-          return 'Specified path where to save the file does not exist';
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => options.format !== 'json' || !options.packageCreatedBy, {
+        error: 'packageCreatedBy cannot be specified with output of json',
+        path: ['packageCreatedBy']
+      })
+      .refine(options => options.format !== 'json' || !options.packageDescription, {
+        error: 'packageDescription cannot be specified with output of json',
+        path: ['packageDescription']
+      })
+      .refine(options => options.format !== 'json' || !options.packageDisplayName, {
+        error: 'packageDisplayName cannot be specified with output of json',
+        path: ['packageDisplayName']
+      })
+      .refine(options => options.format !== 'json' || !options.packageSourceEnvironment, {
+        error: 'packageSourceEnvironment cannot be specified with output of json',
+        path: ['packageSourceEnvironment']
+      })
+      .refine(options => {
+        if (options.path) {
+          return fs.existsSync(path.dirname(options.path));
         }
 
         return true;
-      }
-    );
+      }, {
+        error: 'Specified path where to save the file does not exist',
+        path: ['path']
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/flow-get.spec.ts
+++ b/src/m365/flow/commands/flow-get.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../Auth.js';
+import { cli } from '../../../cli/cli.js';
+import { CommandInfo } from '../../../cli/CommandInfo.js';
 import { Logger } from '../../../cli/Logger.js';
 import { CommandError } from '../../../Command.js';
 import request from '../../../request.js';
@@ -10,7 +12,7 @@ import { session } from '../../../utils/session.js';
 import { accessToken } from '../../../utils/accessToken.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
-import command from './flow-get.js';
+import command, { options } from './flow-get.js';
 import { flowGetResponse } from './flow-get.mock.js';
 
 describe(commands.GET, () => {
@@ -19,6 +21,8 @@ describe(commands.GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -27,6 +31,8 @@ describe(commands.GET, () => {
     sinon.stub(session, 'getId').returns('');
     sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -77,7 +83,7 @@ describe(commands.GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' }) });
     assert(loggerLogSpy.calledWith(flowGetResponse));
   });
 
@@ -94,7 +100,7 @@ describe(commands.GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' }) });
     assert(loggerLogSpy.calledWith(flowGetResponse));
   });
 
@@ -122,7 +128,7 @@ describe(commands.GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' }) });
     assert(loggerLogSpy.calledWith(flowGetResponseClone));
   });
 
@@ -139,7 +145,7 @@ describe(commands.GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', asAdmin: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', asAdmin: true }) });
     assert(loggerLogSpy.calledWith(flowGetResponse));
   });
 
@@ -156,7 +162,7 @@ describe(commands.GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', output: 'json' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', output: 'json' }) });
     assert(loggerLogSpy.calledWith(flowGetResponse));
   });
 
@@ -172,7 +178,7 @@ describe(commands.GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d', environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' }) });
     assert(loggerLogSpy.calledWith(flowGetResponseClone));
   });
 
@@ -184,7 +190,7 @@ describe(commands.GET, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' }) } as any),
       new CommandError(`Access to the environment 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6' is denied.`));
   });
 
@@ -196,7 +202,7 @@ describe(commands.GET, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12' }) } as any),
       new CommandError(`The caller with object id 'da8f7aea-cf43-497f-ad62-c2feae89a194' does not have permission for connection '1c6ee23a-a835-44bc-a4f5-462b658efc12' under Api 'shared_logicflows'.`));
   });
 
@@ -208,7 +214,7 @@ describe(commands.GET, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12', asAdmin: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6', name: '1c6ee23a-a835-44bc-a4f5-462b658efc12', asAdmin: true }) } as any),
       new CommandError(`Could not find flow '1c6ee23a-a835-44bc-a4f5-462b658efc12'.`));
   });
 
@@ -224,7 +230,7 @@ describe(commands.GET, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5', name: '3989cb59-ce1a-4a5c-bb78-257c5c39381d' }) } as any),
       new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/flow/commands/flow-get.spec.ts
+++ b/src/m365/flow/commands/flow-get.spec.ts
@@ -7,6 +7,7 @@ import request from '../../../request.js';
 import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
+import { accessToken } from '../../../utils/accessToken.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
 import command from './flow-get.js';
@@ -24,6 +25,7 @@ describe(commands.GET, () => {
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
   });
 

--- a/src/m365/flow/commands/flow-get.ts
+++ b/src/m365/flow/commands/flow-get.ts
@@ -1,18 +1,22 @@
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import request, { CliRequestOptions } from '../../../request.js';
 import { formatting } from '../../../utils/formatting.js';
 import PowerAutomateCommand from '../../base/PowerAutomateCommand.js';
 import commands from '../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  environmentName: z.string().alias('e'),
+  name: z.string().alias('n'),
+  asAdmin: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  environmentName: string;
-  name: string;
-  asAdmin: boolean;
 }
 
 interface Trigger {
@@ -49,33 +53,8 @@ class FlowGetCommand extends PowerAutomateCommand {
     return 'Gets information about the specified Microsoft Flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        asAdmin: !!args.options.asAdmin
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--asAdmin'
-      }
-    );
+  public get schema(): z.ZodType {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/flow-list.spec.ts
+++ b/src/m365/flow/commands/flow-list.spec.ts
@@ -300,7 +300,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName }) });
     assert(loggerLogSpy.calledOnceWithExactly(regularFlowResponse.value));
   });
 
@@ -313,7 +313,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, sharingStatus: 'ownedByMe' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, sharingStatus: 'ownedByMe' }) });
     assert(loggerLogSpy.calledOnceWithExactly(flowResponse.value));
   });
 
@@ -329,7 +329,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, sharingStatus: 'all' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, sharingStatus: 'all' }) });
     assert(loggerLogSpy.calledOnceWithExactly(flowResponse.value));
   });
 
@@ -342,7 +342,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, sharingStatus: 'personal' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, sharingStatus: 'personal' }) });
     assert(loggerLogSpy.calledOnceWithExactly(flowResponse.value));
   });
 
@@ -355,7 +355,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, sharingStatus: 'sharedWithMe' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, sharingStatus: 'sharedWithMe' }) });
     assert(loggerLogSpy.calledOnceWithExactly(flowResponse.value));
   });
 
@@ -368,7 +368,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, asAdmin: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, asAdmin: true, verbose: true }) });
     assert(loggerLogSpy.calledOnceWithExactly(adminFlowResponse.value));
   });
 
@@ -380,7 +380,7 @@ describe(commands.LIST, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: environmentName } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName }) } as any),
       new CommandError(`Access to the environment '${environmentName}' is denied.`));
   });
 
@@ -396,7 +396,7 @@ describe(commands.LIST, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: environmentName } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName }) } as any),
       new CommandError('An error has occurred'));
   });
 
@@ -420,7 +420,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, withSolutions: true } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, withSolutions: true }) } as any);
 
     assert(loggerLogSpy.calledOnceWithExactly([
       {
@@ -462,7 +462,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c5' }) } as any);
     assert(loggerLogSpy.calledWith([
       {
         name: "1c6ee23a-a835-44bc-a4f5-462b658efc13",
@@ -484,7 +484,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, output: 'text' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, output: 'text' }) });
     const expectedOutput = regularFlowResponse.value.map(f => ({ ...f, displayName: f.properties.displayName }));
     assert(loggerLogSpy.calledOnceWithExactly(expectedOutput));
   });
@@ -498,7 +498,7 @@ describe(commands.LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, asAdmin: true, output: 'text' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, asAdmin: true, output: 'text' }) });
     const expectedOutput = adminFlowResponse.value.map(f => ({ ...f, displayName: f.properties.displayName }));
     assert(loggerLogSpy.calledOnceWithExactly(expectedOutput));
   });

--- a/src/m365/flow/commands/flow-list.spec.ts
+++ b/src/m365/flow/commands/flow-list.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
-import command from './flow-list.js';
+import command, { options } from './flow-list.js';
 import { accessToken } from '../../../utils/accessToken.js';
 
 describe(commands.LIST, () => {
@@ -219,6 +219,7 @@ describe(commands.LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -228,6 +229,7 @@ describe(commands.LIST, () => {
     sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -270,23 +272,23 @@ describe(commands.LIST, () => {
   });
 
   it('fails validation if asAdmin is specified in combination with a sharingStatus', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, asAdmin: true, sharingStatus: 'all' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, asAdmin: true, sharingStatus: 'all' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation if sharingStatus is not a valid sharingstatus', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, sharingStatus: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, sharingStatus: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('passes validation if sharingStatus is valid', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, sharingStatus: 'all' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, sharingStatus: 'all' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation if asAdmin is passed', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, asAdmin: true } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, asAdmin: true });
+    assert.strictEqual(actual.success, true);
   });
 
   it('retrieves available flows', async () => {

--- a/src/m365/flow/commands/flow-list.ts
+++ b/src/m365/flow/commands/flow-list.ts
@@ -1,19 +1,23 @@
+import { z } from 'zod';
 import { Logger } from '../../../cli/Logger.js';
-import GlobalOptions from '../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../Command.js';
 import { formatting } from '../../../utils/formatting.js';
 import { odata } from '../../../utils/odata.js';
 import PowerAutomateCommand from '../../base/PowerAutomateCommand.js';
 import commands from '../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  environmentName: z.string().alias('e'),
+  sharingStatus: z.enum(['all', 'personal', 'ownedByMe', 'sharedWithMe']).optional(),
+  withSolutions: z.boolean().optional(),
+  asAdmin: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  environmentName: string;
-  sharingStatus?: string;
-  withSolutions?: boolean;
-  asAdmin?: boolean;
 }
 
 interface PowerAutomateFlow {
@@ -26,8 +30,6 @@ interface PowerAutomateFlow {
 }
 
 class FlowListCommand extends PowerAutomateCommand {
-  private allowedSharingStatuses = ['all', 'personal', 'ownedByMe', 'sharedWithMe'];
-
   public get name(): string {
     return commands.LIST;
   }
@@ -36,66 +38,18 @@ class FlowListCommand extends PowerAutomateCommand {
     return 'Lists Power Automate flows in the given environment';
   }
 
-  public defaultProperties(): string[] | undefined {
-    return ['name', 'displayName'];
+  public get schema(): z.ZodType {
+    return options;
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initTypes();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        sharingStatus: typeof args.options.sharingStatus !== 'undefined',
-        withSolutions: !!args.options.withSolutions,
-        asAdmin: !!args.options.asAdmin
-      });
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema.refine(options => !(options.asAdmin && options.sharingStatus), {
+      error: 'The options asAdmin and sharingStatus cannot be specified together.'
     });
   }
 
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--sharingStatus [sharingStatus]',
-        autocomplete: this.allowedSharingStatuses
-      },
-      {
-        option: '--withSolutions'
-      },
-      {
-        option: '--asAdmin'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.asAdmin && args.options.sharingStatus) {
-          return `The options asAdmin and sharingStatus cannot be specified together.`;
-        }
-
-        if (args.options.sharingStatus && !this.allowedSharingStatuses.some(status => status === args.options.sharingStatus)) {
-          return `${args.options.sharingStatus} is not a valid sharing status. Allowed values are: ${this.allowedSharingStatuses.join(', ')}`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('environmentName', 'sharingStatus');
-    this.types.boolean.push('withSolutions', 'asAdmin');
+  public defaultProperties(): string[] | undefined {
+    return ['name', 'displayName'];
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/flow-remove.spec.ts
+++ b/src/m365/flow/commands/flow-remove.spec.ts
@@ -93,10 +93,10 @@ describe(commands.REMOVE, () => {
 
   it('prompts before removing the specified Microsoft Flow owned by the currently signed-in user when force option not passed', async () => {
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72'
-      }
+      })
     });
 
     assert(promptIssued);
@@ -108,10 +108,10 @@ describe(commands.REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72'
-      }
+      })
     });
     assert(postSpy.notCalled);
   });
@@ -129,22 +129,22 @@ describe(commands.REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72'
-      }
+      })
     });
     assert(loggerLogToStderrSpy.called);
   });
 
   it('prompts before removing the specified Microsoft Flow owned by another user when force option not passed', async () => {
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         asAdmin: true
-      }
+      })
     });
 
     assert(promptIssued);
@@ -156,11 +156,11 @@ describe(commands.REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         asAdmin: true
-      }
+      })
     });
     assert(postSpy.notCalled);
   });
@@ -178,12 +178,12 @@ describe(commands.REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         asAdmin: true
-      }
+      })
     });
     assert(loggerLogToStderrSpy.called);
   });
@@ -198,12 +198,12 @@ describe(commands.REMOVE, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         force: true
-      }
+      })
     });
     assert(loggerLogToStderrSpy.called);
   });
@@ -218,13 +218,13 @@ describe(commands.REMOVE, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         force: true,
         asAdmin: true
-      }
+      })
     });
     assert(loggerLogToStderrSpy.called);
   });
@@ -239,11 +239,11 @@ describe(commands.REMOVE, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         force: true
-      }
+      })
     } as any), new CommandError(`Access to the environment 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c' is denied.`));
   });
 
@@ -260,10 +260,10 @@ describe(commands.REMOVE, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72'
-      }
+      })
     } as any), new CommandError(`Access to the environment 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c' is denied.`));
   });
 
@@ -275,10 +275,10 @@ describe(commands.REMOVE, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72'
-      }
+      })
     } as any), new CommandError(`Error: Resource '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72' does not exist in environment 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c'`));
   });
 
@@ -287,11 +287,11 @@ describe(commands.REMOVE, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         force: true
-      }
+      })
     } as any), new CommandError(`Error: Resource '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72' does not exist in environment 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c'`));
   });
 });

--- a/src/m365/flow/commands/flow-remove.spec.ts
+++ b/src/m365/flow/commands/flow-remove.spec.ts
@@ -9,14 +9,16 @@ import request from '../../../request.js';
 import { telemetry } from '../../../telemetry.js';
 import { pid } from '../../../utils/pid.js';
 import { session } from '../../../utils/session.js';
+import { accessToken } from '../../../utils/accessToken.js';
 import { sinonUtil } from '../../../utils/sinonUtil.js';
 import commands from '../commands.js';
-import command from './flow-remove.js';
+import command, { options } from './flow-remove.js';
 
 describe(commands.REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let promptIssued: boolean = false;
 
@@ -25,8 +27,10 @@ describe(commands.REMOVE, () => {
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -72,23 +76,19 @@ describe(commands.REMOVE, () => {
   });
 
   it('fails validation if the name is not valid GUID', async () => {
-    const actual = await command.validate({
-      options: {
-        environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
-        name: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
+      name: 'invalid'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('passes validation when the name and environment specified', async () => {
-    const actual = await command.validate({
-      options: {
-        environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
-        name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
+      name: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('prompts before removing the specified Microsoft Flow owned by the currently signed-in user when force option not passed', async () => {

--- a/src/m365/flow/commands/flow-remove.ts
+++ b/src/m365/flow/commands/flow-remove.ts
@@ -1,21 +1,24 @@
-import GlobalOptions from '../../../GlobalOptions.js';
+import { z } from 'zod';
 import { cli } from '../../../cli/cli.js';
 import { Logger } from '../../../cli/Logger.js';
+import { globalOptionsZod } from '../../../Command.js';
 import request, { CliRequestOptions } from '../../../request.js';
 import { formatting } from '../../../utils/formatting.js';
-import { validation } from '../../../utils/validation.js';
 import commands from '../commands.js';
 import PowerAutomateCommand from '../../base/PowerAutomateCommand.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.uuid().alias('n'),
+  environmentName: z.string().alias('e'),
+  asAdmin: z.boolean().optional(),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  environmentName: string;
-  name: string;
-  asAdmin?: boolean;
-  force?: boolean;
 }
 
 class FlowRemoveCommand extends PowerAutomateCommand {
@@ -27,50 +30,8 @@ class FlowRemoveCommand extends PowerAutomateCommand {
     return 'Removes the specified Microsoft Flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        asAdmin: !!args.options.asAdmin,
-        force: !!args.options.force
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--asAdmin'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.name)) {
-          return `${args.options.name} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodType {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/owner/owner-ensure.spec.ts
+++ b/src/m365/flow/commands/owner/owner-ensure.spec.ts
@@ -12,9 +12,10 @@ import { entraUser } from '../../../../utils/entraUser.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
+import { accessToken } from '../../../../utils/accessToken.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './owner-ensure.js';
+import command, { options } from './owner-ensure.js';
 
 describe(commands.OWNER_ENSURE, () => {
   const validEnvironmentName = 'Default-6a2903af-9c03-4c02-a50b-e7419599925b';
@@ -28,14 +29,17 @@ describe(commands.OWNER_ENSURE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -77,34 +81,44 @@ describe(commands.OWNER_ENSURE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if flowName is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: validEnvironmentName, flowName: 'invalid', userId: validUserId, roleName: validRoleName } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if flowName is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: validEnvironmentName, flowName: 'invalid', userId: validUserId, roleName: validRoleName });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: validEnvironmentName, flowName: validFlowName, userId: 'invalid', roleName: validRoleName } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: validEnvironmentName, flowName: validFlowName, userId: 'invalid', roleName: validRoleName });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if groupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: validEnvironmentName, flowName: validFlowName, groupId: 'invalid', roleName: validRoleName } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if groupId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: validEnvironmentName, flowName: validFlowName, groupId: 'invalid', roleName: validRoleName });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if username is not a valid user principal name', async () => {
-    const actual = await command.validate({ options: { environmentName: validEnvironmentName, flowName: validFlowName, userName: 'invalid', roleName: validRoleName } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if username is not a valid user principal name', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: validEnvironmentName, flowName: validFlowName, userName: 'invalid', roleName: validRoleName });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if roleName is not a valid role name', async () => {
-    const actual = await command.validate({ options: { environmentName: validEnvironmentName, flowName: validFlowName, userName: validUserName, roleName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if roleName is not a valid role name', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: validEnvironmentName, flowName: validFlowName, userName: validUserName, roleName: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when required parameters are provided', async () => {
-    const actual = await command.validate({ options: { environmentName: validEnvironmentName, flowName: validFlowName, userName: validUserName, roleName: validRoleName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation when no owner identifier is provided', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: validEnvironmentName, flowName: validFlowName, roleName: validRoleName });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation when multiple owner identifiers are provided', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: validEnvironmentName, flowName: validFlowName, userId: validUserId, groupId: validGroupId, roleName: validRoleName });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('passes validation when required parameters are provided', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: validEnvironmentName, flowName: validFlowName, userName: validUserName, roleName: validRoleName });
+    assert.strictEqual(actual.success, true);
   });
 
   it('adds owner to a flow with userId', async () => {

--- a/src/m365/flow/commands/owner/owner-ensure.spec.ts
+++ b/src/m365/flow/commands/owner/owner-ensure.spec.ts
@@ -144,7 +144,7 @@ describe(commands.OWNER_ENSURE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, userId: validUserId, roleName: 'CanView' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, userId: validUserId, roleName: 'CanView' }) });
     assert.deepStrictEqual(postRequestStub.lastCall.args[0].data, requestBody);
   });
 
@@ -173,7 +173,7 @@ describe(commands.OWNER_ENSURE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, userName: validUserName, roleName: validRoleName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, userName: validUserName, roleName: validRoleName }) });
     assert.deepStrictEqual(postRequestStub.lastCall.args[0].data, requestBody);
   });
 
@@ -200,7 +200,7 @@ describe(commands.OWNER_ENSURE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, groupId: validGroupId, roleName: validRoleName, asAdmin: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, groupId: validGroupId, roleName: validRoleName, asAdmin: true }) });
     assert.deepStrictEqual(postRequestStub.lastCall.args[0].data, requestBody);
   });
 
@@ -229,7 +229,7 @@ describe(commands.OWNER_ENSURE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, groupName: validGroupName, roleName: validRoleName, asAdmin: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, groupName: validGroupName, roleName: validRoleName, asAdmin: true }) });
     assert.deepStrictEqual(postRequestStub.lastCall.args[0].data, requestBody);
   });
 
@@ -271,7 +271,7 @@ describe(commands.OWNER_ENSURE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, groupName: validGroupName, roleName: validRoleName, asAdmin: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: validEnvironmentName, flowName: validFlowName, groupName: validGroupName, roleName: validRoleName, asAdmin: true }) });
     assert.deepStrictEqual(postRequestStub.lastCall.args[0].data, requestBody);
   });
 
@@ -283,7 +283,7 @@ describe(commands.OWNER_ENSURE, () => {
     };
     sinon.stub(request, 'post').rejects(error);
 
-    await assert.rejects(command.action(logger, { options: { environmentName: validEnvironmentName, flowName: validFlowName, roleName: validRoleName, userId: validUserId } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: validEnvironmentName, flowName: validFlowName, roleName: validRoleName, userId: validUserId }) } as any),
       new CommandError(error.error.message));
   });
 });

--- a/src/m365/flow/commands/owner/owner-ensure.ts
+++ b/src/m365/flow/commands/owner/owner-ensure.ts
@@ -1,5 +1,6 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { entraUser } from '../../../../utils/entraUser.js';
@@ -8,24 +9,27 @@ import { validation } from '../../../../utils/validation.js';
 import PowerAutomateCommand from '../../../base/PowerAutomateCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  flowName: z.uuid(),
+  environmentName: z.string().alias('e'),
+  roleName: z.enum(['CanView', 'CanEdit']),
+  userId: z.uuid().optional(),
+  userName: z.string().refine(name => validation.isValidUserPrincipalName(name), {
+    error: e => `'${e.input}' is not a valid userName.`
+  }).optional(),
+  groupId: z.uuid().optional(),
+  groupName: z.string().optional(),
+  asAdmin: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  flowName: string;
-  environmentName: string;
-  roleName: string;
-  userId?: string;
-  userName?: string;
-  groupId?: string;
-  groupName?: string;
-  asAdmin?: boolean;
-}
-
 class FlowOwnerEnsureCommand extends PowerAutomateCommand {
-  private static readonly allowedRoleNames: string[] = ['CanView', 'CanEdit'];
-
   public get name(): string {
     return commands.OWNER_ENSURE;
   }
@@ -34,85 +38,19 @@ class FlowOwnerEnsureCommand extends PowerAutomateCommand {
     return 'Assigns/updates permissions to a Power Automate flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodType {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        asAdmin: !!args.options.asAdmin,
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined',
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema.refine(
+      options => [options.userId, options.userName, options.groupId, options.groupName].filter(x => x !== undefined).length === 1,
       {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--flowName <flowName>'
-      },
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      },
-      {
-        option: '--groupId [groupId]'
-      },
-      {
-        option: '--groupName [groupName]'
-      },
-      {
-        option: '--roleName <roleName>',
-        autocomplete: FlowOwnerEnsureCommand.allowedRoleNames
-      },
-      {
-        option: '--asAdmin'
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['userId', 'userName', 'groupId', 'groupName'] });
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.flowName)) {
-          return `${args.options.flowName} is not a valid GUID.`;
+        error: 'Specify either userId, userName, groupId, or groupName, but not multiple.',
+        params: {
+          customCode: 'optionSet',
+          options: ['userId', 'userName', 'groupId', 'groupName']
         }
-
-        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
-          return `${args.options.userId} is not a valid GUID.`;
-        }
-
-        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
-          return `${args.options.userName} is not a valid userName.`;
-        }
-
-        if (args.options.groupId && !validation.isValidGuid(args.options.groupId)) {
-          return `${args.options.groupId} is not a valid GUID.`;
-        }
-
-        if (FlowOwnerEnsureCommand.allowedRoleNames.indexOf(args.options.roleName) === -1) {
-          return `${args.options.roleName} is not a valid roleName. Valid values are: ${FlowOwnerEnsureCommand.allowedRoleNames.join(', ')}`;
-        }
-
-        return true;
       }
     );
   }
@@ -174,4 +112,4 @@ class FlowOwnerEnsureCommand extends PowerAutomateCommand {
   }
 }
 
-export default new FlowOwnerEnsureCommand(); 
+export default new FlowOwnerEnsureCommand();

--- a/src/m365/flow/commands/owner/owner-ensure.ts
+++ b/src/m365/flow/commands/owner/owner-ensure.ts
@@ -14,11 +14,15 @@ export const options = z.strictObject({
   flowName: z.uuid(),
   environmentName: z.string().alias('e'),
   roleName: z.enum(['CanView', 'CanEdit']),
-  userId: z.uuid().optional(),
+  userId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
   userName: z.string().refine(name => validation.isValidUserPrincipalName(name), {
     error: e => `'${e.input}' is not a valid userName.`
   }).optional(),
-  groupId: z.uuid().optional(),
+  groupId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
   groupName: z.string().optional(),
   asAdmin: z.boolean().optional()
 });

--- a/src/m365/flow/commands/owner/owner-list.spec.ts
+++ b/src/m365/flow/commands/owner/owner-list.spec.ts
@@ -10,9 +10,10 @@ import { telemetry } from '../../../../telemetry.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
+import { accessToken } from '../../../../utils/accessToken.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './owner-list.js';
+import command, { options } from './owner-list.js';
 
 describe(commands.OWNER_LIST, () => {
   const environmentName = 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6';
@@ -27,13 +28,17 @@ describe(commands.OWNER_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -50,7 +55,6 @@ describe(commands.OWNER_LIST, () => {
       }
     };
     loggerLogSpy = sinon.spy(logger, 'log');
-    commandInfo = cli.getCommandInfo(command);
   });
 
   afterEach(() => {
@@ -115,13 +119,13 @@ describe(commands.OWNER_LIST, () => {
       new CommandError(error.error.message));
   });
 
-  it('fails validation if flowName is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if flowName is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if flowName a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if flowName a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/flow/commands/owner/owner-list.spec.ts
+++ b/src/m365/flow/commands/owner/owner-list.spec.ts
@@ -89,7 +89,7 @@ describe(commands.OWNER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, flowName: flowName, output: 'json' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, flowName: flowName, output: 'json' }) });
     assert(loggerLogSpy.calledWith(ownerResponseJson));
   });
 
@@ -102,7 +102,7 @@ describe(commands.OWNER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, flowName: flowName, asAdmin: true, output: 'text' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, flowName: flowName, asAdmin: true, output: 'text' }) });
     assert(loggerLogSpy.calledWith(ownerResponseText));
   });
 
@@ -115,7 +115,7 @@ describe(commands.OWNER_LIST, () => {
     };
     sinon.stub(request, 'get').rejects(error);
 
-    await assert.rejects(command.action(logger, { options: { environmentName: environmentName, flowName: flowName } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName }) } as any),
       new CommandError(error.error.message));
   });
 

--- a/src/m365/flow/commands/owner/owner-list.ts
+++ b/src/m365/flow/commands/owner/owner-list.ts
@@ -1,9 +1,9 @@
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { odata } from '../../../../utils/odata.js';
-import { validation } from '../../../../utils/validation.js';
 import PowerAutomateCommand from '../../../base/PowerAutomateCommand.js';
 import commands from '../../commands.js';
 
@@ -25,14 +25,17 @@ interface FlowPermissionPrincipal {
   type: string;
 }
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  flowName: z.uuid(),
+  environmentName: z.string().alias('e'),
+  asAdmin: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  flowName: string;
-  environmentName: string;
-  asAdmin?: boolean;
 }
 
 class FlowOwnerListCommand extends PowerAutomateCommand {
@@ -48,46 +51,8 @@ class FlowOwnerListCommand extends PowerAutomateCommand {
     return ['roleName', 'id', 'type'];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        asAdmin: !!args.options.asAdmin
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--flowName <flowName>'
-      },
-      {
-        option: '--asAdmin'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.flowName)) {
-          return `${args.options.flowName} is not a valid GUID.`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodType {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/owner/owner-remove.spec.ts
+++ b/src/m365/flow/commands/owner/owner-remove.spec.ts
@@ -13,9 +13,10 @@ import { formatting } from '../../../../utils/formatting.js';
 import { settingsNames } from '../../../../settingsNames.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
+import { accessToken } from '../../../../utils/accessToken.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './owner-remove.js';
+import command, { options } from './owner-remove.js';
 
 describe(commands.OWNER_REMOVE, () => {
   const environmentName = 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6';
@@ -32,6 +33,7 @@ describe(commands.OWNER_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let promptIssued: boolean = false;
 
   before(() => {
@@ -39,8 +41,10 @@ describe(commands.OWNER_REMOVE, () => {
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -232,28 +236,38 @@ describe(commands.OWNER_REMOVE, () => {
     assert(postSpy.notCalled);
   });
 
-  it('fails validation if flowName is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: 'invalid', userId: userId } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if flowName is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: 'invalid', userId: userId });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, userId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, userId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if groupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, groupId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if groupId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, groupId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if username is not a valid user principal name', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, userName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if username is not a valid user principal name', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, userName: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if groupName passed', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, groupName: groupName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation when no owner identifier is provided', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation when multiple owner identifiers are provided', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, userId: userId, groupId: groupId });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('passes validation if groupName passed', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, groupName: groupName });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/flow/commands/owner/owner-remove.spec.ts
+++ b/src/m365/flow/commands/owner/owner-remove.spec.ts
@@ -102,7 +102,7 @@ describe(commands.OWNER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, flowName: flowName, userId: userId, force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, flowName: flowName, userId: userId, force: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, requestBodyUser);
   });
 
@@ -116,7 +116,7 @@ describe(commands.OWNER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, flowName: flowName, userName: userName, force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, flowName: flowName, userName: userName, force: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, requestBodyUser);
   });
 
@@ -131,7 +131,7 @@ describe(commands.OWNER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, flowName: flowName, groupId: groupId, asAdmin: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, flowName: flowName, groupId: groupId, asAdmin: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, requestBodyGroup);
   });
 
@@ -145,7 +145,7 @@ describe(commands.OWNER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, flowName: flowName, groupName: groupName, asAdmin: true, force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, flowName: flowName, groupName: groupName, asAdmin: true, force: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, requestBodyGroup);
   });
 
@@ -174,9 +174,9 @@ describe(commands.OWNER_REMOVE, () => {
     sinon.stub(request, 'post').rejects('POST request executed');
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         verbose: true, environmentName: environmentName, flowName: flowName, groupName: groupName, asAdmin: true, force: true
-      }
+      })
     }), new CommandError(`Multiple groups with name 'Test Group' found. Found: 9b1b1e42-794b-4c71-93ac-5ed92488b67f, 9b1b1e42-794b-4c71-93ac-5ed92488b67g.`));
   });
 
@@ -204,7 +204,7 @@ describe(commands.OWNER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, environmentName: environmentName, flowName: flowName, groupName: groupName, asAdmin: true, force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: environmentName, flowName: flowName, groupName: groupName, asAdmin: true, force: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, requestBodyGroup);
   });
 
@@ -217,12 +217,12 @@ describe(commands.OWNER_REMOVE, () => {
     };
     sinon.stub(request, 'post').rejects(error);
 
-    await assert.rejects(command.action(logger, { options: { environmentName: environmentName, flowName: flowName, userId: userId, force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName, userId: userId, force: true }) } as any),
       new CommandError(error.error.message));
   });
 
   it('prompts before removing the specified owner from a flow when force option not passed', async () => {
-    await command.action(logger, { options: { environmentName: environmentName, flowName: flowName, useName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName, userName: userName }) });
 
     assert(promptIssued);
   });
@@ -232,7 +232,7 @@ describe(commands.OWNER_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    await command.action(logger, { options: { environmentName: environmentName, flowName: flowName, useName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName, userName: userName }) });
     assert(postSpy.notCalled);
   });
 

--- a/src/m365/flow/commands/owner/owner-remove.ts
+++ b/src/m365/flow/commands/owner/owner-remove.ts
@@ -14,11 +14,15 @@ export const options = z.strictObject({
   ...globalOptionsZod.shape,
   flowName: z.uuid(),
   environmentName: z.string().alias('e'),
-  userId: z.uuid().optional(),
+  userId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
   userName: z.string().refine(name => validation.isValidUserPrincipalName(name), {
     error: e => `'${e.input}' is not a valid userName.`
   }).optional(),
-  groupId: z.uuid().optional(),
+  groupId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
   groupName: z.string().optional(),
   asAdmin: z.boolean().optional(),
   force: z.boolean().optional().alias('f')

--- a/src/m365/flow/commands/owner/owner-remove.ts
+++ b/src/m365/flow/commands/owner/owner-remove.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { entraUser } from '../../../../utils/entraUser.js';
@@ -9,19 +10,24 @@ import { validation } from '../../../../utils/validation.js';
 import PowerAutomateCommand from '../../../base/PowerAutomateCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  flowName: z.uuid(),
+  environmentName: z.string().alias('e'),
+  userId: z.uuid().optional(),
+  userName: z.string().refine(name => validation.isValidUserPrincipalName(name), {
+    error: e => `'${e.input}' is not a valid userName.`
+  }).optional(),
+  groupId: z.uuid().optional(),
+  groupName: z.string().optional(),
+  asAdmin: z.boolean().optional(),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  flowName: string;
-  environmentName: string;
-  userId?: string;
-  userName?: string;
-  groupId?: string;
-  groupName?: string;
-  asAdmin?: boolean;
-  force?: boolean;
 }
 
 class FlowOwnerRemoveCommand extends PowerAutomateCommand {
@@ -33,83 +39,21 @@ class FlowOwnerRemoveCommand extends PowerAutomateCommand {
     return 'Removes owner permissions to a Power Automate flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodType {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined',
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined',
-        asAdmin: !!args.options.asAdmin,
-        force: !!args.options.force
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema.refine(
+      options => [options.userId, options.userName, options.groupId, options.groupName].filter(x => x !== undefined).length === 1,
       {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--flowName <flowName>'
-      },
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      },
-      {
-        option: '--groupId [groupId]'
-      },
-      {
-        option: '--groupName [groupName]'
-      },
-      {
-        option: '--asAdmin'
-      },
-      {
-        option: '-f, --force'
+        error: 'Specify either userId, userName, groupId, or groupName, but not multiple.',
+        params: {
+          customCode: 'optionSet',
+          options: ['userId', 'userName', 'groupId', 'groupName']
+        }
       }
     );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.flowName)) {
-          return `${args.options.flowName} is not a valid GUID.`;
-        }
-
-        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
-          return `${args.options.userId} is not a valid GUID.`;
-        }
-
-        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
-          return `${args.options.userName} is not a valid userName.`;
-        }
-
-        if (args.options.groupId && !validation.isValidGuid(args.options.groupId)) {
-          return `${args.options.groupId} is not a valid GUID.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['userId', 'userName', 'groupId', 'groupName'] });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/run/run-cancel.spec.ts
+++ b/src/m365/flow/commands/run/run-cancel.spec.ts
@@ -9,15 +9,17 @@ import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
+import { accessToken } from '../../../../utils/accessToken.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './run-cancel.js';
+import command, { options } from './run-cancel.js';
 
 describe(commands.RUN_CANCEL, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let promptIssued: boolean = false;
 
   before(() => {
@@ -25,8 +27,10 @@ describe(commands.RUN_CANCEL, () => {
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -71,26 +75,22 @@ describe(commands.RUN_CANCEL, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if the flowName is not valid GUID', async () => {
-    const actual = await command.validate({
-      options: {
-        environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
-        flowName: 'invalid',
-        name: '08585981115186985105550762687CU161'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the flowName is not valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({
+      environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
+      flowName: 'invalid',
+      name: '08585981115186985105550762687CU161'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when the name, environmentName and flowName specified', async () => {
-    const actual = await command.validate({
-      options: {
-        environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
-        flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
-        name: '08585981115186985105550762687CU161'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when the name, environmentName and flowName specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
+      flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
+      name: '08585981115186985105550762687CU161'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('prompts before cancelling the specified Microsoft FlowName when force option not passed', async () => {
@@ -284,36 +284,4 @@ describe(commands.RUN_CANCEL, () => {
     } as any), new CommandError(`Request to Azure Resource Manager failed with error: '{"error":{"code":"WorkflowRunNotFound","message":"The workflow '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72' run '08585981115186985105550762688CP233' could not be found."}}`));
   });
 
-  it('supports specifying name', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--name') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying environment', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--environment') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying flow', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--flow') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
 });

--- a/src/m365/flow/commands/run/run-cancel.spec.ts
+++ b/src/m365/flow/commands/run/run-cancel.spec.ts
@@ -95,11 +95,11 @@ describe(commands.RUN_CANCEL, () => {
 
   it('prompts before cancelling the specified Microsoft FlowName when force option not passed', async () => {
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     });
 
 
@@ -111,11 +111,11 @@ describe(commands.RUN_CANCEL, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     });
     assert(postSpy.notCalled);
   });
@@ -130,13 +130,13 @@ describe(commands.RUN_CANCEL, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161',
         force: true
-      }
+      })
     });
     assert(loggerLogSpy.called);
   });
@@ -154,12 +154,12 @@ describe(commands.RUN_CANCEL, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     });
     assert(loggerLogSpy.called);
   });
@@ -174,12 +174,12 @@ describe(commands.RUN_CANCEL, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161',
         force: true
-      }
+      })
     } as any), new CommandError(`You are not permitted to make flows in this 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c'. Please switch to the default environment, or to one of your own environment(s), where you have maker permissions.`));
   });
 
@@ -196,11 +196,11 @@ describe(commands.RUN_CANCEL, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     } as any), new CommandError(`You are not permitted to make flows in this 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c'. Please switch to the default environment, or to one of your own environment(s), where you have maker permissions.`));
   });
 
@@ -217,11 +217,11 @@ describe(commands.RUN_CANCEL, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     } as any), new CommandError(`The caller with object id 'da8f7aea-cf43-497f-ad62-c2feae89a194' does not have permission for connection '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88' under Api 'shared_logicflows'.`));
   });
 
@@ -235,12 +235,12 @@ describe(commands.RUN_CANCEL, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88',
         name: '08585981115186985105550762687CU161',
         force: true
-      }
+      })
     } as any), new CommandError(`The caller with object id 'da8f7aea-cf43-497f-ad62-c2feae89a194' does not have permission for connection '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88' under Api 'shared_logicflows'.`));
   });
 
@@ -257,11 +257,11 @@ describe(commands.RUN_CANCEL, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762688CP233'
-      }
+      })
     } as any), new CommandError(`Request to Azure Resource Manager failed with error: '{"error":{"code":"WorkflowRunNotFound","message":"The workflow '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72' run '08585981115186985105550762688CP233' could not be found."}}`));
   });
 
@@ -275,12 +275,12 @@ describe(commands.RUN_CANCEL, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762688CP233',
         force: true
-      }
+      })
     } as any), new CommandError(`Request to Azure Resource Manager failed with error: '{"error":{"code":"WorkflowRunNotFound","message":"The workflow '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72' run '08585981115186985105550762688CP233' could not be found."}}`));
   });
 

--- a/src/m365/flow/commands/run/run-cancel.ts
+++ b/src/m365/flow/commands/run/run-cancel.ts
@@ -1,21 +1,24 @@
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
-import { validation } from '../../../../utils/validation.js';
 import PowerAutomateCommand from '../../../base/PowerAutomateCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.string().alias('n'),
+  flowName: z.uuid(),
+  environmentName: z.string().alias('e'),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  environmentName: string;
-  flowName: string;
-  name: string;
-  force?: boolean;
 }
 
 class FlowRunCancelCommand extends PowerAutomateCommand {
@@ -27,49 +30,8 @@ class FlowRunCancelCommand extends PowerAutomateCommand {
     return 'Cancels a specific run of the specified Microsoft Flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        force: !!args.options.force
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '--flowName <flowName>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.flowName)) {
-          return `${args.options.flowName} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodType {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/run/run-get.spec.ts
+++ b/src/m365/flow/commands/run/run-get.spec.ts
@@ -7,11 +7,12 @@ import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
+import { accessToken } from '../../../../utils/accessToken.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { cli } from '../../../../cli/cli.js';
-import command from './run-get.js';
+import command, { options } from './run-get.js';
 
 describe(commands.RUN_GET, () => {
   const flowName = '396d5ec9-ae2d-4a84-967d-cd7f56cd8f30';
@@ -216,14 +217,17 @@ describe(commands.RUN_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -400,18 +404,18 @@ describe(commands.RUN_GET, () => {
       new CommandError(`Could not find flow '${flowName}'.`));
   });
 
-  it('fails validation if the flowName is not valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: 'invalid', name: runName } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the flowName is not valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: 'invalid', name: runName });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the withActions parameter is not valid boolean or string', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, name: runName, withActions: -1 } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the withActions parameter is not valid boolean or string', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, name: runName, withActions: -1 });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if the flowName is not valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, name: runName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if the flowName is not valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, name: runName });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/flow/commands/run/run-get.spec.ts
+++ b/src/m365/flow/commands/run/run-get.spec.ts
@@ -414,7 +414,7 @@ describe(commands.RUN_GET, () => {
     assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if the flowName is not valid GUID', () => {
+  it('passes validation when all options are correct', () => {
     const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, name: runName });
     assert.strictEqual(actual.success, true);
   });

--- a/src/m365/flow/commands/run/run-get.spec.ts
+++ b/src/m365/flow/commands/run/run-get.spec.ts
@@ -274,7 +274,7 @@ describe(commands.RUN_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ flowName: flowName, environmentName: environmentName, name: runName, verbose: true }) });
     assert(loggerLogSpy.calledWith(flowResponseFormatted));
   });
 
@@ -287,7 +287,7 @@ describe(commands.RUN_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ flowName: flowName, environmentName: environmentName, name: runName }) });
     assert(loggerLogSpy.calledWith(flowResponseFormattedNoEndTime));
   });
 
@@ -304,7 +304,7 @@ describe(commands.RUN_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, withTrigger: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ flowName: flowName, environmentName: environmentName, name: runName, withTrigger: true, verbose: true }) });
     assert(loggerLogSpy.calledWith(flowResponseFormattedIncludingInformation));
   });
 
@@ -332,7 +332,7 @@ describe(commands.RUN_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, withActions: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ flowName: flowName, environmentName: environmentName, name: runName, withActions: true, verbose: true }) });
     assert(loggerLogSpy.calledWith(commandResultIncluddingAllActions));
   });
 
@@ -360,7 +360,7 @@ describe(commands.RUN_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, withActions: "Compose", verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ flowName: flowName, environmentName: environmentName, name: runName, withActions: "Compose", verbose: true }) });
     assert(loggerLogSpy.calledWith(commandResultIncludingSelectedAction));
   });
 
@@ -388,7 +388,7 @@ describe(commands.RUN_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName, withActions: "Wrong,Wrong2", verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ flowName: flowName, environmentName: environmentName, name: runName, withActions: "Wrong,Wrong2", verbose: true }) });
     assert(loggerLogSpy.calledWith(flowResponseFormattedIncludingActionsBasicInformation));
   });
 
@@ -400,7 +400,7 @@ describe(commands.RUN_GET, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { flowName: flowName, environmentName: environmentName, name: runName } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ flowName: flowName, environmentName: environmentName, name: runName }) } as any),
       new CommandError(`Could not find flow '${flowName}'.`));
   });
 

--- a/src/m365/flow/commands/run/run-get.ts
+++ b/src/m365/flow/commands/run/run-get.ts
@@ -1,21 +1,24 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
-import { validation } from '../../../../utils/validation.js';
 import PowerAutomateCommand from '../../../base/PowerAutomateCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.string().alias('n'),
+  flowName: z.uuid(),
+  environmentName: z.string().alias('e'),
+  withTrigger: z.boolean().optional(),
+  withActions: z.union([z.string(), z.boolean()]).optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  environmentName: string;
-  flowName: string;
-  name: string;
-  withTrigger?: boolean;
-  withActions?: string | boolean;
 }
 
 interface FlowLink {
@@ -79,57 +82,8 @@ class FlowRunGetCommand extends PowerAutomateCommand {
     return 'Gets information about a specific run of the specified Microsoft Flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '--flowName <flowName>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--withTrigger'
-      },
-      {
-        option: '--withActions [withActions]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.flowName)) {
-          return `${args.options.flowName} is not a valid GUID`;
-        }
-
-        if (args.options.withActions && (typeof args.options.withActions !== 'string' && typeof args.options.withActions !== 'boolean')) {
-          return 'the withActions parameter must be a string or boolean';
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        withTrigger: !!args.options.withTrigger,
-        withActions: typeof args.options.withActions !== 'undefined'
-      });
-    });
+  public get schema(): z.ZodType {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/run/run-list.spec.ts
+++ b/src/m365/flow/commands/run/run-list.spec.ts
@@ -179,7 +179,7 @@ describe(commands.RUN_LIST, () => {
       throw 'Invalid request ' + opts.url;
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, flowName: flowName, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName, verbose: true }) });
     assert(loggerLogSpy.calledWith(flowRunListResponse.value));
   });
 
@@ -196,7 +196,7 @@ describe(commands.RUN_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, flowName: flowName, asAdmin: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName, asAdmin: true, verbose: true }) });
     assert(loggerLogSpy.calledWith(flowRunListResponse.value));
   });
 
@@ -213,7 +213,7 @@ describe(commands.RUN_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, flowName: flowName, status: status, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName, status: status, verbose: true }) });
     assert(loggerLogSpy.calledWith(flowRunListResponse.value));
   });
 
@@ -230,7 +230,7 @@ describe(commands.RUN_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, flowName: flowName, triggerStartTime: triggerStartTime, triggerEndTime: triggerEndTime, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName, triggerStartTime: triggerStartTime, triggerEndTime: triggerEndTime, verbose: true }) });
     assert(loggerLogSpy.calledWith(flowRunListResponse.value));
   });
 
@@ -259,7 +259,7 @@ describe(commands.RUN_LIST, () => {
       throw 'Invalid request ' + opts.url;
     });
 
-    await command.action(logger, { options: { environmentName: environmentName, flowName: flowName, withTrigger: true, verbose: true, output: 'json' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName, withTrigger: true, verbose: true, output: 'json' }) });
     assert(loggerLogSpy.calledWith(flowRunListResponseClone.value));
   });
 
@@ -271,14 +271,14 @@ describe(commands.RUN_LIST, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: environmentName, flowName: flowName } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName }) } as any),
       new CommandError(`Access to the environment '${environmentName}' is denied.`));
   });
 
   it('correctly handles no runs for this flow found', async () => {
     sinon.stub(request, 'get').resolves({ value: [] });
 
-    await command.action(logger, { options: { verbose: true, environmentName: 'Default-48595cc3-adce-4267-8e99-0c838923dbb9', flowName: '16c90c26-25e0-4800-8af9-da594e02d427' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, environmentName: 'Default-48595cc3-adce-4267-8e99-0c838923dbb9', flowName: '16c90c26-25e0-4800-8af9-da594e02d427' }) });
     assert(loggerLogSpy.calledWith([]));
   });
 
@@ -294,7 +294,7 @@ describe(commands.RUN_LIST, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { environmentName: environmentName, flowName: flowName } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ environmentName: environmentName, flowName: flowName }) } as any),
       new CommandError('An error has occurred'));
   });
 

--- a/src/m365/flow/commands/run/run-list.spec.ts
+++ b/src/m365/flow/commands/run/run-list.spec.ts
@@ -9,9 +9,10 @@ import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
+import { accessToken } from '../../../../utils/accessToken.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './run-list.js';
+import command, { options } from './run-list.js';
 
 describe(commands.RUN_LIST, () => {
   const environmentName = 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c';
@@ -113,14 +114,17 @@ describe(commands.RUN_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -294,33 +298,33 @@ describe(commands.RUN_LIST, () => {
       new CommandError('An error has occurred'));
   });
 
-  it('fails validation if the flowName is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the flowName is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the status is not a valid status', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, status: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the status is not a valid status', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, status: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the triggerStartTime is not a valid ISO datetime', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, triggerStartTime: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the triggerStartTime is not a valid ISO datetime', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, triggerStartTime: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the triggerEndTime is not a valid ISO datetime', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, triggerEndTime: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the triggerEndTime is not a valid ISO datetime', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, triggerEndTime: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the output is not json and withTrigger is specified', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, output: 'text', withTrigger: true } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the output is not json and withTrigger is specified', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, output: 'text', withTrigger: true });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if all options are passed properly', async () => {
-    const actual = await command.validate({ options: { environmentName: environmentName, flowName: flowName, status: status, triggerStartTime: triggerStartTime, triggerEndTime: triggerEndTime } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if all options are passed properly', () => {
+    const actual = commandOptionsSchema.safeParse({ environmentName: environmentName, flowName: flowName, status: status, triggerStartTime: triggerStartTime, triggerEndTime: triggerEndTime });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/flow/commands/run/run-list.ts
+++ b/src/m365/flow/commands/run/run-list.ts
@@ -1,5 +1,6 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { odata } from '../../../../utils/odata.js';
@@ -7,18 +8,25 @@ import { validation } from '../../../../utils/validation.js';
 import PowerAutomateCommand from '../../../base/PowerAutomateCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  flowName: z.uuid(),
+  environmentName: z.string().alias('e'),
+  status: z.enum(['Succeeded', 'Running', 'Failed', 'Cancelled']).optional(),
+  triggerStartTime: z.string().refine(date => validation.isValidISODateTime(date), {
+    error: e => `'${e.input}' is not a valid datetime.`
+  }).optional(),
+  triggerEndTime: z.string().refine(date => validation.isValidISODateTime(date), {
+    error: e => `'${e.input}' is not a valid datetime.`
+  }).optional(),
+  withTrigger: z.boolean().optional(),
+  asAdmin: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  environmentName: string;
-  flowName: string;
-  status?: string;
-  triggerStartTime?: string;
-  triggerEndTime?: string;
-  withTrigger?: boolean
-  asAdmin?: boolean;
 }
 
 interface PowerAutomateFlowRun {
@@ -38,8 +46,6 @@ interface PowerAutomateFlowRun {
 }
 
 class FlowRunListCommand extends PowerAutomateCommand {
-  public readonly allowedStatusses: string[] = ['Succeeded', 'Running', 'Failed', 'Cancelled'];
-
   public get name(): string {
     return commands.RUN_LIST;
   }
@@ -48,83 +54,23 @@ class FlowRunListCommand extends PowerAutomateCommand {
     return 'Lists runs of the specified Microsoft Flow';
   }
 
-  public defaultProperties(): string[] | undefined {
-    return ['name', 'startTime', 'status'];
+  public get schema(): z.ZodType {
+    return options;
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        status: typeof args.options.status !== 'undefined',
-        triggerStartTime: typeof args.options.triggerStartTime !== 'undefined',
-        triggerEndTime: typeof args.options.triggerEndTime !== 'undefined',
-        withTrigger: !!args.options.withTrigger,
-        asAdmin: !!args.options.asAdmin
-      });
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema.refine(options => {
+      if (options.output !== 'json' && options.withTrigger) {
+        return false;
+      }
+      return true;
+    }, {
+      error: 'The --withTrigger option is only available when output is set to json'
     });
   }
 
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--flowName <flowName>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '--status [status]',
-        autocomplete: this.allowedStatusses
-      },
-      {
-        option: '--triggerStartTime [triggerStartTime]'
-      },
-      {
-        option: '--triggerEndTime [triggerEndTime]'
-      },
-      {
-        option: '--withTrigger'
-      },
-      {
-        option: '--asAdmin'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.flowName)) {
-          return `${args.options.flowName} is not a valid GUID`;
-        }
-
-        if (args.options.status && this.allowedStatusses.indexOf(args.options.status) === -1) {
-          return `'${args.options.status}' is not a valid status. Allowed values are: ${this.allowedStatusses.join(',')}`;
-        }
-
-        if (args.options.triggerStartTime && !validation.isValidISODateTime(args.options.triggerStartTime)) {
-          return `'${args.options.triggerStartTime}' is not a valid datetime.`;
-        }
-
-        if (args.options.triggerEndTime && !validation.isValidISODateTime(args.options.triggerEndTime)) {
-          return `'${args.options.triggerEndTime}' is not a valid datetime.`;
-        }
-
-        if (args.options.output !== 'json' && args.options.withTrigger) {
-          return 'The --withTrigger option is only available when output is set to json';
-        }
-
-        return true;
-      }
-    );
+  public defaultProperties(): string[] | undefined {
+    return ['name', 'startTime', 'status'];
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/flow/commands/run/run-resubmit.spec.ts
+++ b/src/m365/flow/commands/run/run-resubmit.spec.ts
@@ -96,11 +96,11 @@ describe(commands.RUN_RESUBMIT, () => {
 
   it('prompts before resubmitting the specified Microsoft Flow when force option not passed', async () => {
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     });
 
 
@@ -114,11 +114,11 @@ describe(commands.RUN_RESUBMIT, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     });
     assert(postSpy.notCalled);
     assert(getSpy.notCalled);
@@ -137,11 +137,11 @@ describe(commands.RUN_RESUBMIT, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     } as any), new CommandError(`You are not permitted to make flows in this 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c'. Please switch to the default environment, or to one of your own environment(s), where you have maker permissions.`));
   });
 
@@ -158,11 +158,11 @@ describe(commands.RUN_RESUBMIT, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     } as any), new CommandError(`The caller with object id 'da8f7aea-cf43-497f-ad62-c2feae89a194' does not have permission for connection '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88' under Api 'shared_logicflows'.`));
   });
 
@@ -204,11 +204,11 @@ describe(commands.RUN_RESUBMIT, () => {
 
     await assert.rejects(command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
         name: '08585981115186985105550762688CP233'
-      }
+      })
     } as any), new CommandError(`Request to Azure Resource Manager failed with error: '{"error":{"code":"WorkflowRunNotFound","message":"The workflow '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72' run '08585981115186985105550762688CP233' could not be found."}}`));
   });
 
@@ -250,12 +250,12 @@ describe(commands.RUN_RESUBMIT, () => {
 
     await command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         debug: true,
         environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88',
         name: '08585981115186985105550762687CU161'
-      }
+      })
     });
     assert.notStrictEqual(loggerLogToStderrSpy.getCall(1).args[0].indexOf('Retrieved trigger: manual'), -1);
     assert(getStub.called);
@@ -297,13 +297,13 @@ describe(commands.RUN_RESUBMIT, () => {
 
     await command.action(logger, {
       options:
-      {
+      commandOptionsSchema.parse({
         debug: true,
         environmentName: 'Default-d87a7535-dd31-4437-bfe1-95340acd55c6',
         flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88',
         name: '08585981115186985105550762687CU161',
         force: true
-      }
+      })
     });
     assert.strictEqual(getStub.lastCall.args[0].url, 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c6/flows/0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88/triggers?api-version=2016-11-01');
     assert.strictEqual(postStub.lastCall.args[0].url, 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c6/flows/0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88/triggers/manual/histories/08585981115186985105550762687CU161/resubmit?api-version=2016-11-01');

--- a/src/m365/flow/commands/run/run-resubmit.spec.ts
+++ b/src/m365/flow/commands/run/run-resubmit.spec.ts
@@ -9,15 +9,17 @@ import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
+import { accessToken } from '../../../../utils/accessToken.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './run-resubmit.js';
+import command, { options } from './run-resubmit.js';
 
 describe(commands.RUN_RESUBMIT, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let promptIssued: boolean = false;
 
   before(() => {
@@ -25,8 +27,10 @@ describe(commands.RUN_RESUBMIT, () => {
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
+    sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -72,26 +76,22 @@ describe(commands.RUN_RESUBMIT, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if the flowName is not valid GUID', async () => {
-    const actual = await command.validate({
-      options: {
-        environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
-        flowName: 'invalid',
-        name: '08585981115186985105550762687CU161'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the flowName is not valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({
+      environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
+      flowName: 'invalid',
+      name: '08585981115186985105550762687CU161'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when the name, environmentName and flowName specified', async () => {
-    const actual = await command.validate({
-      options: {
-        environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
-        flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
-        name: '08585981115186985105550762687CU161'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when the name, environmentName and flowName specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      environmentName: 'Default-eff8592e-e14a-4ae8-8771-d96d5c549e1c',
+      flowName: '0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac72',
+      name: '08585981115186985105550762687CU161'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('prompts before resubmitting the specified Microsoft Flow when force option not passed', async () => {
@@ -309,36 +309,4 @@ describe(commands.RUN_RESUBMIT, () => {
     assert.strictEqual(postStub.lastCall.args[0].url, 'https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/Default-d87a7535-dd31-4437-bfe1-95340acd55c6/flows/0f64d9dd-01bb-4c1b-95b3-cb4a1a08ac88/triggers/manual/histories/08585981115186985105550762687CU161/resubmit?api-version=2016-11-01');
   });
 
-  it('supports specifying name', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--name') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying environment', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--environment') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports specifying flow', () => {
-    const options = command.options;
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--flow') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
 });

--- a/src/m365/flow/commands/run/run-resubmit.ts
+++ b/src/m365/flow/commands/run/run-resubmit.ts
@@ -1,22 +1,25 @@
+import { z } from 'zod';
 import chalk from 'chalk';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
-import { validation } from '../../../../utils/validation.js';
 import commands from '../../commands.js';
 import PowerAutomateCommand from '../../../base/PowerAutomateCommand.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.string().alias('n'),
+  flowName: z.uuid(),
+  environmentName: z.string().alias('e'),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  force: boolean;
-  environmentName: string;
-  flowName: string;
-  name: string;
 }
 
 class FlowRunResubmitCommand extends PowerAutomateCommand {
@@ -28,49 +31,8 @@ class FlowRunResubmitCommand extends PowerAutomateCommand {
     return 'Resubmits a specific flow run for the specified Microsoft Flow';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        force: args.options.force
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '--flowName <flowName>'
-      },
-      {
-        option: '-e, --environmentName <environmentName>'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.flowName)) {
-          return `${args.options.flowName} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodType {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {


### PR DESCRIPTION
Closes #7304

## Summary

Migrates all 13 remaining `flow` commands from the legacy Options/constructor validation pattern to Zod schema validation.

### Commands migrated

- `flow disable`, `flow enable`, `flow get`, `flow export`, `flow list`, `flow remove`
- `flow owner list`, `flow owner ensure`, `flow owner remove`
- `flow run cancel`, `flow run get`, `flow run list`, `flow run resubmit`

### Changes

- Replaced `interface Options extends GlobalOptions` + `#initOptions`/`#initValidators`/`#initTelemetry` with exported Zod schemas using `z.strictObject()` and `globalOptionsZod.shape`
- Added `get schema()` getter and `getRefinedSchema()` where cross-field validation is needed
- Used `z.uuid()` for GUID validation, `z.enum()` for enum options, `.refine()` for UPN and ISO datetime validation
- Updated all 13 test files to use `commandOptionsSchema.safeParse()` pattern
- Added `accessToken.assertAccessTokenType` stub to all test files
- Removed obsolete "supports specifying" tests

### Testing

- All 15720 tests pass
- Build passes