### PR TITLE
Migrate outlook message and mail commands to Zod

### DIFF
--- a/src/m365/outlook/commands/mail/mail-send.spec.ts
+++ b/src/m365/outlook/commands/mail/mail-send.spec.ts
@@ -313,6 +313,10 @@ describe(commands.MAIL_SEND, () => {
       new CommandError(`An error has occurred`));
   });
 
+  it('defines schema', () => {
+    assert.notStrictEqual(command.schema, undefined);
+  });
+
   it('fails validation if bodyContentType is invalid', () => {
     const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', bodyContentType: 'Invalid' });
     assert.notStrictEqual(actual.success, true);

--- a/src/m365/outlook/commands/mail/mail-send.spec.ts
+++ b/src/m365/outlook/commands/mail/mail-send.spec.ts
@@ -99,7 +99,7 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' }) });
     assert.strictEqual(actual, expected);
   });
 
@@ -125,7 +125,7 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' }) });
     assert.strictEqual(actual, expected);
   });
 
@@ -154,7 +154,7 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com,mail2@domain.com', bodyContents: 'Lorem ipsum' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ subject: 'Lorem ipsum', to: 'mail@domain.com,mail2@domain.com', bodyContents: 'Lorem ipsum' }) });
     assert.strictEqual(actual, expected);
   });
 
@@ -187,7 +187,7 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com,mail2@domain.com', cc: 'mail3@domain.com,mail4@domain.com', bodyContents: 'Lorem ipsum' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ subject: 'Lorem ipsum', to: 'mail@domain.com,mail2@domain.com', cc: 'mail3@domain.com,mail4@domain.com', bodyContents: 'Lorem ipsum' }) });
     assert.strictEqual(actual, expected);
   });
 
@@ -220,7 +220,7 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com,mail2@domain.com', bcc: 'mail3@domain.com,mail4@domain.com', bodyContents: 'Lorem ipsum' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ subject: 'Lorem ipsum', to: 'mail@domain.com,mail2@domain.com', bcc: 'mail3@domain.com,mail4@domain.com', bodyContents: 'Lorem ipsum' }) });
     assert.strictEqual(actual, expected);
   });
 
@@ -247,12 +247,14 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', saveToSentItems: false } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', saveToSentItems: false }) });
     assert.strictEqual(actual, expected);
   });
 
   it('sends email with multiple attachments', async () => {
     const fileContentBase64 = 'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4=';
+    sinon.stub(fs, 'existsSync').returns(true);
+    sinon.stub(fs, 'lstatSync').returns({ isFile: () => true } as any);
     sinon.stub(fs, 'readFileSync').returns(fileContentBase64);
 
     const requestPostStub = sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -264,18 +266,20 @@ describe(commands.MAIL_SEND, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         subject: 'Lorem ipsum',
         to: 'mail@domain.com',
         bodyContents: 'Lorem ipsum',
         attachment: ['C:/File1.txt', 'C:/File2.txt']
-      }
+      })
     });
     assert.deepStrictEqual(requestPostStub.lastCall.args[0].data.message.attachments, [{ '@odata.type': '#microsoft.graph.fileAttachment', name: 'File1.txt', contentBytes: fileContentBase64 }, { '@odata.type': '#microsoft.graph.fileAttachment', name: 'File2.txt', contentBytes: fileContentBase64 }]);
   });
 
   it('sends email with single attachment', async () => {
     const fileContentBase64 = 'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4=';
+    sinon.stub(fs, 'existsSync').returns(true);
+    sinon.stub(fs, 'lstatSync').returns({ isFile: () => true } as any);
     sinon.stub(fs, 'readFileSync').returns(fileContentBase64);
 
     const requestPostStub = sinon.stub(request, 'post').callsFake(async (opts) => {
@@ -287,12 +291,12 @@ describe(commands.MAIL_SEND, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         subject: 'Lorem ipsum',
         to: 'mail@domain.com',
         bodyContents: 'Lorem ipsum',
         attachment: 'C:/File1.txt'
-      }
+      })
     });
     assert.deepStrictEqual(requestPostStub.lastCall.args[0].data.message.attachments, [{ '@odata.type': '#microsoft.graph.fileAttachment', name: 'File1.txt', contentBytes: fileContentBase64 }]);
   });
@@ -309,7 +313,7 @@ describe(commands.MAIL_SEND, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' }) }),
       new CommandError(`An error has occurred`));
   });
 
@@ -441,7 +445,7 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com', mailbox: 'sales@domain.com', bodyContents: 'Lorem ipsum' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ subject: 'Lorem ipsum', to: 'mail@domain.com', mailbox: 'sales@domain.com', bodyContents: 'Lorem ipsum' }) });
     assert.strictEqual(actual, expected);
   });
 
@@ -467,7 +471,7 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { subject: 'Lorem ipsum', to: 'mail@domain.com', sender: 'some-user@domain.com', bodyContents: 'Lorem ipsum' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ subject: 'Lorem ipsum', to: 'mail@domain.com', sender: 'some-user@domain.com', bodyContents: 'Lorem ipsum' }) });
     assert.strictEqual(actual, expected);
   });
 
@@ -476,11 +480,11 @@ describe(commands.MAIL_SEND, () => {
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         subject: 'Lorem ipsum',
         to: 'mail@domain.com',
         bodyContents: 'Lorem ipsum'
-      }
-    } as any), new CommandError(`Specify a upn or user id in the 'sender' option when using app only authentication.`));
+      })
+    }), new CommandError(`Specify a upn or user id in the 'sender' option when using app only authentication.`));
   });
 });

--- a/src/m365/outlook/commands/mail/mail-send.spec.ts
+++ b/src/m365/outlook/commands/mail/mail-send.spec.ts
@@ -14,12 +14,13 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './mail-send.js';
+import command, { options } from './mail-send.js';
 
 describe(commands.MAIL_SEND, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -32,6 +33,7 @@ describe(commands.MAIL_SEND, () => {
       accessToken: 'abc'
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -311,14 +313,14 @@ describe(commands.MAIL_SEND, () => {
       new CommandError(`An error has occurred`));
   });
 
-  it('fails validation if bodyContentType is invalid', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', bodyContentType: 'Invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if bodyContentType is invalid', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', bodyContentType: 'Invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if importance is invalid', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', importance: 'Invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if importance is invalid', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', importance: 'Invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if file doesn\'t exist', async () => {
@@ -364,39 +366,48 @@ describe(commands.MAIL_SEND, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('passes validation when subject, to and bodyContents are specified', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' } }, commandInfo);
+  it('passes validation when valid attachments are specified', async () => {
+    sinon.stub(fs, 'existsSync').returns(true);
+    sinon.stub(fs, 'lstatSync').returns({ isFile: () => true } as any);
+    sinon.stub(fs, 'readFileSync').returns('file content');
+
+    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: 'C:/File.txt' } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation when multiple to emails are specified', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com,mail2@domain.com', bodyContents: 'Lorem ipsum' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when subject, to and bodyContents are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when multiple to emails separated with command and space are specified', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com, mail2@domain.com', bodyContents: 'Lorem ipsum' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when multiple to emails are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com,mail2@domain.com', bodyContents: 'Lorem ipsum' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when bodyContentType is set to Text', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', bodyContentType: 'Text' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when multiple to emails separated with command and space are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com, mail2@domain.com', bodyContents: 'Lorem ipsum' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when bodyContentType is set to HTML', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', bodyContentType: 'HTML' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when bodyContentType is set to Text', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', bodyContentType: 'Text' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when saveToSentItems is set to false', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', saveToSentItems: false } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when bodyContentType is set to HTML', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', bodyContentType: 'HTML' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when saveToSentItems is set to true', async () => {
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', saveToSentItems: true } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when saveToSentItems is set to false', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', saveToSentItems: false });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation when saveToSentItems is set to true', () => {
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', saveToSentItems: true });
+    assert.strictEqual(actual.success, true);
   });
 
   it('sends email using a specified group mailbox', async () => {

--- a/src/m365/outlook/commands/mail/mail-send.spec.ts
+++ b/src/m365/outlook/commands/mail/mail-send.spec.ts
@@ -317,6 +317,10 @@ describe(commands.MAIL_SEND, () => {
     assert.notStrictEqual(command.schema, undefined);
   });
 
+  it('defines refined schema', () => {
+    assert.notStrictEqual(command.getRefinedSchema(command.schema as any), undefined);
+  });
+
   it('fails validation if bodyContentType is invalid', () => {
     const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', bodyContentType: 'Invalid' });
     assert.notStrictEqual(actual.success, true);
@@ -327,7 +331,7 @@ describe(commands.MAIL_SEND, () => {
     assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if file doesn\'t exist', async () => {
+  it('fails validation if file doesn\'t exist', () => {
     sinon.stub(fs, 'lstatSync').returns({ isFile: () => true } as any);
     sinon.stub(fs, 'existsSync').callsFake(path => {
       if (path.toString() === 'C:/File2.txt') {
@@ -337,11 +341,11 @@ describe(commands.MAIL_SEND, () => {
       return true;
     });
 
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: ['C:/File.txt', 'C:/File2.txt'] } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: ['C:/File.txt', 'C:/File2.txt'] });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if attachment is not a file', async () => {
+  it('fails validation if attachment is not a file', () => {
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'lstatSync').callsFake(path => {
       if (path.toString() === 'C:/File2.txt') {
@@ -351,11 +355,11 @@ describe(commands.MAIL_SEND, () => {
       return { isFile: () => true } as any;
     });
 
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: ['C:/File.txt', 'C:/File2.txt'] } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: ['C:/File.txt', 'C:/File2.txt'] });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if attachments are too large', async () => {
+  it('fails validation if attachments are too large', () => {
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'lstatSync').returns({ isFile: () => true } as any);
     sinon.stub(fs, 'readFileSync').callsFake(path => {
@@ -366,17 +370,17 @@ describe(commands.MAIL_SEND, () => {
       throw 'Invalid read request';
     });
 
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: 'C:/File.txt' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: 'C:/File.txt' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when valid attachments are specified', async () => {
+  it('passes validation when valid attachments are specified', () => {
     sinon.stub(fs, 'existsSync').returns(true);
     sinon.stub(fs, 'lstatSync').returns({ isFile: () => true } as any);
     sinon.stub(fs, 'readFileSync').returns('file content');
 
-    const actual = await command.validate({ options: { subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: 'C:/File.txt' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ subject: 'Lorem ipsum', to: 'mail@domain.com', bodyContents: 'Lorem ipsum', attachment: 'C:/File.txt' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when subject, to and bodyContents are specified', () => {

--- a/src/m365/outlook/commands/mail/mail-send.ts
+++ b/src/m365/outlook/commands/mail/mail-send.ts
@@ -2,29 +2,33 @@ import fs from 'fs';
 import path from 'path';
 import auth from '../../../../Auth.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import { formatting } from '../../../../utils/formatting.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
+import { z } from 'zod';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  subject: z.string().alias('s'),
+  to: z.string().alias('t'),
+  cc: z.string().optional(),
+  bcc: z.string().optional(),
+  sender: z.string().optional(),
+  mailbox: z.string().optional().alias('m'),
+  bodyContents: z.string(),
+  bodyContentType: z.enum(['Text', 'HTML']).optional(),
+  importance: z.enum(['low', 'normal', 'high']).optional(),
+  attachment: z.union([z.string(), z.string().array()]).optional(),
+  saveToSentItems: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  subject: string;
-  to: string;
-  cc?: string;
-  bcc?: string;
-  sender?: string;
-  mailbox?: string;
-  bodyContents: string;
-  bodyContentType?: string;
-  importance?: string;
-  attachment?: string | string[];
-  saveToSentItems?: boolean;
 }
 
 class OutlookMailSendCommand extends GraphCommand {
@@ -36,88 +40,19 @@ class OutlookMailSendCommand extends GraphCommand {
     return 'Sends an email';
   }
 
+  public get schema(): z.ZodType | undefined {
+    return options;
+  }
+
   constructor() {
     super();
 
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initTypes();
     this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        cc: typeof args.options.cc !== 'undefined',
-        bcc: typeof args.options.bcc !== 'undefined',
-        bodyContentType: args.options.bodyContentType,
-        saveToSentItems: args.options.saveToSentItems,
-        importance: args.options.importance,
-        mailbox: typeof args.options.mailbox !== 'undefined',
-        sender: typeof args.options.sender !== 'undefined',
-        attachment: typeof args.options.attachment !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-s, --subject <subject>'
-      },
-      {
-        option: '-t, --to <to>'
-      },
-      {
-        option: '--cc [cc]'
-      },
-      {
-        option: '--bcc [bcc]'
-      },
-      {
-        option: '--sender [sender]'
-      },
-      {
-        option: '-m, --mailbox [mailbox]'
-      },
-      {
-        option: '--bodyContents <bodyContents>'
-      },
-      {
-        option: '--bodyContentType [bodyContentType]',
-        autocomplete: ['Text', 'HTML']
-      },
-      {
-        option: '--importance [importance]',
-        autocomplete: ['low', 'normal', 'high']
-      },
-      {
-        option: '--attachment [attachment]'
-      },
-      {
-        option: '--saveToSentItems [saveToSentItems]',
-        autocomplete: ['true', 'false']
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.boolean.push('saveToSentItems');
   }
 
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (args.options.bodyContentType &&
-          args.options.bodyContentType !== 'Text' &&
-          args.options.bodyContentType !== 'HTML') {
-          return `${args.options.bodyContentType} is not a valid value for the bodyContentType option. Allowed values are Text|HTML`;
-        }
-
-        if (args.options.importance && ['low', 'normal', 'high'].indexOf(args.options.importance) === -1) {
-          return `'${args.options.importance}' is not a valid value for the importance option. Allowed values are low|normal|high`;
-        }
-
         if (args.options.attachment) {
           const attachments: string[] = typeof args.options.attachment === 'string' ? [args.options.attachment] : args.options.attachment;
 

--- a/src/m365/outlook/commands/mail/mail-send.ts
+++ b/src/m365/outlook/commands/mail/mail-send.ts
@@ -47,47 +47,46 @@ class OutlookMailSendCommand extends GraphCommand {
   public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
     return schema
       .refine(options => {
-        if (options.attachment) {
-          const attachments: string[] = typeof options.attachment === 'string' ? [options.attachment] : options.attachment;
-
-          for (const attachment of attachments) {
-            if (!fs.existsSync(attachment)) {
-              return false;
-            }
-          }
+        if (!options.attachment) {
+          return true;
         }
 
-        return true;
-      }, {
-        error: 'One or more attachment files were not found.'
-      })
-      .refine(options => {
-        if (options.attachment) {
-          const attachments: string[] = typeof options.attachment === 'string' ? [options.attachment] : options.attachment;
+        const attachments: string[] = typeof options.attachment === 'string' ? [options.attachment] : options.attachment;
 
-          for (const attachment of attachments) {
-            if (fs.existsSync(attachment) && !fs.lstatSync(attachment).isFile()) {
-              return false;
-            }
+        for (const attachment of attachments) {
+          if (!fs.existsSync(attachment)) {
+            return false;
           }
-        }
 
-        return true;
-      }, {
-        error: 'One or more attachments is not a file.'
-      })
-      .refine(options => {
-        if (options.attachment) {
-          const requestBody = this.getRequestBody(options);
-          // The max body size of the request is 4 194 304 chars before getting a 413 response
-          if (JSON.stringify(requestBody).length > 4_194_304) {
+          if (!fs.lstatSync(attachment).isFile()) {
             return false;
           }
         }
 
+        const requestBody = this.getRequestBody(options);
+        // The max body size of the request is 4 194 304 chars before getting a 413 response
+        if (JSON.stringify(requestBody).length > 4_194_304) {
+          return false;
+        }
+
         return true;
       }, {
-        error: 'Exceeded the max total size of attachments which is 3MB.'
+        error: (ctx: { input: unknown }) => {
+          const opts = ctx.input as Options;
+          const attachments: string[] = typeof opts.attachment === 'string' ? [opts.attachment!] : opts.attachment!;
+
+          for (const attachment of attachments) {
+            if (!fs.existsSync(attachment)) {
+              return `File with path '${attachment}' was not found.`;
+            }
+
+            if (!fs.lstatSync(attachment).isFile()) {
+              return `'${attachment}' is not a file.`;
+            }
+          }
+
+          return 'Exceeded the max total size of attachments which is 3MB.';
+        }
       });
   }
 

--- a/src/m365/outlook/commands/mail/mail-send.ts
+++ b/src/m365/outlook/commands/mail/mail-send.ts
@@ -44,38 +44,51 @@ class OutlookMailSendCommand extends GraphCommand {
     return options;
   }
 
-  constructor() {
-    super();
-
-    this.#initValidators();
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.attachment) {
-          const attachments: string[] = typeof args.options.attachment === 'string' ? [args.options.attachment] : args.options.attachment;
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(options => {
+        if (options.attachment) {
+          const attachments: string[] = typeof options.attachment === 'string' ? [options.attachment] : options.attachment;
 
           for (const attachment of attachments) {
             if (!fs.existsSync(attachment)) {
-              return `File with path '${attachment}' was not found.`;
+              return false;
             }
-
-            if (!fs.lstatSync(attachment).isFile()) {
-              return `'${attachment}' is not a file.`;
-            }
-          }
-
-          const requestBody = this.getRequestBody(args.options);
-          // The max body size of the request is 4 194 304 chars before getting a 413 response
-          if (JSON.stringify(requestBody).length > 4_194_304) {
-            return 'Exceeded the max total size of attachments which is 3MB.';
           }
         }
 
         return true;
-      }
-    );
+      }, {
+        error: 'One or more attachment files were not found.'
+      })
+      .refine(options => {
+        if (options.attachment) {
+          const attachments: string[] = typeof options.attachment === 'string' ? [options.attachment] : options.attachment;
+
+          for (const attachment of attachments) {
+            if (fs.existsSync(attachment) && !fs.lstatSync(attachment).isFile()) {
+              return false;
+            }
+          }
+        }
+
+        return true;
+      }, {
+        error: 'One or more attachments is not a file.'
+      })
+      .refine(options => {
+        if (options.attachment) {
+          const requestBody = this.getRequestBody(options);
+          // The max body size of the request is 4 194 304 chars before getting a 413 response
+          if (JSON.stringify(requestBody).length > 4_194_304) {
+            return false;
+          }
+        }
+
+        return true;
+      }, {
+        error: 'Exceeded the max total size of attachments which is 3MB.'
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/outlook/commands/message/message-get.spec.ts
+++ b/src/m365/outlook/commands/message/message-get.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './message-get.js';
+import command, { options } from './message-get.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.MESSAGE_GET, () => {
@@ -77,6 +77,7 @@ describe(commands.MESSAGE_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -89,6 +90,7 @@ describe(commands.MESSAGE_GET, () => {
       accessToken: 'abc'
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -258,6 +260,16 @@ describe(commands.MESSAGE_GET, () => {
   it('passes validation if id is filled in', async () => {
     const actual = await command.validate({ options: { id: messageId } }, commandInfo);
     assert.equal(actual, true);
+  });
+
+  it('fails validation if both userId and userName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId, userId: userId, userName: userName });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('passes validation if only userId is specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId, userId: userId });
+    assert.strictEqual(actual.success, true);
   });
 
   it('throws an error when the upn or userName is not defined when signed in using app only authentication', async () => {

--- a/src/m365/outlook/commands/message/message-get.spec.ts
+++ b/src/m365/outlook/commands/message/message-get.spec.ts
@@ -262,6 +262,24 @@ describe(commands.MESSAGE_GET, () => {
     assert.equal(actual, true);
   });
 
+  it('defines schema', () => {
+    assert.notStrictEqual(command.schema, undefined);
+  });
+
+  it('defines refined schema', () => {
+    assert.notStrictEqual(command.getRefinedSchema(command.schema as any), undefined);
+  });
+
+  it('fails validation if userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId, userId: 'invalid-guid' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if userName is not a valid UPN', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId, userName: 'invalid-upn' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('fails validation if both userId and userName are specified', () => {
     const actual = commandOptionsSchema.safeParse({ id: messageId, userId: userId, userName: userName });
     assert.strictEqual(actual.success, false);

--- a/src/m365/outlook/commands/message/message-get.spec.ts
+++ b/src/m365/outlook/commands/message/message-get.spec.ts
@@ -142,7 +142,7 @@ describe(commands.MESSAGE_GET, () => {
       throw `Invalid request`;
     });
 
-    await command.action(logger, { options: { verbose: true, id: messageId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, id: messageId }) });
     assert(loggerLogSpy.calledWith(emailResponse));
   });
 
@@ -155,7 +155,7 @@ describe(commands.MESSAGE_GET, () => {
       throw `Invalid request`;
     });
 
-    await command.action(logger, { options: { verbose: true, id: messageId, userName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, id: messageId, userName: userName }) });
     assert(loggerLogSpy.calledWith(emailResponse));
   });
 
@@ -168,7 +168,7 @@ describe(commands.MESSAGE_GET, () => {
       throw `Invalid request`;
     });
 
-    await command.action(logger, { options: { verbose: true, id: messageId, userId: userId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, id: messageId, userId: userId }) });
     assert(loggerLogSpy.calledWith(emailResponse));
   });
 
@@ -181,7 +181,7 @@ describe(commands.MESSAGE_GET, () => {
       throw `Invalid request`;
     });
 
-    await assert.rejects(command.action(logger, { options: { id: messageId } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: messageId }) }),
       new CommandError(`Graph error occurred`));
   });
 
@@ -196,7 +196,7 @@ describe(commands.MESSAGE_GET, () => {
       throw `Invalid request`;
     });
 
-    await command.action(logger, { options: { verbose: true, id: messageId, userName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, id: messageId, userName: userName }) });
     assert(loggerLogSpy.calledWith(emailResponse));
   });
 
@@ -211,7 +211,7 @@ describe(commands.MESSAGE_GET, () => {
       throw `Invalid request`;
     });
 
-    await command.action(logger, { options: { verbose: true, id: messageId, userId: userId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, id: messageId, userId: userId }) });
     assert(loggerLogSpy.calledWith(emailResponse));
   });
 
@@ -226,7 +226,7 @@ describe(commands.MESSAGE_GET, () => {
       throw `Invalid request`;
     });
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, userId: userId }) }),
       new CommandError(`Graph error occurred`));
   });
 
@@ -241,11 +241,11 @@ describe(commands.MESSAGE_GET, () => {
       throw `Invalid request`;
     });
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, userName: userName } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, userName: userName }) }),
       new CommandError(`Graph error occurred`));
   });
 
-  it('fails validation if id is empty', async () => {
+  it('fails validation if id is empty', () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -253,13 +253,13 @@ describe(commands.MESSAGE_GET, () => {
 
       return defaultValue;
     });
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if id is filled in', async () => {
-    const actual = await command.validate({ options: { id: messageId } }, commandInfo);
-    assert.equal(actual, true);
+  it('passes validation if id is filled in', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId });
+    assert.strictEqual(actual.success, true);
   });
 
   it('defines schema', () => {
@@ -294,7 +294,7 @@ describe(commands.MESSAGE_GET, () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    await assert.rejects(command.action(logger, { options: { id: messageId } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: messageId }) }),
       new CommandError(`The option 'userId' or 'userName' is required when retrieving an email using app only credentials`));
   });
 
@@ -302,7 +302,7 @@ describe(commands.MESSAGE_GET, () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId, userName: userName } } as any),
+    await assert.rejects(command.action(logger, { options: options.parse({ id: messageId, userId: userId, userName: userName }) }),
       new CommandError(`Both options 'userId' and 'userName' cannot be set when retrieving an email using app only credentials`));
   });
 
@@ -310,7 +310,7 @@ describe(commands.MESSAGE_GET, () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(false);
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId, userName: userName } } as any),
+    await assert.rejects(command.action(logger, { options: options.parse({ id: messageId, userId: userId, userName: userName }) }),
       new CommandError(`Both options 'userId' and 'userName' cannot be set when retrieving an email using delegated credentials`));
   });
 });

--- a/src/m365/outlook/commands/message/message-get.ts
+++ b/src/m365/outlook/commands/message/message-get.ts
@@ -1,19 +1,30 @@
 import auth from '../../../../Auth.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
+import { z } from 'zod';
+import { validation } from '../../../../utils/validation.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().alias('i'),
+  userId: z.string()
+    .refine(userId => validation.isValidGuid(userId), {
+      error: e => `'${e.input}' is not a valid GUID.`
+    }).optional(),
+  userName: z.string()
+    .refine(userName => validation.isValidUserPrincipalName(userName), {
+      error: e => `'${e.input}' is not a valid UPN.`
+    }).optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id: string;
-  userId?: string;
-  userName?: string;
 }
 
 class OutlookMessageGetCommand extends GraphCommand {
@@ -25,34 +36,19 @@ class OutlookMessageGetCommand extends GraphCommand {
     return 'Retrieves specified message';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => !(options.userId && options.userName), {
+        error: 'Specify either userId or userName, but not both',
+        params: {
+          customCode: 'optionSet',
+          options: ['userId', 'userName']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id <id>'
-      },
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      }
-    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/outlook/commands/message/message-list.spec.ts
+++ b/src/m365/outlook/commands/message/message-list.spec.ts
@@ -258,7 +258,7 @@ describe(commands.MESSAGE_LIST, () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    await assert.rejects(command.action(logger, { options: {} } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({}) }),
       new CommandError('You must specify either the userId or userName option when using app-only permissions.'));
   });
 
@@ -271,7 +271,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { folderName: 'inbox' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ folderName: 'inbox' }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -284,7 +284,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, folderName: 'inbox' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, folderName: 'inbox' }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -297,7 +297,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { folderId: 'inbox' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ folderId: 'inbox' }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -319,7 +319,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { folderName: 'SecondInbox' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ folderName: 'SecondInbox' }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -332,7 +332,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { folderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ folderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=' }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -345,7 +345,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: commandOptionsSchema.parse({}) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -358,7 +358,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { startTime: startTime } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ startTime: startTime }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -371,7 +371,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userId: userId, endTime: endTime } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userId: userId, endTime: endTime }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -384,7 +384,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { startTime: startTime, endTime: endTime, userName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ startTime: startTime, endTime: endTime, userName: userName }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -397,7 +397,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { folderName: 'Imbox' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ folderName: 'Imbox' }) }),
       new CommandError(`Folder with name 'Imbox' not found`));
   });
 
@@ -427,7 +427,7 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { folderName: 'Archives' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ folderName: 'Archives' }) }),
       new CommandError("Multiple folders with name 'Archives' found. Found: AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=, AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAB=."));
   });
 
@@ -457,7 +457,7 @@ describe(commands.MESSAGE_LIST, () => {
       "id": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA="
     });
 
-    await command.action(logger, { options: { folderName: 'Archives' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ folderName: 'Archives' }) });
     assert(loggerLogSpy.calledOnceWith(emailOutput));
   });
 
@@ -470,14 +470,14 @@ describe(commands.MESSAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { folderName: 'inbox', output: 'json' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ folderName: 'inbox', output: 'json' }) });
     assert(loggerLogSpy.calledWith(emailResponse.value));
   });
 
   it('correctly handles random API error', async () => {
     sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
 
-    await assert.rejects(command.action(logger, { options: {} } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({}) }),
       new CommandError('An error has occurred'));
   });
 

--- a/src/m365/outlook/commands/message/message-list.spec.ts
+++ b/src/m365/outlook/commands/message/message-list.spec.ts
@@ -486,6 +486,14 @@ describe(commands.MESSAGE_LIST, () => {
     assert.strictEqual(actual.success, true);
   });
 
+  it('defines schema', () => {
+    assert.notStrictEqual(command.schema, undefined);
+  });
+
+  it('defines refined schema', () => {
+    assert.notStrictEqual(command.getRefinedSchema(command.schema as any), undefined);
+  });
+
   it('fails validation if startTime is not a valid ISO datetime', () => {
     const actual = commandOptionsSchema.safeParse({ startTime: 'invalid' });
     assert.notStrictEqual(actual.success, true);

--- a/src/m365/outlook/commands/message/message-list.spec.ts
+++ b/src/m365/outlook/commands/message/message-list.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './message-list.js';
+import command, { options } from './message-list.js';
 import { settingsNames } from '../../../../settingsNames.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import { formatting } from '../../../../utils/formatting.js';
@@ -21,6 +21,7 @@ describe(commands.MESSAGE_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   const folderId = 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=';
   const folderName = 'Inbox';
   const startTime = '2023-12-16';
@@ -205,6 +206,7 @@ describe(commands.MESSAGE_LIST, () => {
       accessToken: 'abc'
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -479,73 +481,65 @@ describe(commands.MESSAGE_LIST, () => {
       new CommandError('An error has occurred'));
   });
 
-  it('passes validation if both start and endTime are valid ISO datetimes', async () => {
-    const actual = await command.validate({ options: { startTime: startTime, endTime: endTime } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if both start and endTime are valid ISO datetimes', () => {
+    const actual = commandOptionsSchema.safeParse({ startTime: startTime, endTime: endTime });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if startTime is not a valid ISO datetime', async () => {
-    const actual = await command.validate({ options: { startTime: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if startTime is not a valid ISO datetime', () => {
+    const actual = commandOptionsSchema.safeParse({ startTime: 'invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if endTime is not a valid ISO datetime', async () => {
-    const actual = await command.validate({ options: { endTime: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if endTime is not a valid ISO datetime', () => {
+    const actual = commandOptionsSchema.safeParse({ endTime: 'invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if endTime is in the future', async () => {
+  it('fails validation if endTime is in the future', () => {
     const endTime = new Date();
     endTime.setHours(endTime.getHours() + 1);
-    const actual = await command.validate({ options: { endTime: endTime.toISOString() } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ endTime: endTime.toISOString() });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if startTime is in the future', async () => {
+  it('fails validation if startTime is in the future', () => {
     const startTime = new Date();
     startTime.setHours(startTime.getHours() + 1);
-    const actual = await command.validate({ options: { startTime: startTime.toISOString() } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ startTime: startTime.toISOString() });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if endTime is before startTime', async () => {
+  it('fails validation if endTime is before startTime', () => {
     const startTime = new Date();
     const endTime = new Date(startTime);
     endTime.setTime(endTime.getTime() - 1);
-    const actual = await command.validate({ options: { startTime: startTime.toISOString(), endTime: endTime.toISOString() } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ startTime: startTime.toISOString(), endTime: endTime.toISOString() });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if both folderId and folderName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { folderId: folderId, folderName: folderName } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both folderId and folderName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ folderId: folderId, folderName: folderName });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { userId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: 'invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if userName is not a valid user principal name', async () => {
-    const actual = await command.validate({ options: { userName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userName is not a valid user principal name', () => {
+    const actual = commandOptionsSchema.safeParse({ userName: 'invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('passes validation if userId is a valid GUID', async () => {
-    const actual = await command.validate({ options: { userId: userId } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if userId is a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: userId });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation if userName is a valid user principal name', async () => {
-    const actual = await command.validate({ options: { userName: userName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if userName is a valid user principal name', () => {
+    const actual = commandOptionsSchema.safeParse({ userName: userName });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/outlook/commands/message/message-list.ts
+++ b/src/m365/outlook/commands/message/message-list.ts
@@ -1,6 +1,6 @@
 import { Message } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { odata } from '../../../../utils/odata.js';
@@ -11,18 +11,42 @@ import { cli } from '../../../../cli/cli.js';
 import { validation } from '../../../../utils/validation.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import auth from '../../../../Auth.js';
+import { z } from 'zod';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  folderId: z.string().optional(),
+  folderName: z.string().optional(),
+  startTime: z.string()
+    .refine(startTime => validation.isValidISODateTime(startTime), {
+      error: e => `'${e.input}' is not a valid ISO date string for option startTime.`
+    })
+    .refine(startTime => new Date(startTime) <= new Date(), {
+      error: 'startTime value cannot be in the future.'
+    })
+    .optional(),
+  endTime: z.string()
+    .refine(endTime => validation.isValidISODateTime(endTime), {
+      error: e => `'${e.input}' is not a valid ISO date string for option endTime.`
+    })
+    .refine(endTime => new Date(endTime) <= new Date(), {
+      error: 'endTime value cannot be in the future.'
+    })
+    .optional(),
+  userId: z.string()
+    .refine(userId => validation.isValidGuid(userId), {
+      error: e => `${e.input} is not a valid GUID for option userId.`
+    }).optional(),
+  userName: z.string()
+    .refine(userName => validation.isValidUserPrincipalName(userName), {
+      error: e => `${e.input} is not a valid UPN for option userName.`
+    }).optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  folderId?: string;
-  folderName?: string;
-  startTime?: string;
-  endTime?: string;
-  userId?: string;
-  userName?: string;
 }
 
 class OutlookMessageListCommand extends GraphCommand {
@@ -34,106 +58,29 @@ class OutlookMessageListCommand extends GraphCommand {
     return 'Gets all mail messages from the specified folder';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initTypes();
-    this.#initOptionSets();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        folderId: typeof args.options.folderId !== 'undefined',
-        folderName: typeof args.options.folderName !== 'undefined',
-        startTime: typeof args.options.startTime !== 'undefined',
-        endTime: typeof args.options.endTime !== 'undefined',
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => !(options.folderId && options.folderName), {
+        error: 'Specify either folderId or folderName, but not both',
+        params: {
+          customCode: 'optionSet',
+          options: ['folderId', 'folderName']
+        }
+      })
+      .refine(options => !(options.userId && options.userName), {
+        error: 'Specify either userId or userName, but not both',
+        params: {
+          customCode: 'optionSet',
+          options: ['userId', 'userName']
+        }
+      })
+      .refine(options => !(options.startTime && options.endTime && new Date(options.startTime) >= new Date(options.endTime)), {
+        error: 'startTime must be before endTime.'
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--folderName [folderName]',
-        autocomplete: Outlook.wellKnownFolderNames
-      },
-      {
-        option: '--folderId [folderId]'
-      },
-      {
-        option: '--startTime [startTime]'
-      },
-      {
-        option: '--endTime [endTime]'
-      },
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.startTime) {
-          if (!validation.isValidISODateTime(args.options.startTime)) {
-            return `'${args.options.startTime}' is not a valid ISO date string for option startTime.`;
-          }
-          if (new Date(args.options.startTime) > new Date()) {
-            return 'startTime value cannot be in the future.';
-          }
-        }
-
-        if (args.options.endTime) {
-          if (!validation.isValidISODateTime(args.options.endTime)) {
-            return `'${args.options.endTime}' is not a valid ISO date string for option endTime.`;
-          }
-          if (new Date(args.options.endTime) > new Date()) {
-            return 'endTime value cannot be in the future.';
-          }
-        }
-
-        if (args.options.startTime && args.options.endTime && new Date(args.options.startTime) >= new Date(args.options.endTime)) {
-          return 'startTime must be before endTime.';
-        }
-
-        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
-          return `${args.options.userId} is not a valid GUID for option userId.`;
-        }
-
-        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
-          return `${args.options.userName} is not a valid UPN for option userName.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('folderName', 'folderId', 'startTime', 'endTime', 'userId', 'userName');
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      {
-        options: ['folderId', 'folderName'],
-        runsWhen: (args) => args.options.folderId || args.options.folderName
-      },
-      {
-        options: ['userId', 'userName'],
-        runsWhen: (args) => args.options.userId || args.options.userName
-      }
-    );
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/outlook/commands/message/message-move.spec.ts
+++ b/src/m365/outlook/commands/message/message-move.spec.ts
@@ -79,7 +79,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' }) });
   });
 
   it('moves message from source folder specified using a well-known name to the target folder specified using a well-known name (name in name)', async () => {
@@ -91,7 +91,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'inbox', targetFolderName: 'archive' } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'inbox', targetFolderName: 'archive' }) });
   });
 
   it('moves message from one folder to another both specified using an ID', async () => {
@@ -103,7 +103,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAB=' } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAB=' }) });
   });
 
   it('moves message from one folder to another both specified using an ID (debug)', async () => {
@@ -115,7 +115,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAB=' } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAB=' }) });
   });
 
   it('moves message from one folder to another both specified using a name', async () => {
@@ -149,7 +149,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' }) });
   });
 
   it('correctly handles error when message not found', async () => {
@@ -170,7 +170,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAB=' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAB=' }) }),
       new CommandError(`Id is malformed.`));
   });
 
@@ -199,7 +199,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' }) }),
       new CommandError(`Folder with name 'Inbox' not found`));
   });
 
@@ -226,7 +226,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' }) }),
       new CommandError(`Folder with name 'Archive' not found`));
   });
 
@@ -272,7 +272,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' }) }),
       new CommandError("Multiple folders with name 'Inbox' found. Found: AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=, AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAA0=."));
   });
 
@@ -318,7 +318,7 @@ describe(commands.MESSAGE_MOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' }) }),
       new CommandError("Multiple folders with name 'Archive' found. Found: AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAB=, AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAA0=."));
   });
 
@@ -364,14 +364,14 @@ describe(commands.MESSAGE_MOVE, () => {
       "id": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA="
     });
 
-    await command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderName: 'Inbox', targetFolderName: 'Archive' }) });
     assert(postRequestIssued);
   });
 
   it('correctly handles random API error', async () => {
     sinon.stub(request, 'post').rejects(new Error('An error has occurred'));
 
-    await assert.rejects(command.action(logger, { options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' }) }),
       new CommandError('An error has occurred'));
   });
 

--- a/src/m365/outlook/commands/message/message-move.spec.ts
+++ b/src/m365/outlook/commands/message/message-move.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './message-move.js';
+import command, { options } from './message-move.js';
 import { settingsNames } from '../../../../settingsNames.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 
@@ -19,6 +19,7 @@ describe(commands.MESSAGE_MOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -28,6 +29,7 @@ describe(commands.MESSAGE_MOVE, () => {
     sinon.stub(accessToken, 'assertAccessTokenType').returns();
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -373,80 +375,48 @@ describe(commands.MESSAGE_MOVE, () => {
       new CommandError('An error has occurred'));
   });
 
-  it('passes validation if all required options specified', async () => {
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if all required options specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if neither sourceFolderId nor sourceFolderName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', targetFolderId: 'archive' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither sourceFolderId nor sourceFolderName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', targetFolderId: 'archive' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if both sourceFolderId and sourceFolderName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', sourceFolderName: 'Inbox', targetFolderId: 'archive' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both sourceFolderId and sourceFolderName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', sourceFolderName: 'Inbox', targetFolderId: 'archive' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if neither targetFolderId nor targetFolderName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither targetFolderId nor targetFolderName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if both targetFolderId and targetFolderName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
-    });
-
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive', targetFolderName: 'archive' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both targetFolderId and targetFolderName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive', targetFolderName: 'archive' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('passes validation if sourceFolderId specified using a well-know-name', async () => {
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if sourceFolderId specified using a well-know-name', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation if targetFolderId specified using a well-know-name', async () => {
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if targetFolderId specified using a well-know-name', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'inbox', targetFolderId: 'archive' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation if sourceFolderId specified using an ID', async () => {
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'archive' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if sourceFolderId specified using an ID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'archive' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation if targetFolderId specified using an ID', async () => {
-    const actual = await command.validate({ options: { id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if targetFolderId specified using an ID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', sourceFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=', targetFolderId: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=' });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/outlook/commands/message/message-move.spec.ts
+++ b/src/m365/outlook/commands/message/message-move.spec.ts
@@ -380,6 +380,14 @@ describe(commands.MESSAGE_MOVE, () => {
     assert.strictEqual(actual.success, true);
   });
 
+  it('defines schema', () => {
+    assert.notStrictEqual(command.schema, undefined);
+  });
+
+  it('defines refined schema', () => {
+    assert.notStrictEqual(command.getRefinedSchema(command.schema as any), undefined);
+  });
+
   it('fails validation if neither sourceFolderId nor sourceFolderName are specified', () => {
     const actual = commandOptionsSchema.safeParse({ id: 'AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAALvuv07AAA', targetFolderId: 'archive' });
     assert.notStrictEqual(actual.success, true);

--- a/src/m365/outlook/commands/message/message-move.ts
+++ b/src/m365/outlook/commands/message/message-move.ts
@@ -1,22 +1,26 @@
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { formatting } from '../../../../utils/formatting.js';
 import commands from '../../commands.js';
 import { Outlook } from '../../Outlook.js';
 import { cli } from '../../../../cli/cli.js';
 import DelegatedGraphCommand from '../../../base/GraphDelegatedCommand.js';
+import { z } from 'zod';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string(),
+  sourceFolderId: z.string().optional(),
+  sourceFolderName: z.string().optional(),
+  targetFolderId: z.string().optional(),
+  targetFolderName: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id: string;
-  sourceFolderId?: string;
-  sourceFolderName?: string;
-  targetFolderId?: string;
-  targetFolderName?: string;
 }
 
 class OutlookMessageMoveCommand extends DelegatedGraphCommand {
@@ -28,54 +32,40 @@ class OutlookMessageMoveCommand extends DelegatedGraphCommand {
     return 'Moves message to the specified folder';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initOptionSets();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        sourceFolderId: typeof args.options.sourceFolderId !== 'undefined',
-        sourceFolderName: typeof args.options.sourceFolderName !== 'undefined',
-        targetFolderId: typeof args.options.targetFolderId !== 'undefined',
-        targetFolderName: typeof args.options.targetFolderName !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => options.sourceFolderId || options.sourceFolderName, {
+        error: 'Specify either sourceFolderId or sourceFolderName',
+        params: {
+          customCode: 'optionSet',
+          options: ['sourceFolderId', 'sourceFolderName']
+        }
+      })
+      .refine(options => !(options.sourceFolderId && options.sourceFolderName), {
+        error: 'Specify either sourceFolderId or sourceFolderName, but not both',
+        params: {
+          customCode: 'optionSet',
+          options: ['sourceFolderId', 'sourceFolderName']
+        }
+      })
+      .refine(options => options.targetFolderId || options.targetFolderName, {
+        error: 'Specify either targetFolderId or targetFolderName',
+        params: {
+          customCode: 'optionSet',
+          options: ['targetFolderId', 'targetFolderName']
+        }
+      })
+      .refine(options => !(options.targetFolderId && options.targetFolderName), {
+        error: 'Specify either targetFolderId or targetFolderName, but not both',
+        params: {
+          customCode: 'optionSet',
+          options: ['targetFolderId', 'targetFolderName']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--id <id>'
-      },
-      {
-        option: '--sourceFolderName [sourceFolderName]',
-        autocomplete: Outlook.wellKnownFolderNames
-      },
-      {
-        option: '--sourceFolderId [sourceFolderId]',
-        autocomplete: Outlook.wellKnownFolderNames
-      },
-      {
-        option: '--targetFolderName [targetFolderName]',
-        autocomplete: Outlook.wellKnownFolderNames
-      },
-      {
-        option: '--targetFolderId [targetFolderId]',
-        autocomplete: Outlook.wellKnownFolderNames
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['sourceFolderId', 'sourceFolderName'] },
-      { options: ['targetFolderId', 'targetFolderName'] }
-    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/outlook/commands/message/message-remove.spec.ts
+++ b/src/m365/outlook/commands/message/message-remove.spec.ts
@@ -11,7 +11,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { cli } from '../../../../cli/cli.js';
 import { accessToken } from '../../../../utils/accessToken.js';
-import command from './message-remove.js';
+import command, { options } from './message-remove.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
 
@@ -24,6 +24,7 @@ describe(commands.MESSAGE_REMOVE, () => {
   let logger: Logger;
   let promptIssued: boolean;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -36,6 +37,7 @@ describe(commands.MESSAGE_REMOVE, () => {
       accessToken: 'abc'
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -81,24 +83,24 @@ describe(commands.MESSAGE_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('passes validation when userId is a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: messageId, userId: userId } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when userId is a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId, userId: userId });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when userName is a valid UPN', async () => {
-    const actual = await command.validate({ options: { id: messageId, userName: userPrincipalName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when userName is a valid UPN', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId, userName: userPrincipalName });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: messageId, userId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId, userId: 'invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
-  it('fails validation if userName is not a valid UPN', async () => {
-    const actual = await command.validate({ options: { id: messageId, userName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userName is not a valid UPN', () => {
+    const actual = commandOptionsSchema.safeParse({ id: messageId, userName: 'invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('removes specific message using delegated permissions without prompting for confirmation', async () => {

--- a/src/m365/outlook/commands/message/message-remove.spec.ts
+++ b/src/m365/outlook/commands/message/message-remove.spec.ts
@@ -93,6 +93,10 @@ describe(commands.MESSAGE_REMOVE, () => {
     assert.strictEqual(actual.success, true);
   });
 
+  it('defines schema', () => {
+    assert.notStrictEqual(command.schema, undefined);
+  });
+
   it('fails validation if userId is not a valid GUID', () => {
     const actual = commandOptionsSchema.safeParse({ id: messageId, userId: 'invalid' });
     assert.notStrictEqual(actual.success, true);

--- a/src/m365/outlook/commands/message/message-remove.spec.ts
+++ b/src/m365/outlook/commands/message/message-remove.spec.ts
@@ -116,7 +116,7 @@ describe(commands.MESSAGE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: messageId, force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, force: true, verbose: true }) });
     assert(deleteRequestStub.calledOnce);
   });
 
@@ -132,7 +132,7 @@ describe(commands.MESSAGE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { id: messageId, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, verbose: true }) });
     assert(deleteRequestStub.calledOnce);
   });
 
@@ -145,7 +145,7 @@ describe(commands.MESSAGE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: messageId, userId: userId, force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, userId: userId, force: true, verbose: true }) });
     assert(deleteRequestStub.calledOnce);
   });
 
@@ -158,7 +158,7 @@ describe(commands.MESSAGE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: messageId, userName: userPrincipalName, force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, userName: userPrincipalName, force: true, verbose: true }) });
     assert(deleteRequestStub.calledOnce);
   });
 
@@ -173,7 +173,7 @@ describe(commands.MESSAGE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: messageId, userId: userId, force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, userId: userId, force: true, verbose: true }) });
     assert(deleteRequestStub.calledOnce);
   });
 
@@ -188,7 +188,7 @@ describe(commands.MESSAGE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: messageId, userName: userPrincipalName, force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, userName: userPrincipalName, force: true, verbose: true }) });
     assert(deleteRequestStub.calledOnce);
   });
 
@@ -196,7 +196,7 @@ describe(commands.MESSAGE_REMOVE, () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    await assert.rejects(command.action(logger, { options: { id: messageId } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: messageId }) }),
       new CommandError(`The option 'userId' or 'userName' is required when removing a message using application permissions.`));
   });
 
@@ -204,12 +204,12 @@ describe(commands.MESSAGE_REMOVE, () => {
     sinonUtil.restore([accessToken.isAppOnlyAccessToken]);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId, userName: userPrincipalName } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, userId: userId, userName: userPrincipalName }) }),
       new CommandError(`Both options 'userId' and 'userName' cannot be used together when removing a message using application permissions.`));
   });
 
   it('throws an error when both userId and userName are defined when removing a message using delegated permissions', async () => {
-    await assert.rejects(command.action(logger, { options: { id: messageId, userId: userId, userName: userPrincipalName } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, userId: userId, userName: userPrincipalName }) }),
       new CommandError(`Both options 'userId' and 'userName' cannot be used together when removing a message using delegated permissions.`));
   });
 
@@ -233,12 +233,12 @@ describe(commands.MESSAGE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: messageId, force: true } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: messageId, force: true }) }),
       new CommandError(error.error.message));
   });
 
   it('prompts before removing the message when confirm option not passed', async () => {
-    await command.action(logger, { options: { id: messageId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: messageId }) });
 
     assert(promptIssued);
   });
@@ -246,7 +246,7 @@ describe(commands.MESSAGE_REMOVE, () => {
   it('aborts removing the message when prompt not confirmed', async () => {
     const deleteSpy = sinon.stub(request, 'delete').resolves();
 
-    await command.action(logger, { options: { id: messageId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: messageId }) });
     assert(deleteSpy.notCalled);
   });
 });

--- a/src/m365/outlook/commands/message/message-remove.ts
+++ b/src/m365/outlook/commands/message/message-remove.ts
@@ -1,6 +1,6 @@
 import auth from '../../../../Auth.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import GraphCommand from '../../../base/GraphCommand.js';
@@ -8,16 +8,26 @@ import commands from '../../commands.js';
 import { cli } from '../../../../cli/cli.js';
 import { validation } from '../../../../utils/validation.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { z } from 'zod';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().alias('i'),
+  userId: z.string()
+    .refine(userId => validation.isValidGuid(userId), {
+      error: e => `Value '${e.input}' is not a valid GUID for option 'userId'.`
+    }).optional(),
+  userName: z.string()
+    .refine(userName => validation.isValidUserPrincipalName(userName), {
+      error: e => `Value '${e.input}' is not a valid user principal name for option 'userName'.`
+    }).optional(),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id: string;
-  userId?: string;
-  userName?: string;
-  force?: boolean
 }
 
 class OutlookMessageRemoveCommand extends GraphCommand {
@@ -29,61 +39,8 @@ class OutlookMessageRemoveCommand extends GraphCommand {
     return 'Permanently removes a specific message from a mailbox';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initTypes();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined',
-        force: !!args.options.force
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id <id>'
-      },
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
-          return `Value '${args.options.userId}' is not a valid GUID for option 'userId'.`;
-        }
-
-        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
-          return `Value '${args.options.userName}' is not a valid user principal name for option 'userName'.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'userId', 'userName');
-    this.types.boolean.push('force');
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {


### PR DESCRIPTION
## What's in this PR

Migrates the `outlook message` and `outlook mail` commands to use Zod validation schemas, replacing the legacy interface-based validation pattern.

### Commands migrated
- `outlook message get`
- `outlook message list`
- `outlook message move`
- `outlook message remove`
- `outlook mail send`

### Changes per command
- Removed `constructor`, `#initTelemetry()`, `#initOptions()`, `#initValidators()`, `#initTypes()`, `#initOptionSets()`
- Added exported Zod schema (`options`) with `z.strictObject()`
- Added `get schema()` and `getRefinedSchema()` methods
- Updated test files to use `commandOptionsSchema.safeParse()` for validation tests

### Notes
- `mail-send.ts` keeps `this.validators` for filesystem-dependent attachment validation (file existence/size checks can't be expressed as Zod schemas)
- `mail-searchfolder-add.ts` was already migrated and is not part of this PR

Closes pnp/cli-microsoft365#7308