### PR TITLE
fix: upgrade outdated dependency overrides and direct deps

### DIFF
--- a/.github/skills/patch-vulnerabilities/SKILL.md
+++ b/.github/skills/patch-vulnerabilities/SKILL.md
@@ -4,15 +4,16 @@ description: >-
   This skill should be used when the user asks to "patch vulnerabilities",
   "fix npm audit issues", "update vulnerable dependencies", "scan and fix
   vulnerabilities", "run npm audit and patch", "fix security vulnerabilities",
-  or needs to iteratively scan, patch, and re-verify npm dependency
-  vulnerabilities with a cooldown safety check.
+  "update outdated dependencies", "audit deps", or needs to iteratively scan,
+  patch, and re-verify npm dependency vulnerabilities and outdated packages
+  with a cooldown safety check.
 ---
 
-# Patch npm Vulnerabilities
+# Patch npm Dependencies
 
-Iteratively scan npm dependencies for vulnerabilities, patch eligible ones
-(respecting a 7-day publish-age cooldown), verify fixes, and repeat until no
-new patchable vulnerabilities remain.
+Comprehensively scan npm dependencies for vulnerabilities, outdated packages,
+and stale overrides. Patch eligible ones (respecting a 7-day publish-age
+cooldown), verify fixes, and repeat until no new patchable issues remain.
 
 ## Prerequisites
 
@@ -25,9 +26,13 @@ new patchable vulnerabilities remain.
 Execute the phases below in a loop. Each pass through the loop is one
 **patch cycle**. Continue cycling until the termination condition is met.
 
-### Phase 1 — Scan
+---
 
-Run `npm audit` to identify vulnerabilities:
+### Phase 1 — Scan (three checks)
+
+Run all three scans to get full coverage of dependency issues.
+
+#### 1A — Security vulnerabilities (`npm audit`)
 
 ```bash
 npm audit --json 2>/dev/null
@@ -48,18 +53,75 @@ To classify each vulnerability:
   chain in the `via` and `effects` fields. Identify the **top-level ancestor**
   (the direct dependency that pulls in the vulnerable transitive package).
 
-If no vulnerabilities are found, stop — the project is clean.
+#### 1B — Outdated direct dependencies (`npm outdated`)
 
-Summarize findings to the user in a table:
+```bash
+npm outdated --json 2>/dev/null
+```
+
+Parse the JSON output. For each entry, extract:
+- Package name
+- Current version
+- Wanted version (max satisfying the declared range)
+- Latest version (latest on registry)
+- Whether upgrading to latest requires a major version bump
+
+**Note:** `npm outdated` only reports direct dependencies listed in
+`dependencies` and `devDependencies`. It does NOT report outdated overrides.
+
+#### 1C — Outdated overrides (manual registry check)
+
+Read the `overrides` field from `package.json` (including nested overrides).
+For each override entry:
+
+```bash
+npm view <package> version --json
+```
+
+Compare the pinned override version against the latest version on the
+registry. If the latest is newer, the override is outdated.
+
+Also check nested overrides. Overrides can be structured as:
+```json
+{
+  "overrides": {
+    "parent-package": {
+      "child-package": "1.2.3"
+    }
+  }
+}
+```
+In this case, check `child-package` against the registry.
+
+#### Phase 1 summary
+
+If no issues are found across all three checks, stop — the project is clean.
+
+Otherwise, present findings in tables:
+
+**Security vulnerabilities:**
 
 | Package | Severity | Current | Fix available | Type | Top-level ancestor |
 |---------|----------|---------|---------------|------|--------------------|
 
+**Outdated direct dependencies:**
+
+| Package | Current | Wanted | Latest | Major bump? |
+|---------|---------|--------|--------|-------------|
+
+**Outdated overrides:**
+
+| Package | Override version | Latest | Context (parent) |
+|---------|-----------------|--------|------------------|
+
+---
+
 ### Phase 2 — Check cooldown eligibility
 
-For each vulnerability that has a fix available, verify the target version's
-publish date against the **7-day cooldown rule**: the fix version must have
-been published at least 7 days ago.
+For every package that has an available upgrade (from any of the three
+checks), verify the target version's publish date against the **7-day
+cooldown rule**: the target version must have been published at least 7 days
+ago.
 
 Query the npm registry for each package:
 
@@ -68,30 +130,33 @@ npm view <package> time --json
 ```
 
 This returns a JSON object mapping version strings to ISO 8601 timestamps.
-Find the entry for the target fix version. Calculate the age:
+Find the entry for the target version. Calculate the age:
 
 ```
 age_days = (now - publish_date) / 86400
 ```
 
 **If `age_days >= 7`**: the package is eligible for patching.
-**If `age_days < 7`**: skip this package for now and report it as "cooling down"
-with the date it becomes eligible.
+**If `age_days < 7`**: skip this package for now and report it as "cooling
+down" with the date it becomes eligible.
 
 Report cooldown status to the user:
 
-| Package | Fix version | Published | Eligible | Eligible date |
-|---------|-------------|-----------|----------|---------------|
+| Package | Target version | Published | Eligible | Eligible date |
+|---------|----------------|-----------|----------|---------------|
 
-If no packages are eligible, stop — remaining vulnerabilities are all in
-cooldown. Report the earliest eligibility date.
+If no packages are eligible, stop — all remaining issues are in cooldown.
+Report the earliest eligibility date.
+
+---
 
 ### Phase 3 — Patch
 
-For each eligible package, apply the fix. The strategy depends on whether
-the vulnerability is in a direct or transitive dependency.
+Apply fixes for all eligible packages, grouped by source.
 
-#### Direct dependencies
+#### 3A — Security vulnerabilities
+
+##### Direct dependencies
 
 1. **Direct fix** — If `npm audit fix` can resolve it without breaking changes:
    ```bash
@@ -115,7 +180,7 @@ the vulnerability is in a direct or transitive dependency.
    Flag this to the user as a **breaking change** and note it requires
    additional testing.
 
-#### Transitive dependencies
+##### Transitive dependencies
 
 Transitive vulnerabilities cannot be fixed by installing the vulnerable
 package directly. Work through the dependency chain instead:
@@ -152,7 +217,42 @@ package directly. Work through the dependency chain instead:
    for now. Note the top-level ancestor and suggest the user open an issue
    or PR upstream.
 
-After patching, build the project and run the test suite to verify nothing broke:
+#### 3B — Outdated direct dependencies
+
+For each outdated direct dependency that passed cooldown:
+
+1. **Patch/minor update** (wanted version matches latest, no major bump):
+   ```bash
+   npm install <package>@<latest-version>
+   ```
+
+2. **Major version update** (latest requires a major bump):
+   ```bash
+   npm install <package>@<latest-version>
+   ```
+   Flag this to the user as a **breaking change** and note it requires
+   additional testing.
+
+#### 3C — Outdated overrides
+
+For each outdated override that passed cooldown:
+
+1. Update the version in the `overrides` section of `package.json` to the
+   latest version.
+
+2. Run `npm install` to apply the override resolution.
+
+3. Flag the change to the user — overrides bypass the parent package's
+   declared compatibility range and may cause runtime issues.
+
+4. If the override was originally added to fix a vulnerability, check whether
+   the parent package now ships a version that includes the fix natively.
+   If so, recommend removing the override entirely and updating the parent
+   package instead.
+
+#### After each patch
+
+Build the project and run the test suite to verify nothing broke:
 
 ```bash
 npm run build && npm test
@@ -165,40 +265,62 @@ If the build or tests fail after a patch:
 
 If tests pass, commit the change:
 - Stage: `git add package.json npm-shrinkwrap.json package-lock.json`
-- Commit with message: `fix: upgrade <package> to <version> to fix <severity> vulnerability`
+- Commit message format:
+  - For vulnerability fixes: `fix: upgrade <package> to <version> to fix <severity> vulnerability`
+  - For outdated dependencies: `fix: upgrade <package> from <old> to <new>`
+  - For outdated overrides: `fix: upgrade <package> override from <old> to <new>`
+
+---
 
 ### Phase 4 — Re-scan and loop
 
-Return to **Phase 1**. Run `npm audit --json` again to check for remaining
-vulnerabilities.
+Return to **Phase 1**. Run all three checks again to verify fixes and detect
+any newly-revealed issues.
+
+---
 
 ### Termination conditions
 
 Stop the loop when any of these is true:
 
-1. `npm audit` reports **zero vulnerabilities**
-2. All remaining vulnerabilities have fixes **in cooldown** (< 7 days old)
-3. All remaining vulnerabilities have **no fix available**
+1. All three scans report **zero issues**
+2. All remaining issues have target versions **in cooldown** (< 7 days old)
+3. All remaining issues have **no fix available**
 4. A patch cycle produced **zero successful patches** (nothing new was fixed)
+
+---
 
 ### Final report
 
 After the loop ends, present a summary:
 
 ```
-## Vulnerability Patch Summary
+## Dependency Patch Summary
 
 Patch cycles completed: N
-Packages patched: list with versions
-  - Direct: list
+
+### Packages patched
+- Security fixes:
+  - Direct: list with versions
   - Transitive (via ancestor update): list
   - Transitive (via override): list
-Remaining vulnerabilities: count
-  - In cooldown (eligible on <date>): list
-  - No fix available: list
-  - Transitive, waiting on upstream: list with top-level ancestor
-Overrides added: list (review periodically and remove when upstream fixes land)
+- Outdated direct dependencies updated: list with old → new versions
+- Outdated overrides updated: list with old → new versions
+
+### Remaining issues
+- Vulnerabilities in cooldown (eligible on <date>): list
+- Outdated packages in cooldown (eligible on <date>): list
+- No fix available: list
+- Transitive, waiting on upstream: list with top-level ancestor
+
+### Overrides
+- Added: list
+- Updated: list
+- Recommend removing (upstream fix available): list
+(Review overrides periodically and remove when upstream fixes land)
 ```
+
+---
 
 ## Important notes
 
@@ -208,3 +330,8 @@ Overrides added: list (review periodically and remove when upstream fixes land)
 - Never force-install a version published less than 7 days ago.
 - If `npm-shrinkwrap.json` exists, include it in commits alongside
   `package-lock.json`.
+- `npm audit` only catches security vulnerabilities — not deprecated or
+  outdated packages.
+- `npm outdated` only catches outdated direct dependencies — not overrides.
+- Overrides are invisible to both `npm audit` and `npm outdated` — they must
+  be checked manually against the registry.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -36,7 +36,7 @@
         "strip-json-comments": "^5.0.3",
         "typescript": "^5.9.3",
         "update-notifier": "^7.3.1",
-        "uuid": "^13.0.1",
+        "uuid": "^14.0.0",
         "yaml": "^2.8.3",
         "yargs-parser": "^22.0.0",
         "zod": "^4.4.1"
@@ -226,19 +226,6 @@
         "iconv-lite": "^0.6.3",
         "long": "^4.0.0",
         "uuid": "^8.3.0"
-      }
-    },
-    "node_modules/@azure/functions-old/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@azure/identity": {
@@ -607,6 +594,8 @@
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
@@ -618,6 +607,8 @@
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -634,6 +625,8 @@
     },
     "node_modules/@grpc/proto-loader/node_modules/long": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
     "node_modules/@humanfs/core": {
@@ -867,6 +860,8 @@
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -902,6 +897,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -917,7 +913,9 @@
       }
     },
     "node_modules/@opentelemetry/configuration": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.218.0.tgz",
+      "integrity": "sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
@@ -954,21 +952,89 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.218.0.tgz",
+      "integrity": "sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-transformer": "0.217.0",
-        "@opentelemetry/sdk-logs": "0.217.0"
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/sdk-logs": "0.218.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
@@ -989,15 +1055,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.218.0.tgz",
+      "integrity": "sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
         "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.217.0",
+        "@opentelemetry/sdk-logs": "0.218.0",
         "@opentelemetry/sdk-trace-base": "2.7.1"
       },
       "engines": {
@@ -1007,16 +1075,84 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.218.0.tgz",
+      "integrity": "sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.217.0",
-        "@opentelemetry/otlp-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
         "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/sdk-metrics": "2.7.1"
       },
@@ -1025,6 +1161,91 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
@@ -1063,7 +1284,9 @@
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.218.0.tgz",
+      "integrity": "sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
@@ -1079,14 +1302,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.218.0.tgz",
+      "integrity": "sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
         "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/sdk-trace-base": "2.7.1"
       },
@@ -1095,6 +1320,72 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
@@ -1115,12 +1406,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.218.0.tgz",
+      "integrity": "sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
         "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/sdk-trace-base": "2.7.1"
       },
@@ -1129,6 +1422,72 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
@@ -1284,19 +1643,87 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.217.0",
-        "@opentelemetry/otlp-transformer": "0.217.0"
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
@@ -1411,30 +1838,32 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.217.0",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.218.0.tgz",
+      "integrity": "sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.217.0",
-        "@opentelemetry/configuration": "0.217.0",
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/configuration": "0.218.0",
         "@opentelemetry/context-async-hooks": "2.7.1",
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.217.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.217.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.217.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.217.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.217.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.217.0",
-        "@opentelemetry/exporter-prometheus": "0.217.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.217.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.217.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.217.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.218.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.218.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.218.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.218.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.218.0",
+        "@opentelemetry/exporter-prometheus": "0.218.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.218.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.218.0",
         "@opentelemetry/exporter-zipkin": "2.7.1",
-        "@opentelemetry/instrumentation": "0.217.0",
-        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/instrumentation": "0.218.0",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
         "@opentelemetry/propagator-b3": "2.7.1",
         "@opentelemetry/propagator-jaeger": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.217.0",
+        "@opentelemetry/sdk-logs": "0.218.0",
         "@opentelemetry/sdk-metrics": "2.7.1",
         "@opentelemetry/sdk-trace-base": "2.7.1",
         "@opentelemetry/sdk-trace-node": "2.7.1",
@@ -1445,6 +1874,166 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/sdk-logs": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.218.0.tgz",
+      "integrity": "sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
+      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -1563,49 +2152,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -1750,6 +2296,7 @@
     "node_modules/@types/node": {
       "version": "24.12.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1859,6 +2406,7 @@
       "version": "8.59.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2388,6 +2936,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2413,6 +2962,7 @@
     "node_modules/adaptive-expressions": {
       "version": "4.23.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.1",
         "@types/atob-lite": "^2.0.2",
@@ -2432,24 +2982,6 @@
         "lru-cache": "^5.1.1",
         "uuid": "^10.0.0",
         "xpath": "^0.0.34"
-      }
-    },
-    "node_modules/adaptive-expressions/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/adaptive-expressions/node_modules/uuid": {
-      "version": "11.1.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/adaptivecards": {
@@ -2693,6 +3225,8 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
@@ -3144,6 +3678,7 @@
     "node_modules/diagnostic-channel": {
       "version": "1.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -3223,6 +3758,8 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -3302,6 +3839,7 @@
       "version": "10.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3611,7 +4149,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.0",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -3621,9 +4161,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4363,7 +4904,9 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.2",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -4372,10 +4915,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.3",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.2",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4437,11 +4982,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.0",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -4667,6 +5216,16 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/mocha/node_modules/strip-json-comments": {
@@ -5037,21 +5596,12 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.2.tgz",
+      "integrity": "sha512-64rfNzkWOZAIazXzpBFPWq6F9up6gMvTzjE2oWIzApx2N/dqVUEE7+bCn2+40780dFVtKOUab8QfxJ6KJDWbqA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
         "long": "^5.3.2"
       },
       "engines": {
@@ -5899,7 +6449,10 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6079,7 +6632,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.1",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -268,37 +268,37 @@
   ],
   "overrides": {
     "adaptive-expressions": {
-      "fast-xml-parser": "5.7.0",
-      "lodash": "4.18.0",
-      "@xmldom/xmldom": "^0.8.13",
-      "uuid": "11.1.1"
+      "fast-xml-parser": "5.8.0",
+      "lodash": "4.18.1",
+      "@xmldom/xmldom": "^0.9.10",
+      "uuid": "14.0.0"
     },
     "adaptivecards": {
       "swiper": "12.1.3"
     },
     "mocha": {
-      "diff": "8.0.4",
+      "diff": "9.0.0",
       "serialize-javascript": "7.0.5"
     },
     "jsonwebtoken": {
-      "jws": "3.2.3"
+      "jws": "4.0.1"
     },
     "axios": {
       "follow-redirects": "1.16.0"
     },
     "@grpc/proto-loader": {
-      "protobufjs": "7.6.0"
+      "protobufjs": "8.4.2"
     },
     "@opentelemetry/otlp-transformer": {
-      "protobufjs": "7.6.0"
+      "protobufjs": "8.4.2"
     },
     "@azure/monitor-opentelemetry": {
-      "@opentelemetry/sdk-node": "0.217.0",
-      "@opentelemetry/exporter-prometheus": "0.217.0"
+      "@opentelemetry/sdk-node": "0.218.0",
+      "@opentelemetry/exporter-prometheus": "0.218.0"
     },
-    "protobufjs": "7.6.0",
+    "protobufjs": "8.4.2",
     "applicationinsights": {
-      "uuid": "11.1.1"
+      "uuid": "14.0.0"
     }
   },
   "dependencies": {
@@ -329,7 +329,7 @@
     "strip-json-comments": "^5.0.3",
     "typescript": "^5.9.3",
     "update-notifier": "^7.3.1",
-    "uuid": "^13.0.1",
+    "uuid": "^14.0.0",
     "yaml": "^2.8.3",
     "yargs-parser": "^22.0.0",
     "zod": "^4.4.1"


### PR DESCRIPTION
## Summary

Upgrades all outdated npm dependency overrides and direct dependencies that have passed the 7-day cooldown period.

## Overrides updated

| Package | Old | New | Parent | Breaking? |
|---------|-----|-----|--------|-----------|
| fast-xml-parser | 5.7.0 | 5.8.0 | adaptive-expressions | No |
| lodash | 4.18.0 | 4.18.1 | adaptive-expressions | No |
| @xmldom/xmldom | ^0.8.13 | ^0.9.10 | adaptive-expressions | No |
| uuid | 11.1.1 | 14.0.0 | adaptive-expressions, applicationinsights | ⚠️ Major |
| diff | 8.0.4 | 9.0.0 | mocha | ⚠️ Major |
| jws | 3.2.3 | 4.0.1 | jsonwebtoken | ⚠️ Major |
| protobufjs | 7.6.0 | 8.4.2 | @grpc/proto-loader, @opentelemetry/otlp-transformer, top-level | ⚠️ Major |
| @opentelemetry/sdk-node | 0.217.0 | 0.218.0 | @azure/monitor-opentelemetry | No |
| @opentelemetry/exporter-prometheus | 0.217.0 | 0.218.0 | @azure/monitor-opentelemetry | No |

## Direct dependencies updated

| Package | Old | New | Breaking? |
|---------|-----|-----|-----------|
| uuid | ^13.0.1 | ^14.0.0 | ⚠️ Major |

## Skipped

- **typescript** 6.0.3: breaks the build (20k+ type errors from `moduleResolution=node10` deprecation becoming a hard error)
- **swiper** 12.2.0: in 7-day cooldown (eligible 2026-06-03)
- **serialize-javascript**, **follow-redirects**: already at latest

## Verification

- ✅ `npm audit`: 0 vulnerabilities
- ✅ Build passes (clean, no warnings)
- ✅ Lint passes
- ✅ All tests pass