### PR TITLE
fix: update command descriptions to third-person singular

### DIFF
--- a/docs/docs/cmd/booking/business/business-get.mdx
+++ b/docs/docs/cmd/booking/business/business-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # booking business get
 
-Retrieve the specified Microsoft Bookings business.
+Retrieves the specified Microsoft Bookings business.
 
 ## Usage
 

--- a/docs/docs/cmd/cli/app/app-add.mdx
+++ b/docs/docs/cmd/cli/app/app-add.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # cli app add
 
-Create a new app registration to use for the CLI for Microsoft 365
+Creates a new app registration to use for the CLI for Microsoft 365
 
 ## Usage
 

--- a/docs/docs/cmd/cli/app/app-reconsent.mdx
+++ b/docs/docs/cmd/cli/app/app-reconsent.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # cli app reconsent
 
-Reconsent all permission scopes used in CLI for Microsoft 365
+Reconsents all permission scopes used in CLI for Microsoft 365
 
 ## Usage
 

--- a/docs/docs/cmd/cli/cli-consent.mdx
+++ b/docs/docs/cmd/cli/cli-consent.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # cli consent
 
-Consent additional permissions for the Microsoft Entra application used by the CLI for Microsoft 365
+Consents additional permissions for the Microsoft Entra application used by the CLI for Microsoft 365
 
 ## Usage
 

--- a/docs/docs/cmd/cli/config/config-list.mdx
+++ b/docs/docs/cmd/cli/config/config-list.mdx
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 
 # cli config list
 
-List all self-set CLI for Microsoft 365 configurations
+Lists all self-set CLI for Microsoft 365 configurations
 
 ## Usage
 

--- a/docs/docs/cmd/connection/connection-list.mdx
+++ b/docs/docs/cmd/connection/connection-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # connection list
 
-Show the list of available connections
+Shows the list of available connections
 
 ## Usage
 

--- a/docs/docs/cmd/connection/connection-remove.mdx
+++ b/docs/docs/cmd/connection/connection-remove.mdx
@@ -2,7 +2,7 @@ import Global from '../_global.mdx';
 
 # connection remove
 
-Remove the specified connection
+Removes the specified connection
 
 ## Usage
 

--- a/docs/docs/cmd/connection/connection-set.mdx
+++ b/docs/docs/cmd/connection/connection-set.mdx
@@ -2,7 +2,7 @@ import Global from '../_global.mdx';
 
 # connection set
 
-Rename the specified connection
+Renames the specified connection
 
 ## Usage
 

--- a/docs/docs/cmd/connection/connection-use.mdx
+++ b/docs/docs/cmd/connection/connection-use.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # connection use
 
-Activate the specified Microsoft 365 tenant connection
+Activates the specified Microsoft 365 tenant connection
 
 ## Usage
 

--- a/docs/docs/cmd/context/option/option-list.mdx
+++ b/docs/docs/cmd/context/option/option-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # context option list
 
-List all options added to the context
+Lists all options added to the context
 
 ## Usage
 

--- a/docs/docs/cmd/entra/administrativeunit/administrativeunit-member-add.mdx
+++ b/docs/docs/cmd/entra/administrativeunit/administrativeunit-member-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra administrativeunit member add
 
-Add a member (user, group, or device) to an administrative unit
+Adds a member (user, group, or device) to an administrative unit
 
 ## Usage
 

--- a/docs/docs/cmd/entra/m365group/m365group-report-activitycounts.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-report-activitycounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra m365group report activitycounts
 
-Get the number of group activities across group workloads
+Gets the number of group activities across group workloads
 
 ## Usage
 

--- a/docs/docs/cmd/entra/m365group/m365group-report-activitydetail.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-report-activitydetail.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra m365group report activitydetail
 
-Get details about Microsoft 365 Groups activity by group.
+Gets details about Microsoft 365 Groups activity by group.
 
 ## Usage
 

--- a/docs/docs/cmd/entra/m365group/m365group-report-activityfilecounts.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-report-activityfilecounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra m365group report activityfilecounts
 
-Gets the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group
+Gets the total number of files and how many of them were active across all group sites associated with a Microsoft 365 Group
 
 ## Usage
 
@@ -52,19 +52,19 @@ This command supports only csv and json output.
 
 ## Examples
 
-Get the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group for the last week
+Get the total number of files and how many of them were active across all group sites associated with a Microsoft 365 Group for the last week
 
 ```sh
 m365 entra m365group report activityfilecounts --period D7
 ```
 
-Get the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group for the last week and exports the report data in the specified path in text format
+Get the total number of files and how many of them were active across all group sites associated with a Microsoft 365 Group for the last week and exports the report data in the specified path in text format
 
 ```sh
 m365 entra m365group report activityfilecounts --period D7 --output text > "m365groupactivityfilecounts.txt"
 ```
 
-Get the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group for the last week and exports the report data in the specified path in json format
+Get the total number of files and how many of them were active across all group sites associated with a Microsoft 365 Group for the last week and exports the report data in the specified path in json format
 
 ```sh
 m365 entra m365group report activityfilecounts --period D7 --output json > "m365groupactivityfilecounts.json"

--- a/docs/docs/cmd/entra/m365group/m365group-report-activityfilecounts.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-report-activityfilecounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra m365group report activityfilecounts
 
-Get the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group
+Gets the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group
 
 ## Usage
 

--- a/docs/docs/cmd/entra/m365group/m365group-report-activitygroupcounts.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-report-activitygroupcounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra m365group report activitygroupcounts
 
-Get the daily total number of groups and how many of them were active based on email conversations, Viva Engage posts, and SharePoint file activities.
+Gets the daily total number of groups and how many of them were active based on email conversations, Viva Engage posts, and SharePoint file activities.
 
 ## Usage
 

--- a/docs/docs/cmd/entra/m365group/m365group-report-activitystorage.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-report-activitystorage.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra m365group report activitystorage
 
-Get the total storage used across all group mailboxes and group sites
+Gets the total storage used across all group mailboxes and group sites
 
 ## Usage
 

--- a/docs/docs/cmd/entra/oauth2grant/oauth2grant-add.mdx
+++ b/docs/docs/cmd/entra/oauth2grant/oauth2grant-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra oauth2grant add
 
-Grant the specified service principal OAuth2 permissions to the specified resource
+Grants the specified service principal OAuth2 permissions to the specified resource
 
 ## Usage
 

--- a/docs/docs/cmd/entra/oauth2grant/oauth2grant-remove.mdx
+++ b/docs/docs/cmd/entra/oauth2grant/oauth2grant-remove.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra oauth2grant remove
 
-Remove specified service principal OAuth2 permissions
+Removes specified service principal OAuth2 permissions
 
 ## Usage
 

--- a/docs/docs/cmd/entra/oauth2grant/oauth2grant-set.mdx
+++ b/docs/docs/cmd/entra/oauth2grant/oauth2grant-set.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra oauth2grant set
 
-Update OAuth2 permissions for the service principal
+Updates OAuth2 permissions for the service principal
 
 ## Usage
 

--- a/docs/docs/cmd/entra/pim/pim-role-assignment-add.mdx
+++ b/docs/docs/cmd/entra/pim/pim-role-assignment-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra pim role assignment add
 
-Request activation of an Entra role assignment for a user or group.
+Requests activation of an Entra role assignment for a user or group.
 
 ## Usage
 

--- a/docs/docs/cmd/entra/pim/pim-role-assignment-remove.mdx
+++ b/docs/docs/cmd/entra/pim/pim-role-assignment-remove.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra pim role assignment remove
 
-Request deactivation of an Entra role assignment for a user or group.
+Requests deactivation of an Entra role assignment for a user or group.
 
 ## Usage
 

--- a/docs/docs/cmd/entra/resourcenamespace/resourcenamespace-list.mdx
+++ b/docs/docs/cmd/entra/resourcenamespace/resourcenamespace-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra resourcenamespace list
 
-Get a list of the RBAC resource namespaces and their properties
+Gets a list of the RBAC resource namespaces and their properties
 
 ## Usage
 

--- a/docs/docs/cmd/entra/roleassignment/roleassignment-add.mdx
+++ b/docs/docs/cmd/entra/roleassignment/roleassignment-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra roleassignment add
 
-Assign a Entra ID role to a user and specify the scope for which the user has been granted access
+Assigns a Entra ID role to a user and specify the scope for which the user has been granted access
 
 ## Usage
 

--- a/docs/docs/cmd/entra/roleassignment/roleassignment-add.mdx
+++ b/docs/docs/cmd/entra/roleassignment/roleassignment-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra roleassignment add
 
-Assigns a Entra ID role to a user and specify the scope for which the user has been granted access
+Assigns a Entra ID role to a user and specifies the scope for which the user has been granted access
 
 ## Usage
 

--- a/docs/docs/cmd/entra/user/user-guest-add.mdx
+++ b/docs/docs/cmd/entra/user/user-guest-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra user guest add
 
-Invite an external user to the organization
+Invites an external user to the organization
 
 ## Usage
 

--- a/docs/docs/cmd/entra/user/user-password-validate.mdx
+++ b/docs/docs/cmd/entra/user/user-password-validate.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # entra user password validate
 
-Check a user's password against the organization's password validation policy
+Checks a user's password against the organization's password validation policy
 
 ## Usage
 

--- a/docs/docs/cmd/external/connection/connection-add.mdx
+++ b/docs/docs/cmd/external/connection/connection-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # external connection add
 
-Add a new external connection
+Adds a new external connection
 
 ## Usage
 

--- a/docs/docs/cmd/external/connection/connection-get.mdx
+++ b/docs/docs/cmd/external/connection/connection-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # external connection get
 
-Allow the administrator to get a specific external connection
+Allows the administrator to get a specific external connection
 
 ## Usage
 

--- a/docs/docs/cmd/external/connection/connection-remove.mdx
+++ b/docs/docs/cmd/external/connection/connection-remove.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # external connection remove
 
-Allow the administrator to remove a specific external connection
+Allows the administrator to remove a specific external connection
 
 ## Usage
 

--- a/docs/docs/cmd/external/connection/connection-schema-add.mdx
+++ b/docs/docs/cmd/external/connection/connection-schema-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # external connection schema add
 
-Allow the administrator to add a schema to a specific external connection
+Allows the administrator to add a schema to a specific external connection
 
 ## Usage
 

--- a/docs/docs/cmd/graph/schemaextension/schemaextension-list.mdx
+++ b/docs/docs/cmd/graph/schemaextension/schemaextension-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # graph schemaextension list
 
-Get a list of schemaExtension objects created in the current tenant, that can be InDevelopment, Available, or Deprecated.
+Gets a list of schemaExtension objects created in the current tenant, that can be InDevelopment, Available, or Deprecated.
 
 ## Usage
 

--- a/docs/docs/cmd/login.mdx
+++ b/docs/docs/cmd/login.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # login
 
-Log in to Microsoft 365
+Logs in to Microsoft 365
 
 ## Usage
 

--- a/docs/docs/cmd/logout.mdx
+++ b/docs/docs/cmd/logout.mdx
@@ -2,7 +2,7 @@ import Global from './_global.mdx';
 
 # logout
 
-Log out from Microsoft 365
+Logs out from Microsoft 365
 
 ## Usage
 

--- a/docs/docs/cmd/onenote/notebook/notebook-add.mdx
+++ b/docs/docs/cmd/onenote/notebook/notebook-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # onenote notebook add
 
-Create a new OneNote notebook.
+Creates a new OneNote notebook.
 
 ## Usage
 

--- a/docs/docs/cmd/onenote/notebook/notebook-list.mdx
+++ b/docs/docs/cmd/onenote/notebook/notebook-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # onenote notebook list
 
-Retrieve a list of notebooks.
+Retrieves a list of notebooks.
 
 ## Usage
 

--- a/docs/docs/cmd/onenote/page/page-list.mdx
+++ b/docs/docs/cmd/onenote/page/page-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # onenote page list
 
-Retrieve a list of OneNote pages.
+Retrieves a list of OneNote pages.
 
 ## Usage
 

--- a/docs/docs/cmd/outlook/calendargroup/calendargroup-get.mdx
+++ b/docs/docs/cmd/outlook/calendargroup/calendargroup-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # outlook calendargroup get
 
-Retrieves a calendar group for a user.
+Retrieves a calendar group for a user
 
 ## Usage
 

--- a/docs/docs/cmd/outlook/mailbox/mailbox-settings-get.mdx
+++ b/docs/docs/cmd/outlook/mailbox/mailbox-settings-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # outlook mailbox settings get
 
-Get the user's mailbox settings
+Gets the user's mailbox settings
 
 ## Usage
 

--- a/docs/docs/cmd/outlook/room/room-list.mdx
+++ b/docs/docs/cmd/outlook/room/room-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # outlook room list
 
-Get a collection of all available rooms
+Gets a collection of all available rooms
 
 ## Usage
 

--- a/docs/docs/cmd/outlook/roomlist/roomlist-list.mdx
+++ b/docs/docs/cmd/outlook/roomlist/roomlist-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # outlook roomlist list
 
-Get a collection of available roomlists
+Gets a collection of available roomlists
 
 ## Usage
 

--- a/docs/docs/cmd/planner/plan/plan-get.mdx
+++ b/docs/docs/cmd/planner/plan/plan-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # planner plan get
 
-Retrieve information about the specified plan
+Retrieves information about the specified plan
 
 ## Usage
 

--- a/docs/docs/cmd/planner/roster/roster-get.mdx
+++ b/docs/docs/cmd/planner/roster/roster-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # planner roster get
 
-Gets information about the specific Microsoft Planner Roster.
+Gets information about the specific Microsoft Planner Roster
 
 ## Usage
 

--- a/docs/docs/cmd/planner/task/task-get.mdx
+++ b/docs/docs/cmd/planner/task/task-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # planner task get
 
-Retrieve the specified planner task
+Retrieves the specified planner task
 
 ## Usage
 

--- a/docs/docs/cmd/planner/task/task-reference-list.mdx
+++ b/docs/docs/cmd/planner/task/task-reference-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # planner task reference list
 
-Retrieves the references associated to a Planner task.
+Retrieves the references associated to a Planner task
 
 ## Usage
 

--- a/docs/docs/cmd/planner/task/task-reference-list.mdx
+++ b/docs/docs/cmd/planner/task/task-reference-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # planner task reference list
 
-Retrieve the references associated to a Planner task.
+Retrieves the references associated to a Planner task.
 
 ## Usage
 

--- a/docs/docs/cmd/pp/aibuildermodel/aibuildermodel-get.mdx
+++ b/docs/docs/cmd/pp/aibuildermodel/aibuildermodel-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # pp aibuildermodel get
 
-Gets a specific AI builder models in the specified Power Platform environment
+Gets a specific AI builder model in the specified Power Platform environment
 
 ## Usage
 

--- a/docs/docs/cmd/pp/aibuildermodel/aibuildermodel-list.mdx
+++ b/docs/docs/cmd/pp/aibuildermodel/aibuildermodel-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # pp aibuildermodel list
 
-List available AI builder models in the specified Power Platform environment
+Lists available AI builder models in the specified Power Platform environment
 
 ## Usage
 

--- a/docs/docs/cmd/pp/copilot/copilot-get.mdx
+++ b/docs/docs/cmd/pp/copilot/copilot-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # pp copilot get
 
-Get information about the specified copilot
+Gets information about the specified copilot
 
 ## Usage
 

--- a/docs/docs/cmd/pp/dataverse/dataverse-table-get.mdx
+++ b/docs/docs/cmd/pp/dataverse/dataverse-table-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # pp dataverse table get
 
-Lists a dataverse table in a given environment
+Gets a dataverse table in a given environment
 
 ## Usage
 

--- a/docs/docs/cmd/pp/dataverse/dataverse-table-get.mdx
+++ b/docs/docs/cmd/pp/dataverse/dataverse-table-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # pp dataverse table get
 
-List a dataverse table in a given environment
+Lists a dataverse table in a given environment
 
 ## Usage
 

--- a/docs/docs/cmd/pp/gateway/gateway-get.mdx
+++ b/docs/docs/cmd/pp/gateway/gateway-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # pp gateway get
 
-Get information about the specified gateway
+Gets information about the specified gateway
 
 ## Usage
 

--- a/docs/docs/cmd/pp/managementapp/managementapp-add.mdx
+++ b/docs/docs/cmd/pp/managementapp/managementapp-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # pp managementapp add
 
-Register management application for Power Platform
+Registers management application for Power Platform
 
 ## Usage
 

--- a/docs/docs/cmd/pp/solution/solution-publisher-get.mdx
+++ b/docs/docs/cmd/pp/solution/solution-publisher-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # pp solution publisher get
 
-Get information about the specified publisher in a given environment.
+Gets information about the specified publisher in a given environment.
 
 ## Usage
 

--- a/docs/docs/cmd/purview/auditlog/auditlog-list.mdx
+++ b/docs/docs/cmd/purview/auditlog/auditlog-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview auditlog list
 
-List audit logs within your tenant
+Lists audit logs within your tenant
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionevent/retentionevent-add.mdx
+++ b/docs/docs/cmd/purview/retentionevent/retentionevent-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionevent add
 
-Create a retention event
+Creates a retention event
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionevent/retentionevent-get.mdx
+++ b/docs/docs/cmd/purview/retentionevent/retentionevent-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionevent get
 
-Get a retention event
+Gets a retention event
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionevent/retentionevent-list.mdx
+++ b/docs/docs/cmd/purview/retentionevent/retentionevent-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionevent list
 
-Get a list of retention events
+Gets a list of retention events
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionevent/retentionevent-remove.mdx
+++ b/docs/docs/cmd/purview/retentionevent/retentionevent-remove.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionevent remove
 
-Delete a retention event
+Deletes a retention event
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-add.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentioneventtype add
 
-Create a retention event type
+Creates a retention event type
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-get.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentioneventtype get
 
-Get a retention event type
+Gets a retention event type
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-list.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentioneventtype list
 
-Get a list of retention event types
+Gets a list of retention event types
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-remove.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-remove.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentioneventtype remove
 
-Delete a retention event type
+Deletes a retention event type
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-set.mdx
+++ b/docs/docs/cmd/purview/retentioneventtype/retentioneventtype-set.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentioneventtype set
 
-Update a retention event type
+Updates a retention event type
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionlabel/retentionlabel-add.mdx
+++ b/docs/docs/cmd/purview/retentionlabel/retentionlabel-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionlabel add
 
-Create a retention label
+Creates a retention label
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionlabel/retentionlabel-get.mdx
+++ b/docs/docs/cmd/purview/retentionlabel/retentionlabel-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionlabel get
 
-Get a retention label
+Gets a retention label
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionlabel/retentionlabel-list.mdx
+++ b/docs/docs/cmd/purview/retentionlabel/retentionlabel-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionlabel list
 
-Get a list of retention labels
+Gets a list of retention labels
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionlabel/retentionlabel-remove.mdx
+++ b/docs/docs/cmd/purview/retentionlabel/retentionlabel-remove.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionlabel remove
 
-Delete a retention label
+Deletes a retention label
 
 ## Usage
 

--- a/docs/docs/cmd/purview/retentionlabel/retentionlabel-set.mdx
+++ b/docs/docs/cmd/purview/retentionlabel/retentionlabel-set.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview retentionlabel set
 
-Update a retention label
+Updates a retention label
 
 ## Usage
 

--- a/docs/docs/cmd/purview/sensitivitylabel/sensitivitylabel-get.mdx
+++ b/docs/docs/cmd/purview/sensitivitylabel/sensitivitylabel-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview sensitivitylabel get
 
-Retrieve the specified sensitivity label
+Retrieves the specified sensitivity label
 
 ## Usage
 

--- a/docs/docs/cmd/purview/sensitivitylabel/sensitivitylabel-list.mdx
+++ b/docs/docs/cmd/purview/sensitivitylabel/sensitivitylabel-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview sensitivitylabel list
 
-Get a list of sensitivity labels
+Gets a list of sensitivity labels
 
 ## Usage
 

--- a/docs/docs/cmd/purview/sensitivitylabel/sensitivitylabel-policysettings-list.mdx
+++ b/docs/docs/cmd/purview/sensitivitylabel/sensitivitylabel-policysettings-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview sensitivitylabel policysettings list
 
-Get a list of policy settings for a sensitivity label.
+Gets a list of policy settings for a sensitivity label.
 
 ## Usage
 

--- a/docs/docs/cmd/purview/threatassessment/threatassessment-add.mdx
+++ b/docs/docs/cmd/purview/threatassessment/threatassessment-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview threatassessment add
 
-Create a threat assessment
+Creates a threat assessment
 
 ## Usage
 

--- a/docs/docs/cmd/purview/threatassessment/threatassessment-get.mdx
+++ b/docs/docs/cmd/purview/threatassessment/threatassessment-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview threatassessment get
 
-Get a threat assessment
+Gets a threat assessment
 
 ## Usage
 

--- a/docs/docs/cmd/purview/threatassessment/threatassessment-list.mdx
+++ b/docs/docs/cmd/purview/threatassessment/threatassessment-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # purview threatassessment list
 
-Get a list of threat assessments
+Gets a list of threat assessments
 
 ## Usage
 

--- a/docs/docs/cmd/spe/containertype/containertype-remove.mdx
+++ b/docs/docs/cmd/spe/containertype/containertype-remove.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spe containertype remove
 
-Remove a specific container type
+Removes a specific container type
 
 ## Usage
 

--- a/docs/docs/cmd/spfx/project/project-permissions-grant.mdx
+++ b/docs/docs/cmd/spfx/project/project-permissions-grant.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spfx project permissions grant
 
-Grant API permissions defined in the current SPFx project
+Grants API permissions defined in the current SPFx project
 
 ## Usage
 

--- a/docs/docs/cmd/spo/app/app-instance-list.mdx
+++ b/docs/docs/cmd/spo/app/app-instance-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo app instance list
 
-Retrieve apps installed in a site
+Retrieves apps installed in a site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-add.mdx
+++ b/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-add.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo applicationcustomizer add
 
-Add an Application Customizer to a site
+Adds an Application Customizer to a site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-get.mdx
+++ b/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo applicationcustomizer get
 
-Get an application customizer that is added to a site
+Gets an application customizer that is added to a site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-list.mdx
+++ b/docs/docs/cmd/spo/applicationcustomizer/applicationcustomizer-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo applicationcustomizer list
 
-Get a list of application customizers that are added to a site
+Gets a list of application customizers that are added to a site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/cdn/cdn-get.mdx
+++ b/docs/docs/cmd/spo/cdn/cdn-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo cdn get
 
-View current status of the specified Microsoft 365 CDN
+Views current status of the specified Microsoft 365 CDN
 
 ## Usage
 

--- a/docs/docs/cmd/spo/cdn/cdn-origin-list.mdx
+++ b/docs/docs/cmd/spo/cdn/cdn-origin-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo cdn origin list
 
-List CDN origins settings for the current SharePoint Online tenant
+Lists CDN origins settings for the current SharePoint Online tenant
 
 ## Usage
 

--- a/docs/docs/cmd/spo/cdn/cdn-set.mdx
+++ b/docs/docs/cmd/spo/cdn/cdn-set.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo cdn set
 
-Enable or disable the specified Microsoft 365 CDN
+Enables or disable the specified Microsoft 365 CDN
 
 ## Usage
 

--- a/docs/docs/cmd/spo/cdn/cdn-set.mdx
+++ b/docs/docs/cmd/spo/cdn/cdn-set.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo cdn set
 
-Enables or disable the specified Microsoft 365 CDN
+Enables or disables the specified Microsoft 365 CDN
 
 ## Usage
 

--- a/docs/docs/cmd/spo/commandset/commandset-add.mdx
+++ b/docs/docs/cmd/spo/commandset/commandset-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo commandset add
 
-Add a ListView Command Set to a site.
+Adds a ListView Command Set to a site.
 
 ## Usage
 

--- a/docs/docs/cmd/spo/commandset/commandset-get.mdx
+++ b/docs/docs/cmd/spo/commandset/commandset-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo commandset get
 
-Get a ListView Command Set that is added to a site
+Gets a ListView Command Set that is added to a site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/commandset/commandset-list.mdx
+++ b/docs/docs/cmd/spo/commandset/commandset-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo commandset list
 
-Get a list of ListView Command Sets that are added to a site
+Gets a list of ListView Command Sets that are added to a site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/commandset/commandset-remove.mdx
+++ b/docs/docs/cmd/spo/commandset/commandset-remove.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo commandset remove
 
-Remove a ListView Command Set that is added to a site
+Removes a ListView Command Set that is added to a site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/file/file-retentionlabel-ensure.mdx
+++ b/docs/docs/cmd/spo/file/file-retentionlabel-ensure.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo file retentionlabel ensure
 
-Apply a retention label to a file
+Applies a retention label to a file
 
 ## Usage
 

--- a/docs/docs/cmd/spo/file/file-version-keep.mdx
+++ b/docs/docs/cmd/spo/file/file-version-keep.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo file version keep
 
-Ensure that a specific file version will never expire
+Ensures that a specific file version will never expire
 
 ## Usage
 

--- a/docs/docs/cmd/spo/folder/folder-retentionlabel-ensure.mdx
+++ b/docs/docs/cmd/spo/folder/folder-retentionlabel-ensure.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo folder retentionlabel ensure
 
-Apply a retention label to a folder
+Applies a retention label to a folder
 
 ## Usage
 

--- a/docs/docs/cmd/spo/group/group-member-add.mdx
+++ b/docs/docs/cmd/spo/group/group-member-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo group member add
 
-Add members to a SharePoint Group
+Adds members to a SharePoint Group
 
 ## Usage
 

--- a/docs/docs/cmd/spo/group/group-member-list.mdx
+++ b/docs/docs/cmd/spo/group/group-member-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo group member list
 
-List the members of a SharePoint Group
+Lists the members of a SharePoint Group
 
 ## Usage
 

--- a/docs/docs/cmd/spo/hubsite/hubsite-connect.mdx
+++ b/docs/docs/cmd/spo/hubsite/hubsite-connect.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo hubsite connect
 
-Connect a hub site to a parent hub site
+Connects a hub site to a parent hub site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/hubsite/hubsite-data-get.mdx
+++ b/docs/docs/cmd/spo/hubsite/hubsite-data-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo hubsite data get
 
-Get hub site data for the specified site
+Gets hub site data for the specified site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/hubsite/hubsite-disconnect.mdx
+++ b/docs/docs/cmd/spo/hubsite/hubsite-disconnect.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo hubsite disconnect
 
-Disconnect a hub site from its parent hub site
+Disconnects a hub site from its parent hub site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.mdx
+++ b/docs/docs/cmd/spo/listitem/listitem-retentionlabel-ensure.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo listitem retentionlabel ensure
 
-Apply a retention label to a list item
+Applies a retention label to a list item
 
 ## Usage
 

--- a/docs/docs/cmd/spo/listitem/listitem-roleinheritance-break.mdx
+++ b/docs/docs/cmd/spo/listitem/listitem-roleinheritance-break.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo listitem roleinheritance break
 
-Break inheritance of list item.
+Breaks inheritance of list item.
 
 ## Usage
 

--- a/docs/docs/cmd/spo/navigation/navigation-node-get.mdx
+++ b/docs/docs/cmd/spo/navigation/navigation-node-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo navigation node get
 
-Gets information about a specific navigation node.
+Gets information about a specific navigation node
 
 ## Usage
 

--- a/docs/docs/cmd/spo/orgassetslibrary/orgassetslibrary-list.mdx
+++ b/docs/docs/cmd/spo/orgassetslibrary/orgassetslibrary-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo orgassetslibrary list
 
-List all libraries that are assigned as asset library
+Lists all libraries that are assigned as asset library
 
 ## Usage
 

--- a/docs/docs/cmd/spo/page/page-column-get.mdx
+++ b/docs/docs/cmd/spo/page/page-column-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo page column get
 
-Get information about a specific column of a modern page
+Gets information about a specific column of a modern page
 
 ## Usage
 

--- a/docs/docs/cmd/spo/page/page-section-get.mdx
+++ b/docs/docs/cmd/spo/page/page-section-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo page section get
 
-Get information about the specified modern page section
+Gets information about the specified modern page section
 
 ## Usage
 

--- a/docs/docs/cmd/spo/page/page-section-list.mdx
+++ b/docs/docs/cmd/spo/page/page-section-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo page section list
 
-List sections in the specific modern page
+Lists sections in the specific modern page
 
 ## Usage
 

--- a/docs/docs/cmd/spo/report/report-siteusagefilecounts.mdx
+++ b/docs/docs/cmd/spo/report/report-siteusagefilecounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo report siteusagefilecounts
 
-Get the total number of files across all sites and the number of active files
+Gets the total number of files across all sites and the number of active files
 
 ## Usage
 

--- a/docs/docs/cmd/spo/serviceprincipal/serviceprincipal-set.mdx
+++ b/docs/docs/cmd/spo/serviceprincipal/serviceprincipal-set.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo serviceprincipal set
 
-Enables or disable the service principal
+Enables or disables the service principal
 
 ## Usage
 

--- a/docs/docs/cmd/spo/serviceprincipal/serviceprincipal-set.mdx
+++ b/docs/docs/cmd/spo/serviceprincipal/serviceprincipal-set.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo serviceprincipal set
 
-Enable or disable the service principal
+Enables or disable the service principal
 
 ## Usage
 

--- a/docs/docs/cmd/spo/site/site-accessrequest-setting-set.mdx
+++ b/docs/docs/cmd/spo/site/site-accessrequest-setting-set.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo site accessrequest setting set
 
-Update access requests for a specific site
+Updates access requests for a specific site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/site/site-appcatalog-list.mdx
+++ b/docs/docs/cmd/spo/site/site-appcatalog-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo site appcatalog list
 
-List all site collection app catalogs within the tenant
+Lists all site collection app catalogs within the tenant
 
 ## Usage
 

--- a/docs/docs/cmd/spo/site/site-apppermission-get.mdx
+++ b/docs/docs/cmd/spo/site/site-apppermission-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo site apppermission get
 
-Get a specific application permissions for the site
+Gets a specific application permissions for the site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/site/site-chrome-set.mdx
+++ b/docs/docs/cmd/spo/site/site-chrome-set.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo site chrome set
 
-Set the chrome header and footer for the specified site
+Sets the chrome header and footer for the specified site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/storageentity/storageentity-get.mdx
+++ b/docs/docs/cmd/spo/storageentity/storageentity-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo storageentity get
 
-Get details for the specified tenant property
+Gets details for the specified tenant property
 
 ## Usage
 

--- a/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-add.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-add.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo tenant applicationcustomizer add
 
-Add an Application Customizer as a tenant-wide extension
+Adds an Application Customizer as a tenant-wide extension
 
 ## Usage
 

--- a/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-get.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-applicationcustomizer-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo tenant applicationcustomizer get
 
-Get an application customizer that is installed tenant-wide
+Gets an application customizer that is installed tenant-wide
 
 ## Usage
 

--- a/docs/docs/cmd/spo/tenant/tenant-commandset-add.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-commandset-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo tenant commandset add
 
-Add a ListView Command Set as a tenant-wide extension
+Adds a ListView Command Set as a tenant-wide extension
 
 ## Usage
 

--- a/docs/docs/cmd/spo/tenant/tenant-commandset-get.mdx
+++ b/docs/docs/cmd/spo/tenant/tenant-commandset-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo tenant commandset get
 
-Get a ListView Command Set that is installed tenant-wide
+Gets a ListView Command Set that is installed tenant-wide
 
 ## Usage
 

--- a/docs/docs/cmd/spo/theme/theme-set.mdx
+++ b/docs/docs/cmd/spo/theme/theme-set.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo theme set
 
-Adds or update a theme
+Adds or updates a theme
 
 ## Usage
 

--- a/docs/docs/cmd/spo/theme/theme-set.mdx
+++ b/docs/docs/cmd/spo/theme/theme-set.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo theme set
 
-Add or update a theme
+Adds or update a theme
 
 ## Usage
 

--- a/docs/docs/cmd/spo/userprofile/userprofile-get.mdx
+++ b/docs/docs/cmd/spo/userprofile/userprofile-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo userprofile get
 
-Get SharePoint user profile properties for the specified user
+Gets SharePoint user profile properties for the specified user
 
 ## Usage
 

--- a/docs/docs/cmd/spo/web/web-add.mdx
+++ b/docs/docs/cmd/spo/web/web-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo web add
 
-Create new subsite
+Creates new subsite
 
 ## Usage
 

--- a/docs/docs/cmd/spo/web/web-get.mdx
+++ b/docs/docs/cmd/spo/web/web-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo web get
 
-Retrieve information about the specified site
+Retrieves information about the specified site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/web/web-remove.mdx
+++ b/docs/docs/cmd/spo/web/web-remove.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo web remove
 
-Delete specified subsite
+Deletes specified subsite
 
 ## Usage
 

--- a/docs/docs/cmd/spo/web/web-retentionlabel-list.mdx
+++ b/docs/docs/cmd/spo/web/web-retentionlabel-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo web retentionlabel list
 
-Gets a list of retention labels that are available on a site.
+Gets a list of retention labels that are available on a site
 
 ## Usage
 

--- a/docs/docs/cmd/spo/web/web-retentionlabel-list.mdx
+++ b/docs/docs/cmd/spo/web/web-retentionlabel-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # spo web retentionlabel list
 
-Get a list of retention labels that are available on a site.
+Gets a list of retention labels that are available on a site.
 
 ## Usage
 

--- a/docs/docs/cmd/spo/web/web-roleinheritance-break.mdx
+++ b/docs/docs/cmd/spo/web/web-roleinheritance-break.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # spo web roleinheritance break
 
-Break role inheritance of subsite
+Breaks role inheritance of subsite
 
 ## Usage
 

--- a/docs/docs/cmd/teams/channel/channel-member-remove.mdx
+++ b/docs/docs/cmd/teams/channel/channel-member-remove.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # teams channel member remove
 
-Remove the specified member from the specified Microsoft Teams private or shared team channel
+Removes the specified member from the specified Microsoft Teams private or shared team channel
 
 ## Usage
 

--- a/docs/docs/cmd/teams/chat/chat-get.mdx
+++ b/docs/docs/cmd/teams/chat/chat-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams chat get
 
-Get a Microsoft Teams chat conversation by id, participants or chat name.
+Gets a Microsoft Teams chat conversation by id, participants or chat name.
 
 ## Usage
 

--- a/docs/docs/cmd/teams/meeting/meeting-add.mdx
+++ b/docs/docs/cmd/teams/meeting/meeting-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams meeting add
 
-Create a new online meeting
+Creates a new online meeting
 
 ## Usage
 

--- a/docs/docs/cmd/teams/meeting/meeting-get.mdx
+++ b/docs/docs/cmd/teams/meeting/meeting-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams meeting get
 
-Get specified meeting details
+Gets specified meeting details
 
 ## Usage
 

--- a/docs/docs/cmd/teams/meeting/meeting-list.mdx
+++ b/docs/docs/cmd/teams/meeting/meeting-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams meeting list
 
-Retrieve all online meetings for a given user or shared mailbox
+Retrieves all online meetings for a given user or shared mailbox
 
 ## Usage
 

--- a/docs/docs/cmd/teams/report/report-deviceusagedistributionusercounts.mdx
+++ b/docs/docs/cmd/teams/report/report-deviceusagedistributionusercounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams report deviceusagedistributionusercounts
 
-Get the number of Microsoft Teams unique users by device type. 
+Gets the number of Microsoft Teams unique users by device type. 
 
 ## Usage
 

--- a/docs/docs/cmd/teams/report/report-deviceusageusercounts.mdx
+++ b/docs/docs/cmd/teams/report/report-deviceusageusercounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams report deviceusageusercounts
 
-Get the number of Microsoft Teams daily unique users by device type
+Gets the number of Microsoft Teams daily unique users by device type
 
 ## Usage
 

--- a/docs/docs/cmd/teams/report/report-directroutingcalls.mdx
+++ b/docs/docs/cmd/teams/report/report-directroutingcalls.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams report directroutingcalls
 
-Get details about direct routing calls made within a given time period
+Gets details about direct routing calls made within a given time period
 
 ## Usage
 

--- a/docs/docs/cmd/teams/report/report-pstncalls.mdx
+++ b/docs/docs/cmd/teams/report/report-pstncalls.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams report pstncalls
 
-Get details about PSTN calls made within a given time period
+Gets details about PSTN calls made within a given time period
 
 ## Usage
 

--- a/docs/docs/cmd/teams/report/report-useractivitycounts.mdx
+++ b/docs/docs/cmd/teams/report/report-useractivitycounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams report useractivitycounts
 
-Get the number of Microsoft Teams activities by activity type. The activity types are team chat messages, private chat messages, calls, and meetings
+Gets the number of Microsoft Teams activities by activity type. The activity types are team chat messages, private chat messages, calls, and meetings
 
 ## Usage
 

--- a/docs/docs/cmd/teams/report/report-useractivityusercounts.mdx
+++ b/docs/docs/cmd/teams/report/report-useractivityusercounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams report useractivityusercounts
 
-Get the number of Microsoft Teams users by activity type. The activity types are number of teams chat messages, private chat messages, calls, or meetings
+Gets the number of Microsoft Teams users by activity type. The activity types are number of teams chat messages, private chat messages, calls, or meetings
 
 ## Usage
 

--- a/docs/docs/cmd/teams/report/report-useractivityuserdetail.mdx
+++ b/docs/docs/cmd/teams/report/report-useractivityuserdetail.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams report useractivityuserdetail
 
-Get details about Microsoft Teams user activity by user
+Gets details about Microsoft Teams user activity by user
 
 ## Usage
 

--- a/docs/docs/cmd/teams/tab/tab-add.mdx
+++ b/docs/docs/cmd/teams/tab/tab-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams tab add
 
-Add a tab to the specified channel
+Adds a tab to the specified channel
 
 ## Usage
 

--- a/docs/docs/cmd/teams/team/team-app-list.mdx
+++ b/docs/docs/cmd/teams/team/team-app-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams team app list
 
-List apps installed in the specified team
+Lists apps installed in the specified team
 
 ## Usage
 

--- a/docs/docs/cmd/teams/user/user-app-add.mdx
+++ b/docs/docs/cmd/teams/user/user-app-add.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # teams user app add
 
-Install an app in the personal scope of the specified user
+Installs an app in the personal scope of the specified user
 
 ## Usage
 

--- a/docs/docs/cmd/teams/user/user-app-list.mdx
+++ b/docs/docs/cmd/teams/user/user-app-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # teams user app list
 
-List the apps installed in the personal scope of the specified user
+Lists the apps installed in the personal scope of the specified user
 
 ## Usage
 

--- a/docs/docs/cmd/teams/user/user-app-remove.mdx
+++ b/docs/docs/cmd/teams/user/user-app-remove.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # teams user app remove
 
-Uninstall an app from the personal scope of the specified user
+Uninstalls an app from the personal scope of the specified user
 
 ## Usage
 

--- a/docs/docs/cmd/teams/user/user-app-upgrade.mdx
+++ b/docs/docs/cmd/teams/user/user-app-upgrade.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # teams user app upgrade
 
-Upgrade an app in the personal scope of the specified user
+Upgrades an app in the personal scope of the specified user
 
 ## Usage
 

--- a/docs/docs/cmd/tenant/people/people-pronouns-set.mdx
+++ b/docs/docs/cmd/tenant/people/people-pronouns-set.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # tenant people pronouns set
 
-Manage pronouns settings for an organization
+Manages pronouns settings for an organization
 
 ## Usage
 

--- a/docs/docs/cmd/tenant/report/report-office365activationcounts.mdx
+++ b/docs/docs/cmd/tenant/report/report-office365activationcounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # tenant report office365activationcounts
 
-Get the count of Microsoft 365 activations on desktops and devices
+Gets the count of Microsoft 365 activations on desktops and devices
 
 ## Usage
 

--- a/docs/docs/cmd/tenant/report/report-office365activationsusercounts.mdx
+++ b/docs/docs/cmd/tenant/report/report-office365activationsusercounts.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # tenant report office365activationsusercounts
 
-Get the count of users that are enabled and those that have activated the Office subscription on desktop or devices or shared computers
+Gets the count of users that are enabled and those that have activated the Office subscription on desktop or devices or shared computers
 
 ## Usage
 

--- a/docs/docs/cmd/tenant/report/report-office365activationsuserdetail.mdx
+++ b/docs/docs/cmd/tenant/report/report-office365activationsuserdetail.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # tenant report office365activationsuserdetail
 
-Get details about users who have activated Microsoft 365
+Gets details about users who have activated Microsoft 365
 
 ## Usage
 

--- a/docs/docs/cmd/tenant/report/report-settings-get.mdx
+++ b/docs/docs/cmd/tenant/report/report-settings-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # tenant report settings get
 
-Get the tenant-level settings for Microsoft 365 reports
+Gets the tenant-level settings for Microsoft 365 reports
 
 ## Usage
 

--- a/docs/docs/cmd/tenant/report/report-settings-set.mdx
+++ b/docs/docs/cmd/tenant/report/report-settings-set.mdx
@@ -2,7 +2,7 @@ import Global from '../../_global.mdx';
 
 # tenant report settings set
 
-Update tenant-level settings for Microsoft 365 reports
+Updates tenant-level settings for Microsoft 365 reports
 
 ## Usage
 

--- a/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-health-get.mdx
+++ b/docs/docs/cmd/tenant/serviceannouncement/serviceannouncement-health-get.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # tenant serviceannouncement health get
 
-Get the health report of a specified service for a tenant
+Gets the health report of a specified service for a tenant
 
 ## Usage
 

--- a/docs/docs/cmd/todo/task/task-list.mdx
+++ b/docs/docs/cmd/todo/task/task-list.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # todo task list
 
-List tasks from a Microsoft To Do task list
+Lists tasks from a Microsoft To Do task list
 
 ## Usage
 

--- a/docs/docs/cmd/todo/task/task-set.mdx
+++ b/docs/docs/cmd/todo/task/task-set.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # todo task set
 
-Update a task in a Microsoft To Do task list
+Updates a task in a Microsoft To Do task list
 
 ## Usage
 

--- a/docs/docs/cmd/viva/engage/engage-role-member-add.mdx
+++ b/docs/docs/cmd/viva/engage/engage-role-member-add.mdx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # viva engage role member add
 
-Assign a Viva Engage role to a user
+Assigns a Viva Engage role to a user
 
 ## Usage
 

--- a/src/m365/booking/commands/business/business-get.ts
+++ b/src/m365/booking/commands/business/business-get.ts
@@ -26,7 +26,7 @@ class BookingBusinessGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve the specified Microsoft Bookings business.';
+    return 'Retrieves the specified Microsoft Bookings business.';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/cli/commands/app/app-add.ts
+++ b/src/m365/cli/commands/app/app-add.ts
@@ -28,7 +28,7 @@ class CliAppAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Creates a Microsoft Entra application registration for CLI for Microsoft 365';
+    return 'Creates a new app registration to use for the CLI for Microsoft 365';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/cli/commands/app/app-reconsent.ts
+++ b/src/m365/cli/commands/app/app-reconsent.ts
@@ -24,7 +24,7 @@ class CliAppReconsentCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Reconsent all permission scopes used in CLI for Microsoft 365';
+    return 'Reconsents all permission scopes used in CLI for Microsoft 365';
   }
 
   public get schema(): z.ZodType {

--- a/src/m365/cli/commands/cli-consent.ts
+++ b/src/m365/cli/commands/cli-consent.ts
@@ -21,7 +21,7 @@ class CliConsentCommand extends AnonymousCommand {
   }
 
   public get description(): string {
-    return 'Consent additional permissions for the Microsoft Entra application used by the CLI for Microsoft 365';
+    return 'Consents additional permissions for the Microsoft Entra application used by the CLI for Microsoft 365';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/cli/commands/config/config-list.ts
+++ b/src/m365/cli/commands/config/config-list.ts
@@ -15,7 +15,7 @@ class CliConfigListCommand extends AnonymousCommand {
   }
 
   public get description(): string {
-    return 'List all self set CLI for Microsoft 365 configurations';
+    return 'Lists all self set CLI for Microsoft 365 configurations';
   }
 
   public get schema(): z.ZodType {

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -27,7 +27,7 @@ class CliConfigSetCommand extends AnonymousCommand {
   }
 
   public get description(): string {
-    return 'Manage global configuration settings about the CLI for Microsoft 365';
+    return 'Manages global configuration settings about the CLI for Microsoft 365';
   }
 
   public get schema(): z.ZodType {

--- a/src/m365/cli/commands/config/config-set.ts
+++ b/src/m365/cli/commands/config/config-set.ts
@@ -27,7 +27,7 @@ class CliConfigSetCommand extends AnonymousCommand {
   }
 
   public get description(): string {
-    return 'Manages global configuration settings about the CLI for Microsoft 365';
+    return 'Sets CLI for Microsoft 365 configuration options';
   }
 
   public get schema(): z.ZodType {

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -44,7 +44,7 @@ class LoginCommand extends Command {
   }
 
   public get description(): string {
-    return 'Log in to Microsoft 365';
+    return 'Logs in to Microsoft 365';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/commands/logout.ts
+++ b/src/m365/commands/logout.ts
@@ -18,7 +18,7 @@ class LogoutCommand extends Command {
   }
 
   public get description(): string {
-    return 'Log out from Microsoft 365';
+    return 'Logs out from Microsoft 365';
   }
 
   public get schema(): z.ZodTypeAny | undefined {

--- a/src/m365/connection/commands/connection-list.ts
+++ b/src/m365/connection/commands/connection-list.ts
@@ -13,7 +13,7 @@ class ConnectionListCommand extends Command {
   }
 
   public get description(): string {
-    return 'Show the list of available connections';
+    return 'Shows the list of available connections';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/connection/commands/connection-remove.ts
+++ b/src/m365/connection/commands/connection-remove.ts
@@ -23,7 +23,7 @@ class ConnectionRemoveCommand extends Command {
   }
 
   public get description(): string {
-    return 'Remove the specified connection';
+    return 'Removes the specified connection';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/connection/commands/connection-set.ts
+++ b/src/m365/connection/commands/connection-set.ts
@@ -28,7 +28,7 @@ class ConnectionSetCommand extends Command {
   }
 
   public get description(): string {
-    return 'Rename the specified connection';
+    return 'Renames the specified connection';
   }
 
   public get schema(): z.ZodType {

--- a/src/m365/connection/commands/connection-use.ts
+++ b/src/m365/connection/commands/connection-use.ts
@@ -23,7 +23,7 @@ class ConnectionUseCommand extends Command {
   }
 
   public get description(): string {
-    return 'Activate the specified Microsoft 365 tenant connection';
+    return 'Activates the specified Microsoft 365 tenant connection';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/context/commands/option/option-list.ts
+++ b/src/m365/context/commands/option/option-list.ts
@@ -14,7 +14,7 @@ class ContextOptionListCommand extends ContextCommand {
   }
 
   public get description(): string {
-    return 'List all options added to the context';
+    return 'Lists all options added to the context';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/administrativeunit/administrativeunit-member-add.ts
+++ b/src/m365/entra/commands/administrativeunit/administrativeunit-member-add.ts
@@ -33,7 +33,7 @@ class EntraAdministrativeUnitMemberAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Adds a member (user, group, device) to an administrative unit';
+    return 'Adds a member (user, group, or device) to an administrative unit';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/administrativeunit/administrativeunit-member-get.ts
+++ b/src/m365/entra/commands/administrativeunit/administrativeunit-member-get.ts
@@ -33,7 +33,7 @@ class EntraAdministrativeUnitMemberGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve a specific member (user, group, or device) of an administrative unit';
+    return 'Retrieves a specific member (user, group, or device) of an administrative unit';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/administrativeunit/administrativeunit-member-get.ts
+++ b/src/m365/entra/commands/administrativeunit/administrativeunit-member-get.ts
@@ -33,7 +33,7 @@ class EntraAdministrativeUnitMemberGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieves a specific member (user, group, or device) of an administrative unit';
+    return 'Retrieves info about a specific member of an administrative unit';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/administrativeunit/administrativeunit-member-remove.ts
+++ b/src/m365/entra/commands/administrativeunit/administrativeunit-member-remove.ts
@@ -36,7 +36,7 @@ class EntraAdministrativeUnitMemberRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Removes a specific member (user, group, or device) from an administrative unit';
+    return 'Removes a member (user, group, or device) from an administrative unit';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/administrativeunit/administrativeunit-member-remove.ts
+++ b/src/m365/entra/commands/administrativeunit/administrativeunit-member-remove.ts
@@ -36,7 +36,7 @@ class EntraAdministrativeUnitMemberRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Remove a specific member (user, group, or device) from an administrative unit';
+    return 'Removes a specific member (user, group, or device) from an administrative unit';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/m365group/m365group-report-activitycounts.ts
+++ b/src/m365/entra/commands/m365group/m365group-report-activitycounts.ts
@@ -7,7 +7,7 @@ class M365GroupReportActivityCountsCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get the number of group activities across group workloads';
+    return 'Gets the number of group activities across group workloads';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/entra/commands/m365group/m365group-report-activitydetail.ts
+++ b/src/m365/entra/commands/m365group/m365group-report-activitydetail.ts
@@ -7,7 +7,7 @@ class M365GroupReportActivityDetailCommand extends DateAndPeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get details about Microsoft 365 Groups activity by group';
+    return 'Gets details about Microsoft 365 Groups activity by group';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/entra/commands/m365group/m365group-report-activityfilecounts.ts
+++ b/src/m365/entra/commands/m365group/m365group-report-activityfilecounts.ts
@@ -7,7 +7,7 @@ class M365GroupReportActivityFileCountsCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Gets the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group';
+    return 'Gets the total number of files and how many of them were active across all group sites associated with a Microsoft 365 Group';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/entra/commands/m365group/m365group-report-activityfilecounts.ts
+++ b/src/m365/entra/commands/m365group/m365group-report-activityfilecounts.ts
@@ -7,7 +7,7 @@ class M365GroupReportActivityFileCountsCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group';
+    return 'Gets the total number of files and how many of them were active across all group sites associated with an Microsoft 365 Group';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/entra/commands/m365group/m365group-report-activitygroupcounts.ts
+++ b/src/m365/entra/commands/m365group/m365group-report-activitygroupcounts.ts
@@ -7,7 +7,7 @@ class M365GroupReportActivityGroupCountsCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get the daily total number of groups and how many of them were active based on email conversations, Viva Engage posts, and SharePoint file activities';
+    return 'Gets the daily total number of groups and how many of them were active based on email conversations, Viva Engage posts, and SharePoint file activities';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/entra/commands/m365group/m365group-report-activitystorage.ts
+++ b/src/m365/entra/commands/m365group/m365group-report-activitystorage.ts
@@ -7,7 +7,7 @@ class M365GroupReportActivityStorageCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get the total storage used across all group mailboxes and group sites';
+    return 'Gets the total storage used across all group mailboxes and group sites';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/entra/commands/oauth2grant/oauth2grant-add.ts
+++ b/src/m365/entra/commands/oauth2grant/oauth2grant-add.ts
@@ -23,7 +23,7 @@ class EntraOAuth2GrantAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Grant the specified service principal OAuth2 permissions to the specified resource';
+    return 'Grants the specified service principal OAuth2 permissions to the specified resource';
   }
 
   public get schema(): z.ZodTypeAny | undefined {

--- a/src/m365/entra/commands/oauth2grant/oauth2grant-remove.ts
+++ b/src/m365/entra/commands/oauth2grant/oauth2grant-remove.ts
@@ -24,7 +24,7 @@ class EntraOAuth2GrantRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Remove specified service principal OAuth2 permissions';
+    return 'Removes specified service principal OAuth2 permissions';
   }
 
   public get schema(): z.ZodTypeAny | undefined {

--- a/src/m365/entra/commands/oauth2grant/oauth2grant-set.ts
+++ b/src/m365/entra/commands/oauth2grant/oauth2grant-set.ts
@@ -23,7 +23,7 @@ class EntraOAuth2GrantSetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Update OAuth2 permissions for the service principal';
+    return 'Updates OAuth2 permissions for the service principal';
   }
 
   public get schema(): z.ZodTypeAny | undefined {

--- a/src/m365/entra/commands/pim/pim-role-assignment-add.ts
+++ b/src/m365/entra/commands/pim/pim-role-assignment-add.ts
@@ -49,7 +49,7 @@ class EntraPimRoleAssignmentAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Request activation of an Entra role assignment for a user or group';
+    return 'Requests activation of an Entra role assignment for a user or group';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/pim/pim-role-assignment-remove.ts
+++ b/src/m365/entra/commands/pim/pim-role-assignment-remove.ts
@@ -41,7 +41,7 @@ class EntraPimRoleAssignmentRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Request deactivation of an Entra role assignment for a user or group';
+    return 'Requests deactivation of an Entra role assignment for a user or group';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/resourcenamespace/resourcenamespace-list.ts
+++ b/src/m365/entra/commands/resourcenamespace/resourcenamespace-list.ts
@@ -13,7 +13,7 @@ class EntraResourcenamespaceListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a list of the RBAC resource namespaces and their properties';
+    return 'Gets a list of the RBAC resource namespaces and their properties';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/roleassignment/roleassignment-add.ts
+++ b/src/m365/entra/commands/roleassignment/roleassignment-add.ts
@@ -47,7 +47,7 @@ class EntraRoleAssignmentAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Assign a Entra ID role to a user and specify the scope for which the user has been granted access';
+    return 'Assigns a Entra ID role to a user and specify the scope for which the user has been granted access';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/roleassignment/roleassignment-add.ts
+++ b/src/m365/entra/commands/roleassignment/roleassignment-add.ts
@@ -47,7 +47,7 @@ class EntraRoleAssignmentAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Assigns a Entra ID role to a user and specify the scope for which the user has been granted access';
+    return 'Assigns a Entra ID role to a user and specifies the scope for which the user has been granted access';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/entra/commands/user/user-guest-add.ts
+++ b/src/m365/entra/commands/user/user-guest-add.ts
@@ -28,7 +28,7 @@ class EntraUserGuestAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Invite an external user to the organization';
+    return 'Invites an external user to the organization';
   }
 
   public get schema(): z.ZodTypeAny | undefined {

--- a/src/m365/entra/commands/user/user-password-validate.ts
+++ b/src/m365/entra/commands/user/user-password-validate.ts
@@ -22,7 +22,7 @@ class EntraUserPasswordValidateCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return "Check a user's password against the organization's password validation policy";
+    return "Checks a user's password against the organization's password validation policy";
   }
 
   public get schema(): z.ZodTypeAny | undefined {

--- a/src/m365/external/commands/connection/connection-get.ts
+++ b/src/m365/external/commands/connection/connection-get.ts
@@ -24,7 +24,7 @@ class ExternalConnectionGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a specific external connection';
+    return 'Gets a specific external connection';
   }
 
   public alias(): string[] | undefined {

--- a/src/m365/external/commands/connection/connection-get.ts
+++ b/src/m365/external/commands/connection/connection-get.ts
@@ -24,7 +24,7 @@ class ExternalConnectionGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Gets a specific external connection';
+    return 'Allows the administrator to get a specific external connection';
   }
 
   public alias(): string[] | undefined {

--- a/src/m365/external/commands/connection/connection-remove.ts
+++ b/src/m365/external/commands/connection/connection-remove.ts
@@ -26,7 +26,7 @@ class ExternalConnectionRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Removes a specific external connection';
+    return 'Allows the administrator to remove a specific external connection';
   }
 
   public alias(): string[] | undefined {

--- a/src/m365/graph/commands/schemaextension/schemaextension-list.ts
+++ b/src/m365/graph/commands/schemaextension/schemaextension-list.ts
@@ -26,7 +26,7 @@ class GraphSchemaExtensionListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a list of schemaExtension objects created in the current tenant, that can be InDevelopment, Available, or Deprecated.';
+    return 'Gets a list of schemaExtension objects created in the current tenant, that can be InDevelopment, Available, or Deprecated.';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/onenote/commands/notebook/notebook-add.ts
+++ b/src/m365/onenote/commands/notebook/notebook-add.ts
@@ -43,7 +43,7 @@ class OneNoteNotebookAddCommand extends GraphDelegatedCommand {
   }
 
   public get description(): string {
-    return 'Create a new OneNote notebook';
+    return 'Creates a new OneNote notebook';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/onenote/commands/notebook/notebook-list.ts
+++ b/src/m365/onenote/commands/notebook/notebook-list.ts
@@ -37,7 +37,7 @@ class OneNoteNotebookListCommand extends GraphDelegatedCommand {
   }
 
   public get description(): string {
-    return 'Retrieve a list of notebooks';
+    return 'Retrieves a list of notebooks';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/onenote/commands/page/page-list.ts
+++ b/src/m365/onenote/commands/page/page-list.ts
@@ -37,7 +37,7 @@ class OneNotePageListCommand extends GraphDelegatedCommand {
   }
 
   public get description(): string {
-    return 'Retrieve a list of OneNote pages.';
+    return 'Retrieves a list of OneNote pages.';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/outlook/commands/calendargroup/calendargroup-get.ts
+++ b/src/m365/outlook/commands/calendargroup/calendargroup-get.ts
@@ -35,7 +35,7 @@ class OutlookCalendarGroupGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve information about a calendar group for a user';
+    return 'Retrieves information about a calendar group for a user';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/outlook/commands/calendargroup/calendargroup-get.ts
+++ b/src/m365/outlook/commands/calendargroup/calendargroup-get.ts
@@ -35,7 +35,7 @@ class OutlookCalendarGroupGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieves information about a calendar group for a user';
+    return 'Retrieves a calendar group for a user';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/outlook/commands/mailbox/mailbox-settings-get.ts
+++ b/src/m365/outlook/commands/mailbox/mailbox-settings-get.ts
@@ -29,7 +29,7 @@ class OutlookMailboxSettingsGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return `Get the user's mailbox settings`;
+    return `Gets the user's mailbox settings`;
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/outlook/commands/room/room-list.ts
+++ b/src/m365/outlook/commands/room/room-list.ts
@@ -19,7 +19,7 @@ class OutlookRoomListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a collection of all available rooms';
+    return 'Gets a collection of all available rooms';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/outlook/commands/roomlist/roomlist-list.ts
+++ b/src/m365/outlook/commands/roomlist/roomlist-list.ts
@@ -14,7 +14,7 @@ class OutlookRoomListListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a collection of available roomlists';
+    return 'Gets a collection of available roomlists';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -34,7 +34,7 @@ class PlannerPlanGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Gets a Microsoft Planner plan';
+    return 'Retrieves information about the specified plan';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -34,7 +34,7 @@ class PlannerPlanGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a Microsoft Planner plan';
+    return 'Gets a Microsoft Planner plan';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/planner/commands/roster/roster-get.ts
+++ b/src/m365/planner/commands/roster/roster-get.ts
@@ -18,7 +18,7 @@ class PlannerRosterGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve information about a specific Microsoft Planner Roster';
+    return 'Retrieves information about a specific Microsoft Planner Roster';
   }
 
   constructor() {

--- a/src/m365/planner/commands/roster/roster-get.ts
+++ b/src/m365/planner/commands/roster/roster-get.ts
@@ -18,7 +18,7 @@ class PlannerRosterGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieves information about a specific Microsoft Planner Roster';
+    return 'Gets information about the specific Microsoft Planner Roster';
   }
 
   constructor() {

--- a/src/m365/planner/commands/task/task-get.ts
+++ b/src/m365/planner/commands/task/task-get.ts
@@ -32,7 +32,7 @@ class PlannerTaskGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve the specified planner task';
+    return 'Retrieves the specified planner task';
   }
 
   constructor() {

--- a/src/m365/planner/commands/task/task-reference-list.ts
+++ b/src/m365/planner/commands/task/task-reference-list.ts
@@ -19,7 +19,7 @@ class PlannerTaskReferenceListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieves the references of the specified planner task';
+    return 'Retrieves the references associated to a Planner task';
   }
 
   constructor() {

--- a/src/m365/planner/commands/task/task-reference-list.ts
+++ b/src/m365/planner/commands/task/task-reference-list.ts
@@ -19,7 +19,7 @@ class PlannerTaskReferenceListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve the references of the specified planner task';
+    return 'Retrieves the references of the specified planner task';
   }
 
   constructor() {

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.ts
@@ -25,7 +25,7 @@ class PpAiBuilderModelGetCommand extends PowerPlatformCommand {
   }
 
   public get description(): string {
-    return 'Get an AI builder model in the specified Power Platform environment.';
+    return 'Gets an AI builder model in the specified Power Platform environment.';
   }
 
   constructor() {

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-get.ts
@@ -25,7 +25,7 @@ class PpAiBuilderModelGetCommand extends PowerPlatformCommand {
   }
 
   public get description(): string {
-    return 'Gets an AI builder model in the specified Power Platform environment.';
+    return 'Gets a specific AI builder model in the specified Power Platform environment';
   }
 
   constructor() {

--- a/src/m365/pp/commands/aibuildermodel/aibuildermodel-list.ts
+++ b/src/m365/pp/commands/aibuildermodel/aibuildermodel-list.ts
@@ -20,7 +20,7 @@ class PpAiBuilderModelListCommand extends PowerPlatformCommand {
   }
 
   public get description(): string {
-    return 'List available AI builder models in the specified Power Platform environment.';
+    return 'Lists available AI builder models in the specified Power Platform environment.';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/pp/commands/copilot/copilot-get.ts
+++ b/src/m365/pp/commands/copilot/copilot-get.ts
@@ -26,7 +26,7 @@ class PpCopilotGetCommand extends PowerPlatformCommand {
   }
 
   public get description(): string {
-    return 'Get information about the specified copilot';
+    return 'Gets information about the specified copilot';
   }
 
   constructor() {

--- a/src/m365/pp/commands/gateway/gateway-get.ts
+++ b/src/m365/pp/commands/gateway/gateway-get.ts
@@ -12,7 +12,7 @@ class PpGatewayGetCommand extends PowerBICommand {
   }
 
   public get description(): string {
-    return "Get information about the specified gateway.";
+    return "Gets information about the specified gateway.";
   }
 
   constructor() {

--- a/src/m365/pp/commands/managementapp/managementapp-add.ts
+++ b/src/m365/pp/commands/managementapp/managementapp-add.ts
@@ -22,7 +22,7 @@ class PpManagementAppAddCommand extends PowerPlatformCommand {
   }
 
   public get description(): string {
-    return 'Register management application for Power Platform';
+    return 'Registers management application for Power Platform';
   }
 
   constructor() {

--- a/src/m365/pp/commands/solution/solution-publisher-get.ts
+++ b/src/m365/pp/commands/solution/solution-publisher-get.ts
@@ -24,7 +24,7 @@ class PpSolutionPublisherGetCommand extends PowerPlatformCommand {
   }
 
   public get description(): string {
-    return 'Get information about the specified publisher in a given environment.';
+    return 'Gets information about the specified publisher in a given environment.';
   }
 
   constructor() {

--- a/src/m365/purview/commands/auditlog/auditlog-list.ts
+++ b/src/m365/purview/commands/auditlog/auditlog-list.ts
@@ -25,7 +25,7 @@ class PurviewAuditLogListCommand extends O365MgmtCommand {
   }
 
   public get description(): string {
-    return 'List audit logs within your tenant';
+    return 'Lists audit logs within your tenant';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/purview/commands/retentionevent/retentionevent-add.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-add.ts
@@ -26,7 +26,7 @@ class PurviewRetentionEventAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Create a retention event';
+    return 'Creates a retention event';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentionevent/retentionevent-get.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-get.ts
@@ -19,7 +19,7 @@ class PurviewRetentionEventGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve the specified retention event';
+    return 'Retrieves the specified retention event';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentionevent/retentionevent-get.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-get.ts
@@ -19,7 +19,7 @@ class PurviewRetentionEventGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieves the specified retention event';
+    return 'Gets a retention event';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentionevent/retentionevent-list.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-list.ts
@@ -13,7 +13,7 @@ class PurviewRetentionEventListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a list of retention events';
+    return 'Gets a list of retention events';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/purview/commands/retentionevent/retentionevent-remove.ts
+++ b/src/m365/purview/commands/retentionevent/retentionevent-remove.ts
@@ -21,7 +21,7 @@ class PurviewRetentionEventRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Delete a retention event';
+    return 'Deletes a retention event';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-add.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-add.ts
@@ -19,7 +19,7 @@ class PurviewRetentionEventTypeAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Create a retention event type';
+    return 'Creates a retention event type';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-get.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-get.ts
@@ -19,7 +19,7 @@ class PurviewRetentionEventTypeGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve the specified retention event type';
+    return 'Retrieves the specified retention event type';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-get.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-get.ts
@@ -19,7 +19,7 @@ class PurviewRetentionEventTypeGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieves the specified retention event type';
+    return 'Gets a retention event type';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-list.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-list.ts
@@ -13,7 +13,7 @@ class PurviewRetentionEventTypeListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a list of retention event types';
+    return 'Gets a list of retention event types';
   }
 
   public get schema(): z.ZodTypeAny | undefined {

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-remove.ts
@@ -21,7 +21,7 @@ class PurviewRetentionEventTypeRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Delete a retention event type';
+    return 'Deletes a retention event type';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentioneventtype/retentioneventtype-set.ts
+++ b/src/m365/purview/commands/retentioneventtype/retentioneventtype-set.ts
@@ -20,7 +20,7 @@ class PurviewRetentionEventTypeSetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Update a retention event type';
+    return 'Updates a retention event type';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-add.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-add.ts
@@ -34,7 +34,7 @@ class PurviewRetentionLabelAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Create a retention label';
+    return 'Creates a retention label';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-get.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-get.ts
@@ -19,7 +19,7 @@ class PurviewRetentionLabelGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve the specified retention label';
+    return 'Retrieves the specified retention label';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-get.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-get.ts
@@ -19,7 +19,7 @@ class PurviewRetentionLabelGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieves the specified retention label';
+    return 'Gets a retention label';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-list.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-list.ts
@@ -13,7 +13,7 @@ class PurviewRetentionLabelListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a list of retention labels';
+    return 'Gets a list of retention labels';
   }
 
   public get schema(): z.ZodTypeAny | undefined {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
@@ -21,7 +21,7 @@ class PurviewRetentionLabelRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Delete a retention label';
+    return 'Deletes a retention label';
   }
 
   constructor() {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-set.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-set.ts
@@ -32,7 +32,7 @@ class PurviewRetentionLabelSetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Update a retention label';
+    return 'Updates a retention label';
   }
 
   constructor() {

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.ts
@@ -23,7 +23,7 @@ class PurviewSensitivityLabelGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve the specified sensitivity label';
+    return 'Retrieves the specified sensitivity label';
   }
 
   constructor() {

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.ts
@@ -22,7 +22,7 @@ class PurviewSensitivityLabelListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a list of sensitivity labels';
+    return 'Gets a list of sensitivity labels';
   }
 
   constructor() {

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.ts
@@ -22,7 +22,7 @@ class PurviewSensitivityLabelPolicySettingsListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a list of policy settings for a sensitivity label';
+    return 'Gets a list of policy settings for a sensitivity label';
   }
 
   constructor() {

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.ts
@@ -32,7 +32,7 @@ class PurviewThreatAssessmentAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Create a threat assessment';
+    return 'Creates a threat assessment';
   }
 
   constructor() {

--- a/src/m365/purview/commands/threatassessment/threatassessment-get.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-get.ts
@@ -20,7 +20,7 @@ class PurviewThreatAssessmentGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a threat assessment';
+    return 'Gets a threat assessment';
   }
 
   constructor() {

--- a/src/m365/purview/commands/threatassessment/threatassessment-list.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-list.ts
@@ -20,7 +20,7 @@ class PurviewThreatAssessmentListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a list of threat assessments';
+    return 'Gets a list of threat assessments';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/spe/commands/containertype/containertype-remove.ts
+++ b/src/m365/spe/commands/containertype/containertype-remove.ts
@@ -34,7 +34,7 @@ class SpeContainerTypeRemoveCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Remove a specific container type';
+    return 'Removes a specific container type';
   }
 
   public get schema(): z.ZodType {

--- a/src/m365/spfx/commands/project/project-permissions-grant.ts
+++ b/src/m365/spfx/commands/project/project-permissions-grant.ts
@@ -16,7 +16,7 @@ class SpfxProjectPermissionSGrantCommand extends BaseProjectCommand {
   }
 
   public get description(): string {
-    return 'Grant API permissions defined in the current SPFx project';
+    return 'Grants API permissions defined in the current SPFx project';
   }
 
   constructor() {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN003005_CFG_localizedResource_pathLib.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN003005_CFG_localizedResource_pathLib.ts
@@ -9,7 +9,7 @@ export class FN003005_CFG_localizedResource_pathLib extends JsonRule {
   }
 
   get title(): string {
-    return 'Updates path of the localized resource';
+    return 'Update path of the localized resource';
   }
 
   get description(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN003005_CFG_localizedResource_pathLib.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN003005_CFG_localizedResource_pathLib.ts
@@ -9,7 +9,7 @@ export class FN003005_CFG_localizedResource_pathLib extends JsonRule {
   }
 
   get title(): string {
-    return 'Update path of the localized resource';
+    return 'Updates path of the localized resource';
   }
 
   get description(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011001_MAN_webpart_schema.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011001_MAN_webpart_schema.ts
@@ -19,7 +19,7 @@ export class FN011001_MAN_webpart_schema extends ManifestRule {
   }
 
   get description(): string {
-    return 'Update schema in manifest';
+    return 'Updates schema in manifest';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011001_MAN_webpart_schema.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011001_MAN_webpart_schema.ts
@@ -19,7 +19,7 @@ export class FN011001_MAN_webpart_schema extends ManifestRule {
   }
 
   get description(): string {
-    return 'Updates schema in manifest';
+    return 'Update schema in manifest';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011002_MAN_applicationCustomizer_schema.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011002_MAN_applicationCustomizer_schema.ts
@@ -19,7 +19,7 @@ export class FN011002_MAN_applicationCustomizer_schema extends ManifestRule {
   }
 
   get description(): string {
-    return 'Update schema in manifest';
+    return 'Updates schema in manifest';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011002_MAN_applicationCustomizer_schema.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011002_MAN_applicationCustomizer_schema.ts
@@ -19,7 +19,7 @@ export class FN011002_MAN_applicationCustomizer_schema extends ManifestRule {
   }
 
   get description(): string {
-    return 'Updates schema in manifest';
+    return 'Update schema in manifest';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011003_MAN_listViewCommandSet_schema.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011003_MAN_listViewCommandSet_schema.ts
@@ -15,11 +15,11 @@ export class FN011003_MAN_listViewCommandSet_schema extends ManifestRule {
   }
 
   get title(): string {
-    return 'Lists view command set manifest schema';
+    return 'List view command set manifest schema';
   }
 
   get description(): string {
-    return 'Updates schema in manifest';
+    return 'Update schema in manifest';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011003_MAN_listViewCommandSet_schema.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011003_MAN_listViewCommandSet_schema.ts
@@ -15,11 +15,11 @@ export class FN011003_MAN_listViewCommandSet_schema extends ManifestRule {
   }
 
   get title(): string {
-    return 'List view command set manifest schema';
+    return 'Lists view command set manifest schema';
   }
 
   get description(): string {
-    return 'Update schema in manifest';
+    return 'Updates schema in manifest';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011004_MAN_fieldCustomizer_schema.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011004_MAN_fieldCustomizer_schema.ts
@@ -19,7 +19,7 @@ export class FN011004_MAN_fieldCustomizer_schema extends ManifestRule {
   }
 
   get description(): string {
-    return 'Updates schema in manifest';
+    return 'Update schema in manifest';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011004_MAN_fieldCustomizer_schema.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011004_MAN_fieldCustomizer_schema.ts
@@ -19,7 +19,7 @@ export class FN011004_MAN_fieldCustomizer_schema extends ManifestRule {
   }
 
   get description(): string {
-    return 'Update schema in manifest';
+    return 'Updates schema in manifest';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011006_MAN_listViewCommandSet_items.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011006_MAN_listViewCommandSet_items.ts
@@ -8,7 +8,7 @@ export class FN011006_MAN_listViewCommandSet_items extends ManifestRule {
   }
 
   get title(): string {
-    return 'List view command set items property';
+    return 'Lists view command set items property';
   }
 
   get description(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011006_MAN_listViewCommandSet_items.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011006_MAN_listViewCommandSet_items.ts
@@ -8,7 +8,7 @@ export class FN011006_MAN_listViewCommandSet_items extends ManifestRule {
   }
 
   get title(): string {
-    return 'Lists view command set items property';
+    return 'List view command set items property';
   }
 
   get description(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011007_MAN_listViewCommandSet_removeCommands.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011007_MAN_listViewCommandSet_removeCommands.ts
@@ -8,7 +8,7 @@ export class FN011007_MAN_listViewCommandSet_removeCommands extends ManifestRule
   }
 
   get title(): string {
-    return 'List view command set commands property';
+    return 'Lists view command set commands property';
   }
 
   get description(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011007_MAN_listViewCommandSet_removeCommands.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011007_MAN_listViewCommandSet_removeCommands.ts
@@ -8,7 +8,7 @@ export class FN011007_MAN_listViewCommandSet_removeCommands extends ManifestRule
   }
 
   get title(): string {
-    return 'Lists view command set commands property';
+    return 'List view command set commands property';
   }
 
   get description(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011010_MAN_webpart_version.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011010_MAN_webpart_version.ts
@@ -12,7 +12,7 @@ export class FN011010_MAN_webpart_version extends ManifestRule {
   }
 
   get description(): string {
-    return 'Updates version in manifest to use automated component versioning';
+    return 'Update version in manifest to use automated component versioning';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN011010_MAN_webpart_version.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN011010_MAN_webpart_version.ts
@@ -12,7 +12,7 @@ export class FN011010_MAN_webpart_version extends ManifestRule {
   }
 
   get description(): string {
-    return 'Update version in manifest to use automated component versioning';
+    return 'Updates version in manifest to use automated component versioning';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN018001_TEAMS_folder.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN018001_TEAMS_folder.ts
@@ -18,7 +18,7 @@ export class FN018001_TEAMS_folder extends Rule {
   }
 
   get description(): string {
-    return 'Create folder for Microsoft Teams tab resources';
+    return 'Creates folder for Microsoft Teams tab resources';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN018001_TEAMS_folder.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN018001_TEAMS_folder.ts
@@ -18,7 +18,7 @@ export class FN018001_TEAMS_folder extends Rule {
   }
 
   get description(): string {
-    return 'Creates folder for Microsoft Teams tab resources';
+    return 'Create folder for Microsoft Teams tab resources';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN018002_TEAMS_manifest.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN018002_TEAMS_manifest.ts
@@ -18,7 +18,7 @@ export class FN018002_TEAMS_manifest extends Rule {
   }
 
   get description(): string {
-    return 'Creates Microsoft Teams tab manifest for the web part';
+    return 'Create Microsoft Teams tab manifest for the web part';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN018002_TEAMS_manifest.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN018002_TEAMS_manifest.ts
@@ -18,7 +18,7 @@ export class FN018002_TEAMS_manifest extends Rule {
   }
 
   get description(): string {
-    return 'Create Microsoft Teams tab manifest for the web part';
+    return 'Creates Microsoft Teams tab manifest for the web part';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN018003_TEAMS_tab20x20_png.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN018003_TEAMS_tab20x20_png.ts
@@ -28,7 +28,7 @@ export class FN018003_TEAMS_tab20x20_png extends Rule {
   }
 
   get description(): string {
-    return 'Creates Microsoft Teams tab small icon for the web part';
+    return 'Create Microsoft Teams tab small icon for the web part';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN018003_TEAMS_tab20x20_png.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN018003_TEAMS_tab20x20_png.ts
@@ -28,7 +28,7 @@ export class FN018003_TEAMS_tab20x20_png extends Rule {
   }
 
   get description(): string {
-    return 'Create Microsoft Teams tab small icon for the web part';
+    return 'Creates Microsoft Teams tab small icon for the web part';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN018004_TEAMS_tab96x96_png.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN018004_TEAMS_tab96x96_png.ts
@@ -28,7 +28,7 @@ export class FN018004_TEAMS_tab96x96_png extends Rule {
   }
 
   get description(): string {
-    return 'Create Microsoft Teams tab large icon for the web part';
+    return 'Creates Microsoft Teams tab large icon for the web part';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN018004_TEAMS_tab96x96_png.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN018004_TEAMS_tab96x96_png.ts
@@ -28,7 +28,7 @@ export class FN018004_TEAMS_tab96x96_png extends Rule {
   }
 
   get description(): string {
-    return 'Creates Microsoft Teams tab large icon for the web part';
+    return 'Create Microsoft Teams tab large icon for the web part';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021003_PKG_engines_node.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021003_PKG_engines_node.ts
@@ -19,7 +19,7 @@ export class FN021003_PKG_engines_node extends JsonRule {
   }
 
   get description(): string {
-    return 'Updates package.json engines.node property';
+    return 'Update package.json engines.node property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021003_PKG_engines_node.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021003_PKG_engines_node.ts
@@ -19,7 +19,7 @@ export class FN021003_PKG_engines_node extends JsonRule {
   }
 
   get description(): string {
-    return 'Update package.json engines.node property';
+    return 'Updates package.json engines.node property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021004_PKG_scripts_build.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021004_PKG_scripts_build.ts
@@ -19,7 +19,7 @@ export class FN021004_PKG_scripts_build extends JsonRule {
   }
 
   get description(): string {
-    return 'Updates package.json scripts.build property';
+    return 'Update package.json scripts.build property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021004_PKG_scripts_build.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021004_PKG_scripts_build.ts
@@ -19,7 +19,7 @@ export class FN021004_PKG_scripts_build extends JsonRule {
   }
 
   get description(): string {
-    return 'Update package.json scripts.build property';
+    return 'Updates package.json scripts.build property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021006_PKG_scripts_clean.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021006_PKG_scripts_clean.ts
@@ -19,7 +19,7 @@ export class FN021006_PKG_scripts_clean extends JsonRule {
   }
 
   get description(): string {
-    return 'Update package.json scripts.clean property';
+    return 'Updates package.json scripts.clean property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021006_PKG_scripts_clean.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021006_PKG_scripts_clean.ts
@@ -19,7 +19,7 @@ export class FN021006_PKG_scripts_clean extends JsonRule {
   }
 
   get description(): string {
-    return 'Updates package.json scripts.clean property';
+    return 'Update package.json scripts.clean property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021007_PKG_scripts_start.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021007_PKG_scripts_start.ts
@@ -19,7 +19,7 @@ export class FN021007_PKG_scripts_start extends JsonRule {
   }
 
   get description(): string {
-    return 'Update package.json scripts.start property';
+    return 'Updates package.json scripts.start property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021007_PKG_scripts_start.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021007_PKG_scripts_start.ts
@@ -19,7 +19,7 @@ export class FN021007_PKG_scripts_start extends JsonRule {
   }
 
   get description(): string {
-    return 'Updates package.json scripts.start property';
+    return 'Update package.json scripts.start property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021008_PKG_scripts_eject_webpack.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021008_PKG_scripts_eject_webpack.ts
@@ -19,7 +19,7 @@ export class FN021008_PKG_scripts_eject_webpack extends JsonRule {
   }
 
   get description(): string {
-    return 'Updates package.json scripts.eject-webpack property';
+    return 'Update package.json scripts.eject-webpack property';
   }
 
   get resolution(): string {

--- a/src/m365/spfx/commands/project/project-upgrade/rules/FN021008_PKG_scripts_eject_webpack.ts
+++ b/src/m365/spfx/commands/project/project-upgrade/rules/FN021008_PKG_scripts_eject_webpack.ts
@@ -19,7 +19,7 @@ export class FN021008_PKG_scripts_eject_webpack extends JsonRule {
   }
 
   get description(): string {
-    return 'Update package.json scripts.eject-webpack property';
+    return 'Updates package.json scripts.eject-webpack property';
   }
 
   get resolution(): string {

--- a/src/m365/spo/commands/app/app-instance-list.ts
+++ b/src/m365/spo/commands/app/app-instance-list.ts
@@ -20,7 +20,7 @@ class SpoAppInStanceListCommand extends SpoAppBaseCommand {
   }
 
   public get description(): string {
-    return 'Retrieve apps installed in a site';
+    return 'Retrieves apps installed in a site';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-add.ts
@@ -28,7 +28,7 @@ class SpoApplicationCustomizerAddCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Add an application customizer to a site.';
+    return 'Adds an application customizer to a site.';
   }
 
   constructor() {

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-get.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-get.ts
@@ -29,7 +29,7 @@ class SpoApplicationCustomizerGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get an application customizer that is added to a site.';
+    return 'Gets an application customizer that is added to a site.';
   }
 
   constructor() {

--- a/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-list.ts
+++ b/src/m365/spo/commands/applicationcustomizer/applicationcustomizer-list.ts
@@ -22,7 +22,7 @@ class SpoApplicationCustomizerListCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get a list of application customizers that are added to a site.';
+    return 'Gets a list of application customizers that are added to a site.';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/spo/commands/cdn/cdn-get.ts
+++ b/src/m365/spo/commands/cdn/cdn-get.ts
@@ -22,7 +22,7 @@ class SpoCdnGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'View current status of the specified Microsoft 365 CDN';
+    return 'Views current status of the specified Microsoft 365 CDN';
   }
 
   constructor() {

--- a/src/m365/spo/commands/cdn/cdn-origin-list.ts
+++ b/src/m365/spo/commands/cdn/cdn-origin-list.ts
@@ -20,7 +20,7 @@ class SpoCdnOriginListCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'List CDN origins settings for the current SharePoint Online tenant';
+    return 'Lists CDN origins settings for the current SharePoint Online tenant';
   }
 
   constructor() {

--- a/src/m365/spo/commands/cdn/cdn-set.ts
+++ b/src/m365/spo/commands/cdn/cdn-set.ts
@@ -24,7 +24,7 @@ class SpoCdnSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Enable or disable the specified Microsoft 365 CDN';
+    return 'Enables or disable the specified Microsoft 365 CDN';
   }
 
   constructor() {

--- a/src/m365/spo/commands/cdn/cdn-set.ts
+++ b/src/m365/spo/commands/cdn/cdn-set.ts
@@ -24,7 +24,7 @@ class SpoCdnSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Enables or disable the specified Microsoft 365 CDN';
+    return 'Enables or disables the specified Microsoft 365 CDN';
   }
 
   constructor() {

--- a/src/m365/spo/commands/commandset/commandset-add.ts
+++ b/src/m365/spo/commands/commandset/commandset-add.ts
@@ -31,7 +31,7 @@ class SpoCommandSetAddCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Add a ListView Command Set to a site.';
+    return 'Adds a ListView Command Set to a site.';
   }
 
   constructor() {

--- a/src/m365/spo/commands/commandset/commandset-get.ts
+++ b/src/m365/spo/commands/commandset/commandset-get.ts
@@ -31,7 +31,7 @@ class SpoCommandSetGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get a ListView Command Set that is added to a site.';
+    return 'Gets a ListView Command Set that is added to a site.';
   }
 
   constructor() {

--- a/src/m365/spo/commands/commandset/commandset-list.ts
+++ b/src/m365/spo/commands/commandset/commandset-list.ts
@@ -21,7 +21,7 @@ class SpoCommandSetListCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get a list of ListView Command Sets that are added to a site.';
+    return 'Gets a list of ListView Command Sets that are added to a site.';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/spo/commands/commandset/commandset-remove.ts
+++ b/src/m365/spo/commands/commandset/commandset-remove.ts
@@ -30,7 +30,7 @@ class SpoCommandSetRemoveCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Remove a ListView Command Set that is added to a site.';
+    return 'Removes a ListView Command Set that is added to a site.';
   }
 
   constructor() {

--- a/src/m365/spo/commands/contenttype/contenttype-set.ts
+++ b/src/m365/spo/commands/contenttype/contenttype-set.ts
@@ -29,7 +29,7 @@ class SpoContentTypeSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Update an existing content type';
+    return 'Updates an existing content type';
   }
 
   constructor() {

--- a/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-ensure.ts
@@ -27,7 +27,7 @@ class SpoFileRetentionLabelEnsureCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Apply a retention label to a file';
+    return 'Applies a retention label to a file';
   }
 
   constructor() {

--- a/src/m365/spo/commands/file/file-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/file/file-retentionlabel-remove.ts
@@ -27,7 +27,7 @@ class SpoFileRetentionLabelRemoveCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Clear the retention label from a file';
+    return 'Clears the retention label from a file';
   }
 
   constructor() {

--- a/src/m365/spo/commands/file/file-version-get.ts
+++ b/src/m365/spo/commands/file/file-version-get.ts
@@ -24,7 +24,7 @@ class SpoFileVersionGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get a specific version of a file in a SharePoint Document library';
+    return 'Gets a specific version of a file in a SharePoint Document library';
   }
 
   constructor() {

--- a/src/m365/spo/commands/file/file-version-get.ts
+++ b/src/m365/spo/commands/file/file-version-get.ts
@@ -24,7 +24,7 @@ class SpoFileVersionGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Gets a specific version of a file in a SharePoint Document library';
+    return 'Gets information about a specific version of a specified file';
   }
 
   constructor() {

--- a/src/m365/spo/commands/file/file-version-keep.ts
+++ b/src/m365/spo/commands/file/file-version-keep.ts
@@ -33,7 +33,7 @@ class SpoFileVersionKeepCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Ensure that a specific file version will never expire';
+    return 'Ensures that a specific file version will never expire';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/spo/commands/folder/folder-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-ensure.ts
@@ -26,7 +26,7 @@ class SpoFolderRetentionLabelEnsureCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Apply a retention label to a folder';
+    return 'Applies a retention label to a folder';
   }
 
   constructor() {

--- a/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/folder/folder-retentionlabel-remove.ts
@@ -27,7 +27,7 @@ class SpoFolderRetentionLabelRemoveCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Clear the retention label from a folder';
+    return 'Clears the retention label from a folder';
   }
 
   constructor() {

--- a/src/m365/spo/commands/group/group-member-add.ts
+++ b/src/m365/spo/commands/group/group-member-add.ts
@@ -29,7 +29,7 @@ class SpoGroupMemberAddCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Add members to a SharePoint Group';
+    return 'Adds members to a SharePoint Group';
   }
 
   constructor() {

--- a/src/m365/spo/commands/group/group-member-list.ts
+++ b/src/m365/spo/commands/group/group-member-list.ts
@@ -22,7 +22,7 @@ class SpoGroupMemberListCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return `List the members of a SharePoint Group`;
+    return 'Lists the members of a SharePoint Group';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/spo/commands/hubsite/hubsite-connect.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-connect.ts
@@ -28,7 +28,7 @@ class SpoHubSiteConnectCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Connect a hub site to a parent hub site';
+    return 'Connects a hub site to a parent hub site';
   }
 
   constructor() {

--- a/src/m365/spo/commands/hubsite/hubsite-data-get.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-data-get.ts
@@ -20,7 +20,7 @@ class SpoHubSiteDataGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get hub site data for the specified site';
+    return 'Gets hub site data for the specified site';
   }
 
   constructor() {

--- a/src/m365/spo/commands/hubsite/hubsite-disconnect.ts
+++ b/src/m365/spo/commands/hubsite/hubsite-disconnect.ts
@@ -26,7 +26,7 @@ class SpoHubSiteDisconnectCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Disconnect a hub site from its parent hub site';
+    return 'Disconnects a hub site from its parent hub site';
   }
 
   constructor() {

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-ensure.ts
@@ -31,7 +31,7 @@ class SpoListItemRetentionLabelEnsureCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Apply a retention label to a list item';
+    return 'Applies a retention label to a list item';
   }
 
   constructor() {

--- a/src/m365/spo/commands/listitem/listitem-retentionlabel-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-retentionlabel-remove.ts
@@ -28,7 +28,7 @@ class SpoListItemRetentionLabelRemoveCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Clear the retention label from a list item';
+    return 'Clears the retention label from a list item';
   }
 
   constructor() {

--- a/src/m365/spo/commands/listitem/listitem-roleinheritance-break.ts
+++ b/src/m365/spo/commands/listitem/listitem-roleinheritance-break.ts
@@ -28,7 +28,7 @@ class SpoListItemRoleInheritanceBreakCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Break inheritance of list item';
+    return 'Breaks inheritance of list item';
   }
 
   constructor() {

--- a/src/m365/spo/commands/navigation/navigation-node-get.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-get.ts
@@ -27,7 +27,7 @@ class SpoNavigationNodeGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Retrieves information about a specific navigation node';
+    return 'Gets information about a specific navigation node';
   }
 
   public get schema(): z.ZodType {

--- a/src/m365/spo/commands/navigation/navigation-node-get.ts
+++ b/src/m365/spo/commands/navigation/navigation-node-get.ts
@@ -27,7 +27,7 @@ class SpoNavigationNodeGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Retrieve information about a specific navigation node';
+    return 'Retrieves information about a specific navigation node';
   }
 
   public get schema(): z.ZodType {

--- a/src/m365/spo/commands/orgassetslibrary/orgassetslibrary-list.ts
+++ b/src/m365/spo/commands/orgassetslibrary/orgassetslibrary-list.ts
@@ -12,7 +12,7 @@ class SpoOrgAssetsLibraryListCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'List all libraries that are assigned as asset library';
+    return 'Lists all libraries that are assigned as asset library';
   }
 
   public async commandAction(logger: Logger): Promise<void> {

--- a/src/m365/spo/commands/page/page-column-get.ts
+++ b/src/m365/spo/commands/page/page-column-get.ts
@@ -24,7 +24,7 @@ class SpoPageColumnGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get information about a specific column of a modern page';
+    return 'Gets information about a specific column of a modern page';
   }
 
   constructor() {

--- a/src/m365/spo/commands/page/page-section-get.ts
+++ b/src/m365/spo/commands/page/page-section-get.ts
@@ -23,7 +23,7 @@ class SpoPageSectionGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get information about the specified modern page section';
+    return 'Gets information about the specified modern page section';
   }
 
   constructor() {

--- a/src/m365/spo/commands/page/page-section-list.ts
+++ b/src/m365/spo/commands/page/page-section-list.ts
@@ -23,7 +23,7 @@ class SpoPageSectionListCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'List sections in the specific modern page';
+    return 'Lists sections in the specific modern page';
   }
 
   constructor() {

--- a/src/m365/spo/commands/report/report-siteusagefilecounts.ts
+++ b/src/m365/spo/commands/report/report-siteusagefilecounts.ts
@@ -11,7 +11,7 @@ class SpoReportSiteUsageFileCountsCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get the total number of files across all sites and the number of active files';
+    return 'Gets the total number of files across all sites and the number of active files';
   }
 }
 

--- a/src/m365/spo/commands/serviceprincipal/serviceprincipal-set.ts
+++ b/src/m365/spo/commands/serviceprincipal/serviceprincipal-set.ts
@@ -22,7 +22,7 @@ class SpoServicePrincipalSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Enable or disable the service principal';
+    return 'Enables or disable the service principal';
   }
 
   constructor() {

--- a/src/m365/spo/commands/serviceprincipal/serviceprincipal-set.ts
+++ b/src/m365/spo/commands/serviceprincipal/serviceprincipal-set.ts
@@ -22,7 +22,7 @@ class SpoServicePrincipalSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Enables or disable the service principal';
+    return 'Enables or disables the service principal';
   }
 
   constructor() {

--- a/src/m365/spo/commands/site/site-accessrequest-setting-set.ts
+++ b/src/m365/spo/commands/site/site-accessrequest-setting-set.ts
@@ -33,7 +33,7 @@ class SpoSiteAccessRequestSettingSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Update access requests for a specific site';
+    return 'Updates access requests for a specific site';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/spo/commands/site/site-appcatalog-list.ts
+++ b/src/m365/spo/commands/site/site-appcatalog-list.ts
@@ -22,7 +22,7 @@ class SpoSiteAppCatalogListCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'List all site collection app catalogs within the tenant';
+    return 'Lists all site collection app catalogs within the tenant';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/spo/commands/site/site-apppermission-get.ts
+++ b/src/m365/spo/commands/site/site-apppermission-get.ts
@@ -22,7 +22,7 @@ class SpoSiteAppPermissionGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a specific application permissions for the site';
+    return 'Gets a specific application permissions for the site';
   }
 
   constructor() {

--- a/src/m365/spo/commands/site/site-chrome-set.ts
+++ b/src/m365/spo/commands/site/site-chrome-set.ts
@@ -52,7 +52,7 @@ class SpoSiteChromeSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Set the chrome header and footer for the specified site';
+    return 'Sets the chrome header and footer for the specified site';
   }
 
   constructor() {

--- a/src/m365/spo/commands/storageentity/storageentity-get.ts
+++ b/src/m365/spo/commands/storageentity/storageentity-get.ts
@@ -21,7 +21,7 @@ class SpoStorageEntityGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get details for the specified tenant property';
+    return 'Gets details for the specified tenant property';
   }
 
   constructor() {

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-add.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-add.ts
@@ -29,7 +29,7 @@ class SpoTenantApplicationCustomizerAddCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Add an application customizer as a tenant wide extension.';
+    return 'Adds an application customizer as a tenant wide extension.';
   }
 
   constructor() {

--- a/src/m365/spo/commands/tenant/tenant-applicationcustomizer-get.ts
+++ b/src/m365/spo/commands/tenant/tenant-applicationcustomizer-get.ts
@@ -27,7 +27,7 @@ class SpoTenantApplicationCustomizerGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get an application customizer that is installed tenant wide';
+    return 'Gets an application customizer that is installed tenant wide';
   }
 
   constructor() {

--- a/src/m365/spo/commands/tenant/tenant-commandset-add.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-add.ts
@@ -33,7 +33,7 @@ class SpoTenantCommandSetAddCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Add a ListView Command Set as a tenant-wide extension.';
+    return 'Adds a ListView Command Set as a tenant-wide extension.';
   }
 
   constructor() {

--- a/src/m365/spo/commands/tenant/tenant-commandset-get.ts
+++ b/src/m365/spo/commands/tenant/tenant-commandset-get.ts
@@ -29,7 +29,7 @@ class SpoTenantCommandSetGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Get a ListView Command Set that is installed tenant wide';
+    return 'Gets a ListView Command Set that is installed tenant wide';
   }
 
   constructor() {

--- a/src/m365/spo/commands/theme/theme-set.ts
+++ b/src/m365/spo/commands/theme/theme-set.ts
@@ -24,7 +24,7 @@ class SpoThemeSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Add or update a theme';
+    return 'Adds or update a theme';
   }
 
   constructor() {

--- a/src/m365/spo/commands/theme/theme-set.ts
+++ b/src/m365/spo/commands/theme/theme-set.ts
@@ -24,7 +24,7 @@ class SpoThemeSetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Adds or update a theme';
+    return 'Adds or updates a theme';
   }
 
   constructor() {

--- a/src/m365/spo/commands/userprofile/userprofile-get.ts
+++ b/src/m365/spo/commands/userprofile/userprofile-get.ts
@@ -22,7 +22,7 @@ class SpoUserProfileGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Gets user profile property for a SharePoint user';
+    return 'Gets SharePoint user profile properties for the specified user';
   }
 
   constructor() {

--- a/src/m365/spo/commands/web/web-add.ts
+++ b/src/m365/spo/commands/web/web-add.ts
@@ -30,7 +30,7 @@ class SpoWebAddCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Create new subsite';
+    return 'Creates new subsite';
   }
 
   constructor() {

--- a/src/m365/spo/commands/web/web-get.ts
+++ b/src/m365/spo/commands/web/web-get.ts
@@ -23,7 +23,7 @@ class SpoWebGetCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Retrieve information about the specified site';
+    return 'Retrieves information about the specified site';
   }
 
   constructor() {

--- a/src/m365/spo/commands/web/web-remove.ts
+++ b/src/m365/spo/commands/web/web-remove.ts
@@ -21,7 +21,7 @@ class SpoWebRemoveCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Delete specified subsite';
+    return 'Deletes specified subsite';
   }
 
   constructor() {

--- a/src/m365/spo/commands/web/web-retentionlabel-list.ts
+++ b/src/m365/spo/commands/web/web-retentionlabel-list.ts
@@ -20,7 +20,7 @@ class SpoWebRetentionLabelListCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return `Get a list of retention labels that are available on a site.`;
+    return 'Gets a list of retention labels that are available on a site';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/spo/commands/web/web-roleinheritance-break.ts
+++ b/src/m365/spo/commands/web/web-roleinheritance-break.ts
@@ -22,7 +22,7 @@ class SpoWebRoleInheritanceBreakCommand extends SpoCommand {
   }
 
   public get description(): string {
-    return 'Break role inheritance of subsite';
+    return 'Breaks role inheritance of subsite';
   }
 
   constructor() {

--- a/src/m365/teams/commands/channel/channel-member-remove.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.ts
@@ -42,7 +42,7 @@ class TeamsChannelMemberRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Remove the specified member from the specified Microsoft Teams private or shared team channel';
+    return 'Removes the specified member from the specified Microsoft Teams private or shared team channel';
   }
 
   constructor() {

--- a/src/m365/teams/commands/chat/chat-get.ts
+++ b/src/m365/teams/commands/chat/chat-get.ts
@@ -27,7 +27,7 @@ class TeamsChatGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get a Microsoft Teams chat conversation by id, participants or chat name.';
+    return 'Gets a Microsoft Teams chat conversation by id, participants or chat name.';
   }
 
   constructor() {

--- a/src/m365/teams/commands/meeting/meeting-get.ts
+++ b/src/m365/teams/commands/meeting/meeting-get.ts
@@ -27,7 +27,7 @@ class TeamsMeetingGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get specified meeting details';
+    return 'Gets specified meeting details';
   }
 
   constructor() {

--- a/src/m365/teams/commands/meeting/meeting-list.ts
+++ b/src/m365/teams/commands/meeting/meeting-list.ts
@@ -30,7 +30,7 @@ class TeamsMeetingListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve all online meetings for a given user or shared mailbox';
+    return 'Retrieves all online meetings for a given user or shared mailbox';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/teams/commands/report/report-deviceusagedistributionusercounts.ts
+++ b/src/m365/teams/commands/report/report-deviceusagedistributionusercounts.ts
@@ -11,7 +11,7 @@ class TeamsReportDeviceUsageDistributionUserCountsCommand extends PeriodBasedRep
   }
 
   public get description(): string {
-    return 'Get the number of Microsoft Teams unique users by device type';
+    return 'Gets the number of Microsoft Teams unique users by device type';
   }
 }
 

--- a/src/m365/teams/commands/report/report-deviceusageusercounts.ts
+++ b/src/m365/teams/commands/report/report-deviceusageusercounts.ts
@@ -7,7 +7,7 @@ class TeamsReportDeviceUsageUserCountsCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get the number of Microsoft Teams daily unique users by device type';
+    return 'Gets the number of Microsoft Teams daily unique users by device type';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/teams/commands/report/report-directroutingcalls.ts
+++ b/src/m365/teams/commands/report/report-directroutingcalls.ts
@@ -25,7 +25,7 @@ class TeamsReportDirectroutingcallsCommand extends GraphApplicationCommand {
   }
 
   public get description(): string {
-    return 'Get details about direct routing calls made within a given time period';
+    return 'Gets details about direct routing calls made within a given time period';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/teams/commands/report/report-pstncalls.ts
+++ b/src/m365/teams/commands/report/report-pstncalls.ts
@@ -25,7 +25,7 @@ class TeamsReportPstncallsCommand extends GraphApplicationCommand {
   }
 
   public get description(): string {
-    return 'Get details about PSTN calls made within a given time period';
+    return 'Gets details about PSTN calls made within a given time period';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/teams/commands/report/report-useractivitycounts.ts
+++ b/src/m365/teams/commands/report/report-useractivitycounts.ts
@@ -7,7 +7,7 @@ class TeamsReportUserActivityCountsCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get the number of Microsoft Teams activities by activity type. The activity types are team chat messages, private chat messages, calls, and meetings.';
+    return 'Gets the number of Microsoft Teams activities by activity type. The activity types are team chat messages, private chat messages, calls, and meetings.';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/teams/commands/report/report-useractivityusercounts.ts
+++ b/src/m365/teams/commands/report/report-useractivityusercounts.ts
@@ -7,7 +7,7 @@ class TeamsReportUserActivityUserCountsCommand extends PeriodBasedReport {
   }
 
   public get description(): string {
-    return 'Get the number of Microsoft Teams users by activity type. The activity types are number of teams chat messages, private chat messages, calls, or meetings.';
+    return 'Gets the number of Microsoft Teams users by activity type. The activity types are number of teams chat messages, private chat messages, calls, or meetings.';
   }
 
   public get usageEndpoint(): string {

--- a/src/m365/teams/commands/report/report-useractivityuserdetail.ts
+++ b/src/m365/teams/commands/report/report-useractivityuserdetail.ts
@@ -11,7 +11,7 @@ class TeamsReportUserActivityUserDetailCommand extends DateAndPeriodBasedReport 
   }
 
   public get description(): string {
-    return 'Get details about Microsoft Teams user activity by user.';
+    return 'Gets details about Microsoft Teams user activity by user.';
   }
 }
 

--- a/src/m365/teams/commands/tab/tab-add.ts
+++ b/src/m365/teams/commands/tab/tab-add.ts
@@ -30,7 +30,7 @@ class TeamsTabAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Add a tab to the specified channel';
+    return 'Adds a tab to the specified channel';
   }
 
   constructor() {

--- a/src/m365/teams/commands/team/team-app-list.ts
+++ b/src/m365/teams/commands/team/team-app-list.ts
@@ -23,7 +23,7 @@ class TeamsTeamAppListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'List apps installed in the specified team';
+    return 'Lists apps installed in the specified team';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/teams/commands/team/team-get.ts
+++ b/src/m365/teams/commands/team/team-get.ts
@@ -23,7 +23,7 @@ class TeamsTeamGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieves information about the specified Microsoft Team';
+    return 'Gets information about the specified Microsoft Teams team';
   }
 
   constructor() {

--- a/src/m365/teams/commands/team/team-get.ts
+++ b/src/m365/teams/commands/team/team-get.ts
@@ -23,7 +23,7 @@ class TeamsTeamGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retrieve information about the specified Microsoft Team';
+    return 'Retrieves information about the specified Microsoft Team';
   }
 
   constructor() {

--- a/src/m365/teams/commands/user/user-app-add.ts
+++ b/src/m365/teams/commands/user/user-app-add.ts
@@ -24,7 +24,7 @@ class TeamsUserAppAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Install an app in the personal scope of the specified user';
+    return 'Installs an app in the personal scope of the specified user';
   }
 
   constructor() {

--- a/src/m365/teams/commands/user/user-app-list.ts
+++ b/src/m365/teams/commands/user/user-app-list.ts
@@ -24,7 +24,7 @@ class TeamsUserAppListCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'List the apps installed in the personal scope of the specified user';
+    return 'Lists the apps installed in the personal scope of the specified user';
   }
 
   constructor() {

--- a/src/m365/teams/commands/user/user-app-remove.ts
+++ b/src/m365/teams/commands/user/user-app-remove.ts
@@ -25,7 +25,7 @@ class TeamsUserAppRemoveCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Uninstall an app from the personal scope of the specified user.';
+    return 'Uninstalls an app from the personal scope of the specified user.';
   }
 
   constructor() {

--- a/src/m365/teams/commands/user/user-app-upgrade.ts
+++ b/src/m365/teams/commands/user/user-app-upgrade.ts
@@ -25,7 +25,7 @@ class TeamsUserAppUpgradeCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Upgrade an app in the personal scope of the specified user';
+    return 'Upgrades an app in the personal scope of the specified user';
   }
 
   constructor() {

--- a/src/m365/tenant/commands/people/people-pronouns-set.ts
+++ b/src/m365/tenant/commands/people/people-pronouns-set.ts
@@ -22,7 +22,7 @@ class TenantPeoplePronounsSetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Manage pronouns settings for an organization';
+    return 'Manages pronouns settings for an organization';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/tenant/commands/report/report-office365activationcounts.ts
+++ b/src/m365/tenant/commands/report/report-office365activationcounts.ts
@@ -19,7 +19,7 @@ class TenantReportOffice365ActivationCountsCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get the count of Microsoft 365 activations on desktops and devices.';
+    return 'Gets the count of Microsoft 365 activations on desktops and devices.';
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/tenant/commands/report/report-office365activationsusercounts.ts
+++ b/src/m365/tenant/commands/report/report-office365activationsusercounts.ts
@@ -19,7 +19,7 @@ class TenantReportOffice365ActivationsUserCountsCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get the count of enabled users with activated Office subscriptions.';
+    return 'Gets the count of enabled users with activated Office subscriptions.';
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/tenant/commands/report/report-office365activationsusercounts.ts
+++ b/src/m365/tenant/commands/report/report-office365activationsusercounts.ts
@@ -19,7 +19,7 @@ class TenantReportOffice365ActivationsUserCountsCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Gets the count of enabled users with activated Office subscriptions.';
+    return 'Gets the count of users that are enabled and those that have activated the Office subscription on desktop or devices or shared computers';
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/tenant/commands/report/report-office365activationsuserdetail.ts
+++ b/src/m365/tenant/commands/report/report-office365activationsuserdetail.ts
@@ -19,7 +19,7 @@ class TenantReportOffice365ActivationsUserDetailCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get details about users who have activated Microsoft 365.';
+    return 'Gets details about users who have activated Microsoft 365.';
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/tenant/commands/report/report-settings-get.ts
+++ b/src/m365/tenant/commands/report/report-settings-get.ts
@@ -9,7 +9,7 @@ class TenantReportSettingsGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Get the tenant-level settings for Microsoft 365 reports';
+    return 'Gets the tenant-level settings for Microsoft 365 reports';
   }
 
   public async commandAction(logger: Logger): Promise<void> {

--- a/src/m365/tenant/commands/report/report-settings-set.ts
+++ b/src/m365/tenant/commands/report/report-settings-set.ts
@@ -22,7 +22,7 @@ class TenantReportSettingsSetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Update tenant-level settings for Microsoft 365 reports';
+    return 'Updates tenant-level settings for Microsoft 365 reports';
   }
 
   public get schema(): z.ZodType | undefined {

--- a/src/m365/tenant/commands/serviceannouncement/serviceannouncement-health-get.ts
+++ b/src/m365/tenant/commands/serviceannouncement/serviceannouncement-health-get.ts
@@ -20,7 +20,7 @@ class TenantServiceAnnouncementHealthGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'This operation provides the health information of a specified service for a tenant';
+    return 'Gets the health report of a specified service for a tenant';
   }
 
   constructor() {

--- a/src/m365/todo/commands/task/task-add.ts
+++ b/src/m365/todo/commands/task/task-add.ts
@@ -33,7 +33,7 @@ class TodoTaskAddCommand extends GraphDelegatedCommand {
   }
 
   public get description(): string {
-    return 'Adds a task to a Microsoft To Do task list';
+    return 'Adds a task to a Microsoft To Do list';
   }
 
   constructor() {

--- a/src/m365/todo/commands/task/task-add.ts
+++ b/src/m365/todo/commands/task/task-add.ts
@@ -33,7 +33,7 @@ class TodoTaskAddCommand extends GraphDelegatedCommand {
   }
 
   public get description(): string {
-    return 'Add a task to a Microsoft To Do task list';
+    return 'Adds a task to a Microsoft To Do task list';
   }
 
   constructor() {

--- a/src/m365/todo/commands/task/task-get.ts
+++ b/src/m365/todo/commands/task/task-get.ts
@@ -23,7 +23,7 @@ class TodoTaskGetCommand extends GraphDelegatedCommand {
   }
 
   public get description(): string {
-    return 'Get a specific task from a Microsoft To Do task list';
+    return 'Gets a specific task from a Microsoft To Do task list';
   }
 
   constructor() {

--- a/src/m365/todo/commands/task/task-list.ts
+++ b/src/m365/todo/commands/task/task-list.ts
@@ -23,7 +23,7 @@ class TodoTaskListCommand extends GraphDelegatedCommand {
   }
 
   public get description(): string {
-    return 'List tasks from a Microsoft To Do task list';
+    return 'Lists tasks from a Microsoft To Do task list';
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/todo/commands/task/task-set.ts
+++ b/src/m365/todo/commands/task/task-set.ts
@@ -32,7 +32,7 @@ class TodoTaskSetCommand extends GraphDelegatedCommand {
   }
 
   public get description(): string {
-    return 'Update a task in a Microsoft To Do task list';
+    return 'Updates a task in a Microsoft To Do task list';
   }
 
   constructor() {

--- a/src/m365/viva/commands/engage/engage-role-member-add.ts
+++ b/src/m365/viva/commands/engage/engage-role-member-add.ts
@@ -34,7 +34,7 @@ class VivaEngageRoleMemberAddCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Assign a Viva Engage role to a user';
+    return 'Assigns a Viva Engage role to a user';
   }
 
   public get schema(): z.ZodType<Options> {


### PR DESCRIPTION
## What's changed

Updates all command descriptions from imperative form to third-person singular for consistency and better LLM tool-calling optimization.

### Why

Third-person singular ("Gets", "Deletes", "Removes") is the standard convention for tool/function descriptions in LLM ecosystems (OpenAI, Anthropic, Azure OpenAI). It:

- Aligns with how LLMs are trained to interpret tool metadata
- Reduces ambiguity in agentic chains (imperative can be misinterpreted as an instruction)
- Matches industry standards (GitHub OpenAPI specs, Microsoft Graph API descriptions)

### Changes

- **161 source code** descriptions updated in `src/m365/`
- **141 documentation** descriptions updated in `docs/docs/cmd/`
- **302 files** changed total
- All verbs converted: Get→Gets, Retrieve→Retrieves, List→Lists, Add→Adds, Remove→Removes, Create→Creates, Delete→Deletes, Update→Updates, and 25 other verbs

### Examples

| Before | After |
|--------|-------|
| Get a Microsoft Planner plan | Gets a Microsoft Planner plan |
| Remove the specified connection | Removes the specified connection |
| Delete a retention label | Deletes a retention label |
| List tasks from a Microsoft To Do task list | Lists tasks from a Microsoft To Do task list |
| Retrieve the specified planner task | Retrieves the specified planner task |
