### PR TITLE
Migrates outlook report commands to Zod

### DIFF
--- a/src/m365/base/DateAndPeriodBasedReport.spec.ts
+++ b/src/m365/base/DateAndPeriodBasedReport.spec.ts
@@ -11,7 +11,7 @@ import request from '../../request.js';
 import { pid } from '../../utils/pid.js';
 import { session } from '../../utils/session.js';
 import { sinonUtil } from '../../utils/sinonUtil.js';
-import DateAndPeriodBasedReport from './DateAndPeriodBasedReport.js';
+import DateAndPeriodBasedReport, { dateAndPeriodBasedReportOptions } from './DateAndPeriodBasedReport.js';
 
 class MockCommand extends DateAndPeriodBasedReport {
   public get name(): string {
@@ -30,11 +30,12 @@ class MockCommand extends DateAndPeriodBasedReport {
   }
 }
 
-describe('PeriodBasedReport', () => {
+describe('DateAndPeriodBasedReport', () => {
   const mockCommand = new MockCommand();
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof dateAndPeriodBasedReportOptions;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -43,6 +44,7 @@ describe('PeriodBasedReport', () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(mockCommand);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof dateAndPeriodBasedReportOptions;
   });
 
   beforeEach(() => {
@@ -81,60 +83,49 @@ describe('PeriodBasedReport', () => {
     assert.notStrictEqual(mockCommand.description, null);
   });
 
-  it('fails validation if period option is not passed', async () => {
-    const actual = mockCommand.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither period nor date option is passed', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation on invalid period', async () => {
-    const actual = mockCommand.validate({ options: { period: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation on invalid period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation on invalid date', async () => {
-    const actual = mockCommand.validate({ options: { date: '10.10.2019' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation on invalid date', () => {
+    const actual = commandOptionsSchema.safeParse({ date: '10.10.2019' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation on valid \'D7\' period', async () => {
-    const actual = await mockCommand.validate({
-      options: {
-        period: 'D7'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation on valid \'D30\' period', async () => {
-    const actual = await mockCommand.validate({
-      options: {
-        period: 'D30'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation on valid \'D30\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D30' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation on valid \'D90\' period', async () => {
-    const actual = await mockCommand.validate({
-      options: {
-        period: 'D90'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation on valid \'D90\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D90' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation on valid \'180\' period', async () => {
-    const actual = await mockCommand.validate({
-      options: {
-        period: 'D90'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation on valid \'D180\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D180' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if both period and date options set', async () => {
-    const actual = await mockCommand.validate({ options: { period: 'D7', date: '2019-07-13' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if both period and date options set', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7', date: '2019-07-13' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('get unique device type in teams and export it in a period', async () => {
@@ -149,19 +140,14 @@ describe('PeriodBasedReport', () => {
       throw 'Invalid request';
     });
 
-    await mockCommand.action(logger, { options: { period: 'D7' } });
+    await mockCommand.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
 
-  it('fails validation if the date option is not a valid date string', async () => {
-    const actual = await mockCommand.validate({
-      options:
-      {
-        date: '2018-X-09'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the date option is not a valid date string', () => {
+    const actual = commandOptionsSchema.safeParse({ date: '2018-X-09' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('gets details about Microsoft Teams user activity by user for the given date', async () => {
@@ -177,7 +163,7 @@ describe('PeriodBasedReport', () => {
       throw 'Invalid request';
     });
 
-    await mockCommand.action(logger, { options: { date: '2019-07-13' } });
+    await mockCommand.action(logger, { options: commandOptionsSchema.parse({ date: '2019-07-13' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(date=2019-07-13)");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -185,7 +171,7 @@ describe('PeriodBasedReport', () => {
   it('correctly handles random API error', async () => {
     sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
 
-    await assert.rejects(mockCommand.action(logger, { options: { period: 'D7' } } as any),
+    await assert.rejects(mockCommand.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }),
       new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/base/DateAndPeriodBasedReport.ts
+++ b/src/m365/base/DateAndPeriodBasedReport.ts
@@ -1,63 +1,37 @@
+import { z } from 'zod';
 import { Logger } from '../../cli/Logger.js';
-import GlobalOptions from '../../GlobalOptions.js';
+import { globalOptionsZod } from '../../Command.js';
 import { formatting } from '../../utils/formatting.js';
 import PeriodBasedReport from './PeriodBasedReport.js';
 
-export interface CommandArgs {
-  options: DateAndPeriodBasedOptions;
-}
+export const dateAndPeriodBasedReportOptions = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['json', 'csv']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).optional().alias('p'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'The supported date format is YYYY-MM-DD').optional().alias('d')
+}).refine(opts => opts.period || opts.date, {
+  message: `Specify either 'period' or 'date'.`,
+  params: {
+    customCode: 'optionSet',
+    options: ['period', 'date']
+  }
+}).refine(opts => !(opts.period && opts.date), {
+  message: `Specify either 'period' or 'date', but not both.`,
+  params: {
+    customCode: 'optionSet',
+    options: ['period', 'date']
+  }
+});
 
-interface DateAndPeriodBasedOptions extends GlobalOptions {
-  period?: string;
-  date?: string;
+declare type Options = z.infer<typeof dateAndPeriodBasedReportOptions>;
+
+export interface CommandArgs {
+  options: Options;
 }
 
 export default abstract class DateAndPeriodBasedReport extends PeriodBasedReport {
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        period: args.options.period,
-        date: typeof args.options.date !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      { option: '-d, --date [date]' }
-    );
-
-    this.options.forEach(option => {
-      option.option = option.option.replace('-p, --period <period>', '-p, --period [period]');
-    });
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!args.options.period && !args.options.date) {
-          return 'Specify period or date, one is required.';
-        }
-
-        if (args.options.period && args.options.date) {
-          return 'Specify period or date but not both.';
-        }
-
-        if (args.options.date && !((args.options.date as string).match(/^\d{4}-\d{2}-\d{2}$/))) {
-          return `${args.options.date} is not a valid date. The supported date format is YYYY-MM-DD`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodType | undefined {
+    return dateAndPeriodBasedReportOptions;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/base/PeriodBasedReport.spec.ts
+++ b/src/m365/base/PeriodBasedReport.spec.ts
@@ -11,7 +11,7 @@ import { telemetry } from '../../telemetry.js';
 import { pid } from '../../utils/pid.js';
 import { session } from '../../utils/session.js';
 import { sinonUtil } from '../../utils/sinonUtil.js';
-import PeriodBasedReport from './PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from './PeriodBasedReport.js';
 
 class MockCommand extends PeriodBasedReport {
   public get name(): string {
@@ -35,6 +35,7 @@ describe('PeriodBasedReport', () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof periodBasedReportOptions;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -43,6 +44,7 @@ describe('PeriodBasedReport', () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(mockCommand);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof periodBasedReportOptions;
   });
 
   beforeEach(() => {
@@ -81,45 +83,34 @@ describe('PeriodBasedReport', () => {
     assert.notStrictEqual(mockCommand.description, null);
   });
 
-  it('fails validation on invalid period', async () => {
-    const actual = await mockCommand.validate({ options: { period: 'abc' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation on invalid period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation on valid \'D7\' period', async () => {
-    const actual = await mockCommand.validate({
-      options: {
-        period: 'D7'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation on valid \'D30\' period', async () => {
-    const actual = await mockCommand.validate({
-      options: {
-        period: 'D30'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation on valid \'D90\' period', async () => {
-    const actual = await mockCommand.validate({
-      options: {
-        period: 'D90'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation on valid \'D30\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D30' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation on valid \'180\' period', async () => {
-    const actual = await mockCommand.validate({
-      options: {
-        period: 'D90'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation on valid \'D90\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D90' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation on valid \'D180\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D180' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('get unique device type in teams and export it in a period', async () => {
@@ -134,7 +125,7 @@ describe('PeriodBasedReport', () => {
       throw 'Invalid request';
     });
 
-    await mockCommand.action(logger, { options: { period: 'D7' } });
+    await mockCommand.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -151,7 +142,7 @@ describe('PeriodBasedReport', () => {
       throw 'Invalid request';
     });
 
-    await mockCommand.action(logger, { options: { period: 'D7' } });
+    await mockCommand.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -167,7 +158,7 @@ describe('PeriodBasedReport', () => {
       throw 'Invalid request';
     });
 
-    await mockCommand.action(logger, { options: { period: 'D7', output: 'json' } });
+    await mockCommand.action(logger, { options: commandOptionsSchema.parse({ period: 'D7', output: 'json' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -184,7 +175,7 @@ describe('PeriodBasedReport', () => {
       throw 'Invalid request';
     });
 
-    await mockCommand.action(logger, { options: { period: 'D7', output: 'text' } });
+    await mockCommand.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -201,7 +192,7 @@ describe('PeriodBasedReport', () => {
       throw 'Invalid request';
     });
 
-    await mockCommand.action(logger, { options: { period: 'D7' } });
+    await mockCommand.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -215,7 +206,7 @@ describe('PeriodBasedReport', () => {
       throw 'Invalid request';
     });
 
-    await mockCommand.action(logger, { options: { debug: true, period: 'D7', output: 'json' } });
+    await mockCommand.action(logger, { options: commandOptionsSchema.parse({ debug: true, period: 'D7', output: 'json' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -223,6 +214,6 @@ describe('PeriodBasedReport', () => {
   it('correctly handles random API error', async () => {
     sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
 
-    await assert.rejects(mockCommand.action(logger, { options: { period: 'D7' } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(mockCommand.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/base/PeriodBasedReport.ts
+++ b/src/m365/base/PeriodBasedReport.ts
@@ -1,15 +1,20 @@
+import { z } from 'zod';
 import { Logger } from '../../cli/Logger.js';
-import GlobalOptions from '../../GlobalOptions.js';
+import { globalOptionsZod } from '../../Command.js';
 import request, { CliRequestOptions } from '../../request.js';
 import { formatting } from '../../utils/formatting.js';
 import GraphCommand from "./GraphCommand.js";
 
-export interface CommandArgs {
-  options: UsagePeriodOptions;
-}
+export const periodBasedReportOptions = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['json', 'csv']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).alias('p')
+});
 
-interface UsagePeriodOptions extends GlobalOptions {
-  period: string;
+declare type Options = z.infer<typeof periodBasedReportOptions>;
+
+export interface CommandArgs {
+  options: Options;
 }
 
 export default abstract class PeriodBasedReport extends GraphCommand {
@@ -19,26 +24,8 @@ export default abstract class PeriodBasedReport extends GraphCommand {
     return ['json', 'csv'];
   }
 
-  constructor() {
-    super();
-
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initOptions(): void {
-    this.options.push(
-      {
-        option: '-p, --period <period>',
-        autocomplete: ['D7', 'D30', 'D90', 'D180']
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      (args) => this.validatePeriod(args),
-    );
+  public get schema(): z.ZodType | undefined {
+    return periodBasedReportOptions;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -99,15 +86,5 @@ export default abstract class PeriodBasedReport extends GraphCommand {
     }
 
     return jsonObj;
-  }
-
-  protected async validatePeriod(args: CommandArgs): Promise<boolean | string> {
-    const period = args.options.period;
-    if (period &&
-      ['D7', 'D30', 'D90', 'D180'].indexOf(period) < 0) {
-      return `${period} is not a valid period type. The supported values are D7|D30|D90|D180`;
-    }
-
-    return true;
   }
 }

--- a/src/m365/outlook/commands/report/report-mailactivitycounts.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailactivitycounts.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailactivitycounts.js';
+import command, { options } from './report-mailactivitycounts.js';
 
 describe(commands.REPORT_MAILACTIVITYCOUNTS, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILACTIVITYCOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILACTIVITYCOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getEmailActivityCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailactivitycounts.ts
+++ b/src/m365/outlook/commands/report/report-mailactivitycounts.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailActivityCountsCommand extends PeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailactivityusercounts.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailactivityusercounts.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailactivityusercounts.js';
+import command, { options } from './report-mailactivityusercounts.js';
 
 describe(commands.REPORT_MAILACTIVITYUSERCOUNTS, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILACTIVITYUSERCOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILACTIVITYUSERCOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getEmailActivityUserCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailactivityusercounts.ts
+++ b/src/m365/outlook/commands/report/report-mailactivityusercounts.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailActivityUserCountsCommand extends PeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailactivityuserdetail.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailactivityuserdetail.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailactivityuserdetail.js';
+import command, { options } from './report-mailactivityuserdetail.js';
 
 describe(commands.REPORT_MAILACTIVITYUSERDETAIL, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILACTIVITYUSERDETAIL, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILACTIVITYUSERDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getEmailActivityUserDetail(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailactivityuserdetail.ts
+++ b/src/m365/outlook/commands/report/report-mailactivityuserdetail.ts
@@ -1,5 +1,7 @@
-import DateAndPeriodBasedReport from '../../../base/DateAndPeriodBasedReport.js';
+import DateAndPeriodBasedReport, { dateAndPeriodBasedReportOptions } from '../../../base/DateAndPeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = dateAndPeriodBasedReportOptions;
 
 class OutlookReportMailActivityUserDetailCommand extends DateAndPeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailappusageappsusercounts.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailappusageappsusercounts.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailappusageappsusercounts.js';
+import command, { options } from './report-mailappusageappsusercounts.js';
 
 describe(commands.REPORT_MAILAPPUSAGEAPPSUSERCOUNTS, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILAPPUSAGEAPPSUSERCOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILAPPUSAGEAPPSUSERCOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getEmailAppUsageAppsUserCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailappusageappsusercounts.ts
+++ b/src/m365/outlook/commands/report/report-mailappusageappsusercounts.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailAppUsageAppsUserCountsCommand extends PeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailappusageusercounts.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailappusageusercounts.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailappusageusercounts.js';
+import command, { options } from './report-mailappusageusercounts.js';
 
 describe(commands.REPORT_MAILAPPUSAGEUSERCOUNTS, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILAPPUSAGEUSERCOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILAPPUSAGEUSERCOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getEmailAppUsageUserCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailappusageusercounts.ts
+++ b/src/m365/outlook/commands/report/report-mailappusageusercounts.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailAppUsageUserCountsCommand extends PeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailappusageuserdetail.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailappusageuserdetail.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailappusageuserdetail.js';
+import command, { options } from './report-mailappusageuserdetail.js';
 
 describe(commands.REPORT_MAILAPPUSAGEUSERDETAIL, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILAPPUSAGEUSERDETAIL, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILAPPUSAGEUSERDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getEmailAppUsageUserDetail(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailappusageuserdetail.ts
+++ b/src/m365/outlook/commands/report/report-mailappusageuserdetail.ts
@@ -1,5 +1,7 @@
-import DateAndPeriodBasedReport from '../../../base/DateAndPeriodBasedReport.js';
+import DateAndPeriodBasedReport, { dateAndPeriodBasedReportOptions } from '../../../base/DateAndPeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = dateAndPeriodBasedReportOptions;
 
 class OutlookReportMailAppUsageUserDetailCommand extends DateAndPeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailappusageversionsusercounts.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailappusageversionsusercounts.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailappusageversionsusercounts.js';
+import command, { options } from './report-mailappusageversionsusercounts.js';
 
 describe(commands.REPORT_MAILAPPUSAGEVERSIONSUSERCOUNTS, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILAPPUSAGEVERSIONSUSERCOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILAPPUSAGEVERSIONSUSERCOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getEmailAppUsageVersionsUserCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailappusageversionsusercounts.ts
+++ b/src/m365/outlook/commands/report/report-mailappusageversionsusercounts.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailAppUsageVersionsUserCountsCommand extends PeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailboxusagedetail.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailboxusagedetail.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailboxusagedetail.js';
+import command, { options } from './report-mailboxusagedetail.js';
 
 describe(commands.REPORT_MAILBOXUSAGEDETAIL, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILBOXUSAGEDETAIL, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILBOXUSAGEDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getMailboxUsageDetail(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailboxusagedetail.ts
+++ b/src/m365/outlook/commands/report/report-mailboxusagedetail.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailboxUsageDetailCommand extends PeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailboxusagemailboxcount.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailboxusagemailboxcount.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailboxusagemailboxcount.js';
+import command, { options } from './report-mailboxusagemailboxcount.js';
 
 describe(commands.REPORT_MAILBOXUSAGEMAILBOXCOUNT, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILBOXUSAGEMAILBOXCOUNT, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILBOXUSAGEMAILBOXCOUNT, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getMailboxUsageMailboxCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailboxusagemailboxcount.ts
+++ b/src/m365/outlook/commands/report/report-mailboxusagemailboxcount.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailboxUsageMailboxCountCommand extends PeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailboxusagequotastatusmailboxcounts.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailboxusagequotastatusmailboxcounts.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailboxusagequotastatusmailboxcounts.js';
+import command, { options } from './report-mailboxusagequotastatusmailboxcounts.js';
 
 describe(commands.REPORT_MAILBOXUSAGEQUOTASTATUSMAILBOXCOUNTS, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILBOXUSAGEQUOTASTATUSMAILBOXCOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILBOXUSAGEQUOTASTATUSMAILBOXCOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getMailboxUsageQuotaStatusMailboxCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailboxusagequotastatusmailboxcounts.ts
+++ b/src/m365/outlook/commands/report/report-mailboxusagequotastatusmailboxcounts.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailboxUsageQuotaStatusMailboxCountsCommand extends PeriodBasedReport {
   public get name(): string {

--- a/src/m365/outlook/commands/report/report-mailboxusagestorage.spec.ts
+++ b/src/m365/outlook/commands/report/report-mailboxusagestorage.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
@@ -8,9 +10,11 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-mailboxusagestorage.js';
+import command, { options } from './report-mailboxusagestorage.js';
 
 describe(commands.REPORT_MAILBOXUSAGESTORAGE, () => {
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let log: string[];
   let logger: Logger;
 
@@ -20,6 +24,8 @@ describe(commands.REPORT_MAILBOXUSAGESTORAGE, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -66,7 +72,7 @@ describe(commands.REPORT_MAILBOXUSAGESTORAGE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getMailboxUsageStorage(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });

--- a/src/m365/outlook/commands/report/report-mailboxusagestorage.ts
+++ b/src/m365/outlook/commands/report/report-mailboxusagestorage.ts
@@ -1,5 +1,7 @@
-import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
+import PeriodBasedReport, { periodBasedReportOptions } from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = periodBasedReportOptions;
 
 class OutlookReportMailboxUsageStorageCommand extends PeriodBasedReport {
   public get name(): string {


### PR DESCRIPTION
Migrates `PeriodBasedReport` and `DateAndPeriodBasedReport` base classes and all 11 outlook report commands from legacy `initOptions`/`initValidators` pattern to Zod schema validation.

## Changes

- Defined `periodBasedReportOptions` Zod schema with `period: z.enum(['D7', 'D30', 'D90', 'D180'])` and `output: z.enum(['json', 'csv'])`
- Defined `dateAndPeriodBasedReportOptions` Zod schema with optional period/date and refinements for mutual exclusivity and date format validation
- All 11 outlook report commands now export `options` from their respective base schemas
- Updated all spec files to use `safeParse`/`parse` patterns

Closes #7309