### PR TITLE
Migrate planner bucket, plan, and tenant settings set commands to Zod

### DIFF
--- a/src/m365/planner/commands/bucket/bucket-add.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './bucket-add.js';
+import command, { options } from './bucket-add.js';
 
 describe(commands.BUCKET_ADD, () => {
   const bucketAddResponse: any = {
@@ -60,6 +60,7 @@ describe(commands.BUCKET_ADD, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -72,6 +73,7 @@ describe(commands.BUCKET_ADD, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -136,92 +138,93 @@ describe(commands.BUCKET_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('passes validation when valid name and planId specified', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'My Planner Bucket',
-        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid name and planId specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: 'My Planner Bucket',
+      planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when valid name, planTitle, and ownerGroupId are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'My Planner Bucket',
-        planTitle: 'My Planner Plan',
-        ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40',
-        orderHint: ' a!'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid name, planTitle, and ownerGroupId are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: 'My Planner Bucket',
+      planTitle: 'My Planner Plan',
+      ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40',
+      orderHint: ' a!'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when valid name, planTitle, and ownerGroupName are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'My Planner Bucket',
-        planTitle: 'My Planner Plan',
-        ownerGroupName: 'My Planner Group',
-        orderHint: ' a!'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid name, planTitle, and ownerGroupName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: 'My Planner Bucket',
+      planTitle: 'My Planner Plan',
+      ownerGroupName: 'My Planner Group',
+      orderHint: ' a!'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if the ownerGroupId is not a valid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        name: 'My Planner Bucket',
-        planTitle: 'My Planner Plan',
-        ownerGroupId: 'not-c49b-4fd4-8223-28f0ac3a6402'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the ownerGroupId is not a valid guid.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: 'My Planner Bucket',
+      planTitle: 'My Planner Plan',
+      ownerGroupId: 'not-c49b-4fd4-8223-28f0ac3a6402'
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: 'My Planner Bucket',
+      planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2',
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('correctly adds planner bucket with name and planId', async () => {
-    const options: any = {
-      name: 'My Planner Bucket',
-      planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-    };
-
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, {
+      options: commandOptionsSchema.parse({
+        name: 'My Planner Bucket',
+        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
+      })
+    });
     assert(loggerLogSpy.calledWith(bucketAddResponse));
   });
 
   it('correctly adds planner bucket with name, planTitle, and ownerGroupName', async () => {
-    const options: any = {
-      name: 'My Planner Bucket',
-      planTitle: 'My Planner Plan',
-      ownerGroupName: 'My Planner Group'
-    };
-
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, {
+      options: commandOptionsSchema.parse({
+        name: 'My Planner Bucket',
+        planTitle: 'My Planner Plan',
+        ownerGroupName: 'My Planner Group'
+      })
+    });
     assert(loggerLogSpy.calledWith(bucketAddResponse));
   });
 
   it('correctly adds planner bucket with name, planTitle, and ownerGroupId', async () => {
-    const options: any = {
-      name: 'My Planner Bucket',
-      planTitle: 'My Planner Plan',
-      ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40',
-      verbose: true
-    };
-
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, {
+      options: commandOptionsSchema.parse({
+        name: 'My Planner Bucket',
+        planTitle: 'My Planner Plan',
+        ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40',
+        verbose: true
+      })
+    });
     assert(loggerLogSpy.calledWith(bucketAddResponse));
   });
 
   it('correctly adds planner bucket with name and rosterId', async () => {
-    const options: any = {
-      name: 'My Planner Bucket',
-      rosterId: 'RuY-PSpdw02drevnYDTCJpgAEfoI',
-      verbose: true
-    };
-
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, {
+      options: commandOptionsSchema.parse({
+        name: 'My Planner Bucket',
+        rosterId: 'RuY-PSpdw02drevnYDTCJpgAEfoI',
+        verbose: true
+      })
+    });
     assert(loggerLogSpy.calledWith(bucketAddResponse));
   });
 
@@ -245,8 +248,8 @@ describe(commands.BUCKET_ADD, () => {
 
   it('correctly handles API OData error', async () => {
     sinonUtil.restore(request.get);
-    sinon.stub(request, 'get').rejects(new Error("An error has occurred."));
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred.'));
 
-    await assert.rejects(command.action(logger, { options: {} }), new CommandError("An error has occurred."));
+    await assert.rejects(command.action(logger, { options: {} as any }), new CommandError('An error has occurred.'));
   });
 });

--- a/src/m365/planner/commands/bucket/bucket-add.ts
+++ b/src/m365/planner/commands/bucket/bucket-add.ts
@@ -1,5 +1,6 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { planner } from '../../../../utils/planner.js';
@@ -7,18 +8,25 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.string().alias('n'),
+  planId: z.string().optional(),
+  planTitle: z.string().optional(),
+  rosterId: z.string().optional(),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional(),
+  orderHint: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  name: string;
-  planId?: string;
-  planTitle?: string;
-  rosterId?: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
-  orderHint?: string;
 }
 
 class PlannerBucketAddCommand extends GraphCommand {
@@ -30,79 +38,26 @@ class PlannerBucketAddCommand extends GraphCommand {
     return 'Adds a new Microsoft Planner bucket';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        planId: typeof args.options.planId !== 'undefined',
-        planTitle: typeof args.options.planTitle !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined',
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined',
-        orderHint: typeof args.options.orderHint !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: "--planId [planId]"
-      },
-      {
-        option: "--planTitle [planTitle]"
-      },
-      {
-        option: '--rosterId [rosterId]'
-      },
-      {
-        option: "--ownerGroupId [ownerGroupId]"
-      },
-      {
-        option: "--ownerGroupName [ownerGroupName]"
-      },
-      {
-        option: "--orderHint [orderHint]"
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId as string)) {
-          return `${args.options.ownerGroupId} is not a valid GUID`;
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.planId, opts.planTitle, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'planId', 'planTitle' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['planId', 'planTitle', 'rosterId']
         }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['planId', 'planTitle', 'rosterId'] },
-      {
-        options: ['ownerGroupId', 'ownerGroupName'],
-        runsWhen: (args) => args.options.planTitle !== undefined
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('name', 'planId', 'planTitle', 'ownerGroupId', 'ownerGroupName', 'orderHint', 'rosterId ');
+      })
+      .refine(opts => !opts.planTitle || [opts.ownerGroupId, opts.ownerGroupName].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId' or 'ownerGroupName'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName']
+        }
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/bucket/bucket-get.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './bucket-get.js';
+import command, { options } from './bucket-get.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.BUCKET_GET, () => {
@@ -92,6 +92,7 @@ describe(commands.BUCKET_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -104,6 +105,7 @@ describe(commands.BUCKET_GET, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
       if (settingName === 'prompt') {
         return false;
@@ -153,7 +155,7 @@ describe(commands.BUCKET_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation when no option is specified', async () => {
+  it('fails validation when no option is specified', () => {
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
       if (settingName === settingsNames.prompt) {
         return false;
@@ -162,101 +164,89 @@ describe(commands.BUCKET_GET, () => {
       return defaultValue;
     });
 
-    const actual = await command.validate({
-      options: {
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when id and plan details are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validBucketId,
-        planId: validPlanId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when id and plan details are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId,
+      planId: validPlanId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when owner group id is not a guid', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupId: invalidOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when owner group id is not a guid', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planTitle: validPlanTitle,
+      ownerGroupId: invalidOwnerGroupId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when plan id is used with owner group name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planId: validPlanId,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when plan id is used with owner group name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planId: validPlanId,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when plan id is used with owner group id', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planId: validPlanId,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when plan id is used with owner group id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planId: validPlanId,
+      ownerGroupId: validOwnerGroupId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when roster id is used with owner group name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        rosterId: validRosterId,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when roster id is used with owner group name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      rosterId: validRosterId,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when roster id is used with owner group id', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        rosterId: validRosterId,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when roster id is used with owner group id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      rosterId: validRosterId,
+      ownerGroupId: validOwnerGroupId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with id', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validBucketId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('validates for a correct input with name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planTitle: validPlanTitle,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId,
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('fails validation when no groups found', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(validOwnerGroupName)}'&$select=id`) {
         return { "value": [] };
       }
@@ -265,11 +255,11 @@ describe(commands.BUCKET_GET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
-      }
+      })
     }), new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`));
   });
 
@@ -283,7 +273,6 @@ describe(commands.BUCKET_GET, () => {
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(validOwnerGroupName)}'&$select=id`) {
         return multipleGroupResponse;
       }
@@ -292,11 +281,11 @@ describe(commands.BUCKET_GET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
-      }
+      })
     }), new CommandError("Multiple groups with name 'Group name' found. Found: 00000000-0000-0000-0000-000000000000."));
   });
 
@@ -310,10 +299,10 @@ describe(commands.BUCKET_GET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planId: validPlanId
-      }
+      })
     }), new CommandError(`The specified bucket '${validBucketName}' does not exist.`));
   });
 
@@ -327,7 +316,6 @@ describe(commands.BUCKET_GET, () => {
     });
 
     sinon.stub(request, 'get').callsFake(async (opts) => {
-
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/${validPlanId}/buckets`) {
         return multipleBucketByNameResponse;
       }
@@ -336,10 +324,10 @@ describe(commands.BUCKET_GET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planId: validPlanId
-      }
+      })
     }), new CommandError("Multiple buckets with name 'Bucket name' found. Found: vncYUXCRBke28qMLB-d4xJcACtNz."));
   });
 
@@ -364,17 +352,16 @@ describe(commands.BUCKET_GET, () => {
     sinon.stub(cli, 'handleMultipleResultsFound').resolves(singleBucketByNameResponse.value[0]);
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
-      }
+      })
     }));
   });
 
   it('correctly gets bucket by id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-
       if (opts.url === `https://graph.microsoft.com/v1.0/planner/buckets/${validBucketId}`) {
         return singleBucketByIdResponse;
       }
@@ -383,15 +370,14 @@ describe(commands.BUCKET_GET, () => {
     });
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validBucketId
-      }
+      })
     }));
   });
 
   it('correctly gets bucket by name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(validOwnerGroupName)}'&$select=id`) {
         return singleGroupResponse;
       }
@@ -409,17 +395,16 @@ describe(commands.BUCKET_GET, () => {
     });
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
-      }
+      })
     }));
   });
 
   it('correctly gets bucket by plan title and owner group ID', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-
       if (opts.url === `https://graph.microsoft.com/v1.0/groups/${validOwnerGroupId}/planner/plans?$select=id,title`) {
         return singlePlanResponse;
       }
@@ -434,11 +419,11 @@ describe(commands.BUCKET_GET, () => {
     });
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupId: validOwnerGroupId
-      }
+      })
     }));
   });
 
@@ -458,11 +443,11 @@ describe(commands.BUCKET_GET, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         rosterId: validRosterId
-      }
-    } as any);
+      })
+    });
     assert(loggerLogSpy.calledWith(singleBucketByIdResponse));
   });
 });

--- a/src/m365/planner/commands/bucket/bucket-get.ts
+++ b/src/m365/planner/commands/bucket/bucket-get.ts
@@ -1,6 +1,7 @@
 import { PlannerBucket } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { planner } from '../../../../utils/planner.js';
@@ -8,18 +9,25 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().optional().alias('i'),
+  name: z.string().optional().alias('n'),
+  planId: z.string().optional(),
+  planTitle: z.string().optional(),
+  rosterId: z.string().optional(),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  name?: string;
-  planId?: string;
-  planTitle?: string;
-  rosterId?: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
 }
 
 class PlannerBucketGetCommand extends GraphCommand {
@@ -31,106 +39,42 @@ class PlannerBucketGetCommand extends GraphCommand {
     return 'Gets the Microsoft Planner bucket in a plan';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        name: typeof args.options.name !== 'undefined',
-        planId: typeof args.options.planId !== 'undefined',
-        planTitle: typeof args.options.planTitle !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined',
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.id, opts.name].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'id' or 'name'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'name']
+        }
+      })
+      .refine(opts => !opts.name || [opts.planId, opts.planTitle, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'planId', 'planTitle' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['planId', 'planTitle', 'rosterId']
+        }
+      })
+      .refine(opts => !opts.planTitle || [opts.ownerGroupId, opts.ownerGroupName].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId' or 'ownerGroupName'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName']
+        }
+      })
+      .refine(opts => !opts.id || (!opts.planId && !opts.planTitle && !opts.rosterId && !opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify planId, planTitle, rosterId, ownerGroupId or ownerGroupName when using id`
+      })
+      .refine(opts => !opts.name || !opts.planId || (!opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify ownerGroupId or ownerGroupName when using planId`
+      })
+      .refine(opts => !opts.name || !opts.rosterId || (!opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify ownerGroupId or ownerGroupName when using rosterId`
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-n, --name [name]'
-      },
-      {
-        option: '--planId [planId]'
-      },
-      {
-        option: "--planTitle [planTitle]"
-      },
-      {
-        option: '--rosterId [rosterId]'
-      },
-      {
-        option: '--ownerGroupId [ownerGroupId]'
-      },
-      {
-        option: '--ownerGroupName [ownerGroupName]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id) {
-          if (args.options.planId || args.options.planTitle || args.options.rosterId || args.options.ownerGroupId || args.options.ownerGroupName) {
-            return 'Don\'t specify planId, planTitle, rosterId, ownerGroupId or ownerGroupName when using id';
-          }
-        }
-
-        if (args.options.name) {
-          if (args.options.planTitle) {
-            if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId)) {
-              return `${args.options.ownerGroupId} is not a valid GUID`;
-            }
-          }
-
-          if (args.options.planId) {
-            if (args.options.ownerGroupId || args.options.ownerGroupName) {
-              return 'Don\'t specify ownerGroupId or ownerGroupName when using planId';
-            }
-          }
-
-          if (args.options.rosterId) {
-            if (args.options.ownerGroupId || args.options.ownerGroupName) {
-              return 'Don\'t specify ownerGroupId or ownerGroupName when using rosterId';
-            }
-          }
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['id', 'name'] },
-      {
-        options: ['planId', 'planTitle', 'rosterId'],
-        runsWhen: (args) => args.options.name !== undefined
-      },
-      {
-        options: ['ownerGroupId', 'ownerGroupName'],
-        runsWhen: (args) => args.options.planTitle !== undefined
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'name', 'planId', 'planTitle', 'ownerGroupId', 'ownerGroupName', 'rosterId ');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/bucket/bucket-list.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './bucket-list.js';
+import command, { options } from './bucket-list.js';
 
 describe(commands.BUCKET_LIST, () => {
   const bucketListResponseValue = [
@@ -65,11 +65,11 @@ describe(commands.BUCKET_LIST, () => {
     }]
   };
 
-
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -82,20 +82,21 @@ describe(commands.BUCKET_LIST, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/beta/planner/rosters/RuY-PSpdw02drevnYDTCJpgAEfoI/plans?$select=id`) {
+      if (opts.url === 'https://graph.microsoft.com/beta/planner/rosters/RuY-PSpdw02drevnYDTCJpgAEfoI/plans?$select=id') {
         return planResponse;
       }
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter('My Planner Group')}'&$select=id`) {
         return groupByDisplayNameResponse;
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans?$select=id,title`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/groups/0d0402ee-970f-4951-90b5-2f24519d2e40/planner/plans?$select=id,title') {
         return plansInOwnerGroup;
       }
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans/iVPMIgdku0uFlou-KLNg6MkAE1O2/buckets`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/planner/plans/iVPMIgdku0uFlou-KLNg6MkAE1O2/buckets') {
         return bucketListResponse;
       }
       throw 'Invalid request';
@@ -142,80 +143,80 @@ describe(commands.BUCKET_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'name', 'planId', 'orderHint']);
   });
 
-  it('passes validation when valid planId is specified', async () => {
-    const actual = await command.validate({
-      options: {
-        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid planId is specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when valid planTitle and ownerGroupId are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        planTitle: 'My Planner Plan',
-        ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid planTitle and ownerGroupId are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      planTitle: 'My Planner Plan',
+      ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when valid planTitle and ownerGroupName are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        planTitle: 'My Planner Plan',
-        ownerGroupName: 'My Planner Group'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid planTitle and ownerGroupName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      planTitle: 'My Planner Plan',
+      ownerGroupName: 'My Planner Group'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if the ownerGroupId is not a valid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        planTitle: 'My Planner Plan',
-        ownerGroupId: 'not-c49b-4fd4-8223-28f0ac3a6402'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the ownerGroupId is not a valid guid.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      planTitle: 'My Planner Plan',
+      ownerGroupId: 'not-c49b-4fd4-8223-28f0ac3a6402'
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2',
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('correctly lists planner buckets with planId', async () => {
-    const options: any = {
+    const args = commandOptionsSchema.parse({
       planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
-    };
+    });
 
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: args });
     assert(loggerLogSpy.calledWith(bucketListResponseValue));
   });
 
   it('correctly lists planner buckets with planTitle and ownerGroupName', async () => {
-    const options: any = {
+    const args = commandOptionsSchema.parse({
       planTitle: 'My Planner Plan',
       ownerGroupName: 'My Planner Group'
-    };
+    });
 
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: args });
     assert(loggerLogSpy.calledWith(bucketListResponseValue));
   });
 
   it('correctly lists planner buckets with planTitle and ownerGroupId', async () => {
-    const options: any = {
+    const args = commandOptionsSchema.parse({
       planTitle: 'My Planner Plan',
       ownerGroupId: '0d0402ee-970f-4951-90b5-2f24519d2e40'
-    };
+    });
 
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: args });
     assert(loggerLogSpy.calledWith(bucketListResponseValue));
   });
 
   it('correctly lists planner buckets by rosterId', async () => {
-    const options: any = {
+    const args = commandOptionsSchema.parse({
       rosterId: 'RuY-PSpdw02drevnYDTCJpgAEfoI'
-    };
+    });
 
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: args });
     assert(loggerLogSpy.calledWith(bucketListResponseValue));
   });
 
@@ -229,17 +230,21 @@ describe(commands.BUCKET_LIST, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         planTitle: 'My Planner Plan',
         ownerGroupName: 'foo'
-      }
+      })
     }), new CommandError(`The specified group 'foo' does not exist.`));
   });
 
   it('correctly handles API OData error', async () => {
     sinonUtil.restore(request.get);
-    sinon.stub(request, 'get').rejects(new Error("An error has occurred."));
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred.'));
 
-    await assert.rejects(command.action(logger, { options: {} } as any), new CommandError("An error has occurred."));
+    await assert.rejects(command.action(logger, {
+      options: commandOptionsSchema.parse({
+        planId: 'iVPMIgdku0uFlou-KLNg6MkAE1O2'
+      })
+    }), new CommandError('An error has occurred.'));
   });
 });

--- a/src/m365/planner/commands/bucket/bucket-list.ts
+++ b/src/m365/planner/commands/bucket/bucket-list.ts
@@ -1,6 +1,7 @@
 import { PlannerBucket } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { odata } from '../../../../utils/odata.js';
 import { planner } from '../../../../utils/planner.js';
@@ -8,16 +9,23 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  planId: z.string().optional(),
+  planTitle: z.string().optional(),
+  rosterId: z.string().optional(),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  planId?: string;
-  planTitle?: string;
-  rosterId?: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
 }
 
 class PlannerBucketListCommand extends GraphCommand {
@@ -33,72 +41,26 @@ class PlannerBucketListCommand extends GraphCommand {
     return ['id', 'name', 'planId', 'orderHint'];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        planId: typeof args.options.planId !== 'undefined',
-        planTitle: typeof args.options.planTitle !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined',
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--planId [planId]'
-      },
-      {
-        option: "--planTitle [planTitle]"
-      },
-      {
-        option: '--rosterId [rosterId]'
-      },
-      {
-        option: '--ownerGroupId [ownerGroupId]'
-      },
-      {
-        option: '--ownerGroupName [ownerGroupName]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId as string)) {
-          return `${args.options.ownerGroupId} is not a valid GUID`;
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.planId, opts.planTitle, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'planId', 'planTitle' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['planId', 'planTitle', 'rosterId']
         }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['planId', 'planTitle', 'rosterId'] },
-      {
-        options: ['ownerGroupId', 'ownerGroupName'],
-        runsWhen: (args) => args.options.planTitle !== undefined
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('planId', 'planTitle', 'ownerGroupId', 'ownerGroupName', 'rosterId ');
+      })
+      .refine(opts => !opts.planTitle || [opts.ownerGroupId, opts.ownerGroupName].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId' or 'ownerGroupName'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName']
+        }
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/bucket/bucket-remove.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './bucket-remove.js';
+import command, { options } from './bucket-remove.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.BUCKET_REMOVE, () => {
@@ -97,6 +97,7 @@ describe(commands.BUCKET_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let promptIssued: boolean = false;
 
   before(() => {
@@ -110,6 +111,7 @@ describe(commands.BUCKET_REMOVE, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => {
       if (settingName === 'prompt') {
         return false;
@@ -164,98 +166,89 @@ describe(commands.BUCKET_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation id when id and plan details are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validBucketId,
-        planId: validPlanId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation id when id and plan details are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId,
+      planId: validPlanId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when owner group id is not a guid', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupId: invalidOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when owner group id is not a guid', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planTitle: validPlanTitle,
+      ownerGroupId: invalidOwnerGroupId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when plan id is used with owner group name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planId: validPlanId,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when plan id is used with owner group name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planId: validPlanId,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when plan id is used with owner group id', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planId: validPlanId,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when plan id is used with owner group id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planId: validPlanId,
+      ownerGroupId: validOwnerGroupId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when roster id is used with owner group name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        rosterId: validRosterId,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when roster id is used with owner group name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      rosterId: validRosterId,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when roster id is used with owner group id', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        rosterId: validRosterId,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when roster id is used with owner group id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      rosterId: validRosterId,
+      ownerGroupId: validOwnerGroupId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with id', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validBucketId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId,
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('validates for a correct input with name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planTitle: validPlanTitle,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('prompts before removing the specified bucket when force option not passed with id', async () => {
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validBucketId
-      }
+      })
     });
-
 
     assert(promptIssued);
   });
@@ -263,9 +256,9 @@ describe(commands.BUCKET_REMOVE, () => {
   it('aborts removing the specified bucket when force option not passed and prompt not confirmed', async () => {
     const postSpy = sinon.spy(request, 'delete');
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validBucketId
-      }
+      })
     });
     assert(postSpy.notCalled);
   });
@@ -280,12 +273,12 @@ describe(commands.BUCKET_REMOVE, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName,
         force: true
-      }
+      })
     }), new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`));
   });
 
@@ -307,12 +300,12 @@ describe(commands.BUCKET_REMOVE, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName,
         force: true
-      }
+      })
     }), new CommandError("Multiple groups with name 'Group name' found. Found: 00000000-0000-0000-0000-000000000000."));
   });
 
@@ -326,11 +319,11 @@ describe(commands.BUCKET_REMOVE, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planId: validPlanId,
         force: true
-      }
+      })
     }), new CommandError(`The specified bucket '${validBucketName}' does not exist.`));
   });
 
@@ -352,11 +345,11 @@ describe(commands.BUCKET_REMOVE, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planId: validPlanId,
         force: true
-      }
+      })
     }), new CommandError("Multiple buckets with name 'Bucket name' found. Found: vncYUXCRBke28qMLB-d4xJcACtNz."));
   });
 
@@ -387,11 +380,11 @@ describe(commands.BUCKET_REMOVE, () => {
     sinon.stub(cli, 'handleMultipleResultsFound').resolves(singleBucketByNameResponse.value[0]);
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName
-      }
+      })
     }));
   });
 
@@ -412,10 +405,10 @@ describe(commands.BUCKET_REMOVE, () => {
     });
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validBucketId,
         force: true
-      }
+      })
     }));
   });
 
@@ -442,12 +435,12 @@ describe(commands.BUCKET_REMOVE, () => {
     });
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName,
         force: true
-      }
+      })
     }));
   });
 
@@ -474,10 +467,10 @@ describe(commands.BUCKET_REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         rosterId: validRosterId
-      }
+      })
     });
 
     assert(deleteStub.called);
@@ -505,12 +498,12 @@ describe(commands.BUCKET_REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupId: validOwnerGroupId,
         verbose: true
-      }
+      })
     }));
   });
 });

--- a/src/m365/planner/commands/bucket/bucket-remove.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.spec.ts
@@ -166,7 +166,7 @@ describe(commands.BUCKET_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation id when id and plan details are specified', () => {
+  it('fails validation when id and plan details are specified', () => {
     const actual = commandOptionsSchema.safeParse({
       id: validBucketId,
       planId: validPlanId

--- a/src/m365/planner/commands/bucket/bucket-remove.ts
+++ b/src/m365/planner/commands/bucket/bucket-remove.ts
@@ -1,7 +1,8 @@
 import { PlannerBucket } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { planner } from '../../../../utils/planner.js';
@@ -9,19 +10,26 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().optional().alias('i'),
+  name: z.string().optional().alias('n'),
+  planId: z.string().optional(),
+  planTitle: z.string().optional(),
+  rosterId: z.string().optional(),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional(),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  name?: string;
-  planId?: string;
-  planTitle?: string;
-  rosterId?: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
-  force?: boolean;
 }
 
 class PlannerBucketRemoveCommand extends GraphCommand {
@@ -33,107 +41,45 @@ class PlannerBucketRemoveCommand extends GraphCommand {
     return 'Removes the Microsoft Planner bucket from a plan';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        name: typeof args.options.name !== 'undefined',
-        planId: typeof args.options.planId !== 'undefined',
-        planTitle: typeof args.options.planTitle !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined',
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined',
-        force: args.options.force || false
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.id, opts.name].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'id' or 'name'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'name']
+        }
+      })
+      .refine(opts => !opts.name || [opts.planId, opts.planTitle, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'planId', 'planTitle' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['planId', 'planTitle', 'rosterId']
+        }
+      })
+      .refine(opts => !opts.planTitle || [opts.ownerGroupId, opts.ownerGroupName].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId' or 'ownerGroupName'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName']
+        }
+      })
+      .refine(opts => !opts.id || (!opts.planId && !opts.planTitle && !opts.rosterId && !opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify planId, planTitle, rosterId, ownerGroupId or ownerGroupName when using id`
+      })
+      .refine(opts => !opts.name || !opts.planTitle || !opts.ownerGroupId || validation.isValidGuid(opts.ownerGroupId), {
+        message: 'The value is not a valid GUID.'
+      })
+      .refine(opts => !opts.name || !opts.planId || (!opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify ownerGroupId or ownerGroupName when using planId`
+      })
+      .refine(opts => !opts.name || !opts.rosterId || (!opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify ownerGroupId or ownerGroupName when using rosterId`
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-n, --name [name]'
-      },
-      {
-        option: '--planId [planId]'
-      },
-      {
-        option: "--planTitle [planTitle]"
-      },
-      {
-        option: '--rosterId [rosterId]'
-      },
-      {
-        option: '--ownerGroupId [ownerGroupId]'
-      },
-      {
-        option: '--ownerGroupName [ownerGroupName]'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id) {
-          if (args.options.planId || args.options.planTitle || args.options.rosterId || args.options.ownerGroupId || args.options.ownerGroupName) {
-            return 'Don\'t specify planId, planTitle, rosterId, ownerGroupId or ownerGroupName when using id';
-          }
-        }
-        else {
-          if (args.options.planTitle) {
-            if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId)) {
-              return `${args.options.ownerGroupId} is not a valid GUID`;
-            }
-          }
-          else if (args.options.planId) {
-            if (args.options.ownerGroupId || args.options.ownerGroupName) {
-              return 'Don\'t specify ownerGroupId or ownerGroupName when using planId';
-            }
-          }
-          else {
-            if (args.options.ownerGroupId || args.options.ownerGroupName) {
-              return 'Don\'t specify ownerGroupId or ownerGroupName when using rosterId';
-            }
-          }
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['id', 'name'] },
-      {
-        options: ['planId', 'planTitle', 'rosterId'],
-        runsWhen: (args) => args.options.name !== undefined
-      },
-      {
-        options: ['ownerGroupId', 'ownerGroupName'],
-        runsWhen: (args) => args.options.planTitle !== undefined
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'name', 'planId', 'planTitle', 'ownerGroupId', 'ownerGroupName', 'rosterId ');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/bucket/bucket-set.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './bucket-set.js';
+import command, { options } from './bucket-set.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.BUCKET_SET, () => {
@@ -98,6 +98,7 @@ describe(commands.BUCKET_SET, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -110,6 +111,7 @@ describe(commands.BUCKET_SET, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -158,100 +160,97 @@ describe(commands.BUCKET_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation id when id and plan details are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validBucketId,
-        planId: validPlanId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation id when id and plan details are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId,
+      planId: validPlanId,
+      newName: 'New name'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when owner group id is not a guid', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupId: invalidOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when owner group id is not a guid', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planTitle: validPlanTitle,
+      ownerGroupId: invalidOwnerGroupId,
+      newName: 'New name'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when plan id is used with owner group name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planId: validPlanId,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when plan id is used with owner group name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planId: validPlanId,
+      ownerGroupName: validOwnerGroupName,
+      newName: 'New name'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when plan id is used with owner group id', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planId: validPlanId,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when plan id is used with owner group id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planId: validPlanId,
+      ownerGroupId: validOwnerGroupId,
+      newName: 'New name'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when roster id is used with owner group name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        rosterId: validRosterId,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when roster id is used with owner group name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      rosterId: validRosterId,
+      ownerGroupName: validOwnerGroupName,
+      newName: 'New name'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when roster id is used with owner group id', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        rosterId: validRosterId,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when roster id is used with owner group id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      rosterId: validRosterId,
+      ownerGroupId: validOwnerGroupId,
+      newName: 'New name'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when new name or order hint is not specified', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validBucketId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when new name or order hint is not specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with id', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validBucketId,
-        newName: 'New name'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId,
+      newName: 'New name',
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with name', async () => {
-    const actual = await command.validate({
-      options: {
-        name: validBucketName,
-        planTitle: validPlanTitle,
-        ownerGroupName: validOwnerGroupName,
-        newName: 'New name'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validBucketId,
+      newName: 'New name'
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('validates for a correct input with name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      name: validBucketName,
+      planTitle: validPlanTitle,
+      ownerGroupName: validOwnerGroupName,
+      newName: 'New name'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('fails validation when no groups found', async () => {
@@ -264,11 +263,12 @@ describe(commands.BUCKET_SET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
-        ownerGroupName: validOwnerGroupName
-      }
+        ownerGroupName: validOwnerGroupName,
+        newName: 'New name'
+      })
     }), new CommandError(`The specified group '${validOwnerGroupName}' does not exist.`));
   });
 
@@ -291,11 +291,12 @@ describe(commands.BUCKET_SET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
-        ownerGroupName: validOwnerGroupName
-      }
+        ownerGroupName: validOwnerGroupName,
+        newName: 'New name'
+      })
     }), new CommandError("Multiple groups with name 'Group name' found. Found: 00000000-0000-0000-0000-000000000000."));
   });
 
@@ -310,10 +311,11 @@ describe(commands.BUCKET_SET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
-        planId: validPlanId
-      }
+        planId: validPlanId,
+        newName: 'New name'
+      })
     }), new CommandError(`The specified bucket '${validBucketName}' does not exist.`));
   });
 
@@ -336,10 +338,11 @@ describe(commands.BUCKET_SET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
-        planId: validPlanId
-      }
+        planId: validPlanId,
+        newName: 'New name'
+      })
     }), new CommandError("Multiple buckets with name 'Bucket name' found. Found: vncYUXCRBke28qMLB-d4xJcACtNz."));
   });
 
@@ -369,13 +372,13 @@ describe(commands.BUCKET_SET, () => {
     sinon.stub(cli, 'handleMultipleResultsFound').resolves(singleBucketByNameResponse.value[0]);
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName,
         newName: 'New bucket name',
         orderHint: validOrderHint
-      }
+      })
     }));
   });
 
@@ -396,10 +399,10 @@ describe(commands.BUCKET_SET, () => {
     });
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validBucketId,
         newName: validBucketName
-      }
+      })
     }));
   });
 
@@ -426,13 +429,13 @@ describe(commands.BUCKET_SET, () => {
     });
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupName: validOwnerGroupName,
         newName: 'New bucket name',
         orderHint: validOrderHint
-      }
+      })
     }));
   });
 
@@ -457,12 +460,12 @@ describe(commands.BUCKET_SET, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         rosterId: validRosterId,
         newName: 'New bucket name',
         orderHint: validOrderHint
-      }
+      })
     });
 
     assert(patchStub.called);
@@ -488,14 +491,14 @@ describe(commands.BUCKET_SET, () => {
     });
 
     await assert.doesNotReject(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         name: validBucketName,
         planTitle: validPlanTitle,
         ownerGroupId: validOwnerGroupId,
         newName: 'New bucket name',
         orderHint: validOrderHint,
         verbose: true
-      }
+      })
     }));
   });
 });

--- a/src/m365/planner/commands/bucket/bucket-set.spec.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.spec.ts
@@ -160,7 +160,7 @@ describe(commands.BUCKET_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation id when id and plan details are specified', () => {
+  it('fails validation when id and plan details are specified', () => {
     const actual = commandOptionsSchema.safeParse({
       id: validBucketId,
       planId: validPlanId,

--- a/src/m365/planner/commands/bucket/bucket-set.ts
+++ b/src/m365/planner/commands/bucket/bucket-set.ts
@@ -1,6 +1,7 @@
 import { PlannerBucket } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { planner } from '../../../../utils/planner.js';
@@ -8,20 +9,27 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().optional().alias('i'),
+  name: z.string().optional().alias('n'),
+  planId: z.string().optional(),
+  planTitle: z.string().optional(),
+  rosterId: z.string().optional(),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional(),
+  newName: z.string().optional(),
+  orderHint: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  name?: string;
-  planId?: string;
-  planTitle?: string;
-  rosterId?: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
-  newName?: string;
-  orderHint?: string;
 }
 
 class PlannerBucketSetCommand extends GraphCommand {
@@ -33,110 +41,45 @@ class PlannerBucketSetCommand extends GraphCommand {
     return 'Updates a Microsoft Planner bucket';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        name: typeof args.options.name !== 'undefined',
-        planId: typeof args.options.planId !== 'undefined',
-        planTitle: typeof args.options.planTitle !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined',
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined',
-        newName: typeof args.options.newName !== 'undefined',
-        orderHint: typeof args.options.orderHint !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.id, opts.name].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'id' or 'name'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'name']
+        }
+      })
+      .refine(opts => !opts.name || [opts.planId, opts.planTitle, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'planId', 'planTitle' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['planId', 'planTitle', 'rosterId']
+        }
+      })
+      .refine(opts => !opts.planTitle || [opts.ownerGroupId, opts.ownerGroupName].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId' or 'ownerGroupName'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName']
+        }
+      })
+      .refine(opts => !opts.id || (!opts.planId && !opts.planTitle && !opts.ownerGroupId && !opts.ownerGroupName && !opts.rosterId), {
+        message: `Don't specify planId, planTitle, ownerGroupId, ownerGroupName or rosterId when using id`
+      })
+      .refine(opts => !opts.name || !opts.planId || (!opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify ownerGroupId or ownerGroupName when using planId`
+      })
+      .refine(opts => !opts.name || !opts.rosterId || (!opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify ownerGroupId or ownerGroupName when using rosterId`
+      })
+      .refine(opts => opts.newName !== undefined || opts.orderHint !== undefined, {
+        message: 'Specify either newName or orderHint'
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-n, --name [name]'
-      },
-      {
-        option: '--planId [planId]'
-      },
-      {
-        option: "--planTitle [planTitle]"
-      },
-      {
-        option: '--rosterId [rosterId]'
-      },
-      {
-        option: '--ownerGroupId [ownerGroupId]'
-      },
-      {
-        option: '--ownerGroupName [ownerGroupName]'
-      },
-      {
-        option: '--newName [newName]'
-      },
-      {
-        option: '--orderHint [orderHint]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id && (args.options.planId || args.options.planTitle || args.options.ownerGroupId || args.options.ownerGroupName || args.options.rosterId)) {
-          return 'Don\'t specify planId, planTitle, ownerGroupId, ownerGroupName or rosterId when using id';
-        }
-
-        if (args.options.name) {
-          if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId)) {
-            return `${args.options.ownerGroupId} is not a valid GUID`;
-          }
-
-          if (args.options.planId && (args.options.ownerGroupId || args.options.ownerGroupName)) {
-            return 'Don\'t specify ownerGroupId or ownerGroupName when using planId';
-          }
-
-          if (args.options.rosterId && (args.options.ownerGroupId || args.options.ownerGroupName)) {
-            return 'Don\'t specify ownerGroupId or ownerGroupName when using rosterId';
-          }
-        }
-
-        if (!args.options.newName && !args.options.orderHint) {
-          return 'Specify either newName or orderHint';
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['id', 'name'] },
-      {
-        options: ['planId', 'planTitle', 'rosterId'],
-        runsWhen: (args) => args.options.name !== undefined
-      },
-      {
-        options: ['ownerGroupId', 'ownerGroupName'],
-        runsWhen: (args) => args.options.planTitle !== undefined
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'name', 'planId', 'planTitle', 'ownerGroupId', 'ownerGroupName', 'orderHint', 'newName', 'rosterId ');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/plan/plan-add.spec.ts
+++ b/src/m365/planner/commands/plan/plan-add.spec.ts
@@ -12,14 +12,14 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './plan-add.js';
-import { settingsNames } from '../../../../settingsNames.js';
+import command, { options } from './plan-add.js';
 
 describe(commands.PLAN_ADD, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   const validId = '2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2';
   const validTitle = 'Plan name';
@@ -98,6 +98,7 @@ describe(commands.PLAN_ADD, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -140,122 +141,97 @@ describe(commands.PLAN_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if the ownerGroupId is not a valid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: 'no guid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if neither the ownerGroupId nor ownerGroupName are provided.', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
+  it('fails validation if the ownerGroupId is not a valid guid.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: 'no guid'
     });
-
-    const actual = await command.validate({
-      options: {
-        title: validTitle
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when both ownerGroupId and ownerGroupName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
+  it('fails validation if neither the ownerGroupId nor ownerGroupName are provided.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle
     });
-
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: validOwnerGroupId,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if shareWithUserIds contains invalid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: validOwnerGroupId,
-        shareWithUserIds: "no guid"
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when both ownerGroupId and ownerGroupName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: validOwnerGroupId,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if shareWithUserNames contains invalid user principal name', async () => {
+  it('fails validation if shareWithUserIds contains invalid guid.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: validOwnerGroupId,
+      shareWithUserIds: 'no guid'
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if shareWithUserNames contains invalid user principal name', () => {
     const shareWithUserNames = ['john.doe@contoso.com', 'foo'];
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: validOwnerGroupId,
-        shareWithUserNames: shareWithUserNames.join(',')
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: validOwnerGroupId,
+      shareWithUserNames: shareWithUserNames.join(',')
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when both shareWithUserIds and shareWithUserNames are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: validOwnerGroupId,
-        shareWithUserIds: validShareWithUserIds,
-        shareWithUserNames: validShareWithUserNames
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when both shareWithUserIds and shareWithUserNames are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: validOwnerGroupId,
+      shareWithUserIds: validShareWithUserIds,
+      shareWithUserNames: validShareWithUserNames
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when valid title and ownerGroupId specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: validOwnerGroupId,
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when valid title, ownerGroupName, and shareWithUserIds specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: validOwnerGroupId,
-        shareWithUserIds: validShareWithUserIds
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid title and ownerGroupId specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when valid title, ownerGroupName, and validShareWithUserNames specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: validOwnerGroupId,
-        shareWithUserNames: validShareWithUserNames
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid title, ownerGroupName, and shareWithUserIds specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: validOwnerGroupId,
+      shareWithUserIds: validShareWithUserIds
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation when valid title, ownerGroupName, and validShareWithUserNames specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: validOwnerGroupId,
+      shareWithUserNames: validShareWithUserNames
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('correctly adds planner plan with given title with available ownerGroupId', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/planner/plans') {
         return planResponse;
       }
 
@@ -263,17 +239,17 @@ describe(commands.PLAN_ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validTitle,
         ownerGroupId: validOwnerGroupId
-      }
+      })
     });
     assert(loggerLogSpy.calledWith(planResponse));
   });
 
   it('correctly adds planner plan with given title with available rosterId', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/planner/plans') {
         return planRosterResponse;
       }
 
@@ -281,10 +257,10 @@ describe(commands.PLAN_ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validTitle,
         rosterId: validRosterId
-      }
+      })
     });
     assert(loggerLogSpy.calledWith(planRosterResponse));
   });
@@ -299,7 +275,7 @@ describe(commands.PLAN_ADD, () => {
     };
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/planner/plans') {
         throw multipleRostersError;
       }
 
@@ -307,11 +283,11 @@ describe(commands.PLAN_ADD, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validTitle,
         rosterId: validRosterId
-      }
-    }), new CommandError(`You can only add 1 plan to a Roster`));
+      })
+    }), new CommandError('You can only add 1 plan to a Roster'));
   });
 
   it('correctly adds planner plan with given title with available ownerGroupName', async () => {
@@ -324,7 +300,7 @@ describe(commands.PLAN_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/planner/plans') {
         return planResponse;
       }
 
@@ -332,10 +308,10 @@ describe(commands.PLAN_ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validTitle,
         ownerGroupName: validOwnerGroupName
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(planResponse));
@@ -351,7 +327,7 @@ describe(commands.PLAN_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/planner/plans') {
         return planResponse;
       }
 
@@ -367,11 +343,11 @@ describe(commands.PLAN_ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validTitle,
         ownerGroupId: validOwnerGroupId,
         shareWithUserIds: validShareWithUserIds
-      }
+      })
     });
     assert(loggerLogSpy.calledWith(outputResponse));
   });
@@ -394,7 +370,7 @@ describe(commands.PLAN_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/planner/plans') {
         return planResponse;
       }
 
@@ -410,11 +386,11 @@ describe(commands.PLAN_ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validTitle,
         ownerGroupId: validOwnerGroupId,
         shareWithUserNames: validShareWithUserNames
-      }
+      })
     });
     assert(loggerLogSpy.calledWith(outputResponse));
   });
@@ -437,7 +413,7 @@ describe(commands.PLAN_ADD, () => {
     });
 
     sinon.stub(request, 'post').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/planner/plans`) {
+      if (opts.url === 'https://graph.microsoft.com/v1.0/planner/plans') {
         return planResponse;
       }
 
@@ -453,17 +429,22 @@ describe(commands.PLAN_ADD, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validTitle,
         ownerGroupId: validOwnerGroupId,
         shareWithUserNames: validShareWithUserNames
-      }
+      })
     }), new CommandError(`Cannot proceed with planner plan creation. The following users provided are invalid : ${user1}`));
   });
 
   it('correctly handles API OData error', async () => {
-    sinon.stub(request, 'get').rejects(new Error("An error has occurred."));
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred.'));
 
-    await assert.rejects(command.action(logger, { options: {} }), new CommandError("An error has occurred."));
+    await assert.rejects(command.action(logger, {
+      options: commandOptionsSchema.parse({
+        title: validTitle,
+        ownerGroupName: validOwnerGroupName
+      })
+    }), new CommandError('An error has occurred.'));
   });
 });

--- a/src/m365/planner/commands/plan/plan-add.ts
+++ b/src/m365/planner/commands/plan/plan-add.ts
@@ -1,7 +1,7 @@
 import { PlannerPlan, PlannerPlanDetails, User } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod, CommandError } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import { CommandError } from '../../../../Command.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
@@ -9,17 +9,32 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  title: z.string().alias('t'),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional(),
+  rosterId: z.string().optional(),
+  shareWithUserIds: z.string()
+    .refine(val => validation.isValidGuidArray(val) === true, {
+      message: 'The value contains invalid GUIDs.'
+    })
+    .optional(),
+  shareWithUserNames: z.string()
+    .refine(val => validation.isValidUserPrincipalNameArray(val) === true, {
+      message: 'The value contains invalid user principal names.'
+    })
+    .optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  title: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
-  rosterId?: string;
-  shareWithUserIds?: string;
-  shareWithUserNames?: string;
 }
 
 class PlannerPlanAddCommand extends GraphCommand {
@@ -31,86 +46,22 @@ class PlannerPlanAddCommand extends GraphCommand {
     return 'Adds a new Microsoft Planner plan';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined',
-        shareWithUserIds: typeof args.options.shareWithUserIds !== 'undefined',
-        shareWithUserNames: typeof args.options.shareWithUserNames !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.ownerGroupId, opts.ownerGroupName, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId', 'ownerGroupName' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName', 'rosterId']
+        }
+      })
+      .refine(opts => !opts.shareWithUserIds || !opts.shareWithUserNames, {
+        message: 'Specify either shareWithUserIds or shareWithUserNames but not both'
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-t, --title <title>'
-      },
-      {
-        option: "--ownerGroupId [ownerGroupId]"
-      },
-      {
-        option: "--ownerGroupName [ownerGroupName]"
-      },
-      {
-        option: "--rosterId [rosterId]"
-      },
-      {
-        option: '--shareWithUserIds [shareWithUserIds]'
-      },
-      {
-        option: '--shareWithUserNames [shareWithUserNames]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId as string)) {
-          return `${args.options.ownerGroupId} is not a valid GUID`;
-        }
-
-        if (args.options.shareWithUserIds && args.options.shareWithUserNames) {
-          return 'Specify either shareWithUserIds or shareWithUserNames but not both';
-        }
-
-        if (args.options.shareWithUserIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.shareWithUserIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for the option 'shareWithUserIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if (args.options.shareWithUserNames) {
-          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.shareWithUserNames);
-          if (isValidUPNArrayResult !== true) {
-            return `The following user principal names are invalid for the option 'shareWithUserNames': ${isValidUPNArrayResult}.`;
-          }
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['ownerGroupId', 'ownerGroupName', 'rosterId'] });
-  }
-
-  #initTypes(): void {
-    this.types.string.push('title', 'ownerGroupId', 'ownerGroupName', 'rosterId', 'shareWithUserIds', 'shareWithUserNames');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/plan/plan-get.spec.ts
+++ b/src/m365/planner/commands/plan/plan-get.spec.ts
@@ -11,13 +11,14 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './plan-get.js';
+import command, { options } from './plan-get.js';
 
 describe(commands.PLAN_GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   const validId = '2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2';
   const validTitle = 'Plan name';
   const validOwnerGroupName = 'Group name';
@@ -60,6 +61,7 @@ describe(commands.PLAN_GET, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -99,52 +101,50 @@ describe(commands.PLAN_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if the ownerGroupId is not a valid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: invalidOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the ownerGroupId is not a valid guid.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: invalidOwnerGroupId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when id specified', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when id specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validId
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when title and valid ownerGroupId specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when title and valid ownerGroupId specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupId: validOwnerGroupId
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when title and valid ownerGroupName specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validTitle,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when title and valid ownerGroupName specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validTitle,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when rosterId specified', async () => {
-    const actual = await command.validate({
-      options: {
-        rosterId: validRosterId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when rosterId specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      rosterId: validRosterId
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validId,
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('correctly get planner plan with given id', async () => {
@@ -161,9 +161,9 @@ describe(commands.PLAN_GET, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validId
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(outputResponse));
@@ -182,12 +182,12 @@ describe(commands.PLAN_GET, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    const options: any = {
+    const argsOptions = commandOptionsSchema.parse({
       title: validTitle,
       ownerGroupId: validOwnerGroupId
-    };
+    });
 
-    await command.action(logger, { options: options });
+    await command.action(logger, { options: argsOptions });
     assert(loggerLogSpy.calledWith(outputResponse));
   });
 
@@ -208,12 +208,12 @@ describe(commands.PLAN_GET, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    const options: any = {
+    const argsOptions = commandOptionsSchema.parse({
       title: validTitle,
       ownerGroupName: validOwnerGroupName
-    };
+    });
 
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: argsOptions });
     assert(loggerLogSpy.calledWith(outputResponse));
   });
 
@@ -230,11 +230,11 @@ describe(commands.PLAN_GET, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    const options: any = {
+    const argsOptions = commandOptionsSchema.parse({
       rosterId: validRosterId
-    };
+    });
 
-    await command.action(logger, { options: options });
+    await command.action(logger, { options: argsOptions });
     assert(loggerLogSpy.calledWith(outputResponse));
   });
 
@@ -248,18 +248,18 @@ describe(commands.PLAN_GET, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    const options: any = {
+    const argsOptions = commandOptionsSchema.parse({
       title: validTitle,
       ownerGroupId: validOwnerGroupId
-    };
+    });
 
-    await assert.rejects(command.action(logger, { options: options } as any));
+    await assert.rejects(command.action(logger, { options: argsOptions }));
     assert(loggerLogSpy.notCalled);
   });
 
   it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').rejects(new Error(`Planner plan with id '${validId}' was not found.`));
 
-    await assert.rejects(command.action(logger, { options: { id: validId } }), new CommandError(`Planner plan with id '${validId}' was not found.`));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: validId }) }), new CommandError(`Planner plan with id '${validId}' was not found.`));
   });
 });

--- a/src/m365/planner/commands/plan/plan-get.ts
+++ b/src/m365/planner/commands/plan/plan-get.ts
@@ -1,6 +1,7 @@
 import { PlannerPlan, PlannerPlanDetails } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { planner } from '../../../../utils/planner.js';
@@ -8,16 +9,23 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().optional().alias('i'),
+  title: z.string().optional().alias('t'),
+  rosterId: z.string().optional(),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  title?: string;
-  rosterId?: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
 }
 
 class PlannerPlanGetCommand extends GraphCommand {
@@ -29,76 +37,26 @@ class PlannerPlanGetCommand extends GraphCommand {
     return 'Get a Microsoft Planner plan';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        title: typeof args.options.title !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined',
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.id, opts.title, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'id', 'title' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'title', 'rosterId']
+        }
+      })
+      .refine(opts => !opts.title || [opts.ownerGroupId, opts.ownerGroupName].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId' or 'ownerGroupName'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-t, --title [title]'
-      },
-      {
-        option: '--rosterId [rosterId]'
-      },
-      {
-        option: '--ownerGroupId [ownerGroupId]'
-      },
-      {
-        option: '--ownerGroupName [ownerGroupName]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId as string)) {
-          return `${args.options.ownerGroupId} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      {
-        options: ['id', 'title', 'rosterId']
-      },
-      {
-        options: ['ownerGroupId', 'ownerGroupName'],
-        runsWhen: (args) => {
-          return args.options.title !== undefined;
-        }
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'title', 'ownerGroupId', 'ownerGroupName', 'rosterId');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/plan/plan-list.spec.ts
+++ b/src/m365/planner/commands/plan/plan-list.spec.ts
@@ -11,8 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './plan-list.js';
-import { settingsNames } from '../../../../settingsNames.js';
+import command, { options } from './plan-list.js';
 
 describe(commands.PLAN_LIST, () => {
   const ownerGroupId = '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4';
@@ -114,6 +113,7 @@ describe(commands.PLAN_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -126,6 +126,7 @@ describe(commands.PLAN_LIST, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -147,8 +148,7 @@ describe(commands.PLAN_LIST, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.get,
-      cli.getSettingWithDefaultValue
+      request.get
     ]);
   });
 
@@ -170,72 +170,54 @@ describe(commands.PLAN_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'title', 'createdDateTime', 'owner']);
   });
 
-  it('fails validation if the ownerGroupId is not a valid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        ownerGroupId: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if neither the ownerGroupId nor ownerGroupName nor rosterId are provided.', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
+  it('fails validation if the ownerGroupId is not a valid guid.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      ownerGroupId: 'invalid'
     });
-
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when ownerGroupId, rosterId and ownerGroupName are specified', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
+  it('fails validation if neither the ownerGroupId nor ownerGroupName nor rosterId are provided.', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
+  });
 
-      return defaultValue;
+  it('fails validation when ownerGroupId, rosterId and ownerGroupName are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      ownerGroupId: ownerGroupId,
+      ownerGroupName: ownerGroupName,
+      rosterId: rosterId
     });
-
-    const actual = await command.validate({
-      options: {
-        ownerGroupId: ownerGroupId,
-        ownerGroupName: ownerGroupName,
-        rosterId: rosterId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when valid ownerGroupId specified', async () => {
-    const actual = await command.validate({
-      options: {
-        ownerGroupId: ownerGroupId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid ownerGroupId specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      ownerGroupId: ownerGroupId
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when valid ownerGroupName specified', async () => {
-    const actual = await command.validate({
-      options: {
-        ownerGroupName: ownerGroupName
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid ownerGroupName specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      ownerGroupName: ownerGroupName
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation when valid rosterId specified', async () => {
-    const actual = await command.validate({
-      options: {
-        rosterId: rosterId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid rosterId specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      rosterId: rosterId
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      ownerGroupId: ownerGroupId,
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('correctly list planner plans with given ownerGroupId', async () => {
@@ -247,11 +229,7 @@ describe(commands.PLAN_LIST, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    const options: any = {
-      ownerGroupId: ownerGroupId
-    };
-
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ ownerGroupId: ownerGroupId }) });
     assert(loggerLogSpy.calledWith(formattedResponse));
   });
 
@@ -268,11 +246,7 @@ describe(commands.PLAN_LIST, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    const options: any = {
-      ownerGroupName: ownerGroupName
-    };
-
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ ownerGroupName: ownerGroupName }) });
     assert(loggerLogSpy.calledWith(formattedResponse));
   });
 
@@ -285,11 +259,7 @@ describe(commands.PLAN_LIST, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    const options: any = {
-      rosterId: rosterId
-    };
-
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ rosterId: rosterId }) });
     assert(loggerLogSpy.calledWith(formattedResponse));
   });
 
@@ -306,17 +276,13 @@ describe(commands.PLAN_LIST, () => {
       throw `Invalid request ${opts.url}`;
     });
 
-    const options: any = {
-      ownerGroupId: ownerGroupId
-    };
-
-    await command.action(logger, { options: options } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ ownerGroupId: ownerGroupId }) });
     assert(loggerLogSpy.calledWith([]));
   });
 
   it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').rejects(new Error('An error has occurred.'));
 
-    await assert.rejects(command.action(logger, { options: {} } as any), new CommandError("An error has occurred."));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ ownerGroupId: ownerGroupId }) }), new CommandError("An error has occurred."));
   });
 });

--- a/src/m365/planner/commands/plan/plan-list.ts
+++ b/src/m365/planner/commands/plan/plan-list.ts
@@ -1,19 +1,27 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { planner } from '../../../../utils/planner.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional(),
+  rosterId: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  ownerGroupId?: string;
-  ownerGroupName?: string;
-  rosterId?: string;
 }
 
 class PlannerPlanListCommand extends GraphCommand {
@@ -25,62 +33,23 @@ class PlannerPlanListCommand extends GraphCommand {
     return 'Returns a list of plans associated with a specified group or roster';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: "--ownerGroupId [ownerGroupId]"
-      },
-      {
-        option: "--ownerGroupName [ownerGroupName]"
-      },
-      {
-        option: "--rosterId [rosterId]"
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId)) {
-          return `${args.options.ownerGroupId} is not a valid GUID`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['ownerGroupId', 'ownerGroupName', 'rosterId'] });
-  }
-
-  #initTypes(): void {
-    this.types.string.push('ownerGroupId', 'ownerGroupName', 'rosterId');
-  }
-
   public defaultProperties(): string[] | undefined {
     return ['id', 'title', 'createdDateTime', 'owner'];
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
+  }
+
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.ownerGroupId, opts.ownerGroupName, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId', 'ownerGroupName' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName', 'rosterId']
+        }
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/plan/plan-remove.spec.ts
+++ b/src/m365/planner/commands/plan/plan-remove.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './plan-remove.js';
+import command, { options } from './plan-remove.js';
 
 describe(commands.PLAN_REMOVE, () => {
   const validPlanTitle = 'My Plan';
@@ -51,6 +51,7 @@ describe(commands.PLAN_REMOVE, () => {
   let logger: Logger;
   let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -63,6 +64,7 @@ describe(commands.PLAN_REMOVE, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -108,72 +110,67 @@ describe(commands.PLAN_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation when id and ownerGroupId is specified', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validPlanId,
-        ownerGroupId: validOwnerGroupId
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when id and ownerGroupId is specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validPlanId,
+      ownerGroupId: validOwnerGroupId
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when title is specified with both ownerGroupName and ownerGroupId', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validPlanTitle,
-        ownerGroupId: validOwnerGroupId,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when title is specified with both ownerGroupName and ownerGroupId', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validPlanTitle,
+      ownerGroupId: validOwnerGroupId,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when title is specified without ownerGroupName or ownerGroupId', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validPlanTitle
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when title is specified without ownerGroupName or ownerGroupId', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validPlanTitle
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when title is specified with invalid ownerGroupId', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validPlanTitle,
-        ownerGroupId: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when title is specified with invalid ownerGroupId', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validPlanTitle,
+      ownerGroupId: 'invalid'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with id', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validPlanId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validPlanId,
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with title', async () => {
-    const actual = await command.validate({
-      options: {
-        title: validPlanTitle,
-        ownerGroupName: validOwnerGroupName
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: validPlanId
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('validates for a correct input with title', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: validPlanTitle,
+      ownerGroupName: validOwnerGroupName
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('prompts before removing the specified plan when force option not passed with id', async () => {
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validPlanId
-      }
+      })
     });
-
 
     assert(promptIssued);
   });
@@ -181,9 +178,9 @@ describe(commands.PLAN_REMOVE, () => {
   it('aborts removing the specified plan when force option not passed and prompt not confirmed', async () => {
     const deleteSpy = sinon.spy(request, 'delete');
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validPlanId
-      }
+      })
     });
     assert(deleteSpy.notCalled);
   });
@@ -205,10 +202,10 @@ describe(commands.PLAN_REMOVE, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validPlanId,
         force: true
-      }
+      })
     });
   });
 
@@ -234,10 +231,10 @@ describe(commands.PLAN_REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validPlanTitle,
         ownerGroupName: validOwnerGroupName
-      }
+      })
     });
   });
 
@@ -260,11 +257,11 @@ describe(commands.PLAN_REMOVE, () => {
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: validPlanTitle,
         ownerGroupId: validOwnerGroupId,
         verbose: true
-      }
+      })
     });
   });
 
@@ -273,10 +270,10 @@ describe(commands.PLAN_REMOVE, () => {
     sinon.stub(request, 'delete').rejects(new Error('An error has occurred'));
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validPlanId,
         force: true
-      }
-    }), new CommandError("An error has occurred"));
+      })
+    }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/planner/commands/plan/plan-remove.ts
+++ b/src/m365/planner/commands/plan/plan-remove.ts
@@ -1,7 +1,8 @@
 import { PlannerPlan } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { planner } from '../../../../utils/planner.js';
@@ -9,16 +10,23 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().optional().alias('i'),
+  title: z.string().optional().alias('t'),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional(),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  title?: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
-  force?: boolean;
 }
 
 class PlannerPlanRemoveCommand extends GraphCommand {
@@ -30,79 +38,29 @@ class PlannerPlanRemoveCommand extends GraphCommand {
     return 'Removes the Microsoft Planner plan';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        title: typeof args.options.title !== 'undefined',
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined',
-        force: !!args.options.force
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.id, opts.title].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'id' or 'title'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'title']
+        }
+      })
+      .refine(opts => !opts.title || [opts.ownerGroupId, opts.ownerGroupName].filter(x => x !== undefined).length === 1, {
+        message: `Specify either ownerGroupId or ownerGroupName when using title.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName']
+        }
+      })
+      .refine(opts => !opts.id || (!opts.ownerGroupId && !opts.ownerGroupName), {
+        message: `Don't specify ownerGroupId or ownerGroupName when using id`
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-t, --title [title]'
-      },
-      {
-        option: '--ownerGroupId [ownerGroupId]'
-      },
-      {
-        option: '--ownerGroupName [ownerGroupName]'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.title) {
-          if (!args.options.ownerGroupId && !args.options.ownerGroupName) {
-            return 'Specify either ownerGroupId or ownerGroupName';
-          }
-
-          if (args.options.ownerGroupId && args.options.ownerGroupName) {
-            return 'Specify either ownerGroupId or ownerGroupName but not both';
-          }
-
-          if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId)) {
-            return `${args.options.ownerGroupId} is not a valid GUID`;
-          }
-        }
-        else if (args.options.ownerGroupId || args.options.ownerGroupName) {
-          return 'Don\'t specify ownerGroupId or ownerGroupName when using id';
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({ options: ['id', 'title'] });
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'title', 'ownerGroupId', 'ownerGroupName');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/planner/commands/plan/plan-set.spec.ts
+++ b/src/m365/planner/commands/plan/plan-set.spec.ts
@@ -12,14 +12,14 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './plan-set.js';
-import { settingsNames } from '../../../../settingsNames.js';
+import command, { options } from './plan-set.js';
 
 describe(commands.PLAN_SET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   const id = '2Vf8JHgsBUiIf-nuvBtv-ZgAAYw2';
   const title = 'Plan name';
@@ -37,25 +37,25 @@ describe(commands.PLAN_SET, () => {
   const category25 = 'Urgent';
 
   const userResponse = {
-    "value": [
+    value: [
       {
-        "id": userId,
-        "userPrincipalName": user
+        id: userId,
+        userPrincipalName: user
       }
     ]
   };
 
   const user1Response = {
-    "value": [
+    value: [
       {
-        "id": user1Id,
-        "userPrincipalName": user1
+        id: user1Id,
+        userPrincipalName: user1
       }
     ]
   };
 
   const etagResponse = {
-    "@odata.etag": "TestEtag"
+    '@odata.etag': 'TestEtag'
   };
 
   const singleGroupsResponse = {
@@ -77,41 +77,41 @@ describe(commands.PLAN_SET, () => {
   };
 
   const planResponse = {
-    "id": id,
-    "title": title
+    id: id,
+    title: title
   };
 
   const planDetailsResponse = {
-    "sharedWith": {
-      "00000000-0000-0000-0000-000000000000": true,
-      "00000000-0000-0000-0000-000000000001": true
+    sharedWith: {
+      '00000000-0000-0000-0000-000000000000': true,
+      '00000000-0000-0000-0000-000000000001': true
     },
-    "categoryDescriptions": {
-      "category1": null,
-      "category2": null,
-      "category3": null,
-      "category4": null,
-      "category5": null,
-      "category6": null,
-      "category7": null,
-      "category8": null,
-      "category9": null,
-      "category10": null,
-      "category11": null,
-      "category12": null,
-      "category13": null,
-      "category14": null,
-      "category15": null,
-      "category16": null,
-      "category17": null,
-      "category18": null,
-      "category19": null,
-      "category20": null,
-      "category21": category21,
-      "category22": null,
-      "category23": null,
-      "category24": null,
-      "category25": category25
+    categoryDescriptions: {
+      category1: null,
+      category2: null,
+      category3: null,
+      category4: null,
+      category5: null,
+      category6: null,
+      category7: null,
+      category8: null,
+      category9: null,
+      category10: null,
+      category11: null,
+      category12: null,
+      category13: null,
+      category14: null,
+      category15: null,
+      category16: null,
+      category17: null,
+      category18: null,
+      category19: null,
+      category20: null,
+      category21: category21,
+      category22: null,
+      category23: null,
+      category24: null,
+      category25: category25
     }
   };
 
@@ -131,6 +131,7 @@ describe(commands.PLAN_SET, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -154,8 +155,7 @@ describe(commands.PLAN_SET, () => {
   afterEach(() => {
     sinonUtil.restore([
       request.get,
-      request.patch,
-      cli.getSettingWithDefaultValue
+      request.patch
     ]);
   });
 
@@ -173,128 +173,100 @@ describe(commands.PLAN_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if the ownerGroupId is not a valid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        title: title,
-        ownerGroupId: 'invalid guid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if shareWithUserNames contains invalid user principal name', async () => {
-    const shareWithUserNames = ['john.doe@contoso.com', 'foo'];
-    const actual = await command.validate({
-      options: {
-        title: title,
-        ownerGroupId: ownerGroupId,
-        shareWithUserNames: shareWithUserNames.join(',')
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('fails validation if neither the ownerGroupId nor ownerGroupName are provided when using title.', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
+  it('fails validation if the ownerGroupId is not a valid guid.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title,
+      ownerGroupId: 'invalid guid'
     });
-
-    const actual = await command.validate({
-      options: {
-        title: title
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when both ownerGroupId and ownerGroupName are specified when using title', async () => {
-    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
-      if (settingName === settingsNames.prompt) {
-        return false;
-      }
-
-      return defaultValue;
+  it('fails validation if shareWithUserNames contains invalid user principal name', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title,
+      ownerGroupId: ownerGroupId,
+      shareWithUserNames: 'john.doe@contoso.com,foo'
     });
-
-    const actual = await command.validate({
-      options: {
-        title: title,
-        ownerGroupId: ownerGroupId,
-        ownerGroupName: ownerGroupName
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if shareWithUserIds contains invalid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        title: title,
-        ownerGroupId: ownerGroupId,
-        shareWithUserIds: "invalid guid"
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if neither the ownerGroupId nor ownerGroupName are provided when using title.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when both shareWithUserIds and shareWithUserNames are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: title,
-        ownerGroupId: ownerGroupId,
-        shareWithUserIds: shareWithUserIds,
-        shareWithUserNames: shareWithUserNames
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when both ownerGroupId and ownerGroupName are specified when using title', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title,
+      ownerGroupId: ownerGroupId,
+      ownerGroupName: ownerGroupName
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when invalid category are specified', async () => {
-    const actual = await command.validate({
-      options: {
-        id: id,
-        category27: 'ToDo',
-        category35: 'Urgent'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if shareWithUserIds contains invalid guid.', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title,
+      ownerGroupId: ownerGroupId,
+      shareWithUserIds: 'invalid guid'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when valid title and ownerGroupId specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: title,
-        ownerGroupName: ownerGroupName
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation when both shareWithUserIds and shareWithUserNames are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title,
+      ownerGroupId: ownerGroupId,
+      shareWithUserIds: shareWithUserIds,
+      shareWithUserNames: shareWithUserNames
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when valid title, ownerGroupName, and shareWithUserIds specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: title,
-        ownerGroupId: ownerGroupId,
-        shareWithUserIds: shareWithUserIds
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('fails validation when invalid category are specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: id,
+      category27: 'ToDo',
+      category35: 'Urgent'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation when valid title, ownerGroupName, and validShareWithUserNames specified', async () => {
-    const actual = await command.validate({
-      options: {
-        title: title,
-        ownerGroupId: ownerGroupId,
-        shareWithUserNames: shareWithUserNames
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid title and ownerGroupName specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title,
+      ownerGroupName: ownerGroupName
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation when valid title, ownerGroupId, and shareWithUserIds specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title,
+      ownerGroupId: ownerGroupId,
+      shareWithUserIds: shareWithUserIds
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation when valid title, ownerGroupId, and shareWithUserNames specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      title: title,
+      ownerGroupId: ownerGroupId,
+      shareWithUserNames: shareWithUserNames
+    });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation with category options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      id: id,
+      category21: category21,
+      category25: category25
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('correctly updates planner plan title with given id (debug)', async () => {
@@ -319,11 +291,11 @@ describe(commands.PLAN_SET, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         id: id,
         newTitle: newTitle
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(outputResponse));
@@ -367,11 +339,11 @@ describe(commands.PLAN_SET, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: title,
         ownerGroupName: ownerGroupName,
         shareWithUserNames: shareWithUserNames
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(outputResponse));
@@ -407,17 +379,17 @@ describe(commands.PLAN_SET, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: title,
         ownerGroupId: ownerGroupId,
         shareWithUserIds: shareWithUserIds
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(outputResponse));
   });
 
-  it('correctly updates planner plan shareWithUserIds with given title and rosterId', async () => {
+  it('correctly updates planner plan shareWithUserIds with given rosterId', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/beta/planner/rosters/${rosterId}/plans?$select=id`) {
         return singlePlansResponse;
@@ -443,16 +415,14 @@ describe(commands.PLAN_SET, () => {
     });
 
     await command.action(logger, {
-      options: {
-        title: title,
+      options: commandOptionsSchema.parse({
         rosterId: rosterId,
         shareWithUserIds: shareWithUserIds
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(outputResponse));
   });
-
 
   it('correctly updates planner plan categories with given id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
@@ -476,12 +446,12 @@ describe(commands.PLAN_SET, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         id: id,
         category21: category21,
         category25: category25
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(outputResponse));
@@ -521,17 +491,22 @@ describe(commands.PLAN_SET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         title: title,
         ownerGroupName: ownerGroupName,
         shareWithUserNames: shareWithUserNames
-      }
+      })
     }), new CommandError(`Cannot proceed with planner plan creation. The following users provided are invalid: ${user1}`));
   });
 
   it('correctly handles API OData error', async () => {
     sinon.stub(request, 'get').rejects(new Error('An error has occurred.'));
 
-    await assert.rejects(command.action(logger, { options: {} }), new CommandError('An error has occurred.'));
+    await assert.rejects(command.action(logger, {
+      options: commandOptionsSchema.parse({
+        id: id,
+        newTitle: newTitle
+      })
+    }), new CommandError('An error has occurred.'));
   });
 });

--- a/src/m365/planner/commands/plan/plan-set.spec.ts
+++ b/src/m365/planner/commands/plan/plan-set.spec.ts
@@ -173,6 +173,11 @@ describe(commands.PLAN_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('allows unknown options', () => {
+    const allowUnknownOptions = command.allowUnknownOptions();
+    assert.strictEqual(allowUnknownOptions, true);
+  });
+
   it('fails validation if the ownerGroupId is not a valid guid.', () => {
     const actual = commandOptionsSchema.safeParse({
       title: title,

--- a/src/m365/planner/commands/plan/plan-set.ts
+++ b/src/m365/planner/commands/plan/plan-set.ts
@@ -1,6 +1,7 @@
 import { PlannerPlan, PlannerPlanDetails, User } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
@@ -9,19 +10,34 @@ import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.object({
+  ...globalOptionsZod.shape,
+  id: z.string().optional().alias('i'),
+  title: z.string().optional().alias('t'),
+  ownerGroupId: z.string()
+    .refine(val => validation.isValidGuid(val), {
+      message: 'The value is not a valid GUID.'
+    })
+    .optional(),
+  ownerGroupName: z.string().optional(),
+  rosterId: z.string().optional(),
+  newTitle: z.string().optional(),
+  shareWithUserIds: z.string()
+    .refine(val => validation.isValidGuidArray(val) === true, {
+      message: 'The value contains invalid GUIDs.'
+    })
+    .optional(),
+  shareWithUserNames: z.string()
+    .refine(val => validation.isValidUserPrincipalNameArray(val) === true, {
+      message: 'The value contains invalid user principal names.'
+    })
+    .optional()
+}).catchall(z.unknown());
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  title?: string;
-  ownerGroupId?: string;
-  ownerGroupName?: string;
-  rosterId?: string;
-  newTitle?: string;
-  shareWithUserIds?: string;
-  shareWithUserNames?: string;
 }
 
 class PlannerPlanSetCommand extends GraphCommand {
@@ -33,146 +49,40 @@ class PlannerPlanSetCommand extends GraphCommand {
     return 'Updates a Microsoft Planner plan';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        title: typeof args.options.title !== 'undefined',
-        ownerGroupId: typeof args.options.ownerGroupId !== 'undefined',
-        ownerGroupName: typeof args.options.ownerGroupName !== 'undefined',
-        rosterId: typeof args.options.rosterId !== 'undefined',
-        newTitle: typeof args.options.newTitle !== 'undefined',
-        shareWithUserIds: typeof args.options.shareWithUserIds !== 'undefined',
-        shareWithUserNames: typeof args.options.shareWithUserNames !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => [opts.id, opts.title, opts.rosterId].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'id', 'title' or 'rosterId'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'title', 'rosterId']
+        }
+      })
+      .refine(opts => !opts.title || [opts.ownerGroupId, opts.ownerGroupName].filter(x => x !== undefined).length === 1, {
+        message: `Specify exactly one of the following options: 'ownerGroupId' or 'ownerGroupName'.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerGroupId', 'ownerGroupName']
+        }
+      })
+      .refine(opts => !opts.shareWithUserIds || !opts.shareWithUserNames, {
+        message: 'Specify either shareWithUserIds or shareWithUserNames but not both'
+      })
+      .refine(opts => {
+        const allowedCategories: string[] = Array.from({ length: 25 }, (_, i) => `category${i + 1}`);
+        const keys = Object.keys(opts);
+        const hasCategoryKey = keys.some(key => key.indexOf('category') !== -1);
+        if (!hasCategoryKey) {
+          return true;
+        }
+        return keys.filter(key => key.indexOf('category') !== -1).every(key => allowedCategories.indexOf(key) !== -1);
+      }, {
+        message: 'Specify category values between category1 to category25'
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-t, --title [title]'
-      },
-      {
-        option: '--ownerGroupId [ownerGroupId]'
-      },
-      {
-        option: '--ownerGroupName [ownerGroupName]'
-      },
-      {
-        option: '--rosterId [rosterId]'
-      },
-      {
-        option: '--newTitle [newTitle]'
-      },
-      {
-        option: '--shareWithUserIds [shareWithUserIds]'
-      },
-      {
-        option: '--shareWithUserNames [shareWithUserNames]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.title) {
-          if (args.options.ownerGroupId && !validation.isValidGuid(args.options.ownerGroupId as string)) {
-            return `${args.options.ownerGroupId} is not a valid GUID`;
-          }
-        }
-
-        if (args.options.shareWithUserIds && args.options.shareWithUserNames) {
-          return 'Specify either shareWithUserIds or shareWithUserNames but not both';
-        }
-
-        if (args.options.shareWithUserIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.shareWithUserIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for the option 'shareWithUserIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if (args.options.shareWithUserNames) {
-          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.shareWithUserNames);
-          if (isValidUPNArrayResult !== true) {
-            return `The following user principal names are invalid for the option 'shareWithUserNames': ${isValidUPNArrayResult}.`;
-          }
-        }
-
-        const allowedCategories: string[] = [
-          'category1',
-          'category2',
-          'category3',
-          'category4',
-          'category5',
-          'category6',
-          'category7',
-          'category8',
-          'category9',
-          'category10',
-          'category11',
-          'category12',
-          'category13',
-          'category14',
-          'category15',
-          'category16',
-          'category17',
-          'category18',
-          'category19',
-          'category20',
-          'category21',
-          'category22',
-          'category23',
-          'category24',
-          'category25'
-        ];
-
-        let invalidCategoryOptions: boolean = false;
-        Object.keys(args.options).forEach(key => {
-          if (key.indexOf('category') !== -1 && allowedCategories.indexOf(key) === -1) {
-            invalidCategoryOptions = true;
-          }
-        });
-
-        if (invalidCategoryOptions) {
-          return 'Specify category values between category1 to category25';
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      {
-        options: ['id', 'title', 'rosterId']
-      },
-      {
-        options: ['ownerGroupId', 'ownerGroupName'],
-        runsWhen: (args) => {
-          return args.options.title !== undefined;
-        }
-      });
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'title', 'ownerGroupId', 'ownerGroupName', 'rosterId', 'newTitle', 'shareWithUserIds', 'shareWithUserNames');
   }
 
   public allowUnknownOptions(): boolean | undefined {
@@ -299,7 +209,7 @@ class PlannerPlanSetCommand extends GraphCommand {
 
     Object.keys(options).forEach(key => {
       if (key.indexOf('category') !== -1) {
-        categories[key] = options[key];
+        categories[key] = (options as any)[key];
         categoriesCount++;
       }
     });

--- a/src/m365/planner/commands/tenant/tenant-settings-set.spec.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-set.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './tenant-settings-set.js';
+import command, { options } from './tenant-settings-set.js';
 
 describe(commands.TENANT_SETTINGS_SET, () => {
   const successResponse = {
@@ -28,6 +28,7 @@ describe(commands.TENANT_SETTINGS_SET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -36,6 +37,7 @@ describe(commands.TENANT_SETTINGS_SET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -73,23 +75,26 @@ describe(commands.TENANT_SETTINGS_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation no options are specified', async () => {
-    const actual = await command.validate({
-      options: {}
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      isPlannerAllowed: true,
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
+  it('fails validation when no options specified', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
+  });
 
-  it('passes validation when valid options specified', async () => {
-    const actual = await command.validate({
-      options: {
-        isPlannerAllowed: 'true',
-        allowCalendarSharing: 'false',
-        allowPlannerMobilePushNotifications: 'false'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation when valid options specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      isPlannerAllowed: true,
+      allowCalendarSharing: false,
+      allowPlannerMobilePushNotifications: false
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('successfully updates tenant planner settings', async () => {
@@ -102,9 +107,9 @@ describe(commands.TENANT_SETTINGS_SET, () => {
     });
 
     await command.action(logger, {
-      options: {
-        isPlannerAllowed: 'true'
-      }
+      options: commandOptionsSchema.parse({
+        isPlannerAllowed: true
+      })
     });
     assert(loggerLogSpy.calledWith(successResponse));
   });
@@ -119,9 +124,9 @@ describe(commands.TENANT_SETTINGS_SET, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
-        isPlannerAllowed: 'true'
-      }
+      options: commandOptionsSchema.parse({
+        isPlannerAllowed: true
+      })
     }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/planner/commands/tenant/tenant-settings-set.ts
+++ b/src/m365/planner/commands/tenant/tenant-settings-set.ts
@@ -1,20 +1,24 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import PlannerCommand from '../../../base/PlannerCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  isPlannerAllowed: z.boolean().optional(),
+  allowCalendarSharing: z.boolean().optional(),
+  allowTenantMoveWithDataLoss: z.boolean().optional(),
+  allowTenantMoveWithDataMigration: z.boolean().optional(),
+  allowRosterCreation: z.boolean().optional(),
+  allowPlannerMobilePushNotifications: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  isPlannerAllowed?: boolean;
-  allowCalendarSharing?: boolean;
-  allowTenantMoveWithDataLoss?: boolean;
-  allowTenantMoveWithDataMigration?: boolean;
-  allowRosterCreation?: boolean;
-  allowPlannerMobilePushNotifications?: boolean;
 }
 
 class PlannerTenantSettingsSetCommand extends PlannerCommand {
@@ -26,83 +30,18 @@ class PlannerTenantSettingsSetCommand extends PlannerCommand {
     return 'Sets Microsoft Planner configuration of the tenant';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initTypes();
-    this.#initValidators();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        isPlannerAllowed: typeof args.options.isPlannerAllowed !== 'undefined',
-        allowCalendarSharing: typeof args.options.allowCalendarSharing !== 'undefined',
-        allowTenantMoveWithDataLoss: typeof args.options.allowTenantMoveWithDataLoss !== 'undefined',
-        allowTenantMoveWithDataMigration: typeof args.options.allowTenantMoveWithDataMigration !== 'undefined',
-        allowRosterCreation: typeof args.options.allowRosterCreation !== 'undefined',
-        allowPlannerMobilePushNotifications: typeof args.options.allowPlannerMobilePushNotifications !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--isPlannerAllowed [isPlannerAllowed]',
-        autocomplete: ['true', 'false']
-      },
-      {
-        option: '--allowCalendarSharing [allowCalendarSharing]',
-        autocomplete: ['true', 'false']
-      },
-      {
-        option: '--allowTenantMoveWithDataLoss [allowTenantMoveWithDataLoss]',
-        autocomplete: ['true', 'false']
-      },
-      {
-        option: '--allowTenantMoveWithDataMigration [allowTenantMoveWithDataMigration]',
-        autocomplete: ['true', 'false']
-      },
-      {
-        option: '--allowRosterCreation [allowRosterCreation]',
-        autocomplete: ['true', 'false']
-      },
-      {
-        option: '--allowPlannerMobilePushNotifications [allowPlannerMobilePushNotifications]',
-        autocomplete: ['true', 'false']
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.boolean.push(
-      'isPlannerAllowed',
-      'allowCalendarSharing',
-      'allowTenantMoveWithDataLoss',
-      'allowTenantMoveWithDataMigration',
-      'allowRosterCreation',
-      'allowPlannerMobilePushNotifications'
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        const optionsArray = [
-          args.options.isPlannerAllowed, args.options.allowCalendarSharing, args.options.allowTenantMoveWithDataLoss,
-          args.options.allowTenantMoveWithDataMigration, args.options.allowRosterCreation, args.options.allowPlannerMobilePushNotifications
-        ];
-
-        if (optionsArray.every(o => typeof o === 'undefined')) {
-          return 'You must specify at least one option';
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine(opts => opts.isPlannerAllowed !== undefined || opts.allowCalendarSharing !== undefined || opts.allowTenantMoveWithDataLoss !== undefined || opts.allowTenantMoveWithDataMigration !== undefined || opts.allowRosterCreation !== undefined || opts.allowPlannerMobilePushNotifications !== undefined, {
+        message: 'You must specify at least one option',
+        params: {
+          customCode: 'required'
         }
-
-        return true;
-      }
-    );
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {


### PR DESCRIPTION
## What's in this PR?

Migrates the following commands from the legacy `initOptions`/`initValidators`/`initTelemetry` pattern to Zod schema validation:

- `planner bucket add`
- `planner bucket get`
- `planner bucket list`
- `planner bucket remove`
- `planner bucket set`
- `planner plan add`
- `planner plan get`
- `planner plan list`
- `planner plan remove`
- `planner plan set`
- `planner tenant settings set`

Closes #7311

## Changes

- Replaced legacy `#initOptions()`, `#initValidators()`, `#initTelemetry()`, `#initTypes()`, `#initOptionSets()` with exported Zod `options` schemas
- Added `schema` getter and `getRefinedSchema()` for cross-field validation (option sets, conditional requirements)
- Updated all test files to use `safeParse()` for validation tests and `parse()` for action tests
- Added unknown-options validation tests where applicable
- Net reduction of ~650 lines of boilerplate code