### PR TITLE
Migrate onenote commands to Zod

### DIFF
--- a/src/m365/onenote/commands/notebook/notebook-add.spec.ts
+++ b/src/m365/onenote/commands/notebook/notebook-add.spec.ts
@@ -137,6 +137,11 @@ describe(commands.NOTEBOOK_ADD, () => {
     assert.strictEqual(actual.success, true);
   });
 
+  it('fails validation if multiple targeting options are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ name: name, userId: '2609af39-7775-4f94-a3dc-0dd67657e900', groupId: '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('enforces the user to use delegated permissions', async () => {
     sinon.stub(request, 'post').resolves();
 

--- a/src/m365/onenote/commands/notebook/notebook-add.spec.ts
+++ b/src/m365/onenote/commands/notebook/notebook-add.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './notebook-add.js';
+import command, { options } from './notebook-add.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { spo } from '../../../../utils/spo.js';
 import { accessToken } from '../../../../utils/accessToken.js';
@@ -56,6 +56,7 @@ describe(commands.NOTEBOOK_ADD, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let accessTokenStub: sinon.SinonStub;
 
   before(() => {
@@ -65,6 +66,7 @@ describe(commands.NOTEBOOK_ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -104,35 +106,35 @@ describe(commands.NOTEBOOK_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if name contains invalid characters', async () => {
-    const actual = await command.validate({ options: { name: 'My notebook /' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if name contains invalid characters', () => {
+    const actual = commandOptionsSchema.safeParse({ name: 'My notebook /' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if name is longer than 128 characters', async () => {
+  it('fails validation if name is longer than 128 characters', () => {
     const longString = 'x'.repeat(129);
-    const actual = await command.validate({ options: { name: longString } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ name: longString });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if webUrl is not a valid webUrl', async () => {
-    const actual = await command.validate({ options: { name: name, webUrl: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if webUrl is not a valid webUrl', () => {
+    const actual = commandOptionsSchema.safeParse({ name: name, webUrl: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { name: name, userId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ name: name, userId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the groupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { name: name, groupId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the groupId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ name: name, groupId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if no option but name specified', async () => {
-    const actual = await command.validate({ options: { name: name } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if no option but name specified', () => {
+    const actual = commandOptionsSchema.safeParse({ name: name });
+    assert.strictEqual(actual.success, true);
   });
 
   it('enforces the user to use delegated permissions', async () => {

--- a/src/m365/onenote/commands/notebook/notebook-add.spec.ts
+++ b/src/m365/onenote/commands/notebook/notebook-add.spec.ts
@@ -145,7 +145,7 @@ describe(commands.NOTEBOOK_ADD, () => {
   it('enforces the user to use delegated permissions', async () => {
     sinon.stub(request, 'post').resolves();
 
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: name }) });
     assert(accessTokenStub.calledOnceWithExactly('delegated'));
   });
 
@@ -158,7 +158,7 @@ describe(commands.NOTEBOOK_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: name, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: name, verbose: true }) });
     assert(loggerLogSpy.calledWith(addResponse));
   });
 
@@ -172,7 +172,7 @@ describe(commands.NOTEBOOK_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: name, userId: userId, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: name, userId: userId, verbose: true }) });
     assert(loggerLogSpy.calledWith(addResponse));
   });
 
@@ -186,7 +186,7 @@ describe(commands.NOTEBOOK_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: name, groupId: groupId, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: name, groupId: groupId, verbose: true }) });
     assert(loggerLogSpy.calledWith(addResponse));
   });
 
@@ -202,7 +202,7 @@ describe(commands.NOTEBOOK_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: name, groupName: groupName, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: name, groupName: groupName, verbose: true }) });
     assert(loggerLogSpy.calledWith(addResponse));
   });
 
@@ -220,7 +220,7 @@ describe(commands.NOTEBOOK_ADD, () => {
 
     sinon.stub(spo, 'getSpoGraphSiteId').resolves(siteId);
 
-    await command.action(logger, { options: { name: name, webUrl: siteUrl, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: name, webUrl: siteUrl, verbose: true }) });
     assert(loggerLogSpy.calledWith(addResponse));
   });
 
@@ -235,7 +235,7 @@ describe(commands.NOTEBOOK_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { name: name, userName: userName, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ name: name, userName: userName, verbose: true }) });
     assert(loggerLogSpy.calledWith(addResponse));
   });
 
@@ -260,6 +260,6 @@ describe(commands.NOTEBOOK_ADD, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { name: name, verbose: true } } as any), new CommandError(error.error.message));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ name: name, verbose: true }) } as any), new CommandError(error.error.message));
   });
 });

--- a/src/m365/onenote/commands/notebook/notebook-add.ts
+++ b/src/m365/onenote/commands/notebook/notebook-add.ts
@@ -1,5 +1,6 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { validation } from '../../../../utils/validation.js';
@@ -8,17 +9,32 @@ import { spo } from '../../../../utils/spo.js';
 import GraphDelegatedCommand from '../../../base/GraphDelegatedCommand.js';
 import { formatting } from '../../../../utils/formatting.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  name: z.string()
+    .refine(name => name.length <= 128, {
+      error: 'The specified name is too long. It should be less than 128 characters.'
+    })
+    .refine(name => !/[?*/:<>|'"]/.test(name), {
+      error: `The specified name contains invalid characters. It cannot contain ?*/:<>|'". Please remove them and try again.`
+    }).alias('n'),
+  userId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
+  userName: z.string().optional(),
+  groupId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
+  groupName: z.string().optional(),
+  webUrl: z.string().refine(url => validation.isValidSharePointUrl(url) === true, {
+    error: e => `'${e.input}' is not a valid SharePoint Online site URL.`
+  }).optional().alias('u')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  name: string;
-  userId?: string;
-  userName?: string;
-  groupId?: string;
-  groupName?: string;
-  webUrl?: string;
 }
 
 class OneNoteNotebookAddCommand extends GraphDelegatedCommand {
@@ -30,87 +46,19 @@ class OneNoteNotebookAddCommand extends GraphDelegatedCommand {
     return 'Create a new OneNote notebook';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined',
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined',
-        webUrl: typeof args.options.webUrl !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => {
+        const opts = [options.userId, options.userName, options.groupId, options.groupName, options.webUrl];
+        const defined = opts.filter(item => item !== undefined);
+        return defined.length <= 1;
+      }, {
+        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.'
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --name <name>'
-      },
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      },
-      {
-        option: '--groupId [groupId]'
-      },
-      {
-        option: '--groupName [groupName]'
-      },
-      {
-        option: '-u, --webUrl [webUrl]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        // check name for invalid characters
-        if (args.options.name.length > 128) {
-          return 'The specified name is too long. It should be less than 128 characters';
-        }
-
-        if (/[?*/:<>|'"]/.test(args.options.name)) {
-          return `The specified name contains invalid characters. It cannot contain ?*/:<>|'". Please remove them and try again.`;
-        }
-
-        if (args.options.userId && !validation.isValidGuid(args.options.userId as string)) {
-          return `${args.options.userId} is not a valid GUID`;
-        }
-
-        if (args.options.groupId && !validation.isValidGuid(args.options.groupId as string)) {
-          return `${args.options.groupId} is not a valid GUID`;
-        }
-
-        if (args.options.webUrl) {
-          return validation.isValidSharePointUrl(args.options.webUrl);
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({
-      options: ['userId', 'userName', 'groupId', 'groupName', 'webUrl'],
-      runsWhen: (args) => {
-        const options = [args.options.userId, args.options.userName, args.options.groupId, args.options.groupName, args.options.webUrl];
-        return options.some(item => item !== undefined);
-      }
-    });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/onenote/commands/notebook/notebook-add.ts
+++ b/src/m365/onenote/commands/notebook/notebook-add.ts
@@ -13,7 +13,7 @@ export const options = z.strictObject({
   ...globalOptionsZod.shape,
   name: z.string()
     .refine(name => name.length <= 128, {
-      error: 'The specified name is too long. It should be less than 128 characters.'
+      error: 'The specified name is too long. It should be at most 128 characters.'
     })
     .refine(name => !/[?*/:<>|'"]/.test(name), {
       error: `The specified name contains invalid characters. It cannot contain ?*/:<>|'". Please remove them and try again.`
@@ -57,7 +57,11 @@ class OneNoteNotebookAddCommand extends GraphDelegatedCommand {
         const defined = opts.filter(item => item !== undefined);
         return defined.length <= 1;
       }, {
-        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.'
+        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.',
+        params: {
+          customCode: 'optionSet',
+          options: ['userId', 'userName', 'groupId', 'groupName', 'webUrl']
+        }
       });
   }
 

--- a/src/m365/onenote/commands/notebook/notebook-list.spec.ts
+++ b/src/m365/onenote/commands/notebook/notebook-list.spec.ts
@@ -94,6 +94,11 @@ describe(commands.NOTEBOOK_LIST, () => {
     assert.strictEqual(actual.success, true);
   });
 
+  it('fails validation if multiple targeting options are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: '2609af39-7775-4f94-a3dc-0dd67657e900', groupId: '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('enforces the user to use delegated permissions', async () => {
     sinon.stub(request, 'get').resolves([]);
 

--- a/src/m365/onenote/commands/notebook/notebook-list.spec.ts
+++ b/src/m365/onenote/commands/notebook/notebook-list.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './notebook-list.js';
+import command, { options } from './notebook-list.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import { formatting } from '../../../../utils/formatting.js';
 
@@ -20,6 +20,7 @@ describe(commands.NOTEBOOK_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let accessTokenStub: sinon.SinonStub;
 
   before(() => {
@@ -29,6 +30,7 @@ describe(commands.NOTEBOOK_LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -72,29 +74,24 @@ describe(commands.NOTEBOOK_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['createdDateTime', 'displayName', 'id']);
   });
 
-  it('fails validation if webUrl is not a valid webUrl', async () => {
-    const actual = await command.validate({
-      options:
-      {
-        webUrl: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if webUrl is not a valid webUrl', () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { userId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the groupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the groupId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ groupId: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if no option specified', async () => {
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if no option specified', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, true);
   });
 
   it('enforces the user to use delegated permissions', async () => {

--- a/src/m365/onenote/commands/notebook/notebook-list.spec.ts
+++ b/src/m365/onenote/commands/notebook/notebook-list.spec.ts
@@ -102,7 +102,7 @@ describe(commands.NOTEBOOK_LIST, () => {
   it('enforces the user to use delegated permissions', async () => {
     sinon.stub(request, 'get').resolves([]);
 
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: commandOptionsSchema.parse({}) });
     assert(accessTokenStub.calledOnceWithExactly('delegated'));
   });
 
@@ -130,7 +130,7 @@ describe(commands.NOTEBOOK_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true }) });
     assert(loggerLogSpy.calledWith([
       {
         "id": "1-99a44a87-c92f-495a-8295-3ab308387821",
@@ -171,7 +171,7 @@ describe(commands.NOTEBOOK_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userId: '2609af39-7775-4f94-a3dc-0dd67657e900' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userId: '2609af39-7775-4f94-a3dc-0dd67657e900' }) });
     assert(loggerLogSpy.calledWith([
       {
         "id": "1-99a44a87-c92f-495a-8295-3ab308387821",
@@ -212,7 +212,7 @@ describe(commands.NOTEBOOK_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: '233e43d0-dc6a-482e-9b4e-0de7a7bce9b4' }) });
     assert(loggerLogSpy.calledWith([
       {
         "id": "1-99a44a87-c92f-495a-8295-3ab308387821",
@@ -238,7 +238,7 @@ describe(commands.NOTEBOOK_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { groupName: 'MyGroup' } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'MyGroup' }) } as any), new CommandError('An error has occurred'));
   });
 
   it('lists Microsoft OneNote notebooks in group by name', async () => {
@@ -277,7 +277,7 @@ describe(commands.NOTEBOOK_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupName: 'MyGroup' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'MyGroup' }) });
     assert(loggerLogSpy.calledWith([
       {
         "id": "1-99a44a87-c92f-495a-8295-3ab308387821",
@@ -303,7 +303,7 @@ describe(commands.NOTEBOOK_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/testsite' } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ webUrl: 'https://contoso.sharepoint.com/sites/testsite' }) } as any), new CommandError('An error has occurred'));
   });
 
   it('lists Microsoft OneNote notebooks for site', async () => {
@@ -345,7 +345,7 @@ describe(commands.NOTEBOOK_LIST, () => {
         throw 'Invalid request';
       });
 
-    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com/sites/testsite', debug: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ webUrl: 'https://contoso.sharepoint.com/sites/testsite', debug: true }) });
     assert(loggerLogSpy.calledWith([
       {
         "id": "1-99a44a87-c92f-495a-8295-3ab308387821",
@@ -386,7 +386,7 @@ describe(commands.NOTEBOOK_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userName: 'user1@contoso.onmicrosoft.com' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userName: 'user1@contoso.onmicrosoft.com' }) });
     assert(loggerLogSpy.calledWith([
       {
         "id": "1-99a44a87-c92f-495a-8295-3ab308387821",

--- a/src/m365/onenote/commands/notebook/notebook-list.ts
+++ b/src/m365/onenote/commands/notebook/notebook-list.ts
@@ -51,7 +51,11 @@ class OneNoteNotebookListCommand extends GraphDelegatedCommand {
         const defined = opts.filter(item => item !== undefined);
         return defined.length <= 1;
       }, {
-        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.'
+        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.',
+        params: {
+          customCode: 'optionSet',
+          options: ['userId', 'userName', 'groupId', 'groupName', 'webUrl']
+        }
       });
   }
 

--- a/src/m365/onenote/commands/notebook/notebook-list.ts
+++ b/src/m365/onenote/commands/notebook/notebook-list.ts
@@ -1,6 +1,7 @@
 import { Notebook } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { odata } from '../../../../utils/odata.js';
 import { validation } from '../../../../utils/validation.js';
@@ -9,16 +10,25 @@ import { formatting } from '../../../../utils/formatting.js';
 import GraphDelegatedCommand from '../../../base/GraphDelegatedCommand.js';
 import { spo } from '../../../../utils/spo.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  userId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
+  userName: z.string().optional(),
+  groupId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
+  groupName: z.string().optional(),
+  webUrl: z.string().refine(url => validation.isValidSharePointUrl(url) === true, {
+    error: e => `'${e.input}' is not a valid SharePoint Online site URL.`
+  }).optional().alias('u')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  userId?: string;
-  userName?: string;
-  groupId?: string;
-  groupName?: string;
-  webUrl?: string;
 }
 
 class OneNoteNotebookListCommand extends GraphDelegatedCommand {
@@ -30,69 +40,23 @@ class OneNoteNotebookListCommand extends GraphDelegatedCommand {
     return 'Retrieve a list of notebooks';
   }
 
+  public get schema(): z.ZodType | undefined {
+    return options;
+  }
+
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => {
+        const opts = [options.userId, options.userName, options.groupId, options.groupName, options.webUrl];
+        const defined = opts.filter(item => item !== undefined);
+        return defined.length <= 1;
+      }, {
+        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.'
+      });
+  }
+
   public defaultProperties(): string[] | undefined {
     return ['createdDateTime', 'displayName', 'id'];
-  }
-
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined',
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined',
-        webUrl: typeof args.options.webUrl !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      { option: '--userId [userId]' },
-      { option: '--userName [userName]' },
-      { option: '--groupId [groupId]' },
-      { option: '--groupName [groupName]' },
-      { option: '-u, --webUrl [webUrl]' }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.userId && !validation.isValidGuid(args.options.userId as string)) {
-          return `${args.options.userId} is not a valid GUID`;
-        }
-
-        if (args.options.groupId && !validation.isValidGuid(args.options.groupId as string)) {
-          return `${args.options.groupId} is not a valid GUID`;
-        }
-
-        if (args.options.webUrl) {
-          return validation.isValidSharePointUrl(args.options.webUrl);
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({
-      options: ['userId', 'userName', 'groupId', 'groupName', 'webUrl'],
-      runsWhen: (args) => {
-        const options = [args.options.userId, args.options.userName, args.options.groupId, args.options.groupName, args.options.webUrl];
-        return options.some(item => item !== undefined);
-      }
-    });
   }
 
   private async getEndpointUrl(args: CommandArgs): Promise<string> {
@@ -108,8 +72,8 @@ class OneNoteNotebookListCommand extends GraphDelegatedCommand {
       endpoint += `groups/${args.options.groupId}`;
     }
     else if (args.options.groupName) {
-      const groupId = await this.getGroupId(args.options.groupName);
-      endpoint += `groups/${groupId}`;
+      const group = await entraGroup.getGroupByDisplayName(args.options.groupName);
+      endpoint += `groups/${group.id!}`;
     }
     else if (args.options.webUrl) {
       const siteId = await spo.getSpoGraphSiteId(args.options.webUrl);
@@ -120,11 +84,6 @@ class OneNoteNotebookListCommand extends GraphDelegatedCommand {
     }
     endpoint += '/onenote/notebooks';
     return endpoint;
-  }
-
-  private async getGroupId(groupName: string): Promise<string> {
-    const group = await entraGroup.getGroupByDisplayName(groupName);
-    return group.id!;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/onenote/commands/page/page-list.spec.ts
+++ b/src/m365/onenote/commands/page/page-list.spec.ts
@@ -171,7 +171,7 @@ describe(commands.PAGE_LIST, () => {
   it('enforces the user to use delegated permissions', async () => {
     sinon.stub(odata, 'getAllItems').resolves([]);
 
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: commandOptionsSchema.parse({}) });
     assert(accessTokenStub.calledOnceWithExactly('delegated'));
   });
 
@@ -183,7 +183,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true }) });
     assert(loggerLogSpy.calledWith(pageResponse.value));
   });
 
@@ -195,7 +195,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userId: userId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userId: userId }) });
     assert(loggerLogSpy.calledWith(pageResponse.value));
   });
 
@@ -207,7 +207,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userName: userName }) });
     assert(loggerLogSpy.calledWith(pageResponse.value));
   });
 
@@ -219,7 +219,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId }) });
     assert(loggerLogSpy.calledWith(pageResponse.value));
   });
 
@@ -238,7 +238,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupName: groupName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: groupName }) });
     assert(loggerLogSpy.calledWith(pageResponse.value));
   });
 
@@ -258,7 +258,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ webUrl: webUrl }) });
     assert(loggerLogSpy.calledWith(pageResponse.value));
   });
 
@@ -282,7 +282,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { webUrl: webUrl } } as any), new CommandError('Requested site could not be found'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ webUrl: webUrl }) } as any), new CommandError('Requested site could not be found'));
   });
 
   it('throws error if group by displayName returns no results', async () => {
@@ -293,7 +293,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { groupName: groupName } } as any), new CommandError(`The specified group '${groupName}' does not exist.`));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ groupName: groupName }) } as any), new CommandError(`The specified group '${groupName}' does not exist.`));
   });
 
   it('throws an error if group by displayName returns multiple results', async () => {
@@ -313,7 +313,7 @@ describe(commands.PAGE_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { groupName: groupName } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ groupName: groupName }) }),
       new CommandError("Multiple groups with name 'Dummy Group A' found. Found: bba4c915-0ac8-47a1-bd05-087a44c92d3b, 9f3c2c36-1682-4922-9ae1-f57d2caf0de1."));
   });
 });

--- a/src/m365/onenote/commands/page/page-list.spec.ts
+++ b/src/m365/onenote/commands/page/page-list.spec.ts
@@ -13,7 +13,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './page-list.js';
+import command, { options } from './page-list.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import { settingsNames } from '../../../../settingsNames.js';
 
@@ -77,6 +77,7 @@ describe(commands.PAGE_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let accessTokenStub: sinon.SinonStub;
 
   before(() => {
@@ -86,6 +87,7 @@ describe(commands.PAGE_LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
     sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName: string, defaultValue: any) => settingName === settingsNames.prompt ? false : defaultValue);
   });
 
@@ -131,34 +133,34 @@ describe(commands.PAGE_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['createdDateTime', 'title', 'id']);
   });
 
-  it('fails validation if the userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { userId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if the groupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if the groupId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ groupId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if webUrl is not a valid SharePoint URL', async () => {
-    const actual = await command.validate({ options: { webUrl: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if webUrl is not a valid SharePoint URL', () => {
+    const actual = commandOptionsSchema.safeParse({ webUrl: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if the groupId is a valid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: groupId } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if the groupId is a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation if the userId is a valid GUID', async () => {
-    const actual = await command.validate({ options: { userId: userId } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if the userId is a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: userId });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation if no option specified', async () => {
-    const actual = await command.validate({ options: {} }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if no option specified', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, true);
   });
 
   it('enforces the user to use delegated permissions', async () => {

--- a/src/m365/onenote/commands/page/page-list.spec.ts
+++ b/src/m365/onenote/commands/page/page-list.spec.ts
@@ -163,6 +163,11 @@ describe(commands.PAGE_LIST, () => {
     assert.strictEqual(actual.success, true);
   });
 
+  it('fails validation if multiple targeting options are specified', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: '0e38b3b3-d9ac-42fa-81db-437ac8caec2f', groupId: 'bba4c915-0ac8-47a1-bd05-087a44c92d3b' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('enforces the user to use delegated permissions', async () => {
     sinon.stub(odata, 'getAllItems').resolves([]);
 

--- a/src/m365/onenote/commands/page/page-list.ts
+++ b/src/m365/onenote/commands/page/page-list.ts
@@ -51,7 +51,11 @@ class OneNotePageListCommand extends GraphDelegatedCommand {
         const defined = opts.filter(item => item !== undefined);
         return defined.length <= 1;
       }, {
-        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.'
+        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.',
+        params: {
+          customCode: 'optionSet',
+          options: ['userId', 'userName', 'groupId', 'groupName', 'webUrl']
+        }
       });
   }
 

--- a/src/m365/onenote/commands/page/page-list.ts
+++ b/src/m365/onenote/commands/page/page-list.ts
@@ -1,6 +1,7 @@
 import { OnenotePage } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { odata } from '../../../../utils/odata.js';
 import { spo } from '../../../../utils/spo.js';
@@ -9,16 +10,25 @@ import commands from '../../commands.js';
 import GraphDelegatedCommand from '../../../base/GraphDelegatedCommand.js';
 import { formatting } from '../../../../utils/formatting.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  userId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
+  userName: z.string().optional(),
+  groupId: z.string().refine(id => validation.isValidGuid(id), {
+    error: e => `'${e.input}' is not a valid GUID.`
+  }).optional(),
+  groupName: z.string().optional(),
+  webUrl: z.string().refine(url => validation.isValidSharePointUrl(url) === true, {
+    error: e => `'${e.input}' is not a valid SharePoint Online site URL.`
+  }).optional().alias('u')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  userId?: string;
-  userName?: string;
-  groupId?: string;
-  groupName?: string;
-  webUrl?: string;
 }
 
 class OneNotePageListCommand extends GraphDelegatedCommand {
@@ -30,69 +40,23 @@ class OneNotePageListCommand extends GraphDelegatedCommand {
     return 'Retrieve a list of OneNote pages.';
   }
 
+  public get schema(): z.ZodType | undefined {
+    return options;
+  }
+
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => {
+        const opts = [options.userId, options.userName, options.groupId, options.groupName, options.webUrl];
+        const defined = opts.filter(item => item !== undefined);
+        return defined.length <= 1;
+      }, {
+        error: 'Specify userId, userName, groupId, groupName, or webUrl, but not multiple.'
+      });
+  }
+
   public defaultProperties(): string[] | undefined {
     return ['createdDateTime', 'title', 'id'];
-  }
-
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined',
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined',
-        webUrl: typeof args.options.webUrl !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      { option: '--userId [userId]' },
-      { option: '--userName [userName]' },
-      { option: '--groupId [groupId]' },
-      { option: '--groupName [groupName]' },
-      { option: '-u, --webUrl [webUrl]' }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
-          return `${args.options.userId} is not a valid GUID`;
-        }
-
-        if (args.options.groupId && !validation.isValidGuid(args.options.groupId)) {
-          return `${args.options.groupId} is not a valid GUID`;
-        }
-
-        if (args.options.webUrl) {
-          return validation.isValidSharePointUrl(args.options.webUrl);
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push({
-      options: ['userId', 'userName', 'groupId', 'groupName', 'webUrl'],
-      runsWhen: (args) => {
-        const options = [args.options.userId, args.options.userName, args.options.groupId, args.options.groupName, args.options.webUrl];
-        return options.some(item => item !== undefined);
-      }
-    });
   }
 
   private async getEndpointUrl(args: CommandArgs): Promise<string> {


### PR DESCRIPTION
Closes #7307

## Summary

Migrates all 3 onenote commands (`notebook-add`, `notebook-list`, `page-list`) from the legacy `#initOptions`/`#initValidators`/`#initTelemetry`/`#initOptionSets` pattern to Zod schemas.

### Changes

- Replaced manual option definitions with `z.strictObject` schemas extending `globalOptionsZod`
- Replaced manual validators with Zod `.refine()` for GUID and SharePoint URL validation
- Replaced `#initOptionSets` with `getRefinedSchema` refinements
- Removed `#initTelemetry` (handled automatically by Zod)
- Updated test files to use `commandOptionsSchema.safeParse()` instead of `command.validate()`
- Net reduction of ~128 lines of code