### PR TITLE
Migrate onedrive report commands to Zod

### DIFF
--- a/src/m365/onedrive/commands/report/report-activityfilecounts.spec.ts
+++ b/src/m365/onedrive/commands/report/report-activityfilecounts.spec.ts
@@ -1,25 +1,32 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-activityfilecounts.js';
+import command, { options } from './report-activityfilecounts.js';
 
 describe(commands.REPORT_ACTIVITYFILECOUNTS, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
-    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(auth, 'restoreAuth').resolves();
     sinon.stub(telemetry, 'trackEvent').resolves();
-    sinon.stub(pid, 'getProcessName').callsFake(() => '');
-    sinon.stub(session, 'getId').callsFake(() => '');
+    sinon.stub(pid, 'getProcessName').returns('');
+    sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -57,6 +64,41 @@ describe(commands.REPORT_ACTIVITYFILECOUNTS, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation on valid \'D30\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D30' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation on valid \'D90\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D90' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation on valid \'D180\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D180' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation on invalid period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if period is missing', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('gets the report for the last week', async () => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveActivityFileCounts(period='D7')`) {
@@ -66,8 +108,14 @@ describe(commands.REPORT_ACTIVITYFILECOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveActivityFileCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('correctly handles random API error', async () => {
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
+
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-activityfilecounts.ts
+++ b/src/m365/onedrive/commands/report/report-activityfilecounts.ts
@@ -1,5 +1,13 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['csv', 'json']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).alias('p')
+});
 
 class OneDriveReportActivityFileCountCommand extends PeriodBasedReport {
   public get name(): string {
@@ -12,6 +20,10 @@ class OneDriveReportActivityFileCountCommand extends PeriodBasedReport {
 
   public get description(): string {
     return 'Gets the number of unique, licensed users that performed file interactions against any OneDrive account';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 }
 

--- a/src/m365/onedrive/commands/report/report-activityusercounts.spec.ts
+++ b/src/m365/onedrive/commands/report/report-activityusercounts.spec.ts
@@ -1,18 +1,23 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-activityusercounts.js';
+import command, { options } from './report-activityusercounts.js';
 
 describe(commands.REPORT_ACTIVITYUSERCOUNTS, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -20,6 +25,8 @@ describe(commands.REPORT_ACTIVITYUSERCOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -57,6 +64,26 @@ describe(commands.REPORT_ACTIVITYUSERCOUNTS, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation on invalid period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if period is missing', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('gets the report for the last week', async () => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserCounts(period='D7')`) {
@@ -66,8 +93,14 @@ describe(commands.REPORT_ACTIVITYUSERCOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('correctly handles random API error', async () => {
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
+
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-activityusercounts.ts
+++ b/src/m365/onedrive/commands/report/report-activityusercounts.ts
@@ -1,5 +1,13 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['csv', 'json']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).alias('p')
+});
 
 class OneDriveReportActivityUserCountCommand extends PeriodBasedReport {
   public get name(): string {
@@ -12,6 +20,10 @@ class OneDriveReportActivityUserCountCommand extends PeriodBasedReport {
 
   public get description(): string {
     return 'Gets the trend in the number of active OneDrive users';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 }
 

--- a/src/m365/onedrive/commands/report/report-activityuserdetail.spec.ts
+++ b/src/m365/onedrive/commands/report/report-activityuserdetail.spec.ts
@@ -1,18 +1,24 @@
 import assert from 'assert';
 import sinon from 'sinon';
+import { z } from 'zod';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-activityuserdetail.js';
+import command, { options } from './report-activityuserdetail.js';
 
 describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodType;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -20,6 +26,8 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
   });
 
   beforeEach(() => {
@@ -57,6 +65,41 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation on valid \'D7\' period', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation on valid date', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ date: '2019-07-13' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation on invalid period', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if neither period nor date is specified', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({});
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if both period and date options set', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ period: 'D7', date: '2019-07-13' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation on invalid date format', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ date: '10.10.2019' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('gets the report for the last week', async () => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserDetail(period='D7')`) {
@@ -66,8 +109,28 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: options.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserDetail(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('gets the report for the given date', async () => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserDetail(date=2019-07-13)`) {
+        return `Report Refresh Date,Site URL,Owner Display Name,Is Deleted,Last Activity Date,File Count,Active File Count,Storage Used (Byte),Storage Allocated (Byte),Owner Principal Name,Report PeriodReport Refresh Date,User Principal Name,Is Deleted,Deleted Date,Last Activity Date,Viewed Or Edited File Count,Synced File Count,Shared Internally File Count,Shared Externally File Count,Assigned Products,Report`;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: options.parse({ date: '2019-07-13' }) });
+    assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserDetail(date=2019-07-13)");
+    assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('correctly handles random API error', async () => {
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
+
+    await assert.rejects(command.action(logger, { options: options.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-activityuserdetail.spec.ts
+++ b/src/m365/onedrive/commands/report/report-activityuserdetail.spec.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import { z } from 'zod';
 import auth from '../../../../Auth.js';
 import { cli } from '../../../../cli/cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
@@ -18,7 +17,7 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let commandOptionsSchema: z.ZodType;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -27,7 +26,7 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -109,7 +108,7 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: options.parse({ period: 'D7' }) });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserDetail(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -123,7 +122,7 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: options.parse({ date: '2019-07-13' }) });
+    await command.action(logger, { options: commandOptionsSchema.parse({ date: '2019-07-13' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserDetail(date=2019-07-13)");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -131,6 +130,6 @@ describe(commands.REPORT_ACTIVITYUSERDETAIL, () => {
   it('correctly handles random API error', async () => {
     sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
 
-    await assert.rejects(command.action(logger, { options: options.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-activityuserdetail.ts
+++ b/src/m365/onedrive/commands/report/report-activityuserdetail.ts
@@ -1,5 +1,15 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import DateAndPeriodBasedReport from '../../../base/DateAndPeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['csv', 'json']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).optional().alias('p'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'The supported date format is YYYY-MM-DD').optional().alias('d')
+});
+declare type Options = z.infer<typeof options>;
 
 class OneDriveReportActivityUserDetailCommand extends DateAndPeriodBasedReport {
   public get name(): string {
@@ -12,6 +22,21 @@ class OneDriveReportActivityUserDetailCommand extends DateAndPeriodBasedReport {
 
   public get description(): string {
     return 'Gets details about OneDrive activity by user';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
+  }
+
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine((opts: Options) => opts.period !== undefined || opts.date !== undefined, {
+        message: 'Specify period or date, one is required.',
+        params: { customCode: 'optionSet', options: ['period', 'date'] }
+      })
+      .refine((opts: Options) => !(opts.period !== undefined && opts.date !== undefined), {
+        message: 'Specify period or date but not both.'
+      });
   }
 }
 

--- a/src/m365/onedrive/commands/report/report-usageaccountcounts.spec.ts
+++ b/src/m365/onedrive/commands/report/report-usageaccountcounts.spec.ts
@@ -1,18 +1,23 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-usageaccountcounts.js';
+import command, { options } from './report-usageaccountcounts.js';
 
 describe(commands.REPORT_USAGEACCOUNTCOUNTS, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -20,6 +25,8 @@ describe(commands.REPORT_USAGEACCOUNTCOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -57,6 +64,26 @@ describe(commands.REPORT_USAGEACCOUNTCOUNTS, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation on invalid period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if period is missing', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('gets the report for the last week', async () => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountCounts(period='D7')`) {
@@ -66,8 +93,14 @@ describe(commands.REPORT_USAGEACCOUNTCOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('correctly handles random API error', async () => {
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
+
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-usageaccountcounts.ts
+++ b/src/m365/onedrive/commands/report/report-usageaccountcounts.ts
@@ -1,5 +1,13 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['csv', 'json']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).alias('p')
+});
 
 class OneDriveReportUsageAccountCountsCommand extends PeriodBasedReport {
   public get name(): string {
@@ -12,6 +20,10 @@ class OneDriveReportUsageAccountCountsCommand extends PeriodBasedReport {
 
   public get description(): string {
     return 'Gets the trend in the number of active OneDrive for Business sites';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 }
 

--- a/src/m365/onedrive/commands/report/report-usageaccountdetail.spec.ts
+++ b/src/m365/onedrive/commands/report/report-usageaccountdetail.spec.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import { z } from 'zod';
 import auth from '../../../../Auth.js';
 import { cli } from '../../../../cli/cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
@@ -18,7 +17,7 @@ describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
-  let commandOptionsSchema: z.ZodType;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -27,7 +26,7 @@ describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
-    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -109,7 +108,7 @@ describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: options.parse({ period: 'D7' }) });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -123,7 +122,7 @@ describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: options.parse({ date: '2019-07-13' }) });
+    await command.action(logger, { options: commandOptionsSchema.parse({ date: '2019-07-13' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(date=2019-07-13)");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
   });
@@ -131,6 +130,6 @@ describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
   it('correctly handles random API error', async () => {
     sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
 
-    await assert.rejects(command.action(logger, { options: options.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-usageaccountdetail.spec.ts
+++ b/src/m365/onedrive/commands/report/report-usageaccountdetail.spec.ts
@@ -1,18 +1,24 @@
 import assert from 'assert';
 import sinon from 'sinon';
+import { z } from 'zod';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-usageaccountdetail.js';
+import command, { options } from './report-usageaccountdetail.js';
 
 describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: z.ZodType;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -20,6 +26,8 @@ describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse()!;
   });
 
   beforeEach(() => {
@@ -57,6 +65,41 @@ describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation on valid \'D7\' period', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation on valid date', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ date: '2019-07-13' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation on invalid period', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if neither period nor date is specified', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({});
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if both period and date options set', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ period: 'D7', date: '2019-07-13' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation on invalid date format', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ date: '10.10.2019' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', async () => {
+    const actual = await commandOptionsSchema.safeParseAsync({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('gets the report for the last week', async () => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D7')`) {
@@ -66,8 +109,28 @@ describe(commands.REPORT_USAGEACCOUNTDETAIL, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: options.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('gets the report for the given date', async () => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(date=2019-07-13)`) {
+        return `Report Refresh Date,Site URL,Owner Display Name,Is Deleted,Last Activity Date,File Count,Active File Count,Storage Used (Byte),Storage Allocated (Byte),Owner Principal Name,Report Period`;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: options.parse({ date: '2019-07-13' }) });
+    assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(date=2019-07-13)");
+    assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('correctly handles random API error', async () => {
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
+
+    await assert.rejects(command.action(logger, { options: options.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-usageaccountdetail.ts
+++ b/src/m365/onedrive/commands/report/report-usageaccountdetail.ts
@@ -1,5 +1,15 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import DateAndPeriodBasedReport from '../../../base/DateAndPeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['csv', 'json']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).optional().alias('p'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'The supported date format is YYYY-MM-DD').optional().alias('d')
+});
+declare type Options = z.infer<typeof options>;
 
 class OneDriveReportUsageAccountDetailCommand extends DateAndPeriodBasedReport {
   public get name(): string {
@@ -12,6 +22,21 @@ class OneDriveReportUsageAccountDetailCommand extends DateAndPeriodBasedReport {
 
   public get description(): string {
     return 'Gets details about OneDrive usage by account';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
+  }
+
+  public getRefinedSchema(schema: typeof options): z.ZodType | undefined {
+    return schema
+      .refine((opts: Options) => opts.period !== undefined || opts.date !== undefined, {
+        message: 'Specify period or date, one is required.',
+        params: { customCode: 'optionSet', options: ['period', 'date'] }
+      })
+      .refine((opts: Options) => !(opts.period !== undefined && opts.date !== undefined), {
+        message: 'Specify period or date but not both.'
+      });
   }
 }
 

--- a/src/m365/onedrive/commands/report/report-usagefilecounts.spec.ts
+++ b/src/m365/onedrive/commands/report/report-usagefilecounts.spec.ts
@@ -1,18 +1,23 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-usagefilecounts.js';
+import command, { options } from './report-usagefilecounts.js';
 
 describe(commands.REPORT_USAGEFILECOUNTS, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -20,6 +25,8 @@ describe(commands.REPORT_USAGEFILECOUNTS, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -57,6 +64,26 @@ describe(commands.REPORT_USAGEFILECOUNTS, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation on invalid period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if period is missing', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('gets the report for the last week', async () => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveUsageFileCounts(period='D7')`) {
@@ -66,8 +93,14 @@ describe(commands.REPORT_USAGEFILECOUNTS, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveUsageFileCounts(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('correctly handles random API error', async () => {
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
+
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-usagefilecounts.ts
+++ b/src/m365/onedrive/commands/report/report-usagefilecounts.ts
@@ -1,5 +1,13 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['csv', 'json']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).alias('p')
+});
 
 class OneDriveReportUsageFileCountsCommand extends PeriodBasedReport {
   public get name(): string {
@@ -12,6 +20,10 @@ class OneDriveReportUsageFileCountsCommand extends PeriodBasedReport {
 
   public get description(): string {
     return 'Gets the total number of files across all sites and how many are active files';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 }
 

--- a/src/m365/onedrive/commands/report/report-usagestorage.spec.ts
+++ b/src/m365/onedrive/commands/report/report-usagestorage.spec.ts
@@ -1,18 +1,23 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
+import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './report-usagestorage.js';
+import command, { options } from './report-usagestorage.js';
 
 describe(commands.REPORT_USAGESTORAGE, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -20,6 +25,8 @@ describe(commands.REPORT_USAGESTORAGE, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -57,6 +64,26 @@ describe(commands.REPORT_USAGESTORAGE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation on invalid period', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'abc' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if period is missing', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ period: 'D7', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('gets the report for the last week', async () => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOneDriveUsageStorage(period='D7')`) {
@@ -66,8 +93,14 @@ describe(commands.REPORT_USAGESTORAGE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { period: 'D7' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) });
     assert.strictEqual(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOneDriveUsageStorage(period='D7')");
     assert.strictEqual(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+  });
+
+  it('correctly handles random API error', async () => {
+    sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
+
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ period: 'D7' }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/onedrive/commands/report/report-usagestorage.ts
+++ b/src/m365/onedrive/commands/report/report-usagestorage.ts
@@ -1,5 +1,13 @@
+import { z } from 'zod';
+import { globalOptionsZod } from '../../../../Command.js';
 import PeriodBasedReport from '../../../base/PeriodBasedReport.js';
 import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  output: z.enum(['csv', 'json']).optional().alias('o'),
+  period: z.enum(['D7', 'D30', 'D90', 'D180']).alias('p')
+});
 
 class OneDriveReportUsageStorageCommand extends PeriodBasedReport {
   public get name(): string {
@@ -12,6 +20,10 @@ class OneDriveReportUsageStorageCommand extends PeriodBasedReport {
 
   public get description(): string {
     return 'Gets the trend on the amount of storage you are using in OneDrive for Business';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 }
 


### PR DESCRIPTION
Migrates all 7 onedrive report commands to use Zod schemas for option validation.

## Changes

### PeriodBased commands (5)
- `onedrive report activityfilecounts`
- `onedrive report activityusercounts`
- `onedrive report usageaccountcounts`
- `onedrive report usagefilecounts`
- `onedrive report usagestorage`

Each defines a `z.strictObject` schema with:
- `period`: required enum (`D7`, `D30`, `D90`, `D180`) with `-p` alias
- `output`: restricted to `csv`/`json` (matching existing `allowedOutputs`)
- Global options spread from `globalOptionsZod`

### DateAndPeriodBased commands (2)
- `onedrive report activityuserdetail`
- `onedrive report usageaccountdetail`

Same as above plus:
- `period`: optional enum with `-p` alias
- `date`: optional string with YYYY-MM-DD regex and `-d` alias
- `getRefinedSchema()` with two refinements:
  - `optionSet` refinement requiring at least one of `period`/`date` (enables CLI prompting)
  - Regular refinement preventing both from being specified simultaneously

### Tests
- All 7 test files updated to use Zod `safeParse`/`parse` patterns
- Added validation tests for: valid periods, invalid periods, missing required options, unknown options
- DateAndPeriodBased tests additionally cover: valid date, invalid date format, mutual exclusivity
- Added error handling tests

### Approach
Zod schemas are defined on each command (not the shared base classes) to avoid impacting other workloads that still use the old options/validators pattern.

Closes #7306