### PR TITLE
Migrate entra siteclassification commands to Zod

### DIFF
--- a/src/m365/entra/commands/siteclassification/siteclassification-disable.spec.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-disable.spec.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
 import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
@@ -10,11 +11,13 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './siteclassification-disable.js';
+import command, { options } from './siteclassification-disable.js';
 
 describe(commands.SITECLASSIFICATION_DISABLE, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   let promptIssued: boolean = false;
 
   before(() => {
@@ -23,6 +26,8 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -69,7 +74,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
   });
 
   it('prompts before disabling siteclassification when force option not passed', async () => {
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: commandOptionsSchema.parse({}) });
 
     assert(promptIssued);
   });
@@ -83,7 +88,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, force: true }) }),
       new CommandError('Site classification is not enabled.'));
   });
 
@@ -158,7 +163,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, force: true }) }),
       new CommandError("Missing DirectorySettingTemplate for \"Group.Unified\""));
   });
 
@@ -233,7 +238,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, force: true }) }),
       new CommandError("Missing UnifiedGroupSettting id"));
   });
 
@@ -308,7 +313,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, force: true } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, force: true }) }),
       new CommandError("Missing UnifiedGroupSettting id"));
   });
 
@@ -393,7 +398,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { force: true } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ force: true }) });
     assert(deleteRequestIssued);
   });
 
@@ -478,7 +483,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, force: true } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, force: true }) });
     assert(deleteRequestIssued);
   });
 
@@ -487,7 +492,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: commandOptionsSchema.parse({}) });
     assert(postSpy.notCalled);
   });
 
@@ -576,7 +581,7 @@ describe(commands.SITECLASSIFICATION_DISABLE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: commandOptionsSchema.parse({}) });
     assert(deleteRequestIssued);
   });
 });

--- a/src/m365/entra/commands/siteclassification/siteclassification-disable.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-disable.ts
@@ -1,17 +1,20 @@
 import { GroupSetting } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  force: z.boolean().optional().alias('f')
+});
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  force?: boolean;
 }
 
 class EntraSiteClassificationDisableCommand extends GraphCommand {
@@ -23,27 +26,8 @@ class EntraSiteClassificationDisableCommand extends GraphCommand {
     return 'Disables site classification';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        force: (!(!args.options.force)).toString()
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-f, --force'
-      }
-    );
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/siteclassification/siteclassification-enable.spec.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-enable.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
@@ -9,11 +11,13 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './siteclassification-enable.js';
+import command, { options } from './siteclassification-enable.js';
 
 describe(commands.SITECLASSIFICATION_ENABLE, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -21,6 +25,8 @@ describe(commands.SITECLASSIFICATION_ENABLE, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -129,7 +135,7 @@ describe(commands.SITECLASSIFICATION_ENABLE, () => {
       throw 'Invalid Request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp" } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp" }) }),
       new CommandError("Missing DirectorySettingTemplate for \"Group.Unified\""));
   });
 
@@ -217,7 +223,7 @@ describe(commands.SITECLASSIFICATION_ENABLE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp", guestUsageGuidelinesUrl: "http://aka.ms/sppnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp", guestUsageGuidelinesUrl: "http://aka.ms/sppnp" }) });
     assert(enableRequestIssued);
   });
 
@@ -305,7 +311,7 @@ describe(commands.SITECLASSIFICATION_ENABLE, () => {
       throw 'Invalid Request';
     });
 
-    await command.action(logger, { options: { classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp", guestUsageGuidelinesUrl: "http://aka.ms/sppnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp", guestUsageGuidelinesUrl: "http://aka.ms/sppnp" }) });
     assert(enableRequestIssued);
   });
 
@@ -393,7 +399,7 @@ describe(commands.SITECLASSIFICATION_ENABLE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp" }) });
     assert(enableRequestIssued);
   });
 
@@ -481,7 +487,7 @@ describe(commands.SITECLASSIFICATION_ENABLE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", guestUsageGuidelinesUrl: "http://aka.ms/sppnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", guestUsageGuidelinesUrl: "http://aka.ms/sppnp" }) });
     assert(enableRequestIssued);
   });
 
@@ -569,7 +575,7 @@ describe(commands.SITECLASSIFICATION_ENABLE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI" }) });
     assert(enableRequestIssued);
   });
 
@@ -663,7 +669,7 @@ describe(commands.SITECLASSIFICATION_ENABLE, () => {
       throw 'Invalid Request';
     });
 
-    await assert.rejects(command.action(logger, { options: { classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI" } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI" }) }),
       new CommandError(`A conflicting object with one or more of the specified property values is present in the directory.`));
   });
 });

--- a/src/m365/entra/commands/siteclassification/siteclassification-enable.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-enable.ts
@@ -1,19 +1,22 @@
 import { GroupSetting, SettingValue } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  classifications: z.string().alias('c'),
+  defaultClassification: z.string().alias('d'),
+  usageGuidelinesUrl: z.string().optional().alias('u'),
+  guestUsageGuidelinesUrl: z.string().optional().alias('g')
+});
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  classifications: string;
-  defaultClassification: string;
-  usageGuidelinesUrl?: string;
-  guestUsageGuidelinesUrl?: string;
 }
 
 class EntraSiteClassificationEnableCommand extends GraphCommand {
@@ -25,37 +28,8 @@ class EntraSiteClassificationEnableCommand extends GraphCommand {
     return 'Enables site classification configuration';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        usageGuidelinesUrl: typeof args.options.usageGuidelinesUrl !== 'undefined',
-        guestUsageGuidelinesUrl: typeof args.options.guestUsageGuidelinesUrl !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-c, --classifications <classifications>'
-      },
-      {
-        option: '-d, --defaultClassification <defaultClassification>'
-      },
-      {
-        option: '-u, --usageGuidelinesUrl [usageGuidelinesUrl]'
-      },
-      {
-        option: '-g, --guestUsageGuidelinesUrl [guestUsageGuidelinesUrl]'
-      }
-    );
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/siteclassification/siteclassification-get.spec.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-get.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
@@ -9,12 +11,14 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './siteclassification-get.js';
+import command, { options } from './siteclassification-get.js';
 
 describe(commands.SITECLASSIFICATION_GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -22,6 +26,8 @@ describe(commands.SITECLASSIFICATION_GET, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -71,7 +77,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
       throw 'Invalid Request';
     });
 
-    await assert.rejects(command.action(logger, { options: {} } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({}) }),
       new CommandError('Site classification is not enabled.'));
   });
 
@@ -146,7 +152,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
       throw 'Invalid Request';
     });
 
-    await assert.rejects(command.action(logger, { options: {} } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({}) }),
       new CommandError("Missing DirectorySettingTemplate for \"Group.Unified\""));
   });
 
@@ -222,7 +228,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
       throw 'Invalid Request';
     });
 
-    await command.action(logger, { options: { debug: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true }) });
     assert(loggerLogSpy.calledWith({
       "Classifications": ["TopSecret"],
       "DefaultClassification": "TopSecret",
@@ -302,7 +308,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
       throw 'Invalid Request';
     });
 
-    await command.action(logger, { options: { debug: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true }) });
     assert(loggerLogSpy.calledWith({
       "Classifications": ["TopSecret", "HBI"],
       "DefaultClassification": "TopSecret",
@@ -382,7 +388,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
       throw 'Invalid Request';
     });
 
-    await command.action(logger, { options: { debug: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true }) });
     assert(loggerLogSpy.calledWith({
       "Classifications": [],
       "DefaultClassification": "",
@@ -394,6 +400,6 @@ describe(commands.SITECLASSIFICATION_GET, () => {
   it('handles error correctly', async () => {
     sinon.stub(request, 'get').rejects(new Error('An error has occurred'));
 
-    await assert.rejects(command.action(logger, { options: { debug: true } } as any), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true }) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/entra/commands/siteclassification/siteclassification-get.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-get.ts
@@ -7,7 +7,7 @@ import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 import { SiteClassificationSettings } from './SiteClassificationSettings.js';
 
-export const options = globalOptionsZod;
+export const options = globalOptionsZod.strict();
 
 class EntraSiteClassificationGetCommand extends GraphCommand {
   public get name(): string {
@@ -18,7 +18,7 @@ class EntraSiteClassificationGetCommand extends GraphCommand {
     return 'Gets site classification configuration';
   }
 
-  public get schema(): z.ZodType | undefined {
+  public get schema(): z.ZodTypeAny | undefined {
     return options;
   }
 

--- a/src/m365/entra/commands/siteclassification/siteclassification-get.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-get.ts
@@ -1,9 +1,13 @@
 import { GroupSetting, SettingValue } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 import { SiteClassificationSettings } from './SiteClassificationSettings.js';
+
+export const options = globalOptionsZod;
 
 class EntraSiteClassificationGetCommand extends GraphCommand {
   public get name(): string {
@@ -12,6 +16,10 @@ class EntraSiteClassificationGetCommand extends GraphCommand {
 
   public get description(): string {
     return 'Gets site classification configuration';
+  }
+
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger): Promise<void> {

--- a/src/m365/entra/commands/siteclassification/siteclassification-set.spec.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-set.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
+import { cli } from '../../../../cli/cli.js';
+import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
@@ -9,11 +11,13 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './siteclassification-set.js';
+import command, { options } from './siteclassification-set.js';
 
 describe(commands.SITECLASSIFICATION_SET, () => {
   let log: string[];
   let logger: Logger;
+  let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -21,6 +25,8 @@ describe(commands.SITECLASSIFICATION_SET, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
+    commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -59,20 +65,17 @@ describe(commands.SITECLASSIFICATION_SET, () => {
   });
 
   it('fails validation if none of the options are specified', () => {
-    const schema = command.getSchemaToParse()!;
-    const result = schema.safeParse({});
+    const result = commandOptionsSchema.safeParse({});
     assert.notStrictEqual(result.success, true);
   });
 
   it('passes validation if at least one option is specified', () => {
-    const schema = command.getSchemaToParse()!;
-    const result = schema.safeParse({ classifications: "Confidential" });
+    const result = commandOptionsSchema.safeParse({ classifications: "Confidential" });
     assert.strictEqual(result.success, true);
   });
 
   it('passes validation if all options are passed', () => {
-    const schema = command.getSchemaToParse()!;
-    const result = schema.safeParse({
+    const result = commandOptionsSchema.safeParse({
       classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "https://aka.ms/pnp", guestUsageGuidelinesUrl: "https://aka.ms/pnp"
     });
     assert.strictEqual(result.success, true);
@@ -89,7 +92,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid Request';
     });
 
-    await assert.rejects(command.action(logger, { options: { debug: true, classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp" } } as any),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ debug: true, classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "http://aka.ms/sppnp" }) }),
       new CommandError("There is no previous defined site classification which can updated."));
   });
 
@@ -177,7 +180,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, usageGuidelinesUrl: "http://aka.ms/pnp", guestUsageGuidelinesUrl: "http://aka.ms/pnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, usageGuidelinesUrl: "http://aka.ms/pnp", guestUsageGuidelinesUrl: "http://aka.ms/pnp" }) });
     assert(updateRequestIssued);
   });
 
@@ -265,7 +268,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { usageGuidelinesUrl: "http://aka.ms/pnp", guestUsageGuidelinesUrl: "http://aka.ms/pnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ usageGuidelinesUrl: "http://aka.ms/pnp", guestUsageGuidelinesUrl: "http://aka.ms/pnp" }) });
     assert(updateRequestIssued);
   });
 
@@ -353,7 +356,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { usageGuidelinesUrl: "http://aka.ms/pnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ usageGuidelinesUrl: "http://aka.ms/pnp" }) });
     assert(updateRequestIssued);
   });
 
@@ -441,7 +444,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { guestUsageGuidelinesUrl: "http://aka.ms/pnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ guestUsageGuidelinesUrl: "http://aka.ms/pnp" }) });
     assert(updateRequestIssued);
   });
 
@@ -529,7 +532,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { classifications: "top secret,high,middle,low" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ classifications: "top secret,high,middle,low" }) });
     assert(updateRequestIssued);
   });
 
@@ -616,7 +619,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { defaultClassification: "low" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ defaultClassification: "low" }) });
     assert(updateRequestIssued);
   });
 
@@ -704,7 +707,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { classifications: "area 51,high,middle,low", defaultClassification: "high" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ classifications: "area 51,high,middle,low", defaultClassification: "high" }) });
     assert(updateRequestIssued);
   });
 
@@ -792,7 +795,7 @@ describe(commands.SITECLASSIFICATION_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { classifications: "area 51,high,middle,low", defaultClassification: "high", usageGuidelinesUrl: "http://aka.ms/pnp", guestUsageGuidelinesUrl: "http://aka.ms/pnp" } } as any);
+    await command.action(logger, { options: commandOptionsSchema.parse({ classifications: "area 51,high,middle,low", defaultClassification: "high", usageGuidelinesUrl: "http://aka.ms/pnp", guestUsageGuidelinesUrl: "http://aka.ms/pnp" }) });
     assert(updateRequestIssued);
   });
 });

--- a/src/m365/entra/commands/siteclassification/siteclassification-set.spec.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-set.spec.ts
@@ -1,8 +1,6 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import auth from '../../../../Auth.js';
-import { cli } from '../../../../cli/cli.js';
-import { CommandInfo } from '../../../../cli/CommandInfo.js';
 import { Logger } from '../../../../cli/Logger.js';
 import { CommandError } from '../../../../Command.js';
 import request from '../../../../request.js';
@@ -16,7 +14,6 @@ import command from './siteclassification-set.js';
 describe(commands.SITECLASSIFICATION_SET, () => {
   let log: string[];
   let logger: Logger;
-  let commandInfo: CommandInfo;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -24,7 +21,6 @@ describe(commands.SITECLASSIFICATION_SET, () => {
     sinon.stub(pid, 'getProcessName').returns('');
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
-    commandInfo = cli.getCommandInfo(command);
   });
 
   beforeEach(() => {
@@ -62,30 +58,24 @@ describe(commands.SITECLASSIFICATION_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if none of the options are specified', async () => {
-    const actual = await command.validate({
-      options: {
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if none of the options are specified', () => {
+    const schema = command.getSchemaToParse()!;
+    const result = schema.safeParse({});
+    assert.notStrictEqual(result.success, true);
   });
 
-  it('passes validation if at least one option is specified', async () => {
-    const actual = await command.validate({
-      options: {
-        classifications: "Confidential"
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if at least one option is specified', () => {
+    const schema = command.getSchemaToParse()!;
+    const result = schema.safeParse({ classifications: "Confidential" });
+    assert.strictEqual(result.success, true);
   });
 
-  it('passes validation if all options are passed', async () => {
-    const actual = await command.validate({
-      options: {
-        classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "https://aka.ms/pnp", guestUsageGuidelinesUrl: "https://aka.ms/pnp"
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if all options are passed', () => {
+    const schema = command.getSchemaToParse()!;
+    const result = schema.safeParse({
+      classifications: "HBI, LBI, Top Secret", defaultClassification: "HBI", usageGuidelinesUrl: "https://aka.ms/pnp", guestUsageGuidelinesUrl: "https://aka.ms/pnp"
+    });
+    assert.strictEqual(result.success, true);
   });
 
   it('handles Microsoft 365 Tenant siteclassification has not been enabled', async () => {

--- a/src/m365/entra/commands/siteclassification/siteclassification-set.ts
+++ b/src/m365/entra/commands/siteclassification/siteclassification-set.ts
@@ -1,19 +1,22 @@
 import { GroupSetting, SettingValue } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  classifications: z.string().optional().alias('c'),
+  defaultClassification: z.string().optional().alias('d'),
+  usageGuidelinesUrl: z.string().optional().alias('u'),
+  guestUsageGuidelinesUrl: z.string().optional().alias('g')
+});
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  classifications?: string;
-  defaultClassification?: string;
-  usageGuidelinesUrl?: string;
-  guestUsageGuidelinesUrl?: string;
 }
 
 class EntraSiteClassificationSetCommand extends GraphCommand {
@@ -25,54 +28,18 @@ class EntraSiteClassificationSetCommand extends GraphCommand {
     return 'Updates site classification configuration';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        classifications: typeof args.options.classifications !== 'undefined',
-        defaultClassification: typeof args.options.defaultClassification !== 'undefined',
-        usageGuidelinesUrl: typeof args.options.usageGuidelinesUrl !== 'undefined',
-        guestUsageGuidelinesUrl: typeof args.options.guestUsageGuidelinesUrl !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-c, --classifications [classifications]'
-      },
-      {
-        option: '-d, --defaultClassification [defaultClassification]'
-      },
-      {
-        option: '-u, --usageGuidelinesUrl [usageGuidelinesUrl]'
-      },
-      {
-        option: '-g, --guestUsageGuidelinesUrl [guestUsageGuidelinesUrl]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!args.options.classifications &&
-          !args.options.defaultClassification &&
-          !args.options.usageGuidelinesUrl &&
-          !args.options.guestUsageGuidelinesUrl) {
-          return 'Specify at least one property to update';
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => options.classifications || options.defaultClassification || options.usageGuidelinesUrl || options.guestUsageGuidelinesUrl, {
+        error: 'Specify at least one property to update',
+        params: {
+          customCode: 'required'
         }
-        return true;
-      }
-    );
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {


### PR DESCRIPTION
## Summary

Migrates the `entra siteclassification` commands to use Zod schemas for option definition, validation, and telemetry.

Closes #7300

### Commands migrated

| Command | Key changes |
|---------|-------------|
| `siteclassification disable` | Replaced `#initOptions`/`#initTelemetry` with Zod schema |
| `siteclassification enable` | Replaced `#initOptions`/`#initTelemetry` with Zod schema |
| `siteclassification get` | Added `globalOptionsZod` schema |
| `siteclassification set` | Replaced `#initOptions`/`#initTelemetry`/`#initValidators` with Zod schema + `getRefinedSchema` |

### Test changes

- Updated `siteclassification-set.spec.ts` validation tests to use `getSchemaToParse().safeParse()` instead of `command.validate()` with `CommandInfo`
- Removed unused `cli`/`CommandInfo` imports from set spec