### PR TITLE
Migrate entra group commands to Zod

### DIFF
--- a/src/m365/entra/commands/group/group-add.spec.ts
+++ b/src/m365/entra/commands/group/group-add.spec.ts
@@ -10,7 +10,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { cli } from '../../../../cli/cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import command from './group-add.js';
+import command, { options } from './group-add.js';
 import { entraUser } from '../../../../utils/entraUser.js';
 import { CommandError } from '../../../../Command.js';
 
@@ -180,6 +180,7 @@ describe(commands.GROUP_ADD, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -188,6 +189,7 @@ describe(commands.GROUP_ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -232,69 +234,69 @@ describe(commands.GROUP_ADD, () => {
 
   it('fails validation if the length of displayName is more than 256 characters', async () => {
     const displayName = 'lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum';
-    const actual = await command.validate({ options: { displayName: displayName, type: 'security' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: displayName, type: 'security' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if the length of mailNickname is more than 64 characters', async () => {
     const mailNickname = 'loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumlorem';
-    const actual = await command.validate({ options: { displayName: 'Cli group', mailNickname: mailNickname, type: 'security' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', mailNickname: mailNickname, type: 'security' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if mailNickname is not valid', async () => {
     const mailNickname = 'lorem ipsum';
-    const actual = await command.validate({ options: { displayName: 'Cli group', mailNickname: mailNickname, type: 'security' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', mailNickname: mailNickname, type: 'security' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if ownerIds contains invalid GUID', async () => {
     const ownerIds = ['7167b488-1ffb-43f1-9547-35969469bada', 'foo'];
-    const actual = await command.validate({ options: { displayName: 'Cli group', ownerIds: ownerIds.join(','), type: 'security' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', ownerIds: ownerIds.join(','), type: 'security' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if ownerUserNames contains invalid user principal name', async () => {
     const ownerUserNames = ['john.doe@contoso.com', 'foo'];
-    const actual = await command.validate({ options: { displayName: 'Cli group', ownerUserNames: ownerUserNames.join(','), type: 'security' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', ownerUserNames: ownerUserNames.join(','), type: 'security' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if memberIds contains invalid GUID', async () => {
     const memberIds = ['7167b488-1ffb-43f1-9547-35969469bada', 'foo'];
-    const actual = await command.validate({ options: { displayName: 'Cli group', memberIds: memberIds.join(','), type: 'security' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', memberIds: memberIds.join(','), type: 'security' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if memberUserNames contains invalid user principal name', async () => {
     const memberUserNames = ['john.doe@contoso.com', 'foo'];
-    const actual = await command.validate({ options: { displayName: 'Cli group', memberUserNames: memberUserNames.join(','), type: 'security' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', memberUserNames: memberUserNames.join(','), type: 'security' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if visibility contains invalid value', async () => {
-    const actual = await command.validate({ options: { displayName: 'Cli group', visibility: 'foo', type: 'microsoft365' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', visibility: 'foo', type: 'microsoft365' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if type contains invalid value', async () => {
-    const actual = await command.validate({ options: { displayName: 'Cli group', visibility: 'Public', type: 'foo' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', visibility: 'Public', type: 'foo' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if type is microsoft365 but visibility is not specified', async () => {
-    const actual = await command.validate({ options: { displayName: 'Cli group', type: 'microsoft365' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', type: 'microsoft365' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with ids', async () => {
-    const actual = await command.validate({ options: { displayName: 'Cli group', ownerIds: userIds.join(','), memberIds: userIds.join(','), type: 'security' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', ownerIds: userIds.join(','), memberIds: userIds.join(','), type: 'security' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with user names', async () => {
-    const actual = await command.validate({ options: { displayName: 'Cli group', ownerUserNames: userUpns.join(','), memberUserNames: userUpns.join(','), type: 'security' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', ownerUserNames: userUpns.join(','), memberUserNames: userUpns.join(','), type: 'security' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('successfully creates Microsoft 365 group without owners and members', async () => {

--- a/src/m365/entra/commands/group/group-add.spec.ts
+++ b/src/m365/entra/commands/group/group-add.spec.ts
@@ -308,7 +308,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365' }) });
     assert(loggerLogSpy.calledWith(microsoft365Group));
   });
 
@@ -321,7 +321,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', extension_b7d8e648520f41d3b9c0fdeb91768a0a_jobGroupTracker: 'JobGroupN' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', extension_b7d8e648520f41d3b9c0fdeb91768a0a_jobGroupTracker: 'JobGroupN' }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, {
       displayName: 'Microsoft 365 Group',
       description: 'Microsoft 365 group',
@@ -343,7 +343,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Security Group', description: 'Security Group', mailNickname: 'SecurityGroup', type: 'security' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Security Group', description: 'Security Group', mailNickname: 'SecurityGroup', type: 'security' }) });
     assert(loggerLogSpy.calledWith(securityGroup));
   });
 
@@ -365,7 +365,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', ownerIds: userIds.join(',') } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', ownerIds: userIds.join(',') }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, addOwnersRequest);
   });
 
@@ -387,7 +387,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', memberIds: userIds.join(',') } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', memberIds: userIds.join(',') }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, addMembersRequest);
   });
 
@@ -411,7 +411,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', ownerUserNames: userUpns.join(',') } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', ownerUserNames: userUpns.join(',') }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, addOwnersRequest);
   });
 
@@ -435,7 +435,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', memberUserNames: userUpns.join(','), verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', memberUserNames: userUpns.join(','), verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, addMembersRequest);
   });
 
@@ -449,7 +449,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', visibility: 'Public', type: 'microsoft365' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', visibility: 'Public', type: 'microsoft365' }) });
     assert(loggerLogSpy.calledWith(groupWithGeneratedMailNickname));
   });
 
@@ -483,7 +483,7 @@ describe(commands.GROUP_ADD, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', ownerIds: userIds.join(',') } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', ownerIds: userIds.join(',') }) }),
       new CommandError(`One or more added object references already exist for the following modified properties: 'members'.`));
   });
 
@@ -499,7 +499,7 @@ describe(commands.GROUP_ADD, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', ownerIds: userIds.join(',') } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', type: 'microsoft365', ownerIds: userIds.join(',') }) }),
       new CommandError('Invalid request'));
   });
 });

--- a/src/m365/entra/commands/group/group-add.ts
+++ b/src/m365/entra/commands/group/group-add.ts
@@ -35,19 +35,19 @@ export const options = z.looseObject({
     .optional().alias('m'),
   ownerIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `The following GUIDs are invalid for the option 'ownerIds': ${e.input}.`
+      error: e => `The following GUIDs are invalid for the option 'ownerIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   ownerUserNames: z.string()
     .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
-      error: e => `The following user principal names are invalid for the option 'ownerUserNames': ${e.input}.`
+      error: e => `The following user principal names are invalid for the option 'ownerUserNames': ${validation.isValidUserPrincipalNameArray(e.input as string)}.`
     }).optional(),
   memberIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `The following GUIDs are invalid for the option 'memberIds': ${e.input}.`
+      error: e => `The following GUIDs are invalid for the option 'memberIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   memberUserNames: z.string()
     .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
-      error: e => `The following user principal names are invalid for the option 'memberUserNames': ${e.input}.`
+      error: e => `The following user principal names are invalid for the option 'memberUserNames': ${validation.isValidUserPrincipalNameArray(e.input as string)}.`
     }).optional(),
   visibility: zod.coercedEnum(VisibilityEnum).optional()
 });

--- a/src/m365/entra/commands/group/group-add.ts
+++ b/src/m365/entra/commands/group/group-add.ts
@@ -1,26 +1,61 @@
 import { Group } from '@microsoft/microsoft-graph-types';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { z } from 'zod';
+import { Logger } from '../../../../cli/Logger.js';
+import { globalOptionsZod } from '../../../../Command.js';
+import request, { CliRequestOptions } from '../../../../request.js';
+import { entraUser } from '../../../../utils/entraUser.js';
+import { validation } from '../../../../utils/validation.js';
+import { zod } from '../../../../utils/zod.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
-import { validation } from '../../../../utils/validation.js';
-import request, { CliRequestOptions } from '../../../../request.js';
-import { Logger } from '../../../../cli/Logger.js';
-import { entraUser } from '../../../../utils/entraUser.js';
+
+const GroupTypeEnum = {
+  microsoft365: 'microsoft365',
+  security: 'security'
+} as const;
+
+const VisibilityEnum = {
+  Public: 'Public',
+  Private: 'Private',
+  HiddenMembership: 'HiddenMembership'
+} as const;
+
+export const options = z.looseObject({
+  ...globalOptionsZod.shape,
+  displayName: z.string().max(256, `The maximum amount of characters for 'displayName' is 256.`).alias('n'),
+  description: z.string().optional().alias('d'),
+  type: zod.coercedEnum(GroupTypeEnum).alias('t'),
+  mailNickname: z.string()
+    .refine(val => validation.isValidMailNickname(val), {
+      error: `Value for option 'mailNickname' must contain only characters in the ASCII character set 0-127 except the following: @ () \\ [] " ; : <> , SPACE.`
+    })
+    .refine(val => val.length <= 64, {
+      error: `The maximum amount of characters for 'mailNickname' is 64.`
+    })
+    .optional().alias('m'),
+  ownerIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `The following GUIDs are invalid for the option 'ownerIds': ${e.input}.`
+    }).optional(),
+  ownerUserNames: z.string()
+    .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
+      error: e => `The following user principal names are invalid for the option 'ownerUserNames': ${e.input}.`
+    }).optional(),
+  memberIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `The following GUIDs are invalid for the option 'memberIds': ${e.input}.`
+    }).optional(),
+  memberUserNames: z.string()
+    .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
+      error: e => `The following user principal names are invalid for the option 'memberUserNames': ${e.input}.`
+    }).optional(),
+  visibility: zod.coercedEnum(VisibilityEnum).optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  displayName: string;
-  description?: string;
-  type: string;
-  mailNickname?: string;
-  ownerIds?: string;
-  ownerUserNames?: string;
-  memberIds?: string;
-  memberUserNames?: string;
-  visibility?: string;
 }
 
 class EntraGroupAddCommand extends GraphCommand {
@@ -36,125 +71,15 @@ class EntraGroupAddCommand extends GraphCommand {
     return true;
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --displayName <displayName>'
-      },
-      {
-        option: '-d, --description [description]'
-      },
-      {
-        option: '-t, --type <type>',
-        autocomplete: ['microsoft365', 'security']
-      },
-      {
-        option: '-m, --mailNickname [mailNickname]'
-      },
-      {
-        option: '--ownerIds [ownerIds]'
-      },
-      {
-        option: '--ownerUserNames [ownerUserNames]'
-      },
-      {
-        option: '--memberIds [memberIds]'
-      },
-      {
-        option: '--memberUserNames [memberUserNames]'
-      },
-      {
-        option: '--visibility [visibility]',
-        autocomplete: ['Public', 'Private', 'HiddenMembership']
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.displayName.length > 256) {
-          return `The maximum amount of characters for 'displayName' is 256.`;
-        }
-
-        if (args.options.mailNickname) {
-          if (!validation.isValidMailNickname(args.options.mailNickname)) {
-            return `Value for option 'mailNickname' must contain only characters in the ASCII character set 0-127 except the following: @ () \\ [] " ; : <> , SPACE.`;
-          }
-
-          if (args.options.mailNickname.length > 64) {
-            return `The maximum amount of characters for 'mailNickname' is 64.`;
-          }
-        }
-
-        if (args.options.ownerIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.ownerIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for the option 'ownerIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if (args.options.ownerUserNames) {
-          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.ownerUserNames);
-          if (isValidUPNArrayResult !== true) {
-            return `The following user principal names are invalid for the option 'ownerUserNames': ${isValidUPNArrayResult}.`;
-          }
-        }
-
-        if (args.options.memberIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.memberIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for the option 'memberIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if (args.options.memberUserNames) {
-          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.memberUserNames);
-          if (isValidUPNArrayResult !== true) {
-            return `The following user principal names are invalid for the option 'memberUserNames': ${isValidUPNArrayResult}.`;
-          }
-        }
-
-        if (['microsoft365', 'security'].indexOf(args.options.type) === -1) {
-          return `Option 'type' must be one of the following values: microsoft365, security.`;
-        }
-
-        if (args.options.type === 'microsoft365' && !args.options.visibility) {
-          return `Option 'visibility' must be specified if the option 'type' is set to microsoft365`;
-        }
-
-        if (args.options.visibility && ['Public', 'Private', 'HiddenMembership'].indexOf(args.options.visibility!) === -1) {
-          return `Option 'visibility' must be one of the following values: Public, Private, HiddenMembership.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        displayName: typeof args.options.displayName !== 'undefined',
-        description: typeof args.options.description !== 'undefined',
-        type: typeof args.options.type !== 'undefined',
-        mailNickname: typeof args.options.mailNickname !== 'undefined',
-        ownerIds: typeof args.options.ownerIds !== 'undefined',
-        ownerUserNames: typeof args.options.ownerUserNames !== 'undefined',
-        memberIds: typeof args.options.memberIds !== 'undefined',
-        memberUserNames: typeof args.options.memberUserNames !== 'undefined',
-        visibility: typeof args.options.visibility !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => options.type !== 'microsoft365' || options.visibility !== undefined, {
+        error: `Option 'visibility' must be specified if the option 'type' is set to microsoft365`
       });
-      this.trackUnknownOptions(this.telemetryProperties, args.options);
-    });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -202,7 +127,7 @@ class EntraGroupAddCommand extends GraphCommand {
       securityEnabled: true
     };
 
-    this.addUnknownOptionsToPayload(requestBody, options);
+    this.addUnknownOptionsToPayloadZod(requestBody, options);
 
     return requestBody;
   }

--- a/src/m365/entra/commands/group/group-get.spec.ts
+++ b/src/m365/entra/commands/group/group-get.spec.ts
@@ -11,13 +11,14 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './group-get.js';
+import command, { options } from './group-get.js';
 
 describe(commands.GROUP_GET, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
   const groupResponse = {
     value: [{
       "id": "1caf7dcd-7e83-4c3a-94f7-932a1299c844",
@@ -60,6 +61,7 @@ describe(commands.GROUP_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -134,17 +136,17 @@ describe(commands.GROUP_GET, () => {
   });
 
   it('fails validation if the id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: '123' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ id: '123' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('passes validation if the id is a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: validId } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ id: validId });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation if required options specified (displayName)', async () => {
-    const actual = await command.validate({ options: { displayName: validDisplayName } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: validDisplayName });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/entra/commands/group/group-get.spec.ts
+++ b/src/m365/entra/commands/group/group-get.spec.ts
@@ -109,7 +109,7 @@ describe(commands.GROUP_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: validId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: validId }) });
     assert(loggerLogSpy.calledWith(groupResponse.value[0]));
   });
 
@@ -124,7 +124,7 @@ describe(commands.GROUP_GET, () => {
 
     sinon.stub(cli, 'handleMultipleResultsFound').resolves(groupResponse);
 
-    await command.action(logger, { options: { displayName: validDisplayName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: validDisplayName }) });
     assert(loggerLogSpy.calledWith(groupResponse.value[0]));
   });
 
@@ -132,7 +132,7 @@ describe(commands.GROUP_GET, () => {
     const errorMessage = 'Something went wrong';
     sinon.stub(request, 'get').rejects(new Error(errorMessage));
 
-    await assert.rejects(command.action(logger, { options: { id: validId } }), new CommandError(errorMessage));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: validId }) }), new CommandError(errorMessage));
   });
 
   it('fails validation if the id is not a valid GUID', async () => {

--- a/src/m365/entra/commands/group/group-get.ts
+++ b/src/m365/entra/commands/group/group-get.ts
@@ -1,19 +1,22 @@
 import { Group } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
-import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.uuid().optional().alias('i'),
+  displayName: z.string().optional().alias('n'),
+  properties: z.string().optional().alias('p')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  displayName?: string;
-  properties?: string;
 }
 
 class EntraGroupGetCommand extends GraphCommand {
@@ -25,55 +28,19 @@ class EntraGroupGetCommand extends GraphCommand {
     return 'Gets information about the specified Entra group';
   }
 
-  constructor() {
-    super();
-
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTelemetry();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-n, --displayName [displayName]'
-      },
-      {
-        option: '-p, --properties [properties]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
-          return `${args.options.id} is not a valid GUID`;
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.id, options.displayName].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: id or displayName.',
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'displayName']
         }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['id', 'displayName'] }
-    );
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        displayName: typeof args.options.displayName !== 'undefined',
-        properties: typeof args.options.properties !== 'undefined'
       });
-    });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/group/group-list.spec.ts
+++ b/src/m365/entra/commands/group/group-list.spec.ts
@@ -140,7 +140,7 @@ describe(commands.GROUP_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
@@ -246,7 +246,7 @@ describe(commands.GROUP_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { debug: true, output: 'text' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ debug: true, output: 'text' }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
@@ -323,7 +323,7 @@ describe(commands.GROUP_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'microsoft365' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'microsoft365' }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
@@ -355,7 +355,7 @@ describe(commands.GROUP_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'microsoft365', properties: 'id,displayName' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'microsoft365', properties: 'id,displayName' }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
@@ -387,7 +387,7 @@ describe(commands.GROUP_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'distribution' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'distribution' }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
@@ -425,7 +425,7 @@ describe(commands.GROUP_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'security' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'security' }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
@@ -461,7 +461,7 @@ describe(commands.GROUP_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'mailEnabledSecurity' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'mailEnabledSecurity' }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00e21c97-7800-4bc1-8024-a400aba6f46d",
@@ -480,6 +480,6 @@ describe(commands.GROUP_LIST, () => {
     const errorMessage = 'Something went wrong';
     sinon.stub(request, 'get').rejects(new Error(errorMessage));
 
-    await assert.rejects(command.action(logger, { options: {} }), new CommandError(errorMessage));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({}) }), new CommandError(errorMessage));
   });
 });

--- a/src/m365/entra/commands/group/group-list.spec.ts
+++ b/src/m365/entra/commands/group/group-list.spec.ts
@@ -11,13 +11,14 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './group-list.js';
+import command, { options } from './group-list.js';
 
 describe(commands.GROUP_LIST, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -26,6 +27,7 @@ describe(commands.GROUP_LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -69,21 +71,17 @@ describe(commands.GROUP_LIST, () => {
   });
 
   it('fails validation when invalid type specified', async () => {
-    const actual = await command.validate({
-      options: {
-        type: 'Invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      type: 'Invalid'
+    });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation when valid type specified', async () => {
-    const actual = await command.validate({
-      options: {
-        type: 'microsoft365'
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      type: 'microsoft365'
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('lists all aad groups in the tenant (verbose)', async () => {

--- a/src/m365/entra/commands/group/group-list.ts
+++ b/src/m365/entra/commands/group/group-list.ts
@@ -1,19 +1,31 @@
 import { Group } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import { CliRequestOptions } from '../../../../request.js';
 import { odata } from '../../../../utils/odata.js';
+import { zod } from '../../../../utils/zod.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+const GroupType = {
+  microsoft365: 'microsoft365',
+  security: 'security',
+  distribution: 'distribution',
+  mailEnabledSecurity: 'mailEnabledSecurity'
+} as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  type: zod.coercedEnum(GroupType).optional(),
+  properties: z.string().optional().alias('p')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  type?: string;
-  properties?: string;
 }
 
 interface ExtendedGroup extends Group {
@@ -21,8 +33,6 @@ interface ExtendedGroup extends Group {
 }
 
 class EntraGroupListCommand extends GraphCommand {
-  private static readonly groupTypes: string[] = ['microsoft365', 'security', 'distribution', 'mailEnabledSecurity'];
-
   public get name(): string {
     return commands.GROUP_LIST;
   }
@@ -35,45 +45,8 @@ class EntraGroupListCommand extends GraphCommand {
     return ['id', 'displayName', 'groupType'];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        type: typeof args.options.type !== 'undefined',
-        properties: typeof args.options.properties !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--type [type]',
-        autocomplete: EntraGroupListCommand.groupTypes
-      },
-      {
-        option: '-p, --properties [properties]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.type && EntraGroupListCommand.groupTypes.every(g => g.toLowerCase() !== args.options.type?.toLowerCase())) {
-          return `${args.options.type} is not a valid type value. Allowed values microsoft365|security|distribution|mailEnabledSecurity.`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -82,9 +55,7 @@ class EntraGroupListCommand extends GraphCommand {
       let useConsistencyLevelHeader = false;
 
       if (args.options.type) {
-        const groupType = EntraGroupListCommand.groupTypes.find(g => g.toLowerCase() === args.options.type?.toLowerCase());
-
-        switch (groupType) {
+        switch (args.options.type) {
           case 'microsoft365':
             requestUrl += `?$filter=groupTypes/any(c:c+eq+'Unified')`;
             break;

--- a/src/m365/entra/commands/group/group-member-add.spec.ts
+++ b/src/m365/entra/commands/group/group-member-add.spec.ts
@@ -9,7 +9,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { cli } from '../../../../cli/cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import command from './group-member-add.js';
+import command, { options } from './group-member-add.js';
 import request from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { entraUser } from '../../../../utils/entraUser.js';
@@ -25,6 +25,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -33,6 +34,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -73,58 +75,58 @@ describe(commands.GROUP_MEMBER_ADD, () => {
   });
 
   it('fails validation if groupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: 'foo', userIds: userIds[0], role: 'Member' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: 'foo', userIds: userIds[0], role: 'Member' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if userIds contains an invalid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: `${userIds[0]},foo`, role: 'Member' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: `${userIds[0]},foo`, role: 'Member' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if subgroupIds contains an invalid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, subgroupIds: `${groupIds[0]},foo`, role: 'Member' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, subgroupIds: `${groupIds[0]},foo`, role: 'Member' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if userNames contains an invalid UPN', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userNames: `${userUpns[0]},foo`, role: 'Member' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userNames: `${userUpns[0]},foo`, role: 'Member' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if role is not a valid role', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.join(','), role: 'foo' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.join(','), role: 'foo' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if subgroups specified by ids are added as owners', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, subgroupIds: groupIds.join(','), role: 'Owner' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, subgroupIds: groupIds.join(','), role: 'Owner' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if subgroups specified by names are added as owners', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, subgroupNames: groupNames.join(','), role: 'Owner' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, subgroupNames: groupNames.join(','), role: 'Owner' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with userIds', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.join(','), role: 'Member' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.join(','), role: 'Member' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with userIds with leading spaces', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.map(i => ' ' + i).join(','), role: 'Member' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.map(i => ' ' + i).join(','), role: 'Member' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with names', async () => {
-    const actual = await command.validate({ options: { groupName: 'IT department', userNames: userUpns.join(','), role: 'Owner' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupName: 'IT department', userNames: userUpns.join(','), role: 'Owner' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with names with trailing spaces', async () => {
-    const actual = await command.validate({ options: { groupName: 'IT department', userNames: userUpns.map(u => u + ' ').join(','), role: 'Member' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupName: 'IT department', userNames: userUpns.map(u => u + ' ').join(','), role: 'Member' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('successfully adds users to the group with userIds', async () => {

--- a/src/m365/entra/commands/group/group-member-add.spec.ts
+++ b/src/m365/entra/commands/group/group-member-add.spec.ts
@@ -221,7 +221,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: commandOptionsSchema.parse({ groupDisplayName: 'Contoso', userNames: userUpns.join(','), role: 'Owner', verbose: true }) });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', userNames: userUpns.join(','), role: 'Owner', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -379,7 +379,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', subgroupNames: groupNames.join(','), role: 'Owner', verbose: true }) });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', subgroupNames: groupNames.join(','), role: 'Member', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -387,7 +387,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
         url: `/groups/${groupId}`,
         headers: { 'content-type': 'application/json;odata.metadata=none' },
         body: {
-          'owners@odata.bind': groupIds.slice(0, 20).map(u => `https://graph.microsoft.com/v1.0/directoryObjects/${u}`)
+          'members@odata.bind': groupIds.slice(0, 20).map(u => `https://graph.microsoft.com/v1.0/directoryObjects/${u}`)
         }
       },
       {
@@ -396,7 +396,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
         url: `/groups/${groupId}`,
         headers: { 'content-type': 'application/json;odata.metadata=none' },
         body: {
-          'owners@odata.bind': groupIds.slice(20, 40).map(u => `https://graph.microsoft.com/v1.0/directoryObjects/${u}`)
+          'members@odata.bind': groupIds.slice(20, 40).map(u => `https://graph.microsoft.com/v1.0/directoryObjects/${u}`)
         }
       }
     ]);

--- a/src/m365/entra/commands/group/group-member-add.spec.ts
+++ b/src/m365/entra/commands/group/group-member-add.spec.ts
@@ -143,7 +143,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), role: 'Member', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), role: 'Member', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -181,7 +181,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
     });
 
     const ids = userIds.map(id => id + ' ').join(',');
-    await command.action(logger, { options: { groupId: groupId, userIds: ids, role: 'Member', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: ids, role: 'Member', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -221,7 +221,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupDisplayName: 'Contoso', userNames: userUpns.join(','), role: 'Owner', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupDisplayName: 'Contoso', userNames: userUpns.join(','), role: 'Owner', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -258,7 +258,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, subgroupIds: groupIds.join(','), role: 'Member', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, subgroupIds: groupIds.join(','), role: 'Member', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -298,7 +298,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupName: 'Contoso', userNames: userUpns.join(','), role: 'Owner', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', userNames: userUpns.join(','), role: 'Owner', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -339,7 +339,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
     });
 
     const userNames = userUpns.map(u => ' ' + u).join(',');
-    await command.action(logger, { options: { groupName: 'Contoso', userNames: userNames, role: 'Owner', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', userNames: userNames, role: 'Owner', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -379,7 +379,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupName: 'Contoso', subgroupNames: groupNames.join(','), role: 'Owner', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', subgroupNames: groupNames.join(','), role: 'Owner', verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, [
       {
         id: 1,
@@ -428,7 +428,7 @@ describe(commands.GROUP_MEMBER_ADD, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), role: 'Member' } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), role: 'Member' }) }),
       new CommandError(`One or more added object references already exist for the following modified properties: 'members'.`));
   });
 });

--- a/src/m365/entra/commands/group/group-member-add.ts
+++ b/src/m365/entra/commands/group/group-member-add.ts
@@ -20,15 +20,15 @@ export const options = z.strictObject({
   groupName: z.string().optional().alias('n'),
   userIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `The following GUIDs are invalid for the option 'userIds': ${e.input}.`
+      error: e => `The following GUIDs are invalid for the option 'userIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   userNames: z.string()
     .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
-      error: e => `The following user principal names are invalid for the option 'userNames': ${e.input}.`
+      error: e => `The following user principal names are invalid for the option 'userNames': ${validation.isValidUserPrincipalNameArray(e.input as string)}.`
     }).optional(),
   subgroupIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `The following GUIDs are invalid for the option 'subgroupIds': ${e.input}.`
+      error: e => `The following GUIDs are invalid for the option 'subgroupIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   subgroupNames: z.string().optional(),
   role: zod.coercedEnum(RoleEnum).alias('r')

--- a/src/m365/entra/commands/group/group-member-add.ts
+++ b/src/m365/entra/commands/group/group-member-add.ts
@@ -1,29 +1,46 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { entraUser } from '../../../../utils/entraUser.js';
 import { validation } from '../../../../utils/validation.js';
+import { zod } from '../../../../utils/zod.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
+
+const RoleEnum = {
+  Owner: 'Owner',
+  Member: 'Member'
+} as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  groupId: z.uuid().optional().alias('i'),
+  groupName: z.string().optional().alias('n'),
+  userIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `The following GUIDs are invalid for the option 'userIds': ${e.input}.`
+    }).optional(),
+  userNames: z.string()
+    .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
+      error: e => `The following user principal names are invalid for the option 'userNames': ${e.input}.`
+    }).optional(),
+  subgroupIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `The following GUIDs are invalid for the option 'subgroupIds': ${e.input}.`
+    }).optional(),
+  subgroupNames: z.string().optional(),
+  role: zod.coercedEnum(RoleEnum).alias('r')
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  groupId?: string;
-  groupName?: string;
-  userIds?: string;
-  userNames?: string;
-  subgroupIds?: string;
-  subgroupNames?: string;
-  role: string;
-}
-
 class EntraGroupMemberAddCommand extends GraphCommand {
-  private readonly roleValues = ['Owner', 'Member'];
-
   public get name(): string {
     return commands.GROUP_MEMBER_ADD;
   }
@@ -32,106 +49,29 @@ class EntraGroupMemberAddCommand extends GraphCommand {
     return 'Adds members to a Microsoft Entra group';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined',
-        userIds: typeof args.options.userIds !== 'undefined',
-        userNames: typeof args.options.userNames !== 'undefined',
-        subgroupIds: typeof args.options.subgroupIds !== 'undefined',
-        subgroupNames: typeof args.options.subgroupNames !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.groupId, options.groupName].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: groupId or groupName.',
+        params: {
+          customCode: 'optionSet',
+          options: ['groupId', 'groupName']
+        }
+      })
+      .refine(options => [options.userIds, options.userNames, options.subgroupIds, options.subgroupNames].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: userIds, userNames, subgroupIds, or subgroupNames.',
+        params: {
+          customCode: 'optionSet',
+          options: ['userIds', 'userNames', 'subgroupIds', 'subgroupNames']
+        }
+      })
+      .refine(options => !(options.subgroupIds || options.subgroupNames) || options.role !== 'Owner', {
+        error: `Subgroups cannot be set as owners.`
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --groupId [groupId]'
-      },
-      {
-        option: '-n, --groupName [groupName]'
-      },
-      {
-        option: '--userIds [userIds]'
-      },
-      {
-        option: '--userNames [userNames]'
-      },
-      {
-        option: '--subgroupIds [subgroupIds]'
-      },
-      {
-        option: '--subgroupNames [subgroupNames]'
-      },
-      {
-        option: '-r, --role <role>',
-        autocomplete: this.roleValues
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.groupId && !validation.isValidGuid(args.options.groupId)) {
-          return `${args.options.groupId} is not a valid GUID for option groupId.`;
-        }
-
-        if (args.options.userIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.userIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for the option 'userIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if (args.options.userNames) {
-          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.userNames);
-          if (isValidUPNArrayResult !== true) {
-            return `The following user principal names are invalid for the option 'userNames': ${isValidUPNArrayResult}.`;
-          }
-        }
-
-        if (args.options.subgroupIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.subgroupIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for the option 'subgroupIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if ((args.options.subgroupIds || args.options.subgroupNames) && args.options.role === 'Owner') {
-          return `Subgroups cannot be set as owners.`;
-        }
-
-        if (this.roleValues.indexOf(args.options.role) === -1) {
-          return `Option 'role' must be one of the following values: ${this.roleValues.join(', ')}.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['groupId', 'groupName'] },
-      { options: ['userIds', 'userNames', 'subgroupIds', 'subgroupNames'] }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('groupId', 'groupName', 'ids', 'userIds', 'userNames', 'subgroupIds', 'subgroupNames', 'role');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/group/group-member-list.spec.ts
+++ b/src/m365/entra/commands/group/group-member-list.spec.ts
@@ -14,7 +14,7 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { settingsNames } from '../../../../settingsNames.js';
 import { formatting } from '../../../../utils/formatting.js';
 import commands from '../../commands.js';
-import command from './group-member-list.js';
+import command, { options } from './group-member-list.js';
 
 describe(commands.GROUP_MEMBER_LIST, () => {
   const groupId = '2c1ba4c4-cd9b-4417-832f-92a34bc34b2a';
@@ -24,6 +24,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -32,6 +33,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -78,31 +80,25 @@ describe(commands.GROUP_MEMBER_LIST, () => {
   });
 
   it('fails validation if the groupId is not a valid guid.', async () => {
-    const actual = await command.validate({
-      options: {
-        groupId: 'not-c49b-4fd4-8223-28f0ac3a6402'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      groupId: 'not-c49b-4fd4-8223-28f0ac3a6402'
+    });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation when invalid role specified', async () => {
-    const actual = await command.validate({
-      options: {
-        groupId: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402',
-        role: 'Invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      groupId: '6703ac8a-c49b-4fd4-8223-28f0ac3a6402',
+      role: 'Invalid'
+    });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation when valid groupId and no role specified', async () => {
-    const actual = await command.validate({
-      options: {
-        groupId: groupId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({
+      groupId: groupId
+    });
+    assert.strictEqual(actual.success, true);
   });
 
   it('correctly lists all users in a Microsoft Entra group by id', async () => {

--- a/src/m365/entra/commands/group/group-member-list.spec.ts
+++ b/src/m365/entra/commands/group/group-member-list.spec.ts
@@ -121,7 +121,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, groupId: groupId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, groupId: groupId }) });
 
     assert(loggerLogSpy.calledOnceWithExactly([
       {
@@ -165,7 +165,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, groupName: groupName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, groupName: groupName }) });
 
     assert(loggerLogSpy.calledOnceWithExactly([
       {
@@ -197,7 +197,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, role: "Owner" } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, role: "Owner" }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00000000-0000-0000-0000-000000000000",
@@ -233,9 +233,9 @@ describe(commands.GROUP_MEMBER_LIST, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         groupName: groupName
-      }
+      })
     }), new CommandError(`Multiple groups with name 'CLI Test Group' found. Found: 9b1b1e42-794b-4c71-93ac-5ed92488b67f, 9b1b1e42-794b-4c71-93ac-5ed92488b67g.`));
   });
 
@@ -261,7 +261,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
 
     sinon.stub(cli, 'handleMultipleResultsFound').resolves({ id: '9b1b1e42-794b-4c71-93ac-5ed92488b67f' });
 
-    await command.action(logger, { options: { groupName: groupName, role: "Owner" } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: groupName, role: "Owner" }) });
     assert(loggerLogSpy.calledOnceWithExactly([
       {
         "id": "00000000-0000-0000-0000-000000000000",
@@ -288,7 +288,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, role: "Member" } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, role: "Member" }) });
 
     assert(loggerLogSpy.calledOnceWithExactly([
       {
@@ -331,7 +331,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, properties: "displayName,mail,memberof/id,memberof/displayName" } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, properties: "displayName,mail,memberof/id,memberof/displayName" }) });
 
     assert(loggerLogSpy.calledOnceWithExactly([
       { "id": "00000000-0000-0000-0000-000000000000", "displayName": "Karl Matteson", "mail": "karl.matteson@contoso.onmicrosoft.com", "memberOf": [{ "displayName": "Life and Music", "id": "d6c88284-c598-468d-8074-56acaf3c0453" }], "roles": ["Owner"] },
@@ -358,7 +358,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, filter: "userType eq 'Guest'" } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, filter: "userType eq 'Guest'" }) });
 
     assert(loggerLogSpy.calledOnceWithExactly([
       {
@@ -393,7 +393,7 @@ describe(commands.GROUP_MEMBER_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { verbose: true, groupId: groupId } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, groupId: groupId }) }),
       new CommandError(error.error.message));
   });
 });

--- a/src/m365/entra/commands/group/group-member-list.ts
+++ b/src/m365/entra/commands/group/group-member-list.ts
@@ -1,23 +1,32 @@
 import { User } from '@microsoft/microsoft-graph-types';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { odata } from '../../../../utils/odata.js';
-import { validation } from '../../../../utils/validation.js';
+import { zod } from '../../../../utils/zod.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+const RoleEnum = {
+  Owner: 'Owner',
+  Member: 'Member'
+} as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  groupId: z.uuid().optional().alias('i'),
+  groupName: z.string().optional().alias('n'),
+  role: zod.coercedEnum(RoleEnum).optional().alias('r'),
+  properties: z.string().optional().alias('p'),
+  filter: z.string().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  groupId?: string;
-  groupName?: string;
-  role?: string;
-  properties?: string;
-  filter?: string;
 }
 
 interface ExtendedUser extends User {
@@ -37,72 +46,19 @@ class EntraGroupMemberListCommand extends GraphCommand {
     return ['id', 'displayName', 'userPrincipalName', 'roles'];
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initOptionSets();
-    this.#initValidators();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined',
-        role: typeof args.options.role !== 'undefined',
-        properties: typeof args.options.properties !== 'undefined',
-        filter: typeof args.options.filter !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.groupId, options.groupName].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: groupId or groupName.',
+        params: {
+          customCode: 'optionSet',
+          options: ['groupId', 'groupName']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: "-i, --groupId [groupId]"
-      },
-      {
-        option: "-n, --groupName [groupName]"
-      },
-      {
-        option: "-r, --role [role]",
-        autocomplete: ["Owner", "Member"]
-      },
-      {
-        option: "-p, --properties [properties]"
-      },
-      {
-        option: "-f, --filter [filter]"
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      {
-        options: ['groupId', 'groupName']
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.groupId && !validation.isValidGuid(args.options.groupId)) {
-          return `${args.options.groupId} is not a valid GUID`;
-        }
-
-        if (args.options.role) {
-          if (['Owner', 'Member'].indexOf(args.options.role) === -1) {
-            return `${args.options.role} is not a valid role value. Allowed values Owner|Member`;
-          }
-        }
-
-        return true;
-      }
-    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/group/group-member-remove.spec.ts
+++ b/src/m365/entra/commands/group/group-member-remove.spec.ts
@@ -132,7 +132,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
   it('prompts before removing the specified users when confirm option not passed', async () => {
     const confirmationStub = sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    await command.action(logger, { options: { groupName: 'IT department', subgroupNames: groupNames.join(','), role: 'Member' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'IT department', subgroupNames: groupNames.join(','), role: 'Member' }) });
 
     assert(confirmationStub.calledOnce);
   });
@@ -142,7 +142,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
 
     const postSpy = sinon.stub(request, 'post').resolves();
 
-    await command.action(logger, { options: { groupId: groupId, userIds: userIds.join(',') } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(',') }) });
     assert(postSpy.notCalled);
   });
 
@@ -162,7 +162,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, Array.from({ length: 20 }, (_, index) => ({
       id: index + 1,
       method: 'DELETE',
@@ -185,7 +185,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, userIds: userIds.map(i => i + ' ').join(','), force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.map(i => i + ' ').join(','), force: true, verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, Array.from({ length: 20 }, (_, index) => ({
       id: index + 1,
       method: 'DELETE',
@@ -213,7 +213,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupName: 'Contoso', userNames: upns.join(','), verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', userNames: upns.join(','), verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, Array.from({ length: 20 }, (_, index) => ({
       id: index + 1,
       method: 'DELETE',
@@ -239,7 +239,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupName: 'Contoso', userNames: upns.map(u => + ' ' + u).join(','), force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', userNames: upns.map(u => + ' ' + u).join(','), force: true, verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, Array.from({ length: 20 }, (_, index) => ({
       id: index + 1,
       method: 'DELETE',
@@ -262,7 +262,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), role: 'Owner', force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), role: 'Owner', force: true, verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, Array.from({ length: 10 }, (_, index) => ({
       id: index + 1,
       method: 'DELETE',
@@ -288,7 +288,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupName: 'Contoso', userNames: upns.join(','), role: 'Member', force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', userNames: upns.join(','), role: 'Member', force: true, verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, Array.from({ length: 10 }, (_, index) => ({
       id: index + 1,
       method: 'DELETE',
@@ -311,7 +311,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, subgroupIds: groupIds.join(','), role: 'Member', force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, subgroupIds: groupIds.join(','), role: 'Member', force: true, verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, Array.from({ length: 3 }, (_, index) => ({
       id: index + 1,
       method: 'DELETE',
@@ -338,7 +338,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, subgroupNames: groupNames.join(','), role: 'Member', force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, subgroupNames: groupNames.join(','), role: 'Member', force: true, verbose: true }) });
     assert.deepStrictEqual(postStub.lastCall.args[0].data.requests, Array.from({ length: 3 }, (_, index) => ({
       id: index + 1,
       method: 'DELETE',
@@ -376,7 +376,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), force: true, verbose: true } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), force: true, verbose: true }) }),
       new CommandError(errorMessage));
   });
 
@@ -409,7 +409,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), suppressNotFound: true, force: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), suppressNotFound: true, force: true, verbose: true }) });
     assert(postStub.calledOnce);
   });
 });

--- a/src/m365/entra/commands/group/group-member-remove.spec.ts
+++ b/src/m365/entra/commands/group/group-member-remove.spec.ts
@@ -9,7 +9,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { cli } from '../../../../cli/cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import command from './group-member-remove.js';
+import command, { options } from './group-member-remove.js';
 import request from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { entraUser } from '../../../../utils/entraUser.js';
@@ -25,6 +25,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -33,6 +34,7 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -73,58 +75,58 @@ describe(commands.GROUP_MEMBER_REMOVE, () => {
   });
 
   it('fails validation if groupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: 'foo', userIds: userIds[0] } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: 'foo', userIds: userIds[0] });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if userIds contains an invalid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: `${userIds[0]},foo` } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: `${userIds[0]},foo` });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if userNames contains an invalid UPN', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userNames: `${upns[0]},foo` } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userNames: `${upns[0]},foo` });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if subgroupIds contains an invalid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, subgroupIds: `${groupIds[0]},foo`, role: 'Member' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, subgroupIds: `${groupIds[0]},foo`, role: 'Member' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if role is not a valid role', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.join(','), role: 'foo' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.join(','), role: 'foo' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if subgroupIds is specified without role option', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, subgroupIds: groupIds[0] } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, subgroupIds: groupIds[0] });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if subgroupNames is specified with owner role', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, subgroupIds: groupIds[0], role: 'Owner' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, subgroupIds: groupIds[0], role: 'Owner' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with ids', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.join(',') } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.join(',') });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with ids with leading spaces', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.map(i => ' ' + i).join(','), role: 'Member' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.map(i => ' ' + i).join(','), role: 'Member' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with names', async () => {
-    const actual = await command.validate({ options: { groupName: 'IT department', userNames: upns.join(',') } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupName: 'IT department', userNames: upns.join(',') });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with names with trailing spaces', async () => {
-    const actual = await command.validate({ options: { groupName: 'IT department', userNames: upns.map(u => u + ' ').join(','), role: 'Owner' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupName: 'IT department', userNames: upns.map(u => u + ' ').join(','), role: 'Owner' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('prompts before removing the specified users when confirm option not passed', async () => {

--- a/src/m365/entra/commands/group/group-member-remove.ts
+++ b/src/m365/entra/commands/group/group-member-remove.ts
@@ -22,15 +22,15 @@ export const options = z.strictObject({
   groupName: z.string().optional().alias('n'),
   userIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `Invalid GUIDs found for option 'ids': ${e.input}.`
+      error: e => `Invalid GUIDs found for option 'userIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   userNames: z.string()
     .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
-      error: e => `Invalid UPNs found for option 'userNames': ${e.input}.`
+      error: e => `Invalid UPNs found for option 'userNames': ${validation.isValidUserPrincipalNameArray(e.input as string)}.`
     }).optional(),
   subgroupIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `Invalid GUIDs found for option 'subgroupIds': ${e.input}.`
+      error: e => `Invalid GUIDs found for option 'subgroupIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   subgroupNames: z.string().optional(),
   role: zod.coercedEnum(RoleEnum).optional().alias('r'),

--- a/src/m365/entra/commands/group/group-member-remove.ts
+++ b/src/m365/entra/commands/group/group-member-remove.ts
@@ -1,33 +1,50 @@
-import GlobalOptions from '../../../../GlobalOptions.js';
-import GraphCommand from '../../../base/GraphCommand.js';
-import commands from '../../commands.js';
+import { z } from 'zod';
+import { cli } from '../../../../cli/cli.js';
+import { Logger } from '../../../../cli/Logger.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { GraphBatchRequest, GraphBatchRequestResponse } from '../../../../utils/types.js';
-import { Logger } from '../../../../cli/Logger.js';
-import { cli } from '../../../../cli/cli.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { entraUser } from '../../../../utils/entraUser.js';
 import { validation } from '../../../../utils/validation.js';
+import { zod } from '../../../../utils/zod.js';
+import GraphCommand from '../../../base/GraphCommand.js';
+import commands from '../../commands.js';
+
+const RoleEnum = {
+  Owner: 'Owner',
+  Member: 'Member'
+} as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  groupId: z.uuid().optional().alias('i'),
+  groupName: z.string().optional().alias('n'),
+  userIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `Invalid GUIDs found for option 'ids': ${e.input}.`
+    }).optional(),
+  userNames: z.string()
+    .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
+      error: e => `Invalid UPNs found for option 'userNames': ${e.input}.`
+    }).optional(),
+  subgroupIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `Invalid GUIDs found for option 'subgroupIds': ${e.input}.`
+    }).optional(),
+  subgroupNames: z.string().optional(),
+  role: zod.coercedEnum(RoleEnum).optional().alias('r'),
+  suppressNotFound: z.boolean().optional(),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  groupId?: string;
-  groupName?: string;
-  userIds?: string;
-  userNames?: string;
-  subgroupIds?: string;
-  subgroupNames?: string;
-  role?: string;
-  suppressNotFound?: boolean;
-  force?: boolean;
-}
-
 class EntraGroupMemberRemoveCommand extends GraphCommand {
-  private readonly roleValues = ['Owner', 'Member'];
-
   public get name(): string {
     return commands.GROUP_MEMBER_REMOVE;
   }
@@ -36,116 +53,29 @@ class EntraGroupMemberRemoveCommand extends GraphCommand {
     return 'Removes members from a Microsoft Entra group';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined',
-        userIds: typeof args.options.userIds !== 'undefined',
-        userNames: typeof args.options.userNames !== 'undefined',
-        subgroupIds: typeof args.options.subgroupIds !== 'undefined',
-        subgroupNames: typeof args.options.subgroupNames !== 'undefined',
-        role: typeof args.options.role !== 'undefined',
-        suppressNotFound: !!args.options.suppressNotFound,
-        force: !!args.options.force
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.groupId, options.groupName].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: groupId or groupName.',
+        params: {
+          customCode: 'optionSet',
+          options: ['groupId', 'groupName']
+        }
+      })
+      .refine(options => [options.userIds, options.userNames, options.subgroupIds, options.subgroupNames].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: userIds, userNames, subgroupIds, or subgroupNames.',
+        params: {
+          customCode: 'optionSet',
+          options: ['userIds', 'userNames', 'subgroupIds', 'subgroupNames']
+        }
+      })
+      .refine(options => !(options.subgroupIds !== undefined || options.subgroupNames !== undefined) || options.role?.toLowerCase() === 'member', {
+        error: `When removing subgroups, the 'role' option must be set to 'Member'.`
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --groupId [groupId]'
-      },
-      {
-        option: '-n, --groupName [groupName]'
-      },
-      {
-        option: '--userIds [userIds]'
-      },
-      {
-        option: '--userNames [userNames]'
-      },
-      {
-        option: '--subgroupIds [subgroupIds]'
-      },
-      {
-        option: '--subgroupNames [subgroupNames]'
-      },
-      {
-        option: '-r, --role [role]',
-        autocomplete: this.roleValues
-      },
-      {
-        option: '--suppressNotFound'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.groupId !== undefined && !validation.isValidGuid(args.options.groupId)) {
-          return `'${args.options.groupId}' is not a valid GUID for option 'groupId'.`;
-        }
-
-        if (args.options.userIds !== undefined) {
-          const invalidGuids = validation.isValidGuidArray(args.options.userIds);
-          if (invalidGuids !== true) {
-            return `Invalid GUIDs found for option 'ids': ${invalidGuids}.`;
-          }
-        }
-
-        if (args.options.userNames !== undefined) {
-          const invalidUpns = validation.isValidUserPrincipalNameArray(args.options.userNames);
-          if (invalidUpns !== true) {
-            return `Invalid UPNs found for option 'userNames': ${invalidUpns}.`;
-          }
-        }
-
-        if (args.options.subgroupIds !== undefined) {
-          const invalidGuids = validation.isValidGuidArray(args.options.subgroupIds);
-          if (invalidGuids !== true) {
-            return `Invalid GUIDs found for option 'subgroupIds': ${invalidGuids}.`;
-          }
-        }
-
-        if (args.options.role !== undefined && this.roleValues.indexOf(args.options.role) === -1) {
-          return `Option 'role' must be one of the following values: ${this.roleValues.join(', ')}.`;
-        }
-
-        if ((args.options.subgroupIds !== undefined || args.options.subgroupNames !== undefined) && args.options.role?.toLowerCase() !== 'member') {
-          return `When removing subgroups, the 'role' option must be set to 'Member'.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['groupId', 'groupName'] },
-      { options: ['userIds', 'userNames', 'subgroupIds', 'subgroupNames'] }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('groupId', 'groupName', 'ids', 'userNames', 'subgroupIds', 'subgroupNames', 'role');
-    this.types.boolean.push('force', 'suppressNotFound');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/group/group-member-set.spec.ts
+++ b/src/m365/entra/commands/group/group-member-set.spec.ts
@@ -154,7 +154,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), role: 'Member', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), role: 'Member', verbose: true }) });
     assert.deepStrictEqual(postStub.firstCall.args[0].data.requests, [
       {
         id: 1,
@@ -221,7 +221,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
     });
 
     const ids = userIds.map(id => id + ' ').join(',');
-    await command.action(logger, { options: { groupId: groupId, userIds: ids, role: 'Member', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: ids, role: 'Member', verbose: true }) });
     assert.deepStrictEqual(postStub.firstCall.args[0].data.requests, [
       {
         id: 1,
@@ -291,7 +291,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { groupName: 'Contoso', userNames: userUpns.join(','), role: 'Owner', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', userNames: userUpns.join(','), role: 'Owner', verbose: true }) });
     assert.deepStrictEqual(postStub.firstCall.args[0].data.requests, [
       {
         id: 1,
@@ -361,7 +361,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
     });
 
     const userNames = userUpns.map(u => ' ' + u).join(',');
-    await command.action(logger, { options: { groupName: 'Contoso', userNames: userNames, role: 'Owner', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ groupName: 'Contoso', userNames: userNames, role: 'Owner', verbose: true }) });
     assert.deepStrictEqual(postStub.firstCall.args[0].data.requests, [
       {
         id: 1,
@@ -411,7 +411,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), role: 'Member' } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), role: 'Member' }) }),
       new CommandError(`One or more added object references already exist for the following modified properties: 'members'.`));
   });
 
@@ -452,7 +452,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), role: 'Member' } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), role: 'Member' }) }),
       new CommandError('Service unavailable.'));
   });
 
@@ -511,7 +511,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { groupId: groupId, userIds: userIds.join(','), role: 'Member' } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ groupId: groupId, userIds: userIds.join(','), role: 'Member' }) }),
       new CommandError('Service unavailable.'));
   });
 });

--- a/src/m365/entra/commands/group/group-member-set.spec.ts
+++ b/src/m365/entra/commands/group/group-member-set.spec.ts
@@ -9,7 +9,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { cli } from '../../../../cli/cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import command from './group-member-set.js';
+import command, { options } from './group-member-set.js';
 import request from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { entraUser } from '../../../../utils/entraUser.js';
@@ -23,6 +23,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -31,6 +32,7 @@ describe(commands.GROUP_MEMBER_SET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -70,43 +72,43 @@ describe(commands.GROUP_MEMBER_SET, () => {
   });
 
   it('fails validation if groupId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: 'foo', userIds: userIds[0], role: 'Member' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: 'foo', userIds: userIds[0], role: 'Member' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if userIds contains an invalid GUID', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: `${userIds[0]},foo`, role: 'Member' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: `${userIds[0]},foo`, role: 'Member' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if userNames contains an invalid UPN', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userNames: `${userUpns[0]},foo`, role: 'Member' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userNames: `${userUpns[0]},foo`, role: 'Member' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if role is not a valid role', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.join(','), role: 'foo' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.join(','), role: 'foo' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with userIds', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.join(','), role: 'Member' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.join(','), role: 'Member' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with userIds with leading spaces', async () => {
-    const actual = await command.validate({ options: { groupId: groupId, userIds: userIds.map(i => ' ' + i).join(','), role: 'Member' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupId: groupId, userIds: userIds.map(i => ' ' + i).join(','), role: 'Member' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with names', async () => {
-    const actual = await command.validate({ options: { groupName: 'IT department', userNames: userUpns.join(','), role: 'Owner' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupName: 'IT department', userNames: userUpns.join(','), role: 'Owner' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with names with trailing spaces', async () => {
-    const actual = await command.validate({ options: { groupName: 'IT department', userNames: userUpns.map(u => u + ' ').join(','), role: 'Owner' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ groupName: 'IT department', userNames: userUpns.map(u => u + ' ').join(','), role: 'Owner' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('successfully updates roles for users with userIds in the group', async () => {

--- a/src/m365/entra/commands/group/group-member-set.ts
+++ b/src/m365/entra/commands/group/group-member-set.ts
@@ -20,11 +20,11 @@ export const options = z.strictObject({
   groupName: z.string().optional().alias('n'),
   userIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `The following GUIDs are invalid for the option 'userIds': ${e.input}.`
+      error: e => `The following GUIDs are invalid for the option 'userIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   userNames: z.string()
     .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
-      error: e => `User principal name '${e.input}' is invalid for option 'userNames'.`
+      error: e => `User principal name '${validation.isValidUserPrincipalNameArray(e.input as string)}' is invalid for option 'userNames'.`
     }).optional(),
   role: zod.coercedEnum(RoleEnum).alias('r')
 });

--- a/src/m365/entra/commands/group/group-member-set.ts
+++ b/src/m365/entra/commands/group/group-member-set.ts
@@ -1,27 +1,41 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { entraUser } from '../../../../utils/entraUser.js';
 import { validation } from '../../../../utils/validation.js';
+import { zod } from '../../../../utils/zod.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
+
+const RoleEnum = {
+  Owner: 'Owner',
+  Member: 'Member'
+} as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  groupId: z.uuid().optional().alias('i'),
+  groupName: z.string().optional().alias('n'),
+  userIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `The following GUIDs are invalid for the option 'userIds': ${e.input}.`
+    }).optional(),
+  userNames: z.string()
+    .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
+      error: e => `User principal name '${e.input}' is invalid for option 'userNames'.`
+    }).optional(),
+  role: zod.coercedEnum(RoleEnum).alias('r')
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  groupId?: string;
-  groupName?: string;
-  userIds?: string;
-  userNames?: string;
-  role: string;
-}
-
 class EntraGroupMemberSetCommand extends GraphCommand {
-  private readonly roleValues = ['Owner', 'Member'];
-
   public get name(): string {
     return commands.GROUP_MEMBER_SET;
   }
@@ -30,87 +44,26 @@ class EntraGroupMemberSetCommand extends GraphCommand {
     return 'Updates the role of members in a Microsoft Entra ID group';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        groupId: typeof args.options.groupId !== 'undefined',
-        groupName: typeof args.options.groupName !== 'undefined',
-        userIds: typeof args.options.userIds !== 'undefined',
-        userNames: typeof args.options.userNames !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.groupId, options.groupName].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: groupId or groupName.',
+        params: {
+          customCode: 'optionSet',
+          options: ['groupId', 'groupName']
+        }
+      })
+      .refine(options => [options.userIds, options.userNames].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: userIds or userNames.',
+        params: {
+          customCode: 'optionSet',
+          options: ['userIds', 'userNames']
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --groupId [groupId]'
-      },
-      {
-        option: '-n, --groupName [groupName]'
-      },
-      {
-        option: '--userIds [userIds]'
-      },
-      {
-        option: '--userNames [userNames]'
-      },
-      {
-        option: '-r, --role <role>',
-        autocomplete: this.roleValues
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.groupId && !validation.isValidGuid(args.options.groupId)) {
-          return `${args.options.groupId} is not a valid GUID for option groupId.`;
-        }
-
-        if (args.options.userIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.userIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for the option 'userIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if (args.options.userNames) {
-          const isValidUserPrincipalNameArray = validation.isValidUserPrincipalNameArray(args.options.userNames);
-          if (isValidUserPrincipalNameArray !== true) {
-            return `User principal name '${isValidUserPrincipalNameArray}' is invalid for option 'userNames'.`;
-          }
-        }
-
-        if (this.roleValues.indexOf(args.options.role) === -1) {
-          return `Option 'role' must be one of the following values: ${this.roleValues.join(', ')}.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['groupId', 'groupName'] },
-      { options: ['userIds', 'userNames'] }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('groupId', 'groupName', 'userIds', 'userNames', 'role');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/group/group-remove.spec.ts
+++ b/src/m365/entra/commands/group/group-remove.spec.ts
@@ -83,7 +83,7 @@ describe(commands.GROUP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, id: groupId, force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, id: groupId, force: true }) });
     assert(deleteRequestStub.called);
   });
 
@@ -100,7 +100,7 @@ describe(commands.GROUP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, displayName: displayName, force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, displayName: displayName, force: true }) });
     assert(deleteRequestStub.called);
     assert(confirmationStub.notCalled);
   });
@@ -118,7 +118,7 @@ describe(commands.GROUP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true, displayName: displayName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, displayName: displayName }) });
     assert(deleteRequestStub.called);
     assert(confirmationStub.calledOnce);
   });
@@ -146,14 +146,14 @@ describe(commands.GROUP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { verbose: true, id: groupId, force: true } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ verbose: true, id: groupId, force: true }) }),
       new CommandError(error.error.message));
   });
 
   it('prompts before removing the specified group when confirm option not passed', async () => {
     const confirmationStub = sinon.stub(cli, 'promptForConfirmation').resolves(false);
 
-    await command.action(logger, { options: { id: groupId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: groupId }) });
 
     assert(confirmationStub.calledOnce);
   });
@@ -183,10 +183,10 @@ describe(commands.GROUP_REMOVE, () => {
     sinon.stub(request, 'delete').rejects('DELETE request executed');
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         displayName: displayName,
         force: true
-      }
+      })
     }), new CommandError(`Multiple groups with name 'CLI Test Group' found. Found: 9b1b1e42-794b-4c71-93ac-5ed92488b67f, 9b1b1e42-794b-4c71-93ac-5ed92488b67g.`));
   });
 
@@ -214,7 +214,7 @@ describe(commands.GROUP_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: displayName, force: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: displayName, force: true }) });
     assert(deleteRequestStub.called);
   });
 
@@ -223,7 +223,7 @@ describe(commands.GROUP_REMOVE, () => {
 
     const deleteSpy = sinon.stub(request, 'delete').resolves();
 
-    await command.action(logger, { options: { id: groupId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: groupId }) });
     assert(deleteSpy.notCalled);
   });
 

--- a/src/m365/entra/commands/group/group-remove.spec.ts
+++ b/src/m365/entra/commands/group/group-remove.spec.ts
@@ -12,7 +12,7 @@ import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
 import { cli } from '../../../../cli/cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import command from './group-remove.js';
+import command, { options } from './group-remove.js';
 import { settingsNames } from '../../../../settingsNames.js';
 import { formatting } from '../../../../utils/formatting.js';
 
@@ -23,6 +23,7 @@ describe(commands.GROUP_REMOVE, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -31,6 +32,7 @@ describe(commands.GROUP_REMOVE, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -226,12 +228,12 @@ describe(commands.GROUP_REMOVE, () => {
   });
 
   it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ id: 'invalid' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation when id is a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: groupId } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ id: groupId });
+    assert.strictEqual(actual.success, true);
   });
 });

--- a/src/m365/entra/commands/group/group-remove.ts
+++ b/src/m365/entra/commands/group/group-remove.ts
@@ -1,20 +1,23 @@
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
-import GraphCommand from '../../../base/GraphCommand.js';
-import commands from '../../commands.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
-import { validation } from '../../../../utils/validation.js';
+import GraphCommand from '../../../base/GraphCommand.js';
+import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.uuid().optional().alias('i'),
+  displayName: z.string().optional().alias('n'),
+  force: z.boolean().optional().alias('f')
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id?: string;
-  displayName?: string;
-  force?: boolean
 }
 
 class EntraGroupRemoveCommand extends GraphCommand {
@@ -26,62 +29,19 @@ class EntraGroupRemoveCommand extends GraphCommand {
     return 'Removes an Entra group';
   }
 
-  constructor() {
-    super();
-
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTelemetry();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: args.options.id !== 'undefined',
-        displayName: args.options.displayName !== 'undefined',
-        force: !!args.options.force
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '-n, --displayName [displayName]'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      {
-        options: ['id', 'displayName']
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
-          return `${args.options.id} is not a valid GUID for option id.`;
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.id, options.displayName].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: id or displayName.',
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'displayName']
         }
-
-        return true;
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'displayName');
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/entra/commands/group/group-set.spec.ts
+++ b/src/m365/entra/commands/group/group-set.spec.ts
@@ -158,7 +158,7 @@ describe(commands.GROUP_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: groupId, description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', newDisplayName: '365 group', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: groupId, description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', newDisplayName: '365 group', verbose: true }) });
     assert.deepStrictEqual(patchRequestStub.lastCall.args[0].data, {
       displayName: '365 group',
       description: 'Microsoft 365 group',
@@ -176,7 +176,7 @@ describe(commands.GROUP_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: groupId, description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', newDisplayName: '365 group', extension_b7d8e648520f41d3b9c0fdeb91768a0a_jobGroupTracker: 'JobGroupN', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: groupId, description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', newDisplayName: '365 group', extension_b7d8e648520f41d3b9c0fdeb91768a0a_jobGroupTracker: 'JobGroupN', verbose: true }) });
     assert.deepStrictEqual(patchRequestStub.lastCall.args[0].data, {
       displayName: '365 group',
       description: 'Microsoft 365 group',
@@ -195,7 +195,7 @@ describe(commands.GROUP_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: '', mailNickname: 'Microsoft365Group', visibility: 'Public', newDisplayName: '365 group' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: '', mailNickname: 'Microsoft365Group', visibility: 'Public', newDisplayName: '365 group' }) });
     assert.deepStrictEqual(patchRequestStub.lastCall.args[0].data, {
       displayName: '365 group',
       description: null,
@@ -254,7 +254,7 @@ describe(commands.GROUP_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: groupId, description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', ownerIds: userIds.join(',') } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: groupId, description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', ownerIds: userIds.join(',') }) });
     assert.deepStrictEqual(postStub.firstCall.args[0].data.requests, [
       {
         id: 1,
@@ -341,7 +341,7 @@ describe(commands.GROUP_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Private', memberUserNames: userUpns.join(','), verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Private', memberUserNames: userUpns.join(','), verbose: true }) });
     assert.deepStrictEqual(postStub.firstCall.args[0].data.requests, [
       {
         id: 1,
@@ -401,7 +401,7 @@ describe(commands.GROUP_SET, () => {
       };
     });
 
-    await assert.rejects(command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', ownerIds: userIds.join(',') } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public', ownerIds: userIds.join(',') }) }),
       new CommandError(`One or more added object references already exist for the following modified properties: 'members'.`));
   });
 
@@ -438,7 +438,7 @@ describe(commands.GROUP_SET, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', ownerIds: userIds.join(',') } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ displayName: 'Microsoft 365 Group', description: 'Microsoft 365 group', ownerIds: userIds.join(',') }) }),
       new CommandError('Service unavailable.'));
   });
 
@@ -454,7 +454,7 @@ describe(commands.GROUP_SET, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { id: groupId, description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public' } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: groupId, description: 'Microsoft 365 group', mailNickname: 'Microsoft365Group', visibility: 'Public' }) }),
       new CommandError('Invalid request'));
   });
 });

--- a/src/m365/entra/commands/group/group-set.spec.ts
+++ b/src/m365/entra/commands/group/group-set.spec.ts
@@ -10,7 +10,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import { cli } from '../../../../cli/cli.js';
 import { CommandInfo } from '../../../../cli/CommandInfo.js';
-import command from './group-set.js';
+import command, { options } from './group-set.js';
 import { entraUser } from '../../../../utils/entraUser.js';
 import { CommandError } from '../../../../Command.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
@@ -23,6 +23,7 @@ describe(commands.GROUP_SET, () => {
   let log: string[];
   let logger: Logger;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -32,6 +33,7 @@ describe(commands.GROUP_SET, () => {
     sinon.stub(entraGroup, 'getGroupIdByDisplayName').withArgs('Microsoft 365 Group').resolves(groupId);
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -77,74 +79,74 @@ describe(commands.GROUP_SET, () => {
 
   it('fails validation if the length of newDisplayName is more than 256 characters', async () => {
     const displayName = 'lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum';
-    const actual = await command.validate({ options: { id: groupId, newDisplayName: displayName } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ id: groupId, newDisplayName: displayName });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if the length of mailNickname is more than 64 characters', async () => {
     const mailNickname = 'loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumlorem';
-    const actual = await command.validate({ options: { displayName: 'Cli group', mailNickname: mailNickname } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', mailNickname: mailNickname });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if mailNickname is not valid', async () => {
     const mailNickname = 'lorem ipsum';
-    const actual = await command.validate({ options: { displayName: 'Cli group', mailNickname: mailNickname } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', mailNickname: mailNickname });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if ownerIds contains invalid GUID', async () => {
     const ownerIds = ['7167b488-1ffb-43f1-9547-35969469bada', 'foo'];
-    const actual = await command.validate({ options: { displayName: 'Cli group', ownerIds: ownerIds.join(',') } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', ownerIds: ownerIds.join(',') });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if ownerUserNames contains invalid user principal name', async () => {
     const ownerUserNames = ['john.doe@contoso.com', 'foo'];
-    const actual = await command.validate({ options: { displayName: 'Cli group', ownerUserNames: ownerUserNames.join(',') } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', ownerUserNames: ownerUserNames.join(',') });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if memberIds contains invalid GUID', async () => {
     const memberIds = ['7167b488-1ffb-43f1-9547-35969469bada', 'foo'];
-    const actual = await command.validate({ options: { displayName: 'Cli group', memberIds: memberIds.join(',') } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', memberIds: memberIds.join(',') });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if memberUserNames contains invalid user principal name', async () => {
     const memberUserNames = ['john.doe@contoso.com', 'foo'];
-    const actual = await command.validate({ options: { displayName: 'Cli group', memberUserNames: memberUserNames.join(',') } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', memberUserNames: memberUserNames.join(',') });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('fails validation if visibility contains invalid value', async () => {
-    const actual = await command.validate({ options: { displayName: 'Cli group', visibility: 'foo' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', visibility: 'foo' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation if id is a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: groupId, newDisplayName: 'Cli group' } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ id: groupId, newDisplayName: 'Cli group' });
+    assert.strictEqual(actual.success, true);
   });
 
   it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: 'foo', newDisplayName: 'Cli group' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ id: 'foo', newDisplayName: 'Cli group' });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with ids', async () => {
-    const actual = await command.validate({ options: { displayName: 'Cli group', ownerIds: userIds.join(',') } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', ownerIds: userIds.join(',') });
+    assert.strictEqual(actual.success, true);
   });
 
   it('passes validation when all required parameters are valid with user names', async () => {
-    const actual = await command.validate({ options: { displayName: 'Cli group', memberUserNames: userUpns.join(',') } }, commandInfo);
-    assert.strictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ displayName: 'Cli group', memberUserNames: userUpns.join(',') });
+    assert.strictEqual(actual.success, true);
   });
 
   it('fails validation if no options to be updated are specified', async () => {
-    const actual = await command.validate({ options: { id: groupId } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ id: groupId });
+    assert.notStrictEqual(actual.success, true);
   });
 
   it('successfully updates group specified by id', async () => {

--- a/src/m365/entra/commands/group/group-set.ts
+++ b/src/m365/entra/commands/group/group-set.ts
@@ -1,35 +1,62 @@
-import GlobalOptions from '../../../../GlobalOptions.js';
-import GraphCommand from '../../../base/GraphCommand.js';
-import commands from '../../commands.js';
-import { validation } from '../../../../utils/validation.js';
-import request, { CliRequestOptions } from '../../../../request.js';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import { entraUser } from '../../../../utils/entraUser.js';
+import { globalOptionsZod } from '../../../../Command.js';
+import request, { CliRequestOptions } from '../../../../request.js';
 import { entraGroup } from '../../../../utils/entraGroup.js';
+import { entraUser } from '../../../../utils/entraUser.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { odata } from '../../../../utils/odata.js';
+import { validation } from '../../../../utils/validation.js';
+import { zod } from '../../../../utils/zod.js';
 import { User } from '@microsoft/microsoft-graph-types';
+import GraphCommand from '../../../base/GraphCommand.js';
+import commands from '../../commands.js';
+
+const VisibilityEnum = {
+  Public: 'Public',
+  Private: 'Private'
+} as const;
+
+export const options = z.looseObject({
+  ...globalOptionsZod.shape,
+  id: z.uuid().optional().alias('i'),
+  displayName: z.string().optional().alias('n'),
+  newDisplayName: z.string().max(256, `The maximum amount of characters for 'newDisplayName' is 256.`).optional(),
+  description: z.string().optional(),
+  mailNickname: z.string()
+    .refine(val => validation.isValidMailNickname(val), {
+      error: e => `Value '${e.input}' for option 'mailNickname' must contain only characters in the ASCII character set 0-127 except the following: @ () \\ [] " ; : <> , SPACE.`
+    })
+    .refine(val => val.length <= 64, {
+      error: `The maximum amount of characters for 'mailNickname' is 64.`
+    })
+    .optional(),
+  ownerIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `The following GUIDs are invalid for option 'ownerIds': ${e.input}.`
+    }).optional(),
+  ownerUserNames: z.string()
+    .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
+      error: e => `The following user principal names are invalid for option 'ownerUserNames': ${e.input}.`
+    }).optional(),
+  memberIds: z.string()
+    .refine(ids => validation.isValidGuidArray(ids) === true, {
+      error: e => `The following GUIDs are invalid for option 'memberIds': ${e.input}.`
+    }).optional(),
+  memberUserNames: z.string()
+    .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
+      error: e => `The following user principal names are invalid for option 'memberUserNames': ${e.input}.`
+    }).optional(),
+  visibility: zod.coercedEnum(VisibilityEnum).optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  id?: string;
-  displayName?: string;
-  newDisplayName?: string;
-  description?: string;
-  mailNickname?: string;
-  ownerIds?: string;
-  ownerUserNames?: string;
-  memberIds?: string;
-  memberUserNames?: string;
-  visibility?: string;
-}
-
 class EntraGroupSetCommand extends GraphCommand {
-  private readonly allowedVisibility: string[] = ['Public', 'Private'];
-
   public get name(): string {
     return commands.GROUP_SET;
   }
@@ -42,150 +69,38 @@ class EntraGroupSetCommand extends GraphCommand {
     return true;
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
-    this.#initTypes();
+  public get schema(): z.ZodType | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        id: typeof args.options.id !== 'undefined',
-        displayName: typeof args.options.displayName !== 'undefined',
-        newDisplayName: typeof args.options.newDisplayName !== 'undefined',
-        description: typeof args.options.description !== 'undefined',
-        mailNickname: typeof args.options.mailNickname !== 'undefined',
-        ownerIds: typeof args.options.ownerIds !== 'undefined',
-        ownerUserNames: typeof args.options.ownerUserNames !== 'undefined',
-        memberIds: typeof args.options.memberIds !== 'undefined',
-        memberUserNames: typeof args.options.memberUserNames !== 'undefined',
-        visibility: typeof args.options.visibility !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(options => [options.id, options.displayName].filter(o => o !== undefined).length === 1, {
+        error: 'Use one of the following options: id or displayName.',
+        params: {
+          customCode: 'optionSet',
+          options: ['id', 'displayName']
+        }
+      })
+      .refine(options => !(options.ownerIds && options.ownerUserNames), {
+        error: 'Use one of the following options: ownerIds or ownerUserNames.',
+        params: {
+          customCode: 'optionSet',
+          options: ['ownerIds', 'ownerUserNames']
+        }
+      })
+      .refine(options => !(options.memberIds && options.memberUserNames), {
+        error: 'Use one of the following options: memberIds or memberUserNames.',
+        params: {
+          customCode: 'optionSet',
+          options: ['memberIds', 'memberUserNames']
+        }
+      })
+      .refine(options => options.newDisplayName !== undefined || options.description !== undefined || options.visibility !== undefined
+        || options.ownerIds !== undefined || options.ownerUserNames !== undefined || options.memberIds !== undefined
+        || options.memberUserNames !== undefined || options.mailNickname !== undefined, {
+        error: `Specify at least one of the following options: 'newDisplayName', 'description', 'visibility', 'ownerIds', 'ownerUserNames', 'memberIds', 'memberUserNames', 'mailNickname'.`
       });
-      this.trackUnknownOptions(this.telemetryProperties, args.options);
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id [id]'
-      },
-      {
-        option: '--mailNickname [mailNickname]'
-      },
-      {
-        option: '-n, --displayName [displayName]'
-      },
-      {
-        option: '--newDisplayName [newDisplayName]'
-      },
-      {
-        option: '--description [description]'
-      },
-      {
-        option: '--ownerIds [ownerIds]'
-      },
-      {
-        option: '--ownerUserNames [ownerUserNames]'
-      },
-      {
-        option: '--memberIds [memberIds]'
-      },
-      {
-        option: '--memberUserNames [memberUserNames]'
-      },
-      {
-        option: '--visibility [visibility]',
-        autocomplete: this.allowedVisibility
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.id && !validation.isValidGuid(args.options.id)) {
-          return `Value '${args.options.id}' is not a valid GUID for option 'id'.`;
-        }
-
-        if (args.options.newDisplayName && args.options.newDisplayName.length > 256) {
-          return `The maximum amount of characters for 'newDisplayName' is 256.`;
-        }
-
-        if (args.options.mailNickname) {
-          if (!validation.isValidMailNickname(args.options.mailNickname)) {
-            return `Value '${args.options.mailNickname}' for option 'mailNickname' must contain only characters in the ASCII character set 0-127 except the following: @ () \\ [] " ; : <> , SPACE.`;
-          }
-
-          if (args.options.mailNickname.length > 64) {
-            return `The maximum amount of characters for 'mailNickname' is 64.`;
-          }
-        }
-
-        if (args.options.ownerIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.ownerIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for option 'ownerIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if (args.options.ownerUserNames) {
-          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.ownerUserNames);
-          if (isValidUPNArrayResult !== true) {
-            return `The following user principal names are invalid for option 'ownerUserNames': ${isValidUPNArrayResult}.`;
-          }
-        }
-
-        if (args.options.memberIds) {
-          const isValidGUIDArrayResult = validation.isValidGuidArray(args.options.memberIds);
-          if (isValidGUIDArrayResult !== true) {
-            return `The following GUIDs are invalid for option 'memberIds': ${isValidGUIDArrayResult}.`;
-          }
-        }
-
-        if (args.options.memberUserNames) {
-          const isValidUPNArrayResult = validation.isValidUserPrincipalNameArray(args.options.memberUserNames);
-          if (isValidUPNArrayResult !== true) {
-            return `The following user principal names are invalid for option 'memberUserNames': ${isValidUPNArrayResult}.`;
-          }
-        }
-
-        if (args.options.visibility && !this.allowedVisibility.includes(args.options.visibility)) {
-          return `Option 'visibility' must be one of the following values: ${this.allowedVisibility.join(', ')}.`;
-        }
-
-        if (args.options.newDisplayName === undefined && args.options.description === undefined && args.options.visibility === undefined
-          && args.options.ownerIds === undefined && args.options.ownerUserNames === undefined && args.options.memberIds === undefined
-          && args.options.memberUserNames === undefined && args.options.mailNickname === undefined) {
-          return `Specify at least one of the following options: 'newDisplayName', 'description', 'visibility', 'ownerIds', 'ownerUserNames', 'memberIds', 'memberUserNames', 'mailNickname'.`;
-        }
-
-        return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['id', 'displayName'] },
-      {
-        options: ['ownerIds', 'ownerUserNames'],
-        runsWhen: (args) => args.options.ownerIds || args.options.ownerUserNames
-      },
-      {
-        options: ['memberIds', 'memberUserNames'],
-        runsWhen: (args) => args.options.memberIds || args.options.memberUserNames
-      }
-    );
-  }
-
-  #initTypes(): void {
-    this.types.string.push('id', 'displayName', 'newDisplayName', 'description', 'mailNickname', 'ownerIds', 'ownerUserNames', 'memberIds', 'memberUserNames', 'visibility');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -207,7 +122,7 @@ class EntraGroupSetCommand extends GraphCommand {
         visibility: args.options.visibility
       };
 
-      this.addUnknownOptionsToPayload(requestBody, args.options);
+      this.addUnknownOptionsToPayloadZod(requestBody, args.options);
 
       const requestOptions: CliRequestOptions = {
         url: `${this.resource}/v1.0/groups/${groupId}`,

--- a/src/m365/entra/commands/group/group-set.ts
+++ b/src/m365/entra/commands/group/group-set.ts
@@ -33,19 +33,19 @@ export const options = z.looseObject({
     .optional(),
   ownerIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `The following GUIDs are invalid for option 'ownerIds': ${e.input}.`
+      error: e => `The following GUIDs are invalid for option 'ownerIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   ownerUserNames: z.string()
     .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
-      error: e => `The following user principal names are invalid for option 'ownerUserNames': ${e.input}.`
+      error: e => `The following user principal names are invalid for option 'ownerUserNames': ${validation.isValidUserPrincipalNameArray(e.input as string)}.`
     }).optional(),
   memberIds: z.string()
     .refine(ids => validation.isValidGuidArray(ids) === true, {
-      error: e => `The following GUIDs are invalid for option 'memberIds': ${e.input}.`
+      error: e => `The following GUIDs are invalid for option 'memberIds': ${validation.isValidGuidArray(e.input as string)}.`
     }).optional(),
   memberUserNames: z.string()
     .refine(names => validation.isValidUserPrincipalNameArray(names) === true, {
-      error: e => `The following user principal names are invalid for option 'memberUserNames': ${e.input}.`
+      error: e => `The following user principal names are invalid for option 'memberUserNames': ${validation.isValidUserPrincipalNameArray(e.input as string)}.`
     }).optional(),
   visibility: zod.coercedEnum(VisibilityEnum).optional()
 });


### PR DESCRIPTION
Closes #7296

## Summary

Migrates all 9 `entra group` commands from the old `#initOptions`/`#initValidators`/`#initTelemetry` pattern to Zod schema validation:

### Commands migrated
- `entra group add`
- `entra group get`
- `entra group list`
- `entra group remove`
- `entra group set`
- `entra group member add`
- `entra group member list`
- `entra group member remove`
- `entra group member set`

### Changes per command
- Replaced `#initOptions()`, `#initValidators()`, `#initOptionSets()`, `#initTypes()`, `#initTelemetry()` and constructor with `z.strictObject`/`z.looseObject` schema
- Added `public get schema()` and `getRefinedSchema()` where needed
- Used `z.uuid()` for GUID fields, `zod.coercedEnum()` for enum options with autocomplete
- Used `.refine()` for cross-field validation (option sets, conditional requirements)
- Used `z.looseObject` for commands with `allowUnknownOptions` (`group-add`, `group-set`)
- Updated `addUnknownOptionsToPayload` → `addUnknownOptionsToPayloadZod`
- Updated all spec files to use `commandOptionsSchema.safeParse()` pattern

### Results
- **Build:** ✅
- **Lint:** ✅
- **Tests:** 15,722 passing ✅
- **Net reduction:** -475 lines