### PR TITLE
Migrate purview commands to Zod schema validation

### DIFF
--- a/src/m365/purview/commands/auditlog/auditlog-list.spec.ts
+++ b/src/m365/purview/commands/auditlog/auditlog-list.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './auditlog-list.js';
+import command, { options } from './auditlog-list.js';
 
 describe(commands.AUDITLOG_LIST, () => {
 
@@ -110,6 +110,7 @@ describe(commands.AUDITLOG_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -118,6 +119,7 @@ describe(commands.AUDITLOG_LIST, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
     if (!auth.connection.accessTokens[auth.defaultResource]) {
       auth.connection.accessTokens[auth.defaultResource] = {
         expiresOn: 'abc',
@@ -165,52 +167,57 @@ describe(commands.AUDITLOG_LIST, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if contentType has an invalid value', async () => {
-    const actual = await command.validate({ options: { contentType: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if contentType has an invalid value', () => {
+    const actual = commandOptionsSchema.safeParse({ contentType: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if startTime is not a valid date', async () => {
-    const actual = await command.validate({ options: { contentType: contentType, startTime: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if startTime is not a valid date', () => {
+    const actual = commandOptionsSchema.safeParse({ contentType: contentType, startTime: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if endTime is not a valid date', async () => {
-    const actual = await command.validate({ options: { contentType: contentType, endTime: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if endTime is not a valid date', () => {
+    const actual = commandOptionsSchema.safeParse({ contentType: contentType, endTime: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if startTime is more than 7 days in the past', async () => {
+  it('fails validation if startTime is more than 7 days in the past', () => {
     const startTime = new Date();
     startTime.setDate(startTime.getDate() - 7);
     startTime.setHours(startTime.getHours() - 2);
-    const actual = await command.validate({ options: { contentType: contentType, startTime: startTime.toISOString() } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ contentType: contentType, startTime: startTime.toISOString() });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if endTime is in the future', async () => {
+  it('fails validation if endTime is in the future', () => {
     const endTime = new Date();
     endTime.setHours(endTime.getHours() + 1);
-    const actual = await command.validate({ options: { contentType: contentType, endTime: endTime.toISOString() } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ contentType: contentType, endTime: endTime.toISOString() });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if endTime is before startTime', async () => {
+  it('fails validation if endTime is before startTime', () => {
     const startTime = new Date();
     const endTime = new Date(startTime);
     endTime.setTime(endTime.getTime() - 1);
-    const actual = await command.validate({ options: { contentType: contentType, startTime: startTime.toISOString(), endTime: endTime.toISOString() } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ contentType: contentType, startTime: startTime.toISOString(), endTime: endTime.toISOString() });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if only contentType is provided', async () => {
-    const actual = await command.validate({ options: { contentType: contentType } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if only contentType is provided', () => {
+    const actual = commandOptionsSchema.safeParse({ contentType: contentType });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation if startTime and endTime are provided', async () => {
-    const actual = await command.validate({ options: { contentType: contentType, startTime: startTime, endTime: endTime } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if startTime and endTime are provided', () => {
+    const actual = commandOptionsSchema.safeParse({ contentType: contentType, startTime: startTime, endTime: endTime });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ contentType: contentType, unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('handles error when unable to start new subscription', async () => {
@@ -234,9 +241,9 @@ describe(commands.AUDITLOG_LIST, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         contentType: 'DLP'
-      }
+      })
     }), new CommandError(`Unable to start subscription 'DLP.All'`));
   });
 
@@ -262,11 +269,11 @@ describe(commands.AUDITLOG_LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         contentType: contentType,
         startTime: startTime,
         endTime: endTime
-      }
+      })
     });
 
     assert(postStub.called);
@@ -338,12 +345,12 @@ describe(commands.AUDITLOG_LIST, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         contentType: contentType,
         startTime: startTime,
         endTime: endTime,
         verbose: true
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(auditLogs.sort((a, b) => a.CreationTime < b.CreationTime ? -1 : a.CreationTime > b.CreationTime ? 1 : 0)));

--- a/src/m365/purview/commands/auditlog/auditlog-list.ts
+++ b/src/m365/purview/commands/auditlog/auditlog-list.ts
@@ -1,25 +1,42 @@
+import { z } from 'zod';
 import Auth from '../../../../Auth.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import { validation } from '../../../../utils/validation.js';
 import O365MgmtCommand from '../../../base/O365MgmtCommand.js';
 import commands from '../../commands.js';
 
+const contentTypeOptions = ['AzureActiveDirectory', 'Exchange', 'SharePoint', 'General', 'DLP'] as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  contentType: z.enum(contentTypeOptions),
+  startTime: z.string().refine(val => validation.isValidISODateTime(val), {
+    message: 'The value is not a valid ISO date time string.'
+  }).refine(val => {
+    const lowerDateLimit = new Date();
+    lowerDateLimit.setDate(lowerDateLimit.getDate() - 7);
+    lowerDateLimit.setHours(lowerDateLimit.getHours() - 1);
+    return new Date(val) >= lowerDateLimit;
+  }, {
+    message: 'startTime value cannot be more than 7 days in the past.'
+  }).optional(),
+  endTime: z.string().refine(val => validation.isValidISODateTime(val), {
+    message: 'The value is not a valid ISO date time string.'
+  }).refine(val => new Date(val) <= new Date(), {
+    message: 'endTime value cannot be in the future.'
+  }).optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  contentType: string;
-  startTime?: string;
-  endTime?: string;
-}
-
 class PurviewAuditLogListCommand extends O365MgmtCommand {
-  private readonly contentTypeOptions = ['AzureActiveDirectory', 'Exchange', 'SharePoint', 'General', 'DLP'];
-
   public get name(): string {
     return commands.AUDITLOG_LIST;
   }
@@ -28,79 +45,24 @@ class PurviewAuditLogListCommand extends O365MgmtCommand {
     return 'List audit logs within your tenant';
   }
 
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
+  }
+
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(opts => {
+        if (opts.startTime && opts.endTime) {
+          return new Date(opts.startTime) < new Date(opts.endTime);
+        }
+        return true;
+      }, {
+        message: 'startTime value must be before endTime.'
+      });
+  }
+
   public defaultProperties(): string[] | undefined {
     return ['CreationTime', 'UserId', 'Operation', 'ObjectId'];
-  }
-
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        startTime: typeof args.options.startTime !== 'undefined',
-        endTime: typeof args.options.endTime !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--contentType <contentType>',
-        autocomplete: this.contentTypeOptions
-      },
-      {
-        option: '--startTime [startTime]'
-      },
-      {
-        option: '--endTime [endTime]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (this.contentTypeOptions.indexOf(args.options.contentType) === -1) {
-          return `'${args.options.contentType}' is not a valid contentType value. Allowed values: ${this.contentTypeOptions}.`;
-        }
-
-        if (args.options.startTime) {
-          if (!validation.isValidISODateTime(args.options.startTime)) {
-            return `'${args.options.startTime}' is not a valid ISO date time string.`;
-          }
-
-          const lowerDateLimit = new Date();
-          lowerDateLimit.setDate(lowerDateLimit.getDate() - 7);
-          lowerDateLimit.setHours(lowerDateLimit.getHours() - 1); // Min date is 7 days ago, however there seems to be an 1h margin
-          if (new Date(args.options.startTime) < lowerDateLimit) {
-            return 'startTime value cannot be more than 7 days in the past.';
-          }
-        }
-
-        if (args.options.endTime) {
-          if (!validation.isValidISODateTime(args.options.endTime)) {
-            return `'${args.options.endTime}' is not a valid ISO date time string.`;
-          }
-
-          if (new Date(args.options.endTime) > new Date()) {
-            return 'endTime value cannot be in the future.';
-          }
-        }
-
-        if (args.options.startTime && args.options.endTime && new Date(args.options.startTime) >= new Date(args.options.endTime)) {
-          return 'startTime value must be before endTime.';
-        }
-
-        return true;
-      }
-    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/purview/commands/auditlog/auditlog-list.ts
+++ b/src/m365/purview/commands/auditlog/auditlog-list.ts
@@ -14,19 +14,19 @@ export const options = z.strictObject({
   ...globalOptionsZod.shape,
   contentType: z.enum(contentTypeOptions),
   startTime: z.string().refine(val => validation.isValidISODateTime(val), {
-    message: 'The value is not a valid ISO date time string.'
+    error: 'The value is not a valid ISO date time string.'
   }).refine(val => {
     const lowerDateLimit = new Date();
     lowerDateLimit.setDate(lowerDateLimit.getDate() - 7);
     lowerDateLimit.setHours(lowerDateLimit.getHours() - 1);
     return new Date(val) >= lowerDateLimit;
   }, {
-    message: 'startTime value cannot be more than 7 days in the past.'
+    error: 'startTime value cannot be more than 7 days in the past.'
   }).optional(),
   endTime: z.string().refine(val => validation.isValidISODateTime(val), {
-    message: 'The value is not a valid ISO date time string.'
+    error: 'The value is not a valid ISO date time string.'
   }).refine(val => new Date(val) <= new Date(), {
-    message: 'endTime value cannot be in the future.'
+    error: 'endTime value cannot be in the future.'
   }).optional()
 });
 
@@ -57,7 +57,7 @@ class PurviewAuditLogListCommand extends O365MgmtCommand {
         }
         return true;
       }, {
-        message: 'startTime value must be before endTime.'
+        error: 'startTime value must be before endTime.'
       });
   }
 

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-add.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-add.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './retentionlabel-add.js';
+import command, { options } from './retentionlabel-add.js';
 
 describe(commands.RETENTIONLABEL_ADD, () => {
   const invalid = 'invalid';
@@ -86,6 +86,7 @@ describe(commands.RETENTIONLABEL_ADD, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -98,6 +99,7 @@ describe(commands.RETENTIONLABEL_ADD, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -138,83 +140,82 @@ describe(commands.RETENTIONLABEL_ADD, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if retentionDuration is not a number', async () => {
-    const actual = await command.validate({
-      options: {
-        displayName: displayName,
-        behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
-        actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: invalid
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if retentionDuration is not a number', () => {
+    const actual = commandOptionsSchema.safeParse({
+      displayName: displayName,
+      behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
+      actionAfterRetentionPeriod: actionAfterRetentionPeriod,
+      retentionDuration: invalid
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with id', async () => {
-    const actual = await command.validate({
-      options: {
-        displayName: displayName,
-        behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
-        actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration,
-        retentionTrigger: retentionTrigger,
-        defaultRecordBehavior: defaultRecordBehavior,
-        descriptionForUsers: descriptionForUsers,
-        descriptionForAdmins: descriptionForAdmins,
-        labelToBeApplied: labelToBeApplied
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with id', () => {
+    const actual = commandOptionsSchema.safeParse({
+      displayName: displayName,
+      behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
+      actionAfterRetentionPeriod: actionAfterRetentionPeriod,
+      retentionDuration: retentionDuration.toString(),
+      retentionTrigger: retentionTrigger,
+      defaultRecordBehavior: defaultRecordBehavior,
+      descriptionForUsers: descriptionForUsers,
+      descriptionForAdmins: descriptionForAdmins,
+      labelToBeApplied: labelToBeApplied
+    });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('rejects invalid behaviorDuringRetentionPeriod', async () => {
-    const actual = await command.validate({
-      options: {
-        displayName: displayName,
-        behaviorDuringRetentionPeriod: invalid,
-        actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, `${invalid} is not a valid behavior of a document with the label. Allowed values are doNotRetain, retain, retainAsRecord, retainAsRegulatoryRecord`);
+  it('rejects invalid behaviorDuringRetentionPeriod', () => {
+    const actual = commandOptionsSchema.safeParse({
+      displayName: displayName,
+      behaviorDuringRetentionPeriod: invalid,
+      actionAfterRetentionPeriod: actionAfterRetentionPeriod,
+      retentionDuration: retentionDuration.toString()
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('rejects invalid actionAfterRetentionPeriod', async () => {
-    const actual = await command.validate({
-      options: {
-        displayName: displayName,
-        behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
-        actionAfterRetentionPeriod: invalid,
-        retentionDuration: retentionDuration
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, `${invalid} is not a valid action to take on a document with the label. Allowed values are none, delete, startDispositionReview`);
+  it('rejects invalid actionAfterRetentionPeriod', () => {
+    const actual = commandOptionsSchema.safeParse({
+      displayName: displayName,
+      behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
+      actionAfterRetentionPeriod: invalid,
+      retentionDuration: retentionDuration.toString()
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('rejects invalid retentionTrigger', async () => {
-    const actual = await command.validate({
-      options: {
-        displayName: displayName,
-        behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
-        actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration,
-        retentionTrigger: invalid
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, `${invalid} is not a valid action retention duration calculation. Allowed values are dateLabeled, dateCreated, dateModified, dateOfEvent`);
+  it('rejects invalid retentionTrigger', () => {
+    const actual = commandOptionsSchema.safeParse({
+      displayName: displayName,
+      behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
+      actionAfterRetentionPeriod: actionAfterRetentionPeriod,
+      retentionDuration: retentionDuration.toString(),
+      retentionTrigger: invalid
+    });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('rejects invalid defaultRecordBehavior', async () => {
-    const actual = await command.validate({
-      options: {
-        displayName: displayName,
-        behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
-        actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration,
-        defaultRecordBehavior: invalid
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, `${invalid} is not a valid state of a record label. Allowed values are startLocked, startUnlocked`);
+  it('rejects invalid defaultRecordBehavior', () => {
+    const actual = commandOptionsSchema.safeParse({
+      displayName: displayName,
+      behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
+      actionAfterRetentionPeriod: actionAfterRetentionPeriod,
+      retentionDuration: retentionDuration.toString(),
+      defaultRecordBehavior: invalid
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({
+      displayName: displayName,
+      behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
+      actionAfterRetentionPeriod: actionAfterRetentionPeriod,
+      retentionDuration: retentionDuration.toString(),
+      unknownOption: 'value'
+    });
+    assert.strictEqual(actual.success, false);
   });
 
   it('throws error when no retention event type found with name', async () => {
@@ -227,14 +228,14 @@ describe(commands.RETENTIONLABEL_ADD, () => {
     });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         displayName: displayName,
         behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
         actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration,
+        retentionDuration: retentionDuration.toString(),
         retentionTrigger: "dateOfEvent",
         eventTypeName: eventTypeName
-      }
+      })
     }), new CommandError(`The specified retention event type '${eventTypeName}' does not exist.`));
   });
 
@@ -248,19 +249,19 @@ describe(commands.RETENTIONLABEL_ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         verbose: true,
         displayName: displayName,
         behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
         actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration,
+        retentionDuration: retentionDuration.toString(),
         retentionTrigger: retentionTrigger,
         defaultRecordBehavior: defaultRecordBehavior,
         descriptionForUsers: descriptionForUsers,
         descriptionForAdmins: descriptionForAdmins,
         labelToBeApplied: labelToBeApplied
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(requestResponse));
@@ -284,20 +285,20 @@ describe(commands.RETENTIONLABEL_ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         verbose: true,
         displayName: displayName,
         behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
         actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration,
+        retentionDuration: retentionDuration.toString(),
         retentionTrigger: "dateOfEvent",
         defaultRecordBehavior: defaultRecordBehavior,
         descriptionForUsers: descriptionForUsers,
         descriptionForAdmins: descriptionForAdmins,
         labelToBeApplied: labelToBeApplied,
         eventTypeName: eventTypeName
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(requestResponse));
@@ -313,20 +314,20 @@ describe(commands.RETENTIONLABEL_ADD, () => {
     });
 
     await command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         debug: true,
         verbose: true,
         displayName: displayName,
         behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
         actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration,
+        retentionDuration: retentionDuration.toString(),
         retentionTrigger: "dateOfEvent",
         defaultRecordBehavior: defaultRecordBehavior,
         descriptionForUsers: descriptionForUsers,
         descriptionForAdmins: descriptionForAdmins,
         labelToBeApplied: labelToBeApplied,
         eventTypeId: eventTypeId
-      }
+      })
     });
 
     assert(loggerLogSpy.calledWith(requestResponse));
@@ -336,12 +337,12 @@ describe(commands.RETENTIONLABEL_ADD, () => {
     sinon.stub(request, 'post').callsFake(() => { throw 'An error has occurred'; });
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         displayName: displayName,
         behaviorDuringRetentionPeriod: behaviorDuringRetentionPeriod,
         actionAfterRetentionPeriod: actionAfterRetentionPeriod,
-        retentionDuration: retentionDuration
-      }
+        retentionDuration: retentionDuration.toString()
+      })
     }), new CommandError("An error has occurred"));
   });
 });

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-add.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-add.ts
@@ -1,34 +1,40 @@
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { odata } from '../../../../utils/odata.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+const behaviorDuringRetentionPeriods = ['doNotRetain', 'retain', 'retainAsRecord', 'retainAsRegulatoryRecord'] as const;
+const actionAfterRetentionPeriods = ['none', 'delete', 'startDispositionReview'] as const;
+const retentionTriggers = ['dateLabeled', 'dateCreated', 'dateModified', 'dateOfEvent'] as const;
+const defaultRecordBehaviors = ['startLocked', 'startUnlocked'] as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  displayName: z.string().alias('n'),
+  behaviorDuringRetentionPeriod: z.enum(behaviorDuringRetentionPeriods),
+  actionAfterRetentionPeriod: z.enum(actionAfterRetentionPeriods),
+  retentionDuration: z.string().refine(val => !isNaN(Number(val)), {
+    message: 'retentionDuration must be a number'
+  }),
+  retentionTrigger: z.enum(retentionTriggers).optional().alias('t'),
+  defaultRecordBehavior: z.enum(defaultRecordBehaviors).optional(),
+  descriptionForUsers: z.string().optional(),
+  descriptionForAdmins: z.string().optional(),
+  labelToBeApplied: z.string().optional(),
+  eventTypeId: z.string().optional(),
+  eventTypeName: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  displayName: string;
-  behaviorDuringRetentionPeriod: string;
-  actionAfterRetentionPeriod: string;
-  retentionDuration: number;
-  retentionTrigger?: string;
-  defaultRecordBehavior?: string;
-  descriptionForUsers?: string;
-  descriptionForAdmins?: string;
-  labelToBeApplied?: string;
-  eventTypeId?: string;
-  eventTypeName?: string;
-}
-
 class PurviewRetentionLabelAddCommand extends GraphCommand {
-  private static readonly behaviorDuringRetentionPeriods = ['doNotRetain', 'retain', 'retainAsRecord', 'retainAsRegulatoryRecord'];
-  private static readonly actionAfterRetentionPeriods = ['none', 'delete', 'startDispositionReview'];
-  private static readonly retentionTriggers = ['dateLabeled', 'dateCreated', 'dateModified', 'dateOfEvent'];
-  private static readonly defaultRecordBehavior = ['startLocked', 'startUnlocked'];
-
   public get name(): string {
     return commands.RETENTIONLABEL_ADD;
   }
@@ -37,105 +43,24 @@ class PurviewRetentionLabelAddCommand extends GraphCommand {
     return 'Create a retention label';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        retentionTrigger: typeof args.options.retentionTrigger !== 'undefined',
-        defaultRecordBehavior: typeof args.options.defaultRecordBehavior !== 'undefined',
-        descriptionForUsers: typeof args.options.descriptionForUsers !== 'undefined',
-        descriptionForAdmins: typeof args.options.descriptionForAdmins !== 'undefined',
-        labelToBeApplied: typeof args.options.labelToBeApplied !== 'undefined',
-        eventTypeId: typeof args.options.eventTypeId !== 'undefined',
-        eventTypeName: typeof args.options.eventTypeName !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-n, --displayName <displayName>'
-      },
-      {
-        option: '--behaviorDuringRetentionPeriod <behaviorDuringRetentionPeriod>',
-        autocomplete: PurviewRetentionLabelAddCommand.behaviorDuringRetentionPeriods
-      },
-      {
-        option: '--actionAfterRetentionPeriod <actionAfterRetentionPeriod>',
-        autocomplete: PurviewRetentionLabelAddCommand.actionAfterRetentionPeriods
-      },
-      {
-        option: '--retentionDuration <retentionDuration>'
-      },
-      {
-        option: '-t, --retentionTrigger [retentionTrigger]',
-        autocomplete: PurviewRetentionLabelAddCommand.retentionTriggers
-      },
-      {
-        option: '--defaultRecordBehavior [defaultRecordBehavior]',
-        autocomplete: PurviewRetentionLabelAddCommand.defaultRecordBehavior
-      },
-      {
-        option: '--descriptionForUsers [descriptionForUsers]'
-      },
-      {
-        option: '--descriptionForAdmins [descriptionForAdmins]'
-      },
-      {
-        option: '--labelToBeApplied [labelToBeApplied]'
-      },
-      {
-        option: '--eventTypeId [eventTypeId]'
-      },
-      {
-        option: '--eventTypeName [eventTypeName]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (isNaN(args.options.retentionDuration)) {
-          return `Specified retentionDuration ${args.options.retentionDuration} is not a number`;
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(opts => {
+        if (opts.retentionTrigger === 'dateOfEvent') {
+          return [opts.eventTypeId, opts.eventTypeName].filter(x => x !== undefined).length === 1;
         }
-
-        if (PurviewRetentionLabelAddCommand.behaviorDuringRetentionPeriods.indexOf(args.options.behaviorDuringRetentionPeriod) === -1) {
-          return `${args.options.behaviorDuringRetentionPeriod} is not a valid behavior of a document with the label. Allowed values are ${PurviewRetentionLabelAddCommand.behaviorDuringRetentionPeriods.join(', ')}`;
-        }
-
-        if (PurviewRetentionLabelAddCommand.actionAfterRetentionPeriods.indexOf(args.options.actionAfterRetentionPeriod) === -1) {
-          return `${args.options.actionAfterRetentionPeriod} is not a valid action to take on a document with the label. Allowed values are ${PurviewRetentionLabelAddCommand.actionAfterRetentionPeriods.join(', ')}`;
-        }
-
-        if (args.options.retentionTrigger &&
-          PurviewRetentionLabelAddCommand.retentionTriggers.indexOf(args.options.retentionTrigger) === -1) {
-          return `${args.options.retentionTrigger} is not a valid action retention duration calculation. Allowed values are ${PurviewRetentionLabelAddCommand.retentionTriggers.join(', ')}`;
-        }
-
-        if (args.options.defaultRecordBehavior &&
-          PurviewRetentionLabelAddCommand.defaultRecordBehavior.indexOf(args.options.defaultRecordBehavior) === -1) {
-          return `${args.options.defaultRecordBehavior} is not a valid state of a record label. Allowed values are ${PurviewRetentionLabelAddCommand.defaultRecordBehavior.join(', ')}`;
-        }
-
         return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      { options: ['eventTypeId', 'eventTypeName'], runsWhen(args) { return args.options.retentionTrigger === 'dateOfEvent'; } }
-    );
+      }, {
+        message: `Specify either 'eventTypeId' or 'eventTypeName', but not both.`,
+        params: {
+          customCode: 'optionSet',
+          options: ['eventTypeId', 'eventTypeName']
+        }
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -149,7 +74,7 @@ class PurviewRetentionLabelAddCommand extends GraphCommand {
       retentionTrigger: retentionTrigger,
       retentionDuration: {
         '@odata.type': '#microsoft.graph.security.retentionDurationInDays',
-        days: args.options.retentionDuration
+        days: Number(args.options.retentionDuration)
       },
       defaultRecordBehavior: defaultRecordBehavior
     };

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-add.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-add.ts
@@ -17,7 +17,7 @@ export const options = z.strictObject({
   behaviorDuringRetentionPeriod: z.enum(behaviorDuringRetentionPeriods),
   actionAfterRetentionPeriod: z.enum(actionAfterRetentionPeriods),
   retentionDuration: z.string().refine(val => !isNaN(Number(val)), {
-    message: 'retentionDuration must be a number'
+    error: 'retentionDuration must be a number'
   }),
   retentionTrigger: z.enum(retentionTriggers).optional().alias('t'),
   defaultRecordBehavior: z.enum(defaultRecordBehaviors).optional(),
@@ -55,7 +55,7 @@ class PurviewRetentionLabelAddCommand extends GraphCommand {
         }
         return true;
       }, {
-        message: `Specify either 'eventTypeId' or 'eventTypeName', but not both.`,
+        error: `Specify either 'eventTypeId' or 'eventTypeName', but not both.`,
         params: {
           customCode: 'optionSet',
           options: ['eventTypeId', 'eventTypeName']

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-get.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-get.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './retentionlabel-get.js';
+import command, { options } from './retentionlabel-get.js';
 
 describe(commands.RETENTIONLABEL_GET, () => {
 
@@ -51,6 +51,7 @@ describe(commands.RETENTIONLABEL_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -63,6 +64,7 @@ describe(commands.RETENTIONLABEL_GET, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -102,6 +104,21 @@ describe(commands.RETENTIONLABEL_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
+  it('fails validation if id is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'invalid' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('passes validation if a correct id is entered', () => {
+    const actual = commandOptionsSchema.safeParse({ id: retentionLabelId });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ id: retentionLabelId, unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
+  });
+
   it('retrieves retention label specified by id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/beta/security/labels/retentionLabels/${retentionLabelId}`) {
@@ -111,7 +128,7 @@ describe(commands.RETENTIONLABEL_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: retentionLabelId, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: retentionLabelId, verbose: true }) });
     assert(loggerLogSpy.calledWith(retentionLabelGetResponse));
   });
 
@@ -124,16 +141,6 @@ describe(commands.RETENTIONLABEL_GET, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: retentionLabelId } }), new CommandError(`Error: The operation couldn't be performed because object '${retentionLabelId}' couldn't be found on 'FfoConfigurationSession'.`));
-  });
-
-  it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
-  });
-
-  it('passes validation if a correct id is entered', async () => {
-    const actual = await command.validate({ options: { id: retentionLabelId } }, commandInfo);
-    assert.strictEqual(actual, true);
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: retentionLabelId }) }), new CommandError(`Error: The operation couldn't be performed because object '${retentionLabelId}' couldn't be found on 'FfoConfigurationSession'.`));
   });
 });

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-get.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-get.ts
@@ -1,16 +1,22 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().refine(val => validation.isValidGuid(val), {
+    message: 'The value must be a valid GUID.'
+  }).alias('i')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id: string;
 }
 
 class PurviewRetentionLabelGetCommand extends GraphCommand {
@@ -22,31 +28,8 @@ class PurviewRetentionLabelGetCommand extends GraphCommand {
     return 'Retrieve the specified retention label';
   }
 
-  constructor() {
-    super();
-
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id <id>'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.id)) {
-          return `'${args.options.id}' is not a valid GUID.`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-get.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-get.ts
@@ -9,7 +9,7 @@ import commands from '../../commands.js';
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
   id: z.string().refine(val => validation.isValidGuid(val), {
-    message: 'The value must be a valid GUID.'
+    error: 'The value must be a valid GUID.'
   }).alias('i')
 });
 

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-remove.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-remove.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './retentionlabel-remove.js';
+import command, { options } from './retentionlabel-remove.js';
 
 describe(commands.RETENTIONLABEL_REMOVE, () => {
   const validId = 'e554d69c-0992-4f9b-8a66-fca3c4d9c531';
@@ -20,6 +20,7 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
   let logger: Logger;
   let promptIssued: boolean = false;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -32,6 +33,7 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -76,30 +78,23 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({
-      options: {
-        id: 'invalid'
-      }
-    }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if id is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with id', async () => {
-    const actual = await command.validate({
-      options: {
-        id: validId
-      }
-    }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with id', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId, unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('prompts before removing the specified retention label when force option not passed', async () => {
-    await command.action(logger, {
-      options: {
-        id: validId
-      }
-    });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: validId }) });
 
 
     assert(promptIssued);
@@ -107,11 +102,7 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
 
   it('aborts removing the specified retention label when force option not passed and prompt not confirmed', async () => {
     const deleteSpy = sinon.spy(request, 'delete');
-    await command.action(logger, {
-      options: {
-        id: validId
-      }
-    });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: validId }) });
     assert(deleteSpy.notCalled);
   });
 
@@ -127,11 +118,7 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, {
-      options: {
-        id: validId
-      }
-    });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: validId }) });
   });
 
   it('Correctly deletes retention label by id when prompt confirmed', async () => {
@@ -143,22 +130,17 @@ describe(commands.RETENTIONLABEL_REMOVE, () => {
       throw 'Invalid Request';
     });
 
-    await command.action(logger, {
-      options: {
-        id: validId,
-        force: true
-      }
-    });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: validId, force: true }) });
   });
 
   it('correctly handles random API error', async () => {
     sinon.stub(request, 'delete').rejects(new Error('An error has occurred'));
 
     await assert.rejects(command.action(logger, {
-      options: {
+      options: commandOptionsSchema.parse({
         id: validId,
         force: true
-      }
+      })
     }), new CommandError("An error has occurred"));
   });
 });

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
@@ -10,7 +10,7 @@ import commands from '../../commands.js';
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
   id: z.string().refine(val => validation.isValidGuid(val), {
-    message: 'The value must be a valid GUID.'
+    error: 'The value must be a valid GUID.'
   }).alias('i'),
   force: z.boolean().optional()
 });

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-remove.ts
@@ -1,18 +1,24 @@
+import { z } from 'zod';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().refine(val => validation.isValidGuid(val), {
+    message: 'The value must be a valid GUID.'
+  }).alias('i'),
+  force: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id: string;
-  force?: boolean;
 }
 
 class PurviewRetentionLabelRemoveCommand extends GraphCommand {
@@ -24,43 +30,8 @@ class PurviewRetentionLabelRemoveCommand extends GraphCommand {
     return 'Delete a retention label';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        force: !!args.options.force
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id <id>'
-      },
-      {
-        option: '-f, --force'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.id)) {
-          return `'${args.options.id}' is not a valid GUID.`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-set.spec.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-set.spec.ts
@@ -10,8 +10,8 @@ import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './retentionlabel-set.js';
 import { session } from '../../../../utils/session.js';
+import command, { options } from './retentionlabel-set.js';
 
 describe(commands.RETENTIONLABEL_SET, () => {
   const validId = 'e554d69c-0992-4f9b-8a66-fca3c4d9c531';
@@ -20,6 +20,7 @@ describe(commands.RETENTIONLABEL_SET, () => {
   let logger: Logger;
   let loggerLogToStderrSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -32,6 +33,7 @@ describe(commands.RETENTIONLABEL_SET, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -70,44 +72,49 @@ describe(commands.RETENTIONLABEL_SET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if id is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation with valid id but no other option specified', async () => {
-    const actual = await command.validate({ options: { id: validId } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation with valid id but no other option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when specifying an invalid value for behaviorDuringRetentionPeriod', async () => {
-    const actual = await command.validate({ options: { id: validId, behaviorDuringRetentionPeriod: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when specifying an invalid value for behaviorDuringRetentionPeriod', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId, behaviorDuringRetentionPeriod: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when specifying an invalid value for actionAfterRetentionPeriod', async () => {
-    const actual = await command.validate({ options: { id: validId, actionAfterRetentionPeriod: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when specifying an invalid value for actionAfterRetentionPeriod', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId, actionAfterRetentionPeriod: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when specifying an invalid value for retentionTrigger', async () => {
-    const actual = await command.validate({ options: { id: validId, retentionTrigger: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when specifying an invalid value for retentionTrigger', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId, retentionTrigger: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation when specifying an invalid value for defaultRecordBehavior', async () => {
-    const actual = await command.validate({ options: { id: validId, defaultRecordBehavior: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation when specifying an invalid value for defaultRecordBehavior', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId, defaultRecordBehavior: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation with valid id and a single option specified', async () => {
-    const actual = await command.validate({ options: { id: validId, retentionDuration: 180 } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation with valid id and a single option specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId, retentionDuration: '180' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('passes validation with valid id and multipe options specified', async () => {
-    const actual = await command.validate({ options: { id: validId, retentionDuration: 180, actionAfterRetentionPeriod: 'none' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation with valid id and multipe options specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId, retentionDuration: '180', actionAfterRetentionPeriod: 'none' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ id: validId, retentionDuration: '180', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('correctly sets field retentionDays and actionAfterRetentionPeriod of a specific retention label by id', async () => {
@@ -119,7 +126,7 @@ describe(commands.RETENTIONLABEL_SET, () => {
       throw 'Invalid Request';
     });
 
-    await command.action(logger, { options: { id: validId, retentionDuration: 180, actionAfterRetentionPeriod: 'none', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: validId, retentionDuration: '180', actionAfterRetentionPeriod: 'none', verbose: true }) });
     assert(loggerLogToStderrSpy.notCalled);
   });
 
@@ -132,7 +139,7 @@ describe(commands.RETENTIONLABEL_SET, () => {
       throw 'Invalid Request';
     });
 
-    await command.action(logger, { options: { id: validId, retentionTrigger: 'dateLabeled', defaultRecordBehavior: 'startLocked', behaviorDuringRetentionPeriod: 'retainAsRecord', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: validId, retentionTrigger: 'dateLabeled', defaultRecordBehavior: 'startLocked', behaviorDuringRetentionPeriod: 'retainAsRecord', verbose: true }) });
     assert(loggerLogToStderrSpy.notCalled);
   });
 
@@ -145,11 +152,11 @@ describe(commands.RETENTIONLABEL_SET, () => {
       throw 'Invalid Request';
     });
 
-    await command.action(logger, { options: { id: validId, descriptionForUsers: 'description for users', descriptionForAdmins: 'description for admins', labelToBeApplied: 'label to be applied', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: validId, descriptionForUsers: 'description for users', descriptionForAdmins: 'description for admins', labelToBeApplied: 'label to be applied', verbose: true }) });
     assert(loggerLogToStderrSpy.notCalled);
   });
 
-  it('fails to set field retentionDays of a specific retention label by id', async () => {
+  it('fails to set field retentionDuration of a specific retention label by id', async () => {
     sinon.stub(request, 'patch').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/beta/security/labels/retentionLabels/${validId}`) {
         throw 'Error occurred when updating the retention label';
@@ -158,6 +165,6 @@ describe(commands.RETENTIONLABEL_SET, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: validId, retentionDays: 180, actionAfterRetentionPeriod: 'none' } }), new CommandError('Error occurred when updating the retention label'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: validId, retentionDuration: '180', actionAfterRetentionPeriod: 'none' }) }), new CommandError('Error occurred when updating the retention label'));
   });
 });

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-set.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-set.ts
@@ -1,32 +1,40 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+const behaviorDuringRetentionPeriodValues = ['doNotRetain', 'retain', 'retainAsRecord', 'retainAsRegulatoryRecord'] as const;
+const actionAfterRetentionPeriodValues = ['none', 'delete', 'startDispositionReview'] as const;
+const retentionTriggerValues = ['dateLabeled', 'dateCreated', 'dateModified', 'dateOfEvent'] as const;
+const defaultRecordBehaviorValues = ['startLocked', 'startUnlocked'] as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().refine(val => validation.isValidGuid(val), {
+    message: 'The value must be a valid GUID.'
+  }).alias('i'),
+  behaviorDuringRetentionPeriod: z.enum(behaviorDuringRetentionPeriodValues).optional(),
+  actionAfterRetentionPeriod: z.enum(actionAfterRetentionPeriodValues).optional(),
+  retentionDuration: z.string().refine(val => !isNaN(Number(val)), {
+    message: 'retentionDuration must be a number'
+  }).optional(),
+  retentionTrigger: z.enum(retentionTriggerValues).optional().alias('t'),
+  defaultRecordBehavior: z.enum(defaultRecordBehaviorValues).optional(),
+  descriptionForUsers: z.string().optional(),
+  descriptionForAdmins: z.string().optional(),
+  labelToBeApplied: z.string().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  id: string;
-  behaviorDuringRetentionPeriod?: string;
-  actionAfterRetentionPeriod?: string;
-  retentionDuration?: number;
-  retentionTrigger?: string;
-  defaultRecordBehavior?: string;
-  descriptionForUsers?: string;
-  descriptionForAdmins?: string;
-  labelToBeApplied?: string;
-}
-
 class PurviewRetentionLabelSetCommand extends GraphCommand {
-  public allowedBehaviorDuringRetentionPeriodValues = ['doNotRetain', 'retain', 'retainAsRecord', 'retainAsRegulatoryRecord'];
-  public allowedActionAfterRetentionPeriodValues = ['none', 'delete', 'startDispositionReview'];
-  public allowedRetentionTriggerValues = ['dateLabeled', 'dateCreated', 'dateModified', 'dateOfEvent'];
-  public allowedDefaultRecordBehaviorValues = ['startLocked', 'startUnlocked'];
-
   public get name(): string {
     return commands.RETENTIONLABEL_SET;
   }
@@ -35,96 +43,18 @@ class PurviewRetentionLabelSetCommand extends GraphCommand {
     return 'Update a retention label';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        behaviorDuringRetentionPeriod: typeof args.options.behaviorDuringRetentionPeriod !== 'undefined',
-        actionAfterRetentionPeriod: typeof args.options.actionAfterRetentionPeriod !== 'undefined',
-        retentionDuration: typeof args.options.retentionDuration !== 'undefined',
-        retentionTrigger: typeof args.options.retentionTrigger !== 'undefined',
-        defaultRecordBehavior: typeof args.options.defaultRecordBehavior !== 'undefined',
-        descriptionForUsers: typeof args.options.descriptionForUsers !== 'undefined',
-        descriptionForAdmins: typeof args.options.descriptionForAdmins !== 'undefined',
-        labelToBeApplied: typeof args.options.labelToBeApplied !== 'undefined'
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(opts => opts.behaviorDuringRetentionPeriod || opts.actionAfterRetentionPeriod || opts.retentionDuration || opts.retentionTrigger || opts.defaultRecordBehavior || opts.descriptionForUsers || opts.descriptionForAdmins || opts.labelToBeApplied, {
+        message: 'Specify at least one property to update.',
+        params: {
+          customCode: 'required'
+        }
       });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id <id>'
-      },
-      {
-        option: '--behaviorDuringRetentionPeriod [behaviorDuringRetentionPeriod]',
-        autocomplete: this.allowedBehaviorDuringRetentionPeriodValues
-      },
-      {
-        option: '--actionAfterRetentionPeriod [actionAfterRetentionPeriod]',
-        autocomplete: this.allowedActionAfterRetentionPeriodValues
-      },
-      {
-        option: '--retentionDuration [retentionDuration]'
-      },
-      {
-        option: '-t, --retentionTrigger [retentionTrigger]',
-        autocomplete: this.allowedRetentionTriggerValues
-      },
-      {
-        option: '--defaultRecordBehavior [defaultRecordBehavior]',
-        autocomplete: this.allowedDefaultRecordBehaviorValues
-      },
-      {
-        option: '--descriptionForUsers [descriptionForUsers]'
-      },
-      {
-        option: '--descriptionForAdmins [descriptionForAdmins]'
-      },
-      {
-        option: '--labelToBeApplied [labelToBeApplied]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.id)) {
-          return `'${args.options.id}' is not a valid GUID.`;
-        }
-
-        const { actionAfterRetentionPeriod, behaviorDuringRetentionPeriod, defaultRecordBehavior, descriptionForAdmins, descriptionForUsers, labelToBeApplied, retentionDuration, retentionTrigger } = args.options;
-        if ([actionAfterRetentionPeriod, behaviorDuringRetentionPeriod, defaultRecordBehavior, descriptionForAdmins, descriptionForUsers, labelToBeApplied, retentionDuration, retentionTrigger].every(i => typeof i === 'undefined')) {
-          return `Specify at least one property to update.`;
-        }
-
-        if (behaviorDuringRetentionPeriod && this.allowedBehaviorDuringRetentionPeriodValues.indexOf(behaviorDuringRetentionPeriod) === -1) {
-          return `'${behaviorDuringRetentionPeriod}' is not a valid value for the behaviorDuringRetentionPeriod option. Allowed values are ${this.allowedBehaviorDuringRetentionPeriodValues.join('|')}`;
-        }
-
-        if (actionAfterRetentionPeriod && this.allowedActionAfterRetentionPeriodValues.indexOf(actionAfterRetentionPeriod) === -1) {
-          return `'${actionAfterRetentionPeriod}' is not a valid value for the actionAfterRetentionPeriod option. Allowed values are ${this.allowedActionAfterRetentionPeriodValues.join('|')}`;
-        }
-
-        if (retentionTrigger && this.allowedRetentionTriggerValues.indexOf(retentionTrigger) === -1) {
-          return `'${retentionTrigger}' is not a valid value for the retentionTrigger option. Allowed values are ${this.allowedRetentionTriggerValues.join('|')}`;
-        }
-
-        if (defaultRecordBehavior && this.allowedDefaultRecordBehaviorValues.indexOf(defaultRecordBehavior) === -1) {
-          return `'${defaultRecordBehavior}' is not a valid value for the defaultRecordBehavior option. Allowed values are ${this.allowedDefaultRecordBehaviorValues.join('|')}`;
-        }
-
-        return true;
-      }
-    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-set.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-set.ts
@@ -14,12 +14,12 @@ const defaultRecordBehaviorValues = ['startLocked', 'startUnlocked'] as const;
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
   id: z.string().refine(val => validation.isValidGuid(val), {
-    message: 'The value must be a valid GUID.'
+    error: 'The value must be a valid GUID.'
   }).alias('i'),
   behaviorDuringRetentionPeriod: z.enum(behaviorDuringRetentionPeriodValues).optional(),
   actionAfterRetentionPeriod: z.enum(actionAfterRetentionPeriodValues).optional(),
   retentionDuration: z.string().refine(val => !isNaN(Number(val)), {
-    message: 'retentionDuration must be a number'
+    error: 'retentionDuration must be a number'
   }).optional(),
   retentionTrigger: z.enum(retentionTriggerValues).optional().alias('t'),
   defaultRecordBehavior: z.enum(defaultRecordBehaviorValues).optional(),
@@ -50,7 +50,8 @@ class PurviewRetentionLabelSetCommand extends GraphCommand {
   public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
     return schema
       .refine(opts => opts.behaviorDuringRetentionPeriod || opts.actionAfterRetentionPeriod || opts.retentionDuration || opts.retentionTrigger || opts.defaultRecordBehavior || opts.descriptionForUsers || opts.descriptionForAdmins || opts.labelToBeApplied, {
-        message: 'Specify at least one property to update.',
+        error: 'Specify at least one property to update.',
+        path: ['behaviorDuringRetentionPeriod'],
         params: {
           customCode: 'required'
         }
@@ -98,7 +99,7 @@ class PurviewRetentionLabelSetCommand extends GraphCommand {
     if (options.retentionDuration) {
       requestBody['retentionDuration'] = {
         '@odata.type': 'microsoft.graph.security.retentionDurationInDays',
-        'days': options.retentionDuration
+        'days': Number(options.retentionDuration)
       };
     }
     return requestBody;

--- a/src/m365/purview/commands/retentionlabel/retentionlabel-set.ts
+++ b/src/m365/purview/commands/retentionlabel/retentionlabel-set.ts
@@ -51,9 +51,9 @@ class PurviewRetentionLabelSetCommand extends GraphCommand {
     return schema
       .refine(opts => opts.behaviorDuringRetentionPeriod || opts.actionAfterRetentionPeriod || opts.retentionDuration || opts.retentionTrigger || opts.defaultRecordBehavior || opts.descriptionForUsers || opts.descriptionForAdmins || opts.labelToBeApplied, {
         error: 'Specify at least one property to update.',
-        path: ['behaviorDuringRetentionPeriod'],
         params: {
-          customCode: 'required'
+          customCode: 'optionSet',
+          options: ['behaviorDuringRetentionPeriod', 'actionAfterRetentionPeriod', 'retentionDuration', 'retentionTrigger', 'defaultRecordBehavior', 'descriptionForUsers', 'descriptionForAdmins', 'labelToBeApplied']
         }
       });
   }

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.spec.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './sensitivitylabel-get.js';
+import command, { options } from './sensitivitylabel-get.js';
 
 describe(commands.SENSITIVITYLABEL_GET, () => {
   const sensitivityLabelId = '6f4fb2db-ecf4-4279-94ba-23d059bf157e';
@@ -38,6 +38,7 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -50,6 +51,7 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -91,34 +93,39 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if id is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if a correct id is entered', async () => {
-    const actual = await command.validate({ options: { id: sensitivityLabelId } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if a correct id is entered', () => {
+    const actual = commandOptionsSchema.safeParse({ id: sensitivityLabelId });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: sensitivityLabelId, userId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: sensitivityLabelId, userId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with a userId defined', async () => {
-    const actual = await command.validate({ options: { id: sensitivityLabelId, userId: userId } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with a userId defined', () => {
+    const actual = commandOptionsSchema.safeParse({ id: sensitivityLabelId, userId: userId });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if userName is not a valid UPN', async () => {
-    const actual = await command.validate({ options: { id: sensitivityLabelId, userName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userName is not a valid UPN', () => {
+    const actual = commandOptionsSchema.safeParse({ id: sensitivityLabelId, userName: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with a userName defined', async () => {
-    const actual = await command.validate({ options: { id: sensitivityLabelId, userName: userName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with a userName defined', () => {
+    const actual = commandOptionsSchema.safeParse({ id: sensitivityLabelId, userName: userName });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ id: sensitivityLabelId, unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('retrieves sensitivity label that the current logged in user has access to', async () => {
@@ -130,7 +137,7 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: sensitivityLabelId, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: sensitivityLabelId, verbose: true }) });
     assert(loggerLogSpy.calledWith(sensitivityLabelGetResponse));
   });
 
@@ -143,7 +150,7 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: sensitivityLabelId, userId: userId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: sensitivityLabelId, userId: userId }) });
     assert(loggerLogSpy.calledWith(sensitivityLabelGetResponse));
   });
 
@@ -156,7 +163,7 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: sensitivityLabelId, userName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: sensitivityLabelId, userName: userName }) });
     assert(loggerLogSpy.calledWith(sensitivityLabelGetResponse));
   });
 
@@ -165,7 +172,7 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
     await assert.rejects(command.action(logger, {
-      options: { id: sensitivityLabelId }
+      options: commandOptionsSchema.parse({ id: sensitivityLabelId })
     }), new CommandError(`Specify at least 'userId' or 'userName' when using application permissions.`));
   });
 
@@ -178,6 +185,6 @@ describe(commands.SENSITIVITYLABEL_GET, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: sensitivityLabelId } }), new CommandError(`Error: The resource could not be found.`));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: sensitivityLabelId }) }), new CommandError(`Error: The resource could not be found.`));
   });
 });

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.ts
@@ -1,20 +1,30 @@
+import { z } from 'zod';
 import auth from '../../../../Auth.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GraphCommand from '../../../base/GraphCommand.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
-import commands from '../../commands.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { validation } from '../../../../utils/validation.js';
 import { accessToken } from '../../../../utils/accessToken.js';
+import { validation } from '../../../../utils/validation.js';
+import GraphCommand from '../../../base/GraphCommand.js';
+import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().refine(val => validation.isValidGuid(val), {
+    message: 'The value must be a valid GUID.'
+  }).alias('i'),
+  userId: z.string().refine(val => validation.isValidGuid(val), {
+    message: 'The value must be a valid GUID.'
+  }).optional(),
+  userName: z.string().refine(val => validation.isValidUserPrincipalName(val), {
+    message: 'The value must be a valid user principal name (UPN).'
+  }).optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id: string;
-  userId?: string;
-  userName?: string;
 }
 
 class PurviewSensitivityLabelGetCommand extends GraphCommand {
@@ -26,55 +36,8 @@ class PurviewSensitivityLabelGetCommand extends GraphCommand {
     return 'Retrieve the specified sensitivity label';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id <id>'
-      },
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.id)) {
-          return `'${args.options.id}' is not a valid GUID.`;
-        }
-
-        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
-          return `${args.options.userId} is not a valid GUID`;
-        }
-
-        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
-          return `${args.options.userName} is not a valid user principal name (UPN)`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-get.ts
@@ -11,13 +11,13 @@ import commands from '../../commands.js';
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
   id: z.string().refine(val => validation.isValidGuid(val), {
-    message: 'The value must be a valid GUID.'
+    error: 'The value must be a valid GUID.'
   }).alias('i'),
   userId: z.string().refine(val => validation.isValidGuid(val), {
-    message: 'The value must be a valid GUID.'
+    error: 'The value must be a valid GUID.'
   }).optional(),
   userName: z.string().refine(val => validation.isValidUserPrincipalName(val), {
-    message: 'The value must be a valid user principal name (UPN).'
+    error: 'The value must be a valid user principal name (UPN).'
   }).optional()
 });
 

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.spec.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './sensitivitylabel-list.js';
+import command, { options } from './sensitivitylabel-list.js';
 
 describe(commands.SENSITIVITYLABEL_LIST, () => {
   const userId = '59f80e08-24b1-41f8-8586-16765fd830d3';
@@ -42,6 +42,7 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -54,6 +55,7 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -95,24 +97,34 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { userId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with a userId defined', async () => {
-    const actual = await command.validate({ options: { userId: userId } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with a userId defined', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: userId });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if userName is not a valid UPN', async () => {
-    const actual = await command.validate({ options: { userName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userName is not a valid UPN', () => {
+    const actual = commandOptionsSchema.safeParse({ userName: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with a userName defined', async () => {
-    const actual = await command.validate({ options: { userName: userName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with a userName defined', () => {
+    const actual = commandOptionsSchema.safeParse({ userName: userName });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation with no options', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('defines correct properties for the default output', () => {
@@ -128,7 +140,7 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: {} });
+    await command.action(logger, { options: commandOptionsSchema.parse({}) });
     assert(loggerLogSpy.calledWith(sensitivityLabelListResponse.value));
   });
 
@@ -141,7 +153,7 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userId: userId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userId: userId }) });
     assert(loggerLogSpy.calledWith(sensitivityLabelListResponse.value));
   });
 
@@ -154,7 +166,7 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userName: userName }) });
     assert(loggerLogSpy.calledWith(sensitivityLabelListResponse.value));
   });
 
@@ -163,7 +175,7 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
     await assert.rejects(command.action(logger, {
-      options: {}
+      options: commandOptionsSchema.parse({})
     }), new CommandError(`Specify at least 'userId' or 'userName' when using application permissions.`));
   });
 
@@ -176,6 +188,6 @@ describe(commands.SENSITIVITYLABEL_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: {} }), new CommandError('An error has occurred'));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({}) }), new CommandError('An error has occurred'));
   });
 });

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.ts
@@ -1,19 +1,27 @@
+import { z } from 'zod';
 import auth from '../../../../Auth.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GraphCommand from '../../../base/GraphCommand.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
-import commands from '../../commands.js';
-import { validation } from '../../../../utils/validation.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import { odata } from '../../../../utils/odata.js';
+import { validation } from '../../../../utils/validation.js';
+import GraphCommand from '../../../base/GraphCommand.js';
+import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  userId: z.string().refine(val => validation.isValidGuid(val), {
+    message: 'The value must be a valid GUID.'
+  }).optional(),
+  userName: z.string().refine(val => validation.isValidUserPrincipalName(val), {
+    message: 'The value must be a valid user principal name (UPN).'
+  }).optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  userId?: string;
-  userName?: string;
 }
 
 class PurviewSensitivityLabelListCommand extends GraphCommand {
@@ -25,48 +33,8 @@ class PurviewSensitivityLabelListCommand extends GraphCommand {
     return 'Get a list of sensitivity labels';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
-          return `${args.options.userId} is not a valid GUID`;
-        }
-
-        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
-          return `${args.options.userName} is not a valid user principal name (UPN)`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
   public defaultProperties(): string[] | undefined {

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-list.ts
@@ -11,10 +11,10 @@ import commands from '../../commands.js';
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
   userId: z.string().refine(val => validation.isValidGuid(val), {
-    message: 'The value must be a valid GUID.'
+    error: 'The value must be a valid GUID.'
   }).optional(),
   userName: z.string().refine(val => validation.isValidUserPrincipalName(val), {
-    message: 'The value must be a valid user principal name (UPN).'
+    error: 'The value must be a valid user principal name (UPN).'
   }).optional()
 });
 

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.spec.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.spec.ts
@@ -12,7 +12,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './sensitivitylabel-policysettings-list.js';
+import command, { options } from './sensitivitylabel-policysettings-list.js';
 
 describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
   const userId = '59f80e08-24b1-41f8-8586-16765fd830d3';
@@ -30,6 +30,7 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -42,6 +43,7 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -83,24 +85,34 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if userId is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { userId: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userId is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with a userId defined', async () => {
-    const actual = await command.validate({ options: { userId: userId } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with a userId defined', () => {
+    const actual = commandOptionsSchema.safeParse({ userId: userId });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if userName is not a valid UPN', async () => {
-    const actual = await command.validate({ options: { userName: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if userName is not a valid UPN', () => {
+    const actual = commandOptionsSchema.safeParse({ userName: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('validates for a correct input with a userName defined', async () => {
-    const actual = await command.validate({ options: { userName: userName } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('validates for a correct input with a userName defined', () => {
+    const actual = commandOptionsSchema.safeParse({ userName: userName });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation with no options', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('retrieves list of policy settings for a sensitivity label that the current logged in user has access to', async () => {
@@ -112,7 +124,7 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) });
     assert(loggerLogSpy.calledWith(sensitivityLabelPolicySettingsListResponse));
   });
 
@@ -125,7 +137,7 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userId: userId } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userId: userId }) });
     assert(loggerLogSpy.calledWith(sensitivityLabelPolicySettingsListResponse));
   });
 
@@ -138,7 +150,7 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { userName: userName } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ userName: userName }) });
     assert(loggerLogSpy.calledWith(sensitivityLabelPolicySettingsListResponse));
   });
 
@@ -147,7 +159,7 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
 
     await assert.rejects(command.action(logger, {
-      options: {}
+      options: commandOptionsSchema.parse({})
     }), new CommandError(`Specify at least 'userId' or 'userName' when using application permissions.`));
   });
 
@@ -160,6 +172,6 @@ describe(commands.SENSITIVITYLABEL_POLICYSETTINGS_LIST, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: {} }), new CommandError(`Error: The resource could not be found.`));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({}) }), new CommandError(`Error: The resource could not be found.`));
   });
 });

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.ts
@@ -1,19 +1,27 @@
+import { z } from 'zod';
 import auth from '../../../../Auth.js';
 import { Logger } from '../../../../cli/Logger.js';
-import GraphCommand from '../../../base/GraphCommand.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
-import commands from '../../commands.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { validation } from '../../../../utils/validation.js';
 import { accessToken } from '../../../../utils/accessToken.js';
+import { validation } from '../../../../utils/validation.js';
+import GraphCommand from '../../../base/GraphCommand.js';
+import commands from '../../commands.js';
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  userId: z.string().refine(val => validation.isValidGuid(val), {
+    message: 'The value must be a valid GUID.'
+  }).optional(),
+  userName: z.string().refine(val => validation.isValidUserPrincipalName(val), {
+    message: 'The value must be a valid user principal name (UPN).'
+  }).optional()
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  userId?: string;
-  userName?: string;
 }
 
 class PurviewSensitivityLabelPolicySettingsListCommand extends GraphCommand {
@@ -25,48 +33,8 @@ class PurviewSensitivityLabelPolicySettingsListCommand extends GraphCommand {
     return 'Get a list of policy settings for a sensitivity label';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        userId: typeof args.options.userId !== 'undefined',
-        userName: typeof args.options.userName !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '--userId [userId]'
-      },
-      {
-        option: '--userName [userName]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.userId && !validation.isValidGuid(args.options.userId)) {
-          return `${args.options.userId} is not a valid GUID`;
-        }
-
-        if (args.options.userName && !validation.isValidUserPrincipalName(args.options.userName)) {
-          return `${args.options.userName} is not a valid user principal name (UPN)`;
-        }
-
-        return true;
-      }
-    );
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.ts
+++ b/src/m365/purview/commands/sensitivitylabel/sensitivitylabel-policysettings-list.ts
@@ -11,10 +11,10 @@ import commands from '../../commands.js';
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
   userId: z.string().refine(val => validation.isValidGuid(val), {
-    message: 'The value must be a valid GUID.'
+    error: 'The value must be a valid GUID.'
   }).optional(),
   userName: z.string().refine(val => validation.isValidUserPrincipalName(val), {
-    message: 'The value must be a valid user principal name (UPN).'
+    error: 'The value must be a valid user principal name (UPN).'
   }).optional()
 });
 

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.spec.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.spec.ts
@@ -13,13 +13,14 @@ import { session } from '../../../../utils/session.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import fs from 'fs';
 import commands from '../../commands.js';
-import command from './threatassessment-add.js';
+import command, { options } from './threatassessment-add.js';
 
 describe(commands.THREATASSESSMENT_ADD, () => {
   let log: string[];
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -32,6 +33,7 @@ describe(commands.THREATASSESSMENT_ADD, () => {
       expiresOn: new Date()
     };
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -106,7 +108,7 @@ describe(commands.THREATASSESSMENT_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'file', expectedAssessment: 'block', category: 'malware', path: 'C:\\Temp\\DummyFile.txt', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'file', expectedAssessment: 'block', category: 'malware', path: 'C:\\Temp\\DummyFile.txt', verbose: true }) });
     assert.strictEqual(postStub.lastCall.args[0].data['@odata.type'], '#microsoft.graph.fileAssessmentRequest');
     assert(loggerLogSpy.calledWith(fileThreatAssessmentRequest));
   });
@@ -139,42 +141,47 @@ describe(commands.THREATASSESSMENT_ADD, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'url', expectedAssessment: 'block', category: 'phishing', url: 'https://phisingurl.be', verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'url', expectedAssessment: 'block', category: 'phishing', url: 'https://phisingurl.be', verbose: true }) });
     assert.strictEqual(postStub.lastCall.args[0].data['@odata.type'], '#microsoft.graph.urlAssessmentRequest');
     assert(loggerLogSpy.calledWith(urlThreatAssessmentRequest));
   });
 
-  it('passes validation if all options are passed propertly', async () => {
-    const actual = await command.validate({ options: { type: 'url', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if all options are passed propertly', () => {
+    const actual = commandOptionsSchema.safeParse({ type: 'url', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' });
+    assert.strictEqual(actual.success, true);
   });
 
-  it('fails validation if type is not a valid type', async () => {
-    const actual = await command.validate({ options: { type: 'invalid', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if type is not a valid type', () => {
+    const actual = commandOptionsSchema.safeParse({ type: 'invalid', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if expectedAssessment is not a valid expectedAssessment', async () => {
-    const actual = await command.validate({ options: { type: 'url', expectedAssessment: 'invalid', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if expectedAssessment is not a valid expectedAssessment', () => {
+    const actual = commandOptionsSchema.safeParse({ type: 'url', expectedAssessment: 'invalid', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if category is not a valid category', async () => {
-    const actual = await command.validate({ options: { type: 'url', expectedAssessment: 'block', category: 'invalid', url: 'https://pnp.github.io/cli-microsoft365/' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if category is not a valid category', () => {
+    const actual = commandOptionsSchema.safeParse({ type: 'url', expectedAssessment: 'block', category: 'invalid', url: 'https://pnp.github.io/cli-microsoft365/' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('fails validation if path is specified and file does not exist', async () => {
+  it('fails validation if path is specified and file does not exist', () => {
     sinonUtil.restore(fs.existsSync);
     sinon.stub(fs, 'existsSync').returns(false);
-    const actual = await command.validate({ options: { type: 'file', expectedAssessment: 'block', category: 'malware', path: 'C:\\Path\\That\\Does\\Not\\Exist' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+    const actual = commandOptionsSchema.safeParse({ type: 'file', expectedAssessment: 'block', category: 'malware', path: 'C:\\Path\\That\\Does\\Not\\Exist' });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ type: 'url', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/', unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('throws an error when we execute the command using application permissions', async () => {
     sinonUtil.restore(accessToken.isAppOnlyAccessToken);
     sinon.stub(accessToken, 'isAppOnlyAccessToken').returns(true);
-    await assert.rejects(command.action(logger, { options: { type: 'url', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' } }),
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ type: 'url', expectedAssessment: 'block', category: 'spam', url: 'https://pnp.github.io/cli-microsoft365/' }) }),
       new CommandError('This command currently does not support app only permissions.'));
   });
 });

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.ts
@@ -1,5 +1,6 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { accessToken } from '../../../../utils/accessToken.js';
 import GraphCommand from '../../../base/GraphCommand.js';
@@ -8,25 +9,28 @@ import auth from '../../../../Auth.js';
 import fs from 'fs';
 import path from 'path';
 
+const allowedTypes = ['file', 'url'] as const;
+const allowedExpectedAssessments = ['block', 'unblock'] as const;
+const allowedCategories = ['spam', 'phishing', 'malware'] as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  type: z.enum(allowedTypes).alias('t'),
+  expectedAssessment: z.enum(allowedExpectedAssessments).alias('e'),
+  category: z.enum(allowedCategories).alias('c'),
+  path: z.string().refine(val => fs.existsSync(val), {
+    message: 'Specified file does not exist.'
+  }).optional().alias('p'),
+  url: z.string().optional().alias('u')
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  type: string;
-  expectedAssessment: string;
-  category: string;
-  recipientEmail?: string;
-  path?: string;
-  url?: string;
-  messageUri?: string;
-}
-
 class PurviewThreatAssessmentAddCommand extends GraphCommand {
-  private readonly allowedTypes = ['file', 'url'];
-  private readonly allowedExpectedAssessments = ['block', 'unblock'];
-  private readonly allowedCategories = ['spam', 'phishing', 'malware'];
-
   public get name(): string {
     return commands.THREATASSESSMENT_ADD;
   }
@@ -35,86 +39,36 @@ class PurviewThreatAssessmentAddCommand extends GraphCommand {
     return 'Create a threat assessment';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-    this.#initOptionSets();
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        path: typeof args.options.path !== 'undefined',
-        url: typeof args.options.url !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-t, --type <type>',
-        autocomplete: this.allowedTypes
-      },
-      {
-        option: '-e, --expectedAssessment <expectedAssessment>',
-        autocomplete: this.allowedExpectedAssessments
-      },
-      {
-        option: '-c, --category <category>',
-        autocomplete: this.allowedCategories
-      },
-      {
-        option: '-p, --path [path]'
-      },
-      {
-        option: '-u, --url [url]'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!this.allowedTypes.some(type => type === args.options.type)) {
-          return `${args.options.type} is not an allowed type. Allowed types are ${this.allowedTypes.join('|')}`;
+  public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
+    return schema
+      .refine(opts => {
+        if (opts.type === 'file') {
+          return opts.path !== undefined;
         }
-
-        if (!this.allowedExpectedAssessments.some(expectedAssessment => expectedAssessment === args.options.expectedAssessment)) {
-          return `${args.options.expectedAssessment} is not an allowed expected assessment. Allowed expected assessments are ${this.allowedExpectedAssessments.join('|')}`;
-        }
-
-        if (!this.allowedCategories.some(category => category === args.options.category)) {
-          return `${args.options.category} is not an allowed category. Allowed categories are ${this.allowedCategories.join('|')}`;
-        }
-
-        if (args.options.path && !fs.existsSync(args.options.path)) {
-          return `File '${args.options.path}' not found. Please provide a valid path to the file.`;
-        }
-
         return true;
-      }
-    );
-  }
-
-  #initOptionSets(): void {
-    this.optionSets.push(
-      {
-        options: ['path'],
-        runsWhen: (args) => {
-          return args.options.type === 'file';
+      }, {
+        message: `'path' is required when type is 'file'.`,
+        path: ['path'],
+        params: {
+          customCode: 'required'
         }
-      },
-      {
-        options: ['url'],
-        runsWhen: (args) => {
-          return args.options.type === 'url';
+      })
+      .refine(opts => {
+        if (opts.type === 'url') {
+          return opts.url !== undefined;
         }
-      }
-    );
+        return true;
+      }, {
+        message: `'url' is required when type is 'url'.`,
+        path: ['url'],
+        params: {
+          customCode: 'required'
+        }
+      });
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/purview/commands/threatassessment/threatassessment-add.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-add.ts
@@ -19,7 +19,7 @@ export const options = z.strictObject({
   expectedAssessment: z.enum(allowedExpectedAssessments).alias('e'),
   category: z.enum(allowedCategories).alias('c'),
   path: z.string().refine(val => fs.existsSync(val), {
-    message: 'Specified file does not exist.'
+    error: 'Specified file does not exist.'
   }).optional().alias('p'),
   url: z.string().optional().alias('u')
 });
@@ -51,7 +51,7 @@ class PurviewThreatAssessmentAddCommand extends GraphCommand {
         }
         return true;
       }, {
-        message: `'path' is required when type is 'file'.`,
+        error: `'path' is required when type is 'file'.`,
         path: ['path'],
         params: {
           customCode: 'required'
@@ -63,7 +63,7 @@ class PurviewThreatAssessmentAddCommand extends GraphCommand {
         }
         return true;
       }, {
-        message: `'url' is required when type is 'url'.`,
+        error: `'url' is required when type is 'url'.`,
         path: ['url'],
         params: {
           customCode: 'required'

--- a/src/m365/purview/commands/threatassessment/threatassessment-get.spec.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-get.spec.ts
@@ -11,7 +11,7 @@ import { pid } from '../../../../utils/pid.js';
 import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './threatassessment-get.js';
+import command, { options } from './threatassessment-get.js';
 
 describe(commands.THREATASSESSMENT_GET, () => {
   const threatAssessmentId = 'c37d695e-d581-4ae9-82a0-9364eba4291e';
@@ -50,6 +50,7 @@ describe(commands.THREATASSESSMENT_GET, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').resolves();
@@ -58,6 +59,7 @@ describe(commands.THREATASSESSMENT_GET, () => {
     sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
   });
 
   beforeEach(() => {
@@ -97,14 +99,19 @@ describe(commands.THREATASSESSMENT_GET, () => {
     assert.notStrictEqual(command.description, null);
   });
 
-  it('fails validation if id is not a valid GUID', async () => {
-    const actual = await command.validate({ options: { id: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if id is not a valid GUID', () => {
+    const actual = commandOptionsSchema.safeParse({ id: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if a correct id is entered and withResults is specified', async () => {
-    const actual = await command.validate({ options: { id: threatAssessmentId, withResults: true } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if a correct id is entered and withResults is specified', () => {
+    const actual = commandOptionsSchema.safeParse({ id: threatAssessmentId, withResults: true });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ id: threatAssessmentId, unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('retrieves threat assessment by specified id', async () => {
@@ -116,7 +123,7 @@ describe(commands.THREATASSESSMENT_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: threatAssessmentId, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: threatAssessmentId, verbose: true }) });
     assert(loggerLogSpy.calledWith(threatAssessmentGetResponse));
   });
 
@@ -129,7 +136,7 @@ describe(commands.THREATASSESSMENT_GET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: threatAssessmentId, withResults: true, verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ id: threatAssessmentId, withResults: true, verbose: true }) });
     assert(loggerLogSpy.calledWith(threatAssessmentGetResponseIncludingResults));
   });
 
@@ -153,6 +160,6 @@ describe(commands.THREATASSESSMENT_GET, () => {
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { id: threatAssessmentId } }), new CommandError(error.error.message));
+    await assert.rejects(command.action(logger, { options: commandOptionsSchema.parse({ id: threatAssessmentId }) }), new CommandError(error.error.message));
   });
 });

--- a/src/m365/purview/commands/threatassessment/threatassessment-get.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-get.ts
@@ -1,17 +1,23 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import request, { CliRequestOptions } from '../../../../request.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  id: z.string().refine(val => validation.isValidGuid(val), {
+    message: 'The value must be a valid GUID.'
+  }).alias('i'),
+  withResults: z.boolean().optional()
+});
+
+declare type Options = z.infer<typeof options>;
+
 interface CommandArgs {
   options: Options;
-}
-
-interface Options extends GlobalOptions {
-  id: string;
-  withResults?: boolean;
 }
 
 class PurviewThreatAssessmentGetCommand extends GraphCommand {
@@ -23,43 +29,8 @@ class PurviewThreatAssessmentGetCommand extends GraphCommand {
     return 'Get a threat assessment';
   }
 
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        includeResults: !!args.options.includeResults,
-        withResults: !!args.options.withResults
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-i, --id <id>'
-      },
-      {
-        option: '--withResults'
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.id)) {
-          return `${args.options.id} is not a valid GUID.`;
-        }
-        return true;
-      }
-    );
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/purview/commands/threatassessment/threatassessment-get.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-get.ts
@@ -9,7 +9,7 @@ import commands from '../../commands.js';
 export const options = z.strictObject({
   ...globalOptionsZod.shape,
   id: z.string().refine(val => validation.isValidGuid(val), {
-    message: 'The value must be a valid GUID.'
+    error: 'The value must be a valid GUID.'
   }).alias('i'),
   withResults: z.boolean().optional()
 });

--- a/src/m365/purview/commands/threatassessment/threatassessment-list.spec.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-list.spec.ts
@@ -8,9 +8,10 @@ import { Logger } from '../../../../cli/Logger.js';
 import request from '../../../../request.js';
 import { telemetry } from '../../../../telemetry.js';
 import { pid } from '../../../../utils/pid.js';
+import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
-import command from './threatassessment-list.js';
+import command, { options } from './threatassessment-list.js';
 
 describe(commands.THREATASSESSMENT_LIST, () => {
   //#region Mocked Responses
@@ -96,12 +97,15 @@ describe(commands.THREATASSESSMENT_LIST, () => {
   let logger: Logger;
   let loggerLogSpy: sinon.SinonSpy;
   let commandInfo: CommandInfo;
+  let commandOptionsSchema: typeof options;
 
   before(() => {
     commandInfo = cli.getCommandInfo(command);
+    commandOptionsSchema = commandInfo.command.getSchemaToParse() as typeof options;
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
     sinon.stub(telemetry, 'trackEvent').resolves();
     sinon.stub(pid, 'getProcessName').callsFake(() => '');
+    sinon.stub(session, 'getId').returns('');
     auth.connection.active = true;
   });
 
@@ -144,14 +148,24 @@ describe(commands.THREATASSESSMENT_LIST, () => {
     assert.deepStrictEqual(command.defaultProperties(), ['id', 'type', 'category']);
   });
 
-  it('fails validation if specified type is invalid ', async () => {
-    const actual = await command.validate({ options: { type: 'invalid' } }, commandInfo);
-    assert.notStrictEqual(actual, true);
+  it('fails validation if specified type is invalid ', () => {
+    const actual = commandOptionsSchema.safeParse({ type: 'invalid' });
+    assert.strictEqual(actual.success, false);
   });
 
-  it('passes validation if type option correctly specified', async () => {
-    const actual = await command.validate({ options: { type: 'file' } }, commandInfo);
-    assert.strictEqual(actual, true);
+  it('passes validation if type option correctly specified', () => {
+    const actual = commandOptionsSchema.safeParse({ type: 'file' });
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('passes validation with no options', () => {
+    const actual = commandOptionsSchema.safeParse({});
+    assert.strictEqual(actual.success, true);
+  });
+
+  it('fails validation with unknown options', () => {
+    const actual = commandOptionsSchema.safeParse({ unknownOption: 'value' });
+    assert.strictEqual(actual.success, false);
   });
 
   it('retrieves threat assessments', async () => {
@@ -203,7 +217,7 @@ describe(commands.THREATASSESSMENT_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { verbose: true } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ verbose: true }) });
     assert(loggerLogSpy.calledOnceWithExactly([threatAssessmentMailItem, threatAssessmentFileItem]));
   });
 
@@ -257,7 +271,7 @@ describe(commands.THREATASSESSMENT_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'mail' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'mail' }) });
     assert(loggerLogSpy.calledOnceWithExactly([threatAssessmentMailItem]));
   });
 
@@ -311,7 +325,7 @@ describe(commands.THREATASSESSMENT_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'emailFile' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'emailFile' }) });
     assert(loggerLogSpy.calledOnceWithExactly([threatAssessmentEmailFileItem]));
   });
 
@@ -345,7 +359,7 @@ describe(commands.THREATASSESSMENT_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'file' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'file' }) });
     assert(loggerLogSpy.calledOnceWithExactly([threatAssessmentFileItem]));
   });
 
@@ -378,7 +392,7 @@ describe(commands.THREATASSESSMENT_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'url' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'url' }) });
     assert(loggerLogSpy.calledOnceWithExactly([threatAssessmentUrlItem]));
   });
 
@@ -411,7 +425,7 @@ describe(commands.THREATASSESSMENT_LIST, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { type: 'url' } });
+    await command.action(logger, { options: commandOptionsSchema.parse({ type: 'url' }) });
     assert(loggerLogSpy.calledOnceWithExactly([{ ...threatAssessmentUrlItem, type: 'Unknown' }]));
   });
 
@@ -424,7 +438,7 @@ describe(commands.THREATASSESSMENT_LIST, () => {
     sinon.stub(request, 'get').callsFake(async () => { throw error; });
 
     await assert.rejects(command.action(logger, {
-      options: {}
+      options: commandOptionsSchema.parse({})
     }), new CommandError('The threat assessments could not be retrieved'));
   });
 });

--- a/src/m365/purview/commands/threatassessment/threatassessment-list.ts
+++ b/src/m365/purview/commands/threatassessment/threatassessment-list.ts
@@ -1,20 +1,24 @@
+import { z } from 'zod';
 import { Logger } from '../../../../cli/Logger.js';
-import GlobalOptions from '../../../../GlobalOptions.js';
+import { globalOptionsZod } from '../../../../Command.js';
 import { odata } from '../../../../utils/odata.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
+
+const allowedTypes = ['mail', 'file', 'emailFile', 'url'] as const;
+
+export const options = z.strictObject({
+  ...globalOptionsZod.shape,
+  type: z.enum(allowedTypes).optional().alias('t')
+});
+
+declare type Options = z.infer<typeof options>;
 
 interface CommandArgs {
   options: Options;
 }
 
-interface Options extends GlobalOptions {
-  type?: string;
-}
-
 class PurviewThreatAssessmentListCommand extends GraphCommand {
-  private static readonly allowedTypes: string[] = ['mail', 'file', 'emailFile', 'url'];
-
   public get name(): string {
     return commands.THREATASSESSMENT_LIST;
   }
@@ -23,45 +27,12 @@ class PurviewThreatAssessmentListCommand extends GraphCommand {
     return 'Get a list of threat assessments';
   }
 
+  public get schema(): z.ZodTypeAny | undefined {
+    return options;
+  }
+
   public defaultProperties(): string[] | undefined {
     return ['id', 'type', 'category'];
-  }
-
-  constructor() {
-    super();
-
-    this.#initTelemetry();
-    this.#initOptions();
-    this.#initValidators();
-  }
-
-  #initTelemetry(): void {
-    this.telemetry.push((args: CommandArgs) => {
-      Object.assign(this.telemetryProperties, {
-        type: typeof args.options.type !== 'undefined'
-      });
-    });
-  }
-
-  #initOptions(): void {
-    this.options.unshift(
-      {
-        option: '-t, --type [type]',
-        autocomplete: PurviewThreatAssessmentListCommand.allowedTypes
-      }
-    );
-  }
-
-  #initValidators(): void {
-    this.validators.push(
-      async (args: CommandArgs) => {
-        if (args.options.type && PurviewThreatAssessmentListCommand.allowedTypes.indexOf(args.options.type) < 0) {
-          return `${args.options.type} is not a valid type. Allowed values are ${PurviewThreatAssessmentListCommand.allowedTypes.join(', ')}`;
-        }
-
-        return true;
-      }
-    );
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {


### PR DESCRIPTION
## What's in this PR

Migrates the following commands from the legacy `#initOptions()`/`#initValidators()`/`#initTelemetry()` pattern to Zod schema-based validation:

- `purview auditlog list`
- `purview retentionlabel add`
- `purview retentionlabel get`
- `purview retentionlabel remove`
- `purview retentionlabel set`
- `purview sensitivitylabel get`
- `purview sensitivitylabel list`
- `purview sensitivitylabel policysettings list`
- `purview threatassessment add`
- `purview threatassessment get`
- `purview threatassessment list`

Closes #7316

## Changes

- Replaced legacy `constructor()`, `#initOptions()`, `#initValidators()`, `#initTelemetry()`, and `#initOptionSets()` methods with Zod schema definitions
- Added `schema` getter and `getRefinedSchema()` where cross-field validation is needed
- Used `z.enum()` for options with fixed autocomplete values
- Used `.refine()` for GUID validation, UPN validation, date validation, and file existence checks
- Updated all spec files to use `commandOptionsSchema.safeParse()` for validation tests and `commandOptionsSchema.parse()` for action tests
- Added "fails validation with unknown options" tests to all spec files
- Net reduction of ~371 lines of code