### PR TITLE
Fixes JSON output newline escaping. Closes #7397

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -643,10 +643,7 @@ export default abstract class Command {
   }
 
   public getJsonOutput(logStatement: any): string {
-    return JSON
-      .stringify(logStatement, null, 2)
-      // replace unescaped newlines with escaped newlines #2807
-      .replace(/([^\\])\\n/g, '$1\\\\\\n');
+    return JSON.stringify(logStatement, null, 2);
   }
 
   public async getCsvOutput(logStatement: any[], options: GlobalOptions): Promise<string> {

--- a/src/cli/cli.spec.ts
+++ b/src/cli/cli.spec.ts
@@ -1666,17 +1666,16 @@ describe('cli', () => {
     assert.strictEqual(actual, JSON.stringify(o, null, 2));
   });
 
-  it('properly handles new line characters in JSON output', async () => {
+  it('preserves newline characters in JSON output values', async () => {
     const input = {
-      "_ObjectIdentity_": "b61700a0-9062-3000-659e-7f5738e3385a|908bed80-a04a-4433-b4a0-883d9847d110:1b11f502-9eb0-401a-b164-68933e6e9443\nSiteProperties\nhttps%3a%2f%2fm365x954810.sharepoint.com%2fsites%2fsite1617"
+      crlf: 'line1\r\nline2',
+      lf: 'line1\nline2',
+      literalBackslashN: 'line1\\nline2'
     };
-    const expected = [
-      '{',
-      '  "_ObjectIdentity_": "b61700a0-9062-3000-659e-7f5738e3385a|908bed80-a04a-4433-b4a0-883d9847d110:1b11f502-9eb0-401a-b164-68933e6e9443\\\\\\nSiteProperties\\\\\\nhttps%3a%2f%2fm365x954810.sharepoint.com%2fsites%2fsite1617"',
-      '}'
-    ].join('\n');
     const actual = await cli.formatOutput(mockCommand, input, { output: 'json' });
-    assert.strictEqual(actual, expected);
+
+    assert.strictEqual(actual, JSON.stringify(input, null, 2));
+    assert.deepStrictEqual(JSON.parse(actual), input);
   });
 
   it('formats object with array as csv', async () => {


### PR DESCRIPTION
Closes #7397

## Summary

- Removes the post-`JSON.stringify` newline rewrite that added literal backslashes to parsed string values.
- Updates the JSON-output regression to assert LF, CRLF, and literal `\n` values round-trip unchanged.

## Validation

- `npm run build`
- `npx mocha --no-config --require source-map-support/register dist/cli/cli.spec.js`
- `npm run lint`