### PR TITLE
fix: remove getJsonOutput regex that corrupts string values containing newlines

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -644,9 +644,7 @@ export default abstract class Command {
 
   public getJsonOutput(logStatement: any): string {
     return JSON
-      .stringify(logStatement, null, 2)
-      // replace unescaped newlines with escaped newlines #2807
-      .replace(/([^\\])\\n/g, '$1\\\\\\n');
+      .stringify(logStatement, null, 2);
   }
 
   public async getCsvOutput(logStatement: any[], options: GlobalOptions): Promise<string> {


### PR DESCRIPTION
Fixes #7397

## Problem
`Command.getJsonOutput()` post-processes `JSON.stringify` output with a regex intended to escape newlines (referencing #2807):

```ts
.replace(/([^\\])\\n/g, '\\\\\\n');
```

`JSON.stringify` already emits valid JSON (all control characters in string values are escaped), so this regex never has a legitimate match to fix — but its single-character lookbehind cannot see escape context, so it **corrupts data**: any `\\n` escape inside a string value that is preceded by a non-backslash character gets rewritten, which **injects a literal backslash into the parsed value**.

## Fix
Remove the `.replace()` call. `JSON.stringify` correctly handles all escaping.

## Verification
- Pure JS repro from the issue: `JSON.parse(JSON.stringify({b: 'line1\\r\\nline2'}))` — works correctly without the regex
- Existing JSON output unaffected — other commands continue to work
- No test changes needed (no existing tests cover `getJsonOutput`)

## Changes
```
 src/Command.ts | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)
```