### PR TITLE
Adds support for applying built-in Microsoft site designs (store 1). Closes #7460

### DIFF
--- a/docs/docs/cmd/spo/sitedesign/sitedesign-apply.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-apply.mdx
@@ -15,17 +15,27 @@ m365 spo sitedesign apply [options]
 ## Options
 
 ```md definition-list
-`-i, --id <id>`
-: The ID of the site design to apply
+`-i, --id [id]`
+: The ID of the site design to apply. Specify either `id` or `template` but not both.
+
+`--template [template]`
+: The name of a built-in Microsoft site design to apply (e.g. `Event`, `Department`, `HumanResources`). Specify either `id` or `template` but not both.
 
 `-u, --webUrl <webUrl>`
 : The URL of the site to apply the site design to
 
 `--asTask`
-: Apply site design as task. Required for large site designs
+: Apply site design as task. Required for large site designs. Not supported when applying a built-in site design (`builtIn` or `template`)
+
+`-b, --builtIn`
+: Apply the site design specified through `id` from the built-in Microsoft site designs store instead of the site designs registered on the tenant. Automatically implied when using `template`
 ```
 
 <Global />
+
+## Remarks
+
+Use [spo sitedesign list --builtIn](./sitedesign-list.mdx) to discover the available values for `template`, along with the matching `id` that can be used together with `builtIn`.
 
 ## Examples
 
@@ -39,6 +49,18 @@ Apply large site design to the specified site
 
 ```sh
 m365 spo sitedesign apply --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --webUrl https://contoso.sharepoint.com/sites/project-x --asTask
+```
+
+Apply the built-in Microsoft _Event_ site design to the specified site
+
+```sh
+m365 spo sitedesign apply --template Event --webUrl https://contoso.sharepoint.com/sites/project-x
+```
+
+Apply a built-in Microsoft site design by ID to the specified site
+
+```sh
+m365 spo sitedesign apply --id 3d5ef50b-88a0-42a7-9fb2-8036009f6f42 --builtIn --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-get.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-get.mdx
@@ -20,13 +20,16 @@ m365 spo sitedesign get [options]
 
 `--title [title]`
 : Site design title. Specify either `id` or `title` but not both.
+
+`-b, --builtIn`
+: Retrieve the specified design from the built-in Microsoft site designs (e.g. Event, Department, Human Resources) instead of the site designs registered on the tenant.
 ```
 
 <Global />
 
 ## Remarks
 
-If the specified `id` or `title` doesn't refer to an existing site design, you will get a `File not found` error.
+If the specified `id` or `title` doesn't refer to an existing site design, you will get a `File not found` error. When using the `builtIn` option and no matching design is found, you will get a `The specified site design does not exist` error.
 
 ## Examples
 
@@ -40,6 +43,12 @@ Get information about the site design with title _Contoso Site Design_
 
 ```sh
 m365 spo sitedesign get --title "Contoso Site Design"
+```
+
+Get information about the built-in Microsoft site design with title _Event_
+
+```sh
+m365 spo sitedesign get --title Event --builtIn
 ```
 
 ## Response
@@ -152,6 +161,24 @@ m365 spo sitedesign get --title "Contoso Site Design"
   WebTemplate | 64
   Id | 00281728-3bc1-41d3-92b6-8fc493dcf4cc
   Version | 1
+  ```
+
+  </TabItem>
+</Tabs>
+
+### `builtIn` response
+
+When using the `builtIn` option, the response contains only the `Id` and `Title` of the built-in site design, enriched with a `Template` property containing the matching template name that can be used with the [spo sitedesign apply](./sitedesign-apply.mdx) command's `template` option.
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ```json
+  {
+    "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42",
+    "Title": "Event",
+    "Template": "Event"
+  }
   ```
 
   </TabItem>

--- a/docs/docs/cmd/spo/sitedesign/sitedesign-list.mdx
+++ b/docs/docs/cmd/spo/sitedesign/sitedesign-list.mdx
@@ -14,6 +14,11 @@ m365 spo sitedesign list [options]
 
 ## Options
 
+```md definition-list
+`-b, --builtIn`
+: List the built-in Microsoft site designs (e.g. Event, Department, Human Resources) instead of the site designs registered on the tenant.
+```
+
 <Global />
 
 ## Examples
@@ -22,6 +27,12 @@ List available site designs
 
 ```sh
 m365 spo sitedesign list
+```
+
+List the built-in Microsoft site designs
+
+```sh
+m365 spo sitedesign list --builtIn
 ```
 
 ## Response
@@ -111,6 +122,41 @@ m365 spo sitedesign list
   WebTemplate | 64
   Id | 00281728-3bc1-41d3-92b6-8fc493dcf4cc
   Version | 1
+  ```
+
+  </TabItem>
+</Tabs>
+
+### `builtIn` response
+
+When using the `builtIn` option, the response contains only the `Id` and `Title` of each built-in site design, enriched with a `Template` property containing the matching template name that can be used with the [spo sitedesign apply](./sitedesign-apply.mdx) command's `template` option.
+
+<Tabs>
+  <TabItem value="JSON">
+
+  ```json
+  [
+    {
+      "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42",
+      "Title": "Event",
+      "Template": "Event"
+    },
+    {
+      "Id": "73495f08-0140-499b-8927-dd26a546f26a",
+      "Title": "Department",
+      "Template": "Department"
+    }
+  ]
+  ```
+
+  </TabItem>
+  <TabItem value="Text">
+
+  ```text
+  Id                                    Title
+  ------------------------------------  ----------
+  3d5ef50b-88a0-42a7-9fb2-8036009f6f42  Event
+  73495f08-0140-499b-8927-dd26a546f26a  Department
   ```
 
   </TabItem>

--- a/src/m365/spo/commands/sitedesign/BuiltInSiteDesigns.ts
+++ b/src/m365/spo/commands/sitedesign/BuiltInSiteDesigns.ts
@@ -1,0 +1,50 @@
+// GUID-to-name mapping of the built-in Microsoft site designs available in the SharePoint
+// site template store (store 1). Ported from PnP PowerShell's BuiltInSiteTemplateSettings so
+// the same friendly names can be used across both tools.
+// See https://learn.microsoft.com/powershell/module/sharepoint-online/set-spobuiltinsitetemplatesettings?view=sharepoint-ps#description
+export const builtInSiteDesigns: { id: string; template: string }[] = [
+  { id: '00000000-0000-0000-0000-000000000000', template: 'All' },
+  { id: '9522236e-6802-4972-a10d-e98dc74b3344', template: 'EventPlanning' },
+  { id: 'f0a3abf4-afe8-4409-b7f3-484113dee93e', template: 'ProjectManagement' },
+  { id: '695e52c9-8af7-4bd3-b7a5-46aca95e1c7e', template: 'TrainingAndCourses' },
+  { id: '64aaa31e-7a1e-4337-b646-0b700aa9a52c', template: 'TrainingAndDevelopmentTeam' },
+  { id: 'e4ec393e-da09-4816-b6b2-195393656edd', template: 'RetailManagement' },
+  { id: 'af9037eb-09ef-4217-80fe-465d37511b33', template: 'EmployeeOnboardingTeam' },
+  { id: '33537eba-a7d6-4d76-96cc-ee1930bd3907', template: 'SetUpYourHomePage' },
+  { id: 'fb513aef-c06f-4dc3-b08c-963a2d2360c1', template: 'CrisisCommunicationTeam' },
+  { id: '71308406-f31d-445f-85c7-b31942d1508c', template: 'ITHelpDesk' },
+  { id: '2a7dd756-75f6-4f0f-a06a-a672939ea2a3', template: 'ContractsManagement' },
+  { id: '403ffe4e-12d4-41a2-8153-208069eaf2b8', template: 'AccountsPayable' },
+  { id: 'c8b3137a-ca4c-48a9-b356-a8e7987dd693', template: 'StandardTeam' },
+  { id: '951190b8-8541-4f8c-8e8a-10a17c466c94', template: 'CrisisManagement' },
+  { id: '73495f08-0140-499b-8927-dd26a546f26a', template: 'Department' },
+  { id: 'cd4c26b2-b231-419a-8bb4-9b1d9b83aef6', template: 'LeadershipConnection' },
+  { id: 'b8ef3134-92a2-4c9d-bca6-c2f14e79fe98', template: 'LearningCentral' },
+  { id: '2a23fa44-52b0-4814-baba-06fef1ab931e', template: 'NewEmployeeOnboarding' },
+  { id: '6142d2a0-63a5-4ba0-aede-d9fefca2c767', template: 'Showcase' },
+  { id: '811ecf9a-b33f-44e6-81bd-da77729906dc', template: 'StoreCollaboration' },
+  { id: '34a39504-194c-4605-87be-d48d00070c67', template: 'VolunteerCenter' },
+  { id: 'f6cc5403-0d63-442e-96c0-285923709ffc', template: 'Blank' },
+  { id: 'f2c6bb0c-9234-40c2-9ec3-ee86a70330fb', template: 'BrandCentral' },
+  { id: '96c933ac-3698-44c7-9f4a-5fd17d71af9e', template: 'StandardCommunication' },
+  { id: '3d5ef50b-88a0-42a7-9fb2-8036009f6f42', template: 'Event' },
+  { id: 'c298ddc9-628d-48bf-b1e5-5939a1962fb1', template: 'HumanResources' },
+  { id: '30eebaf6-48ea-4af9-a564-a5c50297c826', template: 'OrganizationHome' },
+  { id: '94e24f52-dfaf-40e4-b629-df2c85570adc', template: 'CopilotCampaign' },
+  { id: 'da99c5d9-baad-4e81-81f6-03a061972d49', template: 'VivaCampaign' }
+];
+
+export function getBuiltInSiteDesignId(template: string): string | undefined {
+  return builtInSiteDesigns.find(d => d.template === template)?.id;
+}
+
+export function getBuiltInSiteDesignTemplateName(id: string): string | undefined {
+  return builtInSiteDesigns.find(d => d.id.toLowerCase() === id.toLowerCase())?.template;
+}
+
+// 'All' (GUID 00000000-0000-0000-0000-000000000000) is a placeholder used by
+// Get/Set-SPOBuiltInSiteTemplateSettings to refer to every built-in template at once. It doesn't
+// identify an actual applicable site design, so it's excluded from the list of applyable templates.
+export function getBuiltInSiteDesignTemplateNames(): string[] {
+  return builtInSiteDesigns.filter(d => d.template !== 'All').map(d => d.template);
+}

--- a/src/m365/spo/commands/sitedesign/sitedesign-apply.spec.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-apply.spec.ts
@@ -12,6 +12,7 @@ import { session } from '../../../../utils/session.js';
 import { sinonUtil } from '../../../../utils/sinonUtil.js';
 import commands from '../../commands.js';
 import command from './sitedesign-apply.js';
+import { settingsNames } from '../../../../settingsNames.js';
 
 describe(commands.SITEDESIGN_APPLY, () => {
   let log: string[];
@@ -47,7 +48,8 @@ describe(commands.SITEDESIGN_APPLY, () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      request.post
+      request.post,
+      cli.getSettingWithDefaultValue
     ]);
   });
 
@@ -150,11 +152,130 @@ describe(commands.SITEDESIGN_APPLY, () => {
     } as any), new CommandError('An error has occurred'));
   });
 
+  it('applies a built-in site design by id, passing store 1', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.ApplySiteDesign`) > -1 &&
+        JSON.stringify(opts.data) === JSON.stringify({
+          siteDesignId: '3d5ef50b-88a0-42a7-9fb2-8036009f6f42',
+          webUrl: 'https://contoso.sharepoint.com',
+          store: 1
+        })) {
+        return {
+          value: [{ "Outcome": "0", "OutcomeText": null, "Title": "Apply theme" }]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        id: '3d5ef50b-88a0-42a7-9fb2-8036009f6f42',
+        webUrl: 'https://contoso.sharepoint.com',
+        builtIn: true
+      }
+    });
+    assert(loggerLogSpy.calledWith([{ "Outcome": "0", "OutcomeText": null, "Title": "Apply theme" }]));
+  });
+
+  it('applies a built-in site design by template name, resolving the id and passing store 1', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.ApplySiteDesign`) > -1 &&
+        JSON.stringify(opts.data) === JSON.stringify({
+          siteDesignId: '3d5ef50b-88a0-42a7-9fb2-8036009f6f42',
+          webUrl: 'https://contoso.sharepoint.com',
+          store: 1
+        })) {
+        return {
+          value: [{ "Outcome": "0", "OutcomeText": null, "Title": "Apply theme" }]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        template: 'Event',
+        webUrl: 'https://contoso.sharepoint.com'
+      }
+    });
+    assert(loggerLogSpy.calledWith([{ "Outcome": "0", "OutcomeText": null, "Title": "Apply theme" }]));
+  });
+
+  it('fails validation if id and template are both specified', async () => {
+    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
+      if (settingName === settingsNames.prompt) {
+        return false;
+      }
+
+      return defaultValue;
+    });
+
+    const actual = await command.validate({ options: { id: '9b142c22-037f-4a7f-9017-e9d8c0e34b99', template: 'Event', webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if neither id nor template are specified', async () => {
+    sinon.stub(cli, 'getSettingWithDefaultValue').callsFake((settingName, defaultValue) => {
+      if (settingName === settingsNames.prompt) {
+        return false;
+      }
+
+      return defaultValue;
+    });
+
+    const actual = await command.validate({ options: { webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if template is not a valid built-in site design', async () => {
+    const actual = await command.validate({ options: { template: 'Invalid', webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('passes validation if template is a valid built-in site design', async () => {
+    const actual = await command.validate({ options: { template: 'Event', webUrl: 'https://contoso.sharepoint.com' } }, commandInfo);
+    assert.strictEqual(actual, true);
+  });
+
+  it('fails validation if asTask is combined with builtIn', async () => {
+    const actual = await command.validate({ options: { id: '9b142c22-037f-4a7f-9017-e9d8c0e34b99', webUrl: 'https://contoso.sharepoint.com', builtIn: true, asTask: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if asTask is combined with template', async () => {
+    const actual = await command.validate({ options: { template: 'Event', webUrl: 'https://contoso.sharepoint.com', asTask: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
   it('supports specifying id', () => {
     const options = command.options;
     let containsOption = false;
     options.forEach(o => {
       if (o.option.indexOf('--id') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying template', () => {
+    const options = command.options;
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--template') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying builtIn', () => {
+    const options = command.options;
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--builtIn') > -1) {
         containsOption = true;
       }
     });

--- a/src/m365/spo/commands/sitedesign/sitedesign-apply.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-apply.ts
@@ -5,6 +5,7 @@ import { spo } from '../../../../utils/spo.js';
 import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
+import { getBuiltInSiteDesignId, getBuiltInSiteDesignTemplateNames } from './BuiltInSiteDesigns.js';
 
 interface CommandArgs {
   options: Options;
@@ -12,7 +13,9 @@ interface CommandArgs {
 
 export interface Options extends GlobalOptions {
   asTask: boolean;
-  id: string;
+  id?: string;
+  template?: string;
+  builtIn?: boolean;
   webUrl: string;
 }
 
@@ -31,12 +34,15 @@ class SpoSiteDesignApplyCommand extends SpoCommand {
     this.#initTelemetry();
     this.#initOptions();
     this.#initValidators();
+    this.#initOptionSets();
   }
 
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        asTask: args.options.asTask || false
+        asTask: args.options.asTask || false,
+        builtIn: args.options.builtIn || false,
+        template: typeof args.options.template !== 'undefined'
       });
     });
   }
@@ -44,13 +50,20 @@ class SpoSiteDesignApplyCommand extends SpoCommand {
   #initOptions(): void {
     this.options.unshift(
       {
-        option: '-i, --id <id>'
+        option: '-i, --id [id]'
       },
       {
         option: '-u, --webUrl <webUrl>'
       },
       {
         option: '--asTask'
+      },
+      {
+        option: '-b, --builtIn'
+      },
+      {
+        option: '--template [template]',
+        autocomplete: getBuiltInSiteDesignTemplateNames()
       }
     );
   }
@@ -58,8 +71,16 @@ class SpoSiteDesignApplyCommand extends SpoCommand {
   #initValidators(): void {
     this.validators.push(
       async (args: CommandArgs) => {
-        if (!validation.isValidGuid(args.options.id)) {
+        if (args.options.id && !validation.isValidGuid(args.options.id)) {
           return `${args.options.id} is not a valid GUID`;
+        }
+
+        if (args.options.template && !getBuiltInSiteDesignTemplateNames().includes(args.options.template)) {
+          return `${args.options.template} is not a valid built-in site design template. Allowed values are: ${getBuiltInSiteDesignTemplateNames().join(', ')}`;
+        }
+
+        if (args.options.asTask && (args.options.builtIn || args.options.template)) {
+          return `The asTask option is not supported when applying a built-in site design`;
         }
 
         return validation.isValidSharePointUrl(args.options.webUrl);
@@ -67,13 +88,28 @@ class SpoSiteDesignApplyCommand extends SpoCommand {
     );
   }
 
+  #initOptionSets(): void {
+    this.optionSets.push(
+      { options: ['id', 'template'] }
+    );
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const spoUrl: string = await spo.getSpoUrl(logger, this.debug);
+      const isBuiltIn: boolean = !!args.options.builtIn || !!args.options.template;
+      const siteDesignId: string = args.options.template
+        ? getBuiltInSiteDesignId(args.options.template) as string
+        : args.options.id as string;
+
       const requestBody: any = {
-        siteDesignId: args.options.id,
+        siteDesignId: siteDesignId,
         webUrl: args.options.webUrl
       };
+
+      if (isBuiltIn) {
+        requestBody.store = 1;
+      }
 
       const requestOptions: any = {
         url: `${spoUrl}/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.${args.options.asTask ? 'AddSiteDesignTask' : 'ApplySiteDesign'}`,

--- a/src/m365/spo/commands/sitedesign/sitedesign-get.spec.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-get.spec.ts
@@ -420,11 +420,126 @@ describe(commands.SITEDESIGN_GET, () => {
     await assert.rejects(command.action(logger, { options: { id: 'ca360b7e-1946-4292-b854-e0ad904f1055' } } as any), new CommandError('File Not Found.'));
   });
 
+  it('gets information about the specified built-in site design by id', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesigns`) > -1 &&
+        JSON.stringify(opts.data) === JSON.stringify({ store: 1 })) {
+        return {
+          value: [
+            {
+              "Title": "Event",
+              "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42"
+            },
+            {
+              "Title": "Department",
+              "Id": "73495f08-0140-499b-8927-dd26a546f26a"
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { id: '3d5ef50b-88a0-42a7-9fb2-8036009f6f42', builtIn: true } });
+    assert(loggerLogSpy.calledWith({
+      "Title": "Event",
+      "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42",
+      "Template": "Event"
+    }));
+  });
+
+  it('gets information about the specified built-in site design by title', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesigns`) > -1 &&
+        JSON.stringify(opts.data) === JSON.stringify({ store: 1 })) {
+        return {
+          value: [
+            {
+              "Title": "Event",
+              "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42"
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { title: 'Event', builtIn: true } });
+    assert(loggerLogSpy.calledWith({
+      "Title": "Event",
+      "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42",
+      "Template": "Event"
+    }));
+  });
+
+  it('handles selecting single result when multiple built-in site designs with the specified title are found', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesigns`) > -1 &&
+        JSON.stringify(opts.data) === JSON.stringify({ store: 1 })) {
+        return {
+          value: [
+            {
+              "Title": "Event",
+              "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42"
+            },
+            {
+              "Title": "Event",
+              "Id": "73495f08-0140-499b-8927-dd26a546f26a"
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(cli, 'handleMultipleResultsFound').resolves({
+      "Title": "Event",
+      "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42"
+    });
+
+    await command.action(logger, { options: { title: 'Event', builtIn: true } });
+    assert(loggerLogSpy.calledWith({
+      "Title": "Event",
+      "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42",
+      "Template": "Event"
+    }));
+  });
+
+  it('fails to get built-in site design when it does not exist', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesigns`) > -1) {
+        return { value: [] };
+      }
+      throw 'Invalid request';
+    });
+
+    await assert.rejects(command.action(logger, {
+      options: {
+        title: 'Non-existing built-in design',
+        builtIn: true
+      }
+    } as any), new CommandError('The specified site design does not exist'));
+  });
+
   it('supports specifying id', () => {
     const options = command.options;
     let containsOption = false;
     options.forEach(o => {
       if (o.option.indexOf('--id') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports specifying builtIn', () => {
+    const options = command.options;
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--builtIn') > -1) {
         containsOption = true;
       }
     });

--- a/src/m365/spo/commands/sitedesign/sitedesign-get.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-get.ts
@@ -8,6 +8,7 @@ import { validation } from '../../../../utils/validation.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
 import { SiteDesign } from './SiteDesign.js';
+import { getBuiltInSiteDesignTemplateName } from './BuiltInSiteDesigns.js';
 
 interface CommandArgs {
   options: Options;
@@ -16,6 +17,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   id?: string;
   title?: string;
+  builtIn?: boolean;
 }
 
 class SpoSiteDesignGetCommand extends SpoCommand {
@@ -40,7 +42,8 @@ class SpoSiteDesignGetCommand extends SpoCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         id: typeof args.options.id !== 'undefined',
-        title: typeof args.options.title !== 'undefined'
+        title: typeof args.options.title !== 'undefined',
+        builtIn: args.options.builtIn || false
       });
     });
   }
@@ -52,6 +55,9 @@ class SpoSiteDesignGetCommand extends SpoCommand {
       },
       {
         option: '--title [title]'
+      },
+      {
+        option: '-b, --builtIn'
       }
     );
   }
@@ -104,9 +110,48 @@ class SpoSiteDesignGetCommand extends SpoCommand {
     return matchingSiteDesigns[0].Id;
   }
 
+  private async getBuiltInSiteDesign(args: CommandArgs, spoUrl: string): Promise<SiteDesign> {
+    const requestOptions: CliRequestOptions = {
+      url: `${spoUrl}/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesigns`,
+      headers: {
+        'content-type': 'application/json;charset=utf-8',
+        accept: 'application/json;odata=nometadata'
+      },
+      data: { store: 1 },
+      responseType: 'json'
+    };
+
+    const response: { value: SiteDesign[] } = await request.post<{ value: SiteDesign[] }>(requestOptions);
+
+    const matchingSiteDesigns: SiteDesign[] = args.options.id
+      ? response.value.filter(x => x.Id.toLowerCase() === (args.options.id as string).toLowerCase())
+      : response.value.filter(x => x.Title === args.options.title);
+
+    if (matchingSiteDesigns.length === 0) {
+      throw `The specified site design does not exist`;
+    }
+
+    if (matchingSiteDesigns.length > 1) {
+      const resultAsKeyValuePair = formatting.convertArrayToHashTable('Id', matchingSiteDesigns);
+      return cli.handleMultipleResultsFound<SiteDesign>(`Multiple site designs with title '${args.options.title}' found.`, resultAsKeyValuePair);
+    }
+
+    return matchingSiteDesigns[0];
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const spoUrl: string = await spo.getSpoUrl(logger, this.debug);
+
+      if (args.options.builtIn) {
+        const siteDesign: SiteDesign = await this.getBuiltInSiteDesign(args, spoUrl);
+        await logger.log({
+          ...siteDesign,
+          Template: getBuiltInSiteDesignTemplateName(siteDesign.Id)
+        });
+        return;
+      }
+
       const siteDesignId: string = await this.getSiteDesignId(args, spoUrl);
       const requestOptions: any = {
         url: `${spoUrl}/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesignMetadata`,

--- a/src/m365/spo/commands/sitedesign/sitedesign-list.spec.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-list.spec.ts
@@ -62,7 +62,7 @@ describe(commands.SITEDESIGN_LIST, () => {
   });
 
   it('defines correct properties for the default output', () => {
-    assert.deepStrictEqual(command.defaultProperties(), ['Id', 'IsDefault', 'Title', 'Version', 'WebTemplate']);
+    assert.deepStrictEqual(command.defaultProperties(), ['Id', 'IsDefault', 'Title', 'Version', 'WebTemplate', 'Template']);
   });
 
   it('lists available site designs', async () => {
@@ -276,5 +276,52 @@ describe(commands.SITEDESIGN_LIST, () => {
     sinon.stub(request, 'post').rejects({ error: { 'odata.error': { message: { value: 'An error has occurred' } } } });
 
     await assert.rejects(command.action(logger, { options: {} } as any), new CommandError('An error has occurred'));
+  });
+
+  it('lists built-in Microsoft site designs and enriches them with the matching template name', async () => {
+    sinon.stub(request, 'post').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.GetSiteDesigns`) > -1 &&
+        JSON.stringify(opts.data) === JSON.stringify({ store: 1 })) {
+        return {
+          value: [
+            {
+              "Title": "Event",
+              "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42"
+            },
+            {
+              "Title": "Department",
+              "Id": "73495f08-0140-499b-8927-dd26a546f26a"
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, { options: { builtIn: true } });
+    assert(loggerLogSpy.calledWith([
+      {
+        "Title": "Event",
+        "Id": "3d5ef50b-88a0-42a7-9fb2-8036009f6f42",
+        "Template": "Event"
+      },
+      {
+        "Title": "Department",
+        "Id": "73495f08-0140-499b-8927-dd26a546f26a",
+        "Template": "Department"
+      }
+    ]));
+  });
+
+  it('supports specifying builtIn', () => {
+    const options = command.options;
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--builtIn') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
   });
 });

--- a/src/m365/spo/commands/sitedesign/sitedesign-list.ts
+++ b/src/m365/spo/commands/sitedesign/sitedesign-list.ts
@@ -1,9 +1,19 @@
 import { Logger } from '../../../../cli/Logger.js';
+import GlobalOptions from '../../../../GlobalOptions.js';
 import request from '../../../../request.js';
 import { spo } from '../../../../utils/spo.js';
 import SpoCommand from '../../../base/SpoCommand.js';
 import commands from '../../commands.js';
 import { SiteDesign } from './SiteDesign.js';
+import { getBuiltInSiteDesignTemplateName } from './BuiltInSiteDesigns.js';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  builtIn?: boolean;
+}
 
 class SpoSiteDesignListCommand extends SpoCommand {
   public get name(): string {
@@ -15,10 +25,33 @@ class SpoSiteDesignListCommand extends SpoCommand {
   }
 
   public defaultProperties(): string[] | undefined {
-    return ['Id', 'IsDefault', 'Title', 'Version', 'WebTemplate'];
+    return ['Id', 'IsDefault', 'Title', 'Version', 'WebTemplate', 'Template'];
   }
 
-  public async commandAction(logger: Logger): Promise<void> {
+  constructor() {
+    super();
+
+    this.#initTelemetry();
+    this.#initOptions();
+  }
+
+  #initTelemetry(): void {
+    this.telemetry.push((args: CommandArgs) => {
+      Object.assign(this.telemetryProperties, {
+        builtIn: args.options.builtIn || false
+      });
+    });
+  }
+
+  #initOptions(): void {
+    this.options.unshift(
+      {
+        option: '-b, --builtIn'
+      }
+    );
+  }
+
+  public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     try {
       const spoUrl: string = await spo.getSpoUrl(logger, this.debug);
       const requestOptions: any = {
@@ -28,8 +61,23 @@ class SpoSiteDesignListCommand extends SpoCommand {
         },
         responseType: 'json'
       };
+
+      if (args.options.builtIn) {
+        requestOptions.headers['content-type'] = 'application/json;charset=utf-8';
+        requestOptions.data = { store: 1 };
+      }
+
       const res: { value: SiteDesign[] } = await request.post(requestOptions);
-      await logger.log(res.value);
+
+      if (args.options.builtIn) {
+        await logger.log(res.value.map(siteDesign => ({
+          ...siteDesign,
+          Template: getBuiltInSiteDesignTemplateName(siteDesign.Id)
+        })));
+      }
+      else {
+        await logger.log(res.value);
+      }
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);


### PR DESCRIPTION
## Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Summary

Closes #7460

Adds support for Microsoft's built-in SharePoint site designs (the "store 1" designs) to `spo sitedesign apply`, `spo sitedesign get` and `spo sitedesign list`. Previously, these commands only reached tenant-registered custom designs (store 0) via the `SiteScriptUtility` REST API. Built-in Microsoft site templates such as **Event**, **Department** and **Human Resources** live in a separate store and could only be reached by adding `"store": 1` to the same REST calls — making them inaccessible from the CLI without a raw `m365 request` call.

This mirrors the equivalent feature already shipped in PnP PowerShell: https://github.com/pnp/powershell/pull/5358

## Modified commands

**`spo sitedesign list`**
- New `-b, --builtIn` switch. When specified, calls `SiteScriptUtility.GetSiteDesigns` with `store: 1` and returns all built-in Microsoft site designs, enriched with a `Template` property containing the matching friendly template name.
- Existing default behaviour (listing tenant-custom designs) is unchanged.

**`spo sitedesign get`**
- New `-b, --builtIn` switch. When specified, resolves a single built-in design by `--id` or `--title` from the store 1 list (rather than `GetSiteDesignMetadata`, which only supports store 0), enriched with the same `Template` property.
- Existing default behaviour is unchanged.

**`spo sitedesign apply`**
- New `--template <template>` option (mutually exclusive with `--id`). Resolves the GUID from a static mapping of built-in Microsoft site design names and calls `SiteScriptUtility.ApplySiteDesign` with `store: 1`.
- New `-b, --builtIn` switch, usable together with `--id`, for applying a built-in design when you already know its GUID.
- `--asTask` is rejected when combined with `--builtIn`/`--template`, since the built-in store has no `AddSiteDesignTask` equivalent.
- Existing `--id`-only behaviour (custom designs, store 0) is unchanged.

## Implementation notes

- Added `src/m365/spo/commands/sitedesign/BuiltInSiteDesigns.ts`, a GUID-to-name mapping for all built-in Microsoft site design templates, ported from PnP PowerShell's `BuiltInSiteTemplateSettings` so both tools expose the same friendly names.
- Documentation included (`.mdx` help pages updated with new options, examples and response shapes for the built-in case).
- Developed with AI assistance
- Tested