### PR TITLE
Add GitLab CI/CD support to federated identity login. Closes #7463

### DIFF
--- a/docs/docs/cmd/login.mdx
+++ b/docs/docs/cmd/login.mdx
@@ -78,7 +78,18 @@ When logging in to Microsoft 365 using the user name and password, next to the a
 
 When logging in to Microsoft 365 using a certificate, the CLI for Microsoft 365 will store the contents of the certificate so that it can automatically re-authenticate if necessary. The contents of the certificate are removed by re-authenticating using the device code or by calling the [logout](logout.mdx) command.  
 
-Federated Identity is currently supported in GitHub Actions. To use this you need to set `authType` to `federatedIdentity` and specify `appId` and `tenant` to the values of the app registration you've configured a federated credential on. 
+Federated Identity is currently supported in GitHub Actions, Azure DevOps and GitLab CI/CD. To use this you need to set `authType` to `federatedIdentity` and specify `appId` and `tenant` to the values of the app registration you've configured a federated credential on.
+
+To use Federated Identity in GitLab CI/CD, the job must request an ID token named `GITLAB_OIDC_TOKEN` with audience `api://AzureADTokenExchange`, for example:
+
+```yaml
+job:
+  id_tokens:
+    GITLAB_OIDC_TOKEN:
+      aud: api://AzureADTokenExchange
+```
+
+The corresponding federated credential on the Microsoft Entra app registration must have issuer `https://gitlab.com` (or your self-managed GitLab instance URL) and a subject matching the GitLab OIDC claim for the job, for example `project_path:<group>/<project>:ref_type:branch:ref:<branch>`.
 
 To log in to Microsoft 365 using a certificate or secret, you will typically [create a custom Microsoft Entra application](../user-guide/using-own-identity.mdx). To use this application with the CLI for Microsoft 365, you will set the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the application's ID and the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Microsoft Entra tenant, where you created the Microsoft Entra application. Also, please make sure to read about [the caveats when using the certificate login option](../user-guide/cli-certificate-caveats.mdx).
 
@@ -202,7 +213,7 @@ Log in to Microsoft 365 using a user-assigned managed identity with `clientId` s
 m365 login --authType identity --userName ac9fbed5-804c-4362-a369-21a4ec51109e
 ```
 
-Log in to Microsoft 365 using a federated identity. Can currently only be used in GitHub Actions.
+Log in to Microsoft 365 using a federated identity. Can currently only be used in GitHub Actions, Azure DevOps and GitLab CI/CD.
 
 ```sh
 m365 login --authType federatedIdentity --appId eb96cfd0-abfa-4477-8d1d-c6dfde3efb19 --tenant 9a1a1bbd-e158-4cf5-967d-a53b8e85c628

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -1591,19 +1591,21 @@ describe('Auth', () => {
     assert.strictEqual(requestPostStub.secondCall.args[0].data.indexOf(`client_assertion=${federatedIdentityClientAssertion}`) > -1, true);
   });
 
-  it('fails when not using federated identity from GitHub Action or Azure DevOps Pipeline', async () => {
+  it('fails when not using federated identity from GitHub Action, Azure DevOps Pipeline or GitLab CI/CD', async () => {
     process.env = {
       ACTIONS_ID_TOKEN_REQUEST_URL: '',
       ACTIONS_ID_TOKEN_REQUEST_TOKEN: '',
       SYSTEM_OIDCREQUESTURI: '',
-      SYSTEM_ACCESSTOKEN: ''
+      SYSTEM_ACCESSTOKEN: '',
+      GITLAB_CI: '',
+      GITLAB_OIDC_TOKEN: ''
     };
 
     auth.connection.authType = AuthType.FederatedIdentity;
     auth.connection.appId = appId;
     auth.connection.tenant = tenant;
 
-    await assert.rejects(auth.ensureAccessToken(resource, logger, true), new CommandError('Federated identity is currently only supported in GitHub Actions and Azure DevOps.'));
+    await assert.rejects(auth.ensureAccessToken(resource, logger, true), new CommandError('Federated identity is currently only supported in GitHub Actions, Azure DevOps and GitLab CI/CD.'));
   });
 
   it('fails when using federated identity from Azure DevOps Pipeline, but SYSTEM_ACCESSTOKEN not available', async () => {
@@ -1655,6 +1657,64 @@ describe('Auth', () => {
     auth.connection.tenant = 'common';
 
     await assert.rejects(auth.ensureAccessToken(resource, logger, true), new CommandError(`The appId and tenant parameters are required when not using a service connection.`));
+  });
+
+  it('calls api with correct params using federated identity flow from GitLab CI/CD', async () => {
+    const gitlabOidcToken = 'eyJ0eXAiOiJKV1QiLCJ-GitLabFederationClientAssertion-...';
+    process.env = {
+      GITLAB_CI: 'true',
+      GITLAB_OIDC_TOKEN: gitlabOidcToken
+    };
+    const accessToken = 'eyJ0eXAiOiJKV1QiLCJ-EntraIDAccessToken...';
+
+    const requestPostStub = sinon.stub(request, 'post').callsFake(async (opts) => {
+      if (opts.url === `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`) {
+        return {
+          "access_token": accessToken,
+          "expires_in": "3599",
+          "ext_expires_in": "3599",
+          "token_type": "Bearer"
+        };
+      }
+
+      throw { error: { "error": "Invalid POST Request" } };
+    });
+
+    auth.connection.authType = AuthType.FederatedIdentity;
+    auth.connection.appId = appId;
+    auth.connection.tenant = tenant;
+
+    const ensuredAccessToken = await auth.ensureAccessToken(resource, logger, true);
+    assert.strictEqual(ensuredAccessToken, accessToken);
+    assert(requestPostStub.calledOnce);
+    assert.strictEqual(requestPostStub.firstCall.args[0].data.indexOf(`client_id=${appId}`) > -1, true);
+    assert.strictEqual(requestPostStub.firstCall.args[0].data.indexOf(`client_assertion=${gitlabOidcToken}`) > -1, true);
+  });
+
+  it('fails when using federated identity from GitLab CI/CD with empty appId and tenant option', async () => {
+    process.env = {
+      GITLAB_CI: 'true',
+      GITLAB_OIDC_TOKEN: 'eyJ0eXAiOiJKV1QiLCJ-GitLabFederationClientAssertion-...'
+    };
+
+    auth.connection.authType = AuthType.FederatedIdentity;
+    auth.connection.appId = undefined;
+    auth.connection.tenant = 'common';
+
+    await assert.rejects(auth.ensureAccessToken(resource, logger, true), new CommandError('The appId and tenant parameters are required when using Federated Identity in GitLab CI/CD.'));
+  });
+
+  it('fails when using federated identity from GitLab CI/CD with empty tenant option', async () => {
+    process.env = {
+      GITLAB_CI: 'true',
+      GITLAB_OIDC_TOKEN: 'eyJ0eXAiOiJKV1QiLCJ-GitLabFederationClientAssertion-...'
+    };
+
+    auth.connection.authType = AuthType.FederatedIdentity;
+    auth.connection.appId = appId;
+    auth.connection.tenant = 'common';
+
+    await assert.rejects(auth.ensureAccessToken(resource, logger, true), new CommandError('The appId and tenant parameters are required when using Federated Identity in GitLab CI/CD.'));
   });
 
   it('returns access token if persisting connection fails', async () => {

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -757,8 +757,21 @@ export class Auth {
 
       return this.getAccessTokenWithFederatedToken(resource, federationToken, logger, debug);
     }
+    else if (process.env.GITLAB_CI && process.env.GITLAB_OIDC_TOKEN) {
+      if (debug) {
+        await logger.logToStderr('GITLAB_CI and GITLAB_OIDC_TOKEN env variables found. The context is GitLab CI/CD...');
+      }
+
+      if (!this.connection.appId || this.connection.tenant === 'common') {
+        throw new CommandError('The appId and tenant parameters are required when using Federated Identity in GitLab CI/CD.');
+      }
+
+      // GitLab's id_tokens feature mints the OIDC JWT directly into the configured job variable, so no
+      // separate request to GitLab is needed to obtain the federation token before exchanging it with Entra ID.
+      return this.getAccessTokenWithFederatedToken(resource, process.env.GITLAB_OIDC_TOKEN, logger, debug);
+    }
     else {
-      throw new CommandError('Federated identity is currently only supported in GitHub Actions and Azure DevOps.');
+      throw new CommandError('Federated identity is currently only supported in GitHub Actions, Azure DevOps and GitLab CI/CD.');
     }
   }
 


### PR DESCRIPTION
## Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Summary

Closes #7463

Adds GitLab CI/CD support to `m365 login --authType federatedIdentity`, alongside the existing GitHub Actions and Azure DevOps support. GitLab CI/CD jobs can request an OIDC ID token via the `id_tokens` keyword; this token is exchanged for an Entra ID access token via the CLI's existing federated token exchange, with no change needed to the exchange logic itself.

This mirrors the equivalent feature already shipped in PnP PowerShell: https://github.com/pnp/powershell/pull/5395

## Changes

**`login`**
- New GitLab CI/CD branch in the federated identity flow: detects `GITLAB_CI` and `GITLAB_OIDC_TOKEN` environment variables (populated by GitLab's `id_tokens` CI/CD keyword) and exchanges the OIDC token for an Entra ID access token via the existing federated token exchange — no extra HTTP round-trip needed, since GitLab injects the signed JWT directly into the job variable.
- Requires `--appId` and `--tenant` to be specified explicitly for GitLab CI/CD, matching the existing requirement for Azure DevOps without a service connection.
- Documentation updated with the required `id_tokens` YAML configuration and the federated credential issuer/subject requirements for GitLab.

## Implementation notes

- All changes are in `src/Auth.ts` (provider detection + error message) and `src/Auth.spec.ts` (3 new tests covering the success path and both validation failures), following the exact pattern already used for GitHub Actions/Azure DevOps in the same file.
- No new `AuthType` value needed — `federatedIdentity` is already provider-agnostic; this only adds a new environment-variable detection branch.
- Documentation included (`docs/docs/cmd/login.mdx` updated with GitLab CI/CD example and requirements).
- Developed with AI assistance
- Tested (verified end-to-end against a real GitLab CI/CD pipeline with federated login succeeding)