### PR TITLE
Add json token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
   - Client Secret
   - Device Code
   - Federated identity
+  - Token
   - Username and Password
 - Manage your SharePoint Framework projects
   - Upgrade your projects

--- a/docs/docs/cmd/login.mdx
+++ b/docs/docs/cmd/login.mdx
@@ -22,7 +22,7 @@ m365 login [options]
 : ID of the tenant from which accounts should authenticate. Use `common` or `organization` for multitenant apps. Defaults to `common` if not specified and if the config value `tenantId` and the environment variable `CLIMICROSOFT365_TENANT` are also not set.
 
 `-t, --authType [authType]`
-: The type of authentication to use. Allowed values `certificate`, `deviceCode`, `password`, `identity`, `federatedIdentity`, `browser`, `secret`. Default `deviceCode`
+: The type of authentication to use. Allowed values `certificate`, `deviceCode`, `password`, `identity`, `federatedIdentity`, `browser`, `secret`, `token`. Default `deviceCode`
 
 `-u, --userName [userName]`
 : Name of the user to authenticate. Required when `authType` is set to `password`
@@ -41,6 +41,9 @@ m365 login [options]
 
 `-s, --secret [secret]`
 : Client Secret of the Microsoft Entra application to use for authentication. Required when `authType` is set to `secret`.
+
+`--tokenFile [tokenFile]`
+: Path to the file containing a pre-obtained access token. Required when `authType` is set to `token`. The file can be a JSON file with an `access_token` or `accessToken` property, or a plain-text file containing the JWT.
 
 `--cloud [cloud]`
 : Cloud to connect to. Allowed values `Public`, `USGov`, `USGovHigh`, `USGovDoD` and `China`. Default `Public`
@@ -64,7 +67,7 @@ The CLI determines the `appId` and `tenant` values in the following order of pre
 2. The `clientId` or `tenantId` value set in the configuration.
 3. The `CLIMICROSOFT365_ENTRAAPPID` or `CLIMICROSOFT365_TENANT` environment variable.
 
-For `appId`, it is **required** that at least one of the options is specified during login.
+For `appId`, it is **required** that at least one of the options is specified during login, except when using `authType` `identity`, `federatedIdentity`, or `token`.
 
 For `tenant`, if none are specified, the CLI will default to `common`.
 
@@ -79,6 +82,8 @@ When logging in to Microsoft 365 using the user name and password, next to the a
 When logging in to Microsoft 365 using a certificate, the CLI for Microsoft 365 will store the contents of the certificate so that it can automatically re-authenticate if necessary. The contents of the certificate are removed by re-authenticating using the device code or by calling the [logout](logout.mdx) command.  
 
 Federated Identity is currently supported in GitHub Actions. To use this you need to set `authType` to `federatedIdentity` and specify `appId` and `tenant` to the values of the app registration you've configured a federated credential on. 
+
+To log in to Microsoft 365 using a pre-obtained access token, set `authType` to `token` and specify the path to the token file using the `tokenFile` option. The CLI reads the token from the file and skips all interactive and non-interactive login flows. When the cached token expires, the CLI re-reads the token file.
 
 To log in to Microsoft 365 using a certificate or secret, you will typically [create a custom Microsoft Entra application](../user-guide/using-own-identity.mdx). To use this application with the CLI for Microsoft 365, you will set the `CLIMICROSOFT365_ENTRAAPPID` environment variable to the application's ID and the `CLIMICROSOFT365_TENANT` environment variable to the ID of the Microsoft Entra tenant, where you created the Microsoft Entra application. Also, please make sure to read about [the caveats when using the certificate login option](../user-guide/cli-certificate-caveats.mdx).
 
@@ -224,6 +229,12 @@ Log in to Microsoft 365 using a client secret by providing the application and t
 
 ```sh
 m365 login --authType secret --appId 31359c7f-bd7e-475c-86db-fdb8c937548c --tenant 31359c7f-bd7e-475c-86db-fdb8c937548a --secret topSeCr3t@007
+```
+
+Log in to Microsoft 365 using a pre-obtained access token from a JSON file.
+
+```sh
+m365 login --authType token --tokenFile /Users/user/dev/token.json
 ```
 
 Ensures that the user is signed in, initiates the login flow if the user isn't signed in

--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -1929,6 +1929,83 @@ describe('Auth', () => {
     assert(acquireTokenByClientCredentialStub.called);
   });
 
+  it('retrieves token from token file when authType token specified', async () => {
+    const jwtPayload = Buffer.from(JSON.stringify({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      oid: identityId,
+      upn: identityName,
+      tid: identityTenantId
+    })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    auth.connection.authType = AuthType.Token;
+    auth.connection.tokenFile = '/tmp/token.json';
+    readFileSyncStub.returns(JSON.stringify({ access_token: jwt }));
+
+    const accessTokenValue = await auth.ensureAccessToken(resource, logger);
+
+    assert.strictEqual(accessTokenValue, jwt);
+    assert.strictEqual(auth.connection.accessTokens[resource].accessToken, jwt);
+  });
+
+  it('retrieves token from token file when authType token specified (debug)', async () => {
+    const jwtPayload = Buffer.from(JSON.stringify({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      oid: identityId,
+      upn: identityName,
+      tid: identityTenantId
+    })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    auth.connection.authType = AuthType.Token;
+    auth.connection.tokenFile = '/tmp/token.json';
+    readFileSyncStub.returns(JSON.stringify({ access_token: jwt }));
+
+    await auth.ensureAccessToken(resource, logger, true);
+
+    assert(loggerLogToStderrSpy.calledWith('Retrieving access token from token file...'));
+  });
+
+  it('re-reads token file when cached token expired and authType token specified', async () => {
+    const expiredJwtPayload = Buffer.from(JSON.stringify({
+      exp: Math.floor(Date.now() / 1000) - 3600,
+      oid: identityId,
+      upn: identityName,
+      tid: identityTenantId
+    })).toString('base64');
+    const expiredJwt = `abc.${expiredJwtPayload}.def`;
+    const freshJwtPayload = Buffer.from(JSON.stringify({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      oid: identityId,
+      upn: identityName,
+      tid: identityTenantId
+    })).toString('base64');
+    const freshJwt = `abc.${freshJwtPayload}.def`;
+    auth.connection.authType = AuthType.Token;
+    auth.connection.tokenFile = '/tmp/token.json';
+    auth.connection.active = true;
+    auth.connection.accessTokens[resource] = {
+      accessToken: expiredJwt,
+      expiresOn: new Date(Date.now() - 1000)
+    };
+    readFileSyncStub.returns(JSON.stringify({ access_token: freshJwt }));
+
+    const accessTokenValue = await auth.ensureAccessToken(resource, logger);
+
+    assert.strictEqual(accessTokenValue, freshJwt);
+    assert.strictEqual(readFileSyncStub.called, true);
+  });
+
+  it('fails when token file is not specified and authType token specified', async () => {
+    auth.connection.authType = AuthType.Token;
+
+    try {
+      await auth.ensureAccessToken(resource, logger);
+      assert.fail('Expected error');
+    }
+    catch (err: any) {
+      assert.strictEqual(err.message, 'Token file is not specified.');
+    }
+  });
+
   it('configures cloud for auth to AzureChina for China cloud', async () => {
     auth.connection.cloudType = CloudType.China;
     const actual: msal.Configuration = await (auth as any).getAuthClientConfiguration(logger, false);

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -64,6 +64,7 @@ export class Connection {
   certificateType: CertificateType = CertificateType.Unknown;
   certificate?: string;
   thumbprint?: string;
+  tokenFile?: string;
   accessTokens: Hash<AccessToken>;
   spoUrl?: string;
   // SharePoint tenantId used to execute CSOM requests
@@ -71,7 +72,7 @@ export class Connection {
   // ID of the Microsoft Entra ID app used to authenticate
   appId?: string;
   // ID of the tenant where the Microsoft Entra app is registered; common if multi-tenant
-  tenant: string = 'common';
+  tenant?: string;
   cloudType: CloudType = CloudType.Public;
 
   constructor() {
@@ -93,6 +94,7 @@ export class Connection {
     this.cloudType = CloudType.Public;
     this.certificate = undefined;
     this.thumbprint = undefined;
+    this.tokenFile = undefined;
     this.spoUrl = undefined;
     this.spoTenantId = undefined;
     this.appId = cli.getClientId();
@@ -107,7 +109,8 @@ export enum AuthType {
   Identity = 'identity',
   FederatedIdentity = 'federatedIdentity',
   Browser = 'browser',
-  Secret = 'secret'
+  Secret = 'secret',
+  Token = 'token'
 }
 
 export enum CertificateType {
@@ -229,7 +232,8 @@ export class Auth {
     if (this.connection.authType !== AuthType.Certificate &&
       this.connection.authType !== AuthType.Secret &&
       this.connection.authType !== AuthType.Identity &&
-      this.connection.authType !== AuthType.FederatedIdentity) {
+      this.connection.authType !== AuthType.FederatedIdentity &&
+      this.connection.authType !== AuthType.Token) {
       this.clientApplication = await this.getPublicClient(logger, debug);
       if (this.clientApplication) {
         const accounts = await this.clientApplication.getTokenCache().getAllAccounts();
@@ -262,6 +266,9 @@ export class Auth {
           break;
         case AuthType.Secret:
           getTokenPromise = this.ensureAccessTokenWithSecret.bind(this);
+          break;
+        case AuthType.Token:
+          getTokenPromise = this.ensureAccessTokenWithToken.bind(this);
           break;
       }
     }
@@ -848,6 +855,18 @@ export class Auth {
     });
   }
 
+  private async ensureAccessTokenWithToken(resource: string, logger: Logger, debug: boolean): Promise<AccessToken | null> {
+    if (debug) {
+      await logger.logToStderr(`Retrieving access token from token file...`);
+    }
+
+    if (!this.connection.tokenFile) {
+      throw new CommandError('Token file is not specified.');
+    }
+
+    return accessTokenUtil.accessToken.readAccessTokenFromFile(this.connection.tokenFile);
+  }
+
   private async calculateThumbprint(certificate: NodeForge.pki.Certificate): Promise<string> {
     const nodeForge = (await import('node-forge')).default;
     const { md, asn1, pki } = nodeForge;
@@ -935,7 +954,8 @@ export class Auth {
     if (this.connection.authType !== AuthType.Certificate &&
       this.connection.authType !== AuthType.Secret &&
       this.connection.authType !== AuthType.Identity &&
-      this.connection.authType !== AuthType.FederatedIdentity) {
+      this.connection.authType !== AuthType.FederatedIdentity &&
+      this.connection.authType !== AuthType.Token) {
       this.clientApplication = await this.getPublicClient(logger, debug);
 
       if (this.clientApplication) {

--- a/src/m365/cli/commands/cli-doctor.spec.ts
+++ b/src/m365/cli/commands/cli-doctor.spec.ts
@@ -566,6 +566,46 @@ describe(commands.DOCTOR, () => {
     }));
   });
 
+  it('omits tenant information in diagnostic output when using token authentication', async () => {
+    const jwt = JSON.stringify({
+      aud: 'https://graph.microsoft.com',
+      scp: 'Sites.Read.All'
+    });
+    const jwt64 = Buffer.from(jwt).toString('base64');
+    const accessToken = `abc.${jwt64}.def`;
+
+    sinon.stub(auth.connection, 'accessTokens').value({
+      'https://graph.microsoft.com': { 'expiresOn': '2021-07-04T09:52:18.000Z', 'accessToken': `${accessToken}` }
+    });
+    sinon.stub(os, 'platform').returns('win32');
+    sinon.stub(os, 'version').returns('Windows 10 Pro');
+    sinon.stub(os, 'release').returns('10.0.19043');
+    sinon.stub(packageJSON, 'version').value('3.11.0');
+    sinon.stub(process, 'version').value('v14.17.0');
+    auth.connection.appId = undefined;
+    sinon.stub(auth.connection, 'tenant').value(undefined);
+    sinon.stub(auth.connection, 'authType').value(AuthType.Token);
+    sinon.stub(process, 'env').value({ 'CLIMICROSOFT365_ENV': '' });
+
+    await command.action(logger, { options: commandOptionsSchema.parse({}) });
+    assert(loggerLogSpy.calledWith({
+      authMode: 'token',
+      cliEntraAppId: undefined,
+      cliEntraAppTenant: undefined,
+      cliEnvironment: '',
+      cliVersion: '3.11.0',
+      cliConfig: {},
+      nodeVersion: 'v14.17.0',
+      os: { 'platform': 'win32', 'version': 'Windows 10 Pro', 'release': '10.0.19043' },
+      roles: [],
+      scopes: {
+        'https://graph.microsoft.com': [
+          'Sites.Read.All'
+        ]
+      }
+    }));
+  });
+
   it('retrieves CLI Configuration in the diagnostic information about the current environment', async () => {
     const jwt = JSON.stringify({
       aud: 'https://graph.microsoft.com',

--- a/src/m365/cli/commands/cli-doctor.ts
+++ b/src/m365/cli/commands/cli-doctor.ts
@@ -18,7 +18,7 @@ interface CliDiagnosticInfo {
   };
   authMode: string;
   cliEntraAppId?: string;
-  cliEntraAppTenant: string;
+  cliEntraAppTenant?: string;
   cliEnvironment: string;
   nodeVersion: string;
   cliVersion: string;
@@ -63,7 +63,9 @@ class CliDoctorCommand extends Command {
       cliVersion: app.packageJson().version,
       nodeVersion: process.version,
       cliEntraAppId: auth.connection.appId,
-      cliEntraAppTenant: validation.isValidGuid(auth.connection.tenant) ? 'single' : auth.connection.tenant,
+      cliEntraAppTenant: auth.connection.tenant
+        ? (validation.isValidGuid(auth.connection.tenant) ? 'single' : auth.connection.tenant)
+        : undefined,
       authMode: auth.connection.authType,
       cliEnvironment: process.env.CLIMICROSOFT365_ENV ? process.env.CLIMICROSOFT365_ENV : '',
       cliConfig: cli.getConfig().all,

--- a/src/m365/commands/ConnectionDetails.ts
+++ b/src/m365/commands/ConnectionDetails.ts
@@ -3,6 +3,6 @@ export interface ConnectionDetails {
   connectedAs: string;
   authType: string;
   appId?: string;
-  appTenant: string;
+  appTenant?: string;
   cloudType: string;
 }

--- a/src/m365/commands/login.spec.ts
+++ b/src/m365/commands/login.spec.ts
@@ -358,6 +358,40 @@ describe(commands.LOGIN, () => {
     assert.strictEqual(auth.connection.secret, 'unBrEakaBle@123', 'Incorrect secret set');
   });
 
+  it('logs in to Microsoft 365 using token when authType token set', async () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => true);
+    await command.action(logger, {
+      options: commandOptionsSchema.parse({
+        authType: 'token',
+        tokenFile: '/tmp/token.json'
+      })
+    });
+    assert.strictEqual(auth.connection.authType, AuthType.Token, 'Incorrect authType set');
+    assert.strictEqual(auth.connection.tokenFile, '/tmp/token.json', 'Incorrect tokenFile set');
+  });
+
+  it('does not set appId and tenant when authType token set even if configured in CLI', async () => {
+    sinonUtil.restore(config.get);
+    sinon.stub(config, 'get').callsFake(setting => {
+      if (setting === settingsNames.clientId) {
+        return '00000000-0000-0000-0000-000000000000';
+      }
+      if (setting === settingsNames.tenantId) {
+        return '11111111-1111-1111-1111-111111111111';
+      }
+      return undefined;
+    });
+    sinon.stub(fs, 'existsSync').callsFake(() => true);
+    await command.action(logger, {
+      options: commandOptionsSchema.parse({
+        authType: 'token',
+        tokenFile: '/tmp/token.json'
+      })
+    });
+    assert.strictEqual(auth.connection.appId, undefined, 'appId should not be set for token auth');
+    assert.strictEqual(auth.connection.tenant, undefined, 'tenant should not be set for token auth');
+  });
+
   it('logs in to Microsoft 365 using client secret authType "secret" with secret set in CLI config', async () => {
     sinonUtil.restore(config.get);
     sinon.stub(config, 'get').callsFake(setting => {
@@ -454,6 +488,22 @@ describe(commands.LOGIN, () => {
     const actual = commandOptionsSchema.safeParse({
       authType: 'certificate',
       certificateFile: 'certificate'
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if authType is set to token and tokenFile not specified', () => {
+    const actual = commandOptionsSchema.safeParse({
+      authType: 'token'
+    });
+    assert.strictEqual(actual.success, false);
+  });
+
+  it('fails validation if authType is set to token and tokenFile does not exist', () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => false);
+    const actual = commandOptionsSchema.safeParse({
+      authType: 'token',
+      tokenFile: '/tmp/token.json'
     });
     assert.strictEqual(actual.success, false);
   });
@@ -963,6 +1013,34 @@ describe(commands.LOGIN, () => {
         ensure: true,
         authType: 'secret',
         secret: 'topSeCr3t@008'
+      })
+    });
+
+    assert(deactivateStub.called);
+  });
+
+  it(`starts the login flow again when using a different token file`, async () => {
+    const future = new Date();
+    future.setSeconds(future.getSeconds() + 10);
+    Object.assign(auth.connection, {
+      active: true,
+      authType: AuthType.Token,
+      tokenFile: '/tmp/token1.json',
+      appId: '00000000-0000-0000-0000-000000000000',
+      tenant: '00000000-0000-0000-0000-000000000000'
+    });
+    auth.connection.accessTokens[auth.defaultResource] = {
+      expiresOn: future.toISOString(),
+      accessToken: 'abc'
+    };
+
+    sinon.stub(fs, 'existsSync').callsFake(() => true);
+
+    await command.action(logger, {
+      options: commandOptionsSchema.parse({
+        ensure: true,
+        authType: 'token',
+        tokenFile: '/tmp/token2.json'
       })
     });
 

--- a/src/m365/commands/login.ts
+++ b/src/m365/commands/login.ts
@@ -25,6 +25,10 @@ export const options = z.strictObject({
   appId: z.string().optional(),
   tenant: z.string().optional(),
   secret: z.string().optional().alias('s'),
+  tokenFile: z.string().optional()
+    .refine(filePath => !filePath || fs.existsSync(filePath), {
+      error: e => `Token file ${e.input} does not exist`
+    }),
   connectionName: z.string()
     .refine(async name => !(await auth.getAllConnections()).some(c => c.name === name), {
       error: e => `Connection with name '${e.input}' already exists.`
@@ -53,7 +57,7 @@ class LoginCommand extends Command {
 
   public getRefinedSchema(schema: typeof options): z.ZodObject<any> | undefined {
     return schema
-      .refine(options => typeof options.appId !== 'undefined' || cli.getClientId() || options.authType === 'identity' || options.authType === 'federatedIdentity', {
+      .refine(options => typeof options.appId !== 'undefined' || cli.getClientId() || options.authType === 'identity' || options.authType === 'federatedIdentity' || options.authType === 'token', {
         error: `appId is required. TIP: use the "m365 setup" command to configure the default appId.`,
         path: ['appId'],
         params: {
@@ -99,6 +103,13 @@ class LoginCommand extends Command {
         cli.getConfig().get(settingsNames.clientSecret), {
         error: 'Secret is required when using secret authentication.',
         path: ['secret'],
+        params: {
+          customCode: 'required'
+        }
+      })
+      .refine(options => options.authType !== 'token' || options.tokenFile, {
+        error: 'Token file is required when using token authentication.',
+        path: ['tokenFile'],
         params: {
           customCode: 'required'
         }
@@ -149,12 +160,14 @@ class LoginCommand extends Command {
       return true;
     }
 
-    if (options.appId && options.appId !== auth.connection.appId) {
-      return true;
-    }
+    if (authType !== AuthType.Token) {
+      if (options.appId && options.appId !== auth.connection.appId) {
+        return true;
+      }
 
-    if (options.tenant && options.tenant !== auth.connection.tenant) {
-      return true;
+      if (options.tenant && options.tenant !== auth.connection.tenant) {
+        return true;
+      }
     }
 
     if (authType === AuthType.Password && (options.password && options.userName !== auth.connection.userName)) {
@@ -170,6 +183,10 @@ class LoginCommand extends Command {
     }
 
     if (authType === AuthType.Secret && (options.secret && options.secret !== auth.connection.secret)) {
+      return true;
+    }
+
+    if (authType === AuthType.Token && (options.tokenFile && options.tokenFile !== auth.connection.tokenFile)) {
       return true;
     }
 
@@ -223,8 +240,14 @@ class LoginCommand extends Command {
     }
 
     const authType = args.options.authType || cli.getSettingWithDefaultValue<string>(settingsNames.authType, 'deviceCode');
-    auth.connection.appId = args.options.appId || cli.getClientId();
-    auth.connection.tenant = args.options.tenant || cli.getTenant();
+    if (authType === 'token') {
+      auth.connection.appId = undefined;
+      auth.connection.tenant = undefined;
+    }
+    else {
+      auth.connection.appId = args.options.appId || cli.getClientId();
+      auth.connection.tenant = args.options.tenant || cli.getTenant();
+    }
     auth.connection.name = args.options.connectionName;
 
     switch (authType) {
@@ -252,6 +275,10 @@ class LoginCommand extends Command {
       case 'secret':
         auth.connection.authType = AuthType.Secret;
         auth.connection.secret = args.options.secret || cli.getConfig().get(settingsNames.clientSecret);
+        break;
+      case 'token':
+        auth.connection.authType = AuthType.Token;
+        auth.connection.tokenFile = args.options.tokenFile;
         break;
     }
 

--- a/src/utils/accessToken.spec.ts
+++ b/src/utils/accessToken.spec.ts
@@ -1,9 +1,10 @@
 import assert from 'assert';
-import { accessToken } from '../utils/accessToken.js';
-import { sinonUtil } from './sinonUtil.js';
+import fs from 'fs';
 import sinon from 'sinon';
 import auth from '../Auth.js';
 import { CommandError } from '../Command.js';
+import { accessToken } from '../utils/accessToken.js';
+import { sinonUtil } from './sinonUtil.js';
 
 describe('utils/accessToken', () => {
 
@@ -16,7 +17,8 @@ describe('utils/accessToken', () => {
 
   afterEach(() => {
     sinonUtil.restore([
-      accessToken.isAppOnlyAccessToken
+      accessToken.isAppOnlyAccessToken,
+      fs.readFileSync
     ]);
   });
 
@@ -198,5 +200,124 @@ describe('utils/accessToken', () => {
     const payload = Buffer.from('not-json').toString('base64');
     const token = `header.${payload}.signature`;
     assert.deepStrictEqual(accessToken.getScopesFromAccessToken(token), []);
+  });
+
+  it('reads access token from JSON token file using access_token property', () => {
+    const jwtPayload = Buffer.from(JSON.stringify({
+      exp: 1893456000,
+      oid: '028de82d-7fd9-476e-a9fd-be9714280ff3'
+    })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify({ access_token: jwt }));
+
+    const actual = accessToken.readAccessTokenFromFile('/tmp/token.json');
+
+    assert.strictEqual(actual.accessToken, jwt);
+    assert.strictEqual((actual.expiresOn as Date).getTime(), 1893456000000);
+  });
+
+  it('reads access token from JSON token file using accessToken property', () => {
+    const jwtPayload = Buffer.from(JSON.stringify({
+      exp: 1893456000
+    })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify({ accessToken: jwt }));
+
+    const actual = accessToken.readAccessTokenFromFile('/tmp/token.json');
+
+    assert.strictEqual(actual.accessToken, jwt);
+    assert.strictEqual((actual.expiresOn as Date).getTime(), 1893456000000);
+  });
+
+  it('reads access token from plain text token file', () => {
+    const jwtPayload = Buffer.from(JSON.stringify({
+      exp: 1893456000
+    })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    sinon.stub(fs, 'readFileSync').returns(jwt);
+
+    const actual = accessToken.readAccessTokenFromFile('/tmp/token.txt');
+
+    assert.strictEqual(actual.accessToken, jwt);
+    assert.strictEqual((actual.expiresOn as Date).getTime(), 1893456000000);
+  });
+
+  it('reads expires_on from JSON token file', () => {
+    const jwtPayload = Buffer.from(JSON.stringify({ oid: '028de82d-7fd9-476e-a9fd-be9714280ff3' })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify({
+      access_token: jwt,
+      expires_on: '1893456000'
+    }));
+
+    const actual = accessToken.readAccessTokenFromFile('/tmp/token.json');
+
+    assert.strictEqual(actual.accessToken, jwt);
+    assert.strictEqual((actual.expiresOn as Date).getTime(), 1893456000000);
+  });
+
+  it('reads string expiresOn from JSON token file', () => {
+    const jwtPayload = Buffer.from(JSON.stringify({ oid: '028de82d-7fd9-476e-a9fd-be9714280ff3' })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify({
+      accessToken: jwt,
+      expiresOn: '2030-01-01T00:00:00.000Z'
+    }));
+
+    const actual = accessToken.readAccessTokenFromFile('/tmp/token.json');
+
+    assert.strictEqual((actual.expiresOn as Date).getTime(), new Date('2030-01-01T00:00:00.000Z').getTime());
+  });
+
+  it('reads numeric expiresOn from JSON token file', () => {
+    const jwtPayload = Buffer.from(JSON.stringify({ oid: '028de82d-7fd9-476e-a9fd-be9714280ff3' })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify({
+      accessToken: jwt,
+      expiresOn: 1893456000
+    }));
+
+    const actual = accessToken.readAccessTokenFromFile('/tmp/token.json');
+
+    assert.strictEqual((actual.expiresOn as Date).getTime(), 1893456000000);
+  });
+
+  it('throws error when token file does not contain a valid access token', () => {
+    sinon.stub(fs, 'readFileSync').returns('not-a-token');
+
+    assert.throws(() => accessToken.readAccessTokenFromFile('/tmp/token.txt'), (err: any) => {
+      return err instanceof CommandError && err.message === 'Token file does not contain a valid access token.';
+    });
+  });
+
+  it('throws error when JSON token file does not contain an access token property', () => {
+    sinon.stub(fs, 'readFileSync').returns('{}');
+
+    assert.throws(() => accessToken.readAccessTokenFromFile('/tmp/token.json'), (err: any) => {
+      return err instanceof CommandError && err.message === 'Token file does not contain a valid access token.';
+    });
+  });
+
+  it('reads access token from JSON token file containing a string value', () => {
+    const jwtPayload = Buffer.from(JSON.stringify({
+      exp: 1893456000
+    })).toString('base64');
+    const jwt = `abc.${jwtPayload}.def`;
+    sinon.stub(fs, 'readFileSync').returns(JSON.stringify(jwt));
+
+    const actual = accessToken.readAccessTokenFromFile('/tmp/token.json');
+
+    assert.strictEqual(actual.accessToken, jwt);
+    assert.strictEqual((actual.expiresOn as Date).getTime(), 1893456000000);
+  });
+
+  it('returns null expiresOn when token payload cannot be parsed', () => {
+    const jwt = 'abc.!!!.def';
+    sinon.stub(fs, 'readFileSync').returns(jwt);
+
+    const actual = accessToken.readAccessTokenFromFile('/tmp/token.txt');
+
+    assert.strictEqual(actual.accessToken, jwt);
+    assert.strictEqual(actual.expiresOn, null);
   });
 });

--- a/src/utils/accessToken.ts
+++ b/src/utils/accessToken.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import type { AccessToken } from "../Auth.js";
 import auth from "../Auth.js";
 import { CommandError } from "../Command.js";
 
@@ -134,6 +136,60 @@ export const accessToken = {
     }
 
     return scopes;
+  },
+
+  readAccessTokenFromFile(filePath: string): AccessToken {
+    const contents = fs.readFileSync(filePath, 'utf8').trim();
+    let accessTokenString: string | undefined;
+    let expiresOn: Date | null = null;
+
+    try {
+      const parsed: any = JSON.parse(contents);
+      if (typeof parsed === 'string') {
+        accessTokenString = parsed;
+      }
+      else {
+        accessTokenString = parsed.access_token || parsed.accessToken;
+        if (parsed.expires_on) {
+          expiresOn = new Date(parseInt(parsed.expires_on, 10) * 1000);
+        }
+        else if (parsed.expiresOn) {
+          expiresOn = typeof parsed.expiresOn === 'number' ?
+            new Date(parsed.expiresOn * 1000) :
+            new Date(parsed.expiresOn);
+        }
+      }
+    }
+    catch {
+      accessTokenString = contents;
+    }
+
+    if (!accessTokenString) {
+      throw new CommandError('Token file does not contain a valid access token.');
+    }
+
+    const chunks = accessTokenString.split('.');
+    if (chunks.length !== 3) {
+      throw new CommandError('Token file does not contain a valid access token.');
+    }
+
+    if (!expiresOn) {
+      try {
+        const payloadString = Buffer.from(chunks[1], 'base64').toString();
+        const payload: any = JSON.parse(payloadString);
+        if (payload.exp) {
+          expiresOn = new Date(payload.exp * 1000);
+        }
+      }
+      catch {
+        // Do nothing
+      }
+    }
+
+    return {
+      accessToken: accessTokenString,
+      expiresOn
+    };
   },
 
   /**

--- a/src/utils/fsUtil.spec.ts
+++ b/src/utils/fsUtil.spec.ts
@@ -1,9 +1,28 @@
 import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { fsUtil } from './fsUtil.js';
 
 describe('utils/fsUtil', () => {
   it('should get safe filename when file\'name.txt', () => {
     const result = fsUtil.getSafeFileName('file\'name.txt');
     assert.strictEqual(result, 'file\'\'name.txt');
+  });
+
+  it('copies a directory recursively when destination does not exist', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fsutil-'));
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+
+    fs.mkdirSync(src);
+    fs.writeFileSync(path.join(src, 'file.txt'), 'content');
+
+    fsUtil.copyRecursiveSync(src, dest);
+
+    assert.strictEqual(fs.existsSync(dest), true);
+    assert.strictEqual(fs.readFileSync(path.join(dest, 'file.txt'), 'utf8'), 'content');
+
+    fs.rmSync(root, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
This is implementation of `m365 login --authType token --tokenfile {{ access_token_file.json }}` for authentication with explicitly supplied access token file.

Resolves #7470

Code in this PR is created with AI assistance. It was tested by humans.
