### PR TITLE
Adds support for shared channels to 'teams channel member' commands. Closes #7132

### DIFF
--- a/docs/docs/cmd/teams/channel/channel-member-add.mdx
+++ b/docs/docs/cmd/teams/channel/channel-member-add.mdx
@@ -41,7 +41,9 @@ m365 teams channel member add [options]
 
 At least one owner must be assigned to a private or shared channel.
 
-You can only add members and owners of a team to a private channel.
+You can only add members and owners of a team to a private channel. For a shared channel, you can also add users who are not a member of the team.
+
+Members can only be managed for private and shared channels. Standard channels inherit their membership from the team.
 
 ## Examples
 

--- a/docs/docs/cmd/teams/channel/channel-member-remove.mdx
+++ b/docs/docs/cmd/teams/channel/channel-member-remove.mdx
@@ -40,6 +40,10 @@ m365 teams channel member remove [options]
 
 <Global />
 
+## Remarks
+
+Members can only be managed for private and shared channels. Standard channels inherit their membership from the team.
+
 ## Examples
   
 Remove the user _johndoe@example.com_ from the Microsoft Teams team with id 00000000-0000-0000-0000-000000000000 and channel id 19:00000000000000000000000000000000@thread.skype

--- a/docs/docs/cmd/teams/channel/channel-member-set.mdx
+++ b/docs/docs/cmd/teams/channel/channel-member-set.mdx
@@ -42,6 +42,10 @@ m365 teams channel member set [options]
 
 <Global />
 
+## Remarks
+
+Members can only be managed for private and shared channels. Standard channels inherit their membership from the team.
+
 ## Examples
   
 Updates the role of the user to owner in the Microsoft Teams team with id 00000000-0000-0000-0000-000000000000 and channel id 19:00000000000000000000000000000000@thread.skype

--- a/src/m365/teams/commands/channel/channel-member-add.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.spec.ts
@@ -120,6 +120,22 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
     "membershipType": "private"
   };
 
+  const singleSharedChannelResponse: any = {
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams('47d6625d-a540-4b59-a4ab-19b787e40593')/channels",
+    "@odata.count": 1,
+    "value": [
+      {
+        "id": "19:586a8b9e36c4479bbbd378e439a96df2@thread.skype",
+        "displayName": "Shared Channel",
+        "description": null,
+        "isFavoriteByDefault": null,
+        "email": "",
+        "webUrl": "https://teams.microsoft.com/l/channel/19%3a586a8b9e36c4479bbbd378e439a96df2%40thread.skype/Shared+Channel?groupId=47d6625d-a540-4b59-a4ab-19b787e40593&tenantId=d544d1e7-d321-494b-870a-1beac97967a2",
+        "membershipType": "shared"
+      }
+    ]
+  };
+
   const singleUserResponse: any = {
     "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
     "value": [
@@ -443,6 +459,27 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
     assert(loggerLogSpy.notCalled);
   });
 
+  it('adds conversation members to a shared channel using teamId, channelName, and userIds', async () => {
+    sinonUtil.restore(request.get);
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/${formatting.encodeQueryParameter('47d6625d-a540-4b59-a4ab-19b787e40593')}/channels?$filter=displayName eq '${formatting.encodeQueryParameter('Shared Channel')}'`) {
+        return singleSharedChannelResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        teamId: "47d6625d-a540-4b59-a4ab-19b787e40593",
+        channelName: "Shared Channel",
+        userIds: "admin@contoso.com",
+        owner: true
+      }
+    });
+    assert(loggerLogSpy.notCalled);
+  });
+
   it('fails adding conversation members with invalid channelName', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
@@ -469,7 +506,7 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
     } as any), new CommandError(`The specified channel 'Other Private Channel' does not exist in the Microsoft Teams team with ID '47d6625d-a540-4b59-a4ab-19b787e40593'`));
   });
 
-  it('fails to get channel when channel does is not private', async () => {
+  it('fails to get channel when channel is not a private or shared channel', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter('Human Resources')}'`) {
@@ -495,7 +532,7 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
         teamId: "47d6625d-a540-4b59-a4ab-19b787e40593",
         channelName: "Other Channel"
       }
-    } as any), new CommandError('The specified channel is not a private channel'));
+    } as any), new CommandError('The specified channel is not a private or shared channel'));
   });
 
   it('fails when group has no team', async () => {

--- a/src/m365/teams/commands/channel/channel-member-add.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.ts
@@ -180,8 +180,8 @@ class TeamsChannelMemberAddCommand extends GraphCommand {
       throw `The specified channel '${args.options.channelName}' does not exist in the Microsoft Teams team with ID '${teamId}'`;
     }
 
-    if (channelItem.membershipType !== "private") {
-      throw `The specified channel is not a private channel`;
+    if (channelItem.membershipType !== "private" && channelItem.membershipType !== "shared") {
+      throw `The specified channel is not a private or shared channel`;
     }
 
     return channelItem.id!;

--- a/src/m365/teams/commands/channel/channel-member-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.spec.ts
@@ -211,7 +211,7 @@ describe(commands.CHANNEL_MEMBER_REMOVE, () => {
     } as any), new CommandError('The specified channel does not exist in the Microsoft Teams team'));
   });
 
-  it('fails to get channel when channel does is not private', async () => {
+  it('fails to get channel when channel is not a private or shared channel', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/teams/${formatting.encodeQueryParameter('00000000-0000-0000-0000-000000000000')}/channels?$filter=displayName eq '${formatting.encodeQueryParameter('Other Channel')}'`) {
@@ -236,7 +236,43 @@ describe(commands.CHANNEL_MEMBER_REMOVE, () => {
         force: true,
         verbose: true
       }
-    } as any), new CommandError('The specified channel is not a private channel'));
+    } as any), new CommandError('The specified channel is not a private or shared channel'));
+  });
+
+  it('correctly get channel id by channel name of a shared channel', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/v1.0/teams/00000000-0000-0000-0000-000000000000/channels?$filter=displayName eq '`) > -1) {
+        return {
+          value: [
+            {
+              "id": "19:00000000000000000000000000000000@thread.skype",
+              "membershipType": "shared"
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'delete').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf('/v1.0/teams/00000000-0000-0000-0000-000000000000/channels/19:00000000000000000000000000000000@thread.skype/members/00000') > -1) {
+        return;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        teamId: '00000000-0000-0000-0000-000000000000',
+        channelName: 'Shared Channel',
+        id: '00000',
+        force: true,
+        verbose: true
+      }
+    });
+    assert.strictEqual(log.length, 1);
   });
 
   it('correctly get channel id by channel name', async () => {

--- a/src/m365/teams/commands/channel/channel-member-remove.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.ts
@@ -207,8 +207,8 @@ class TeamsChannelMemberRemoveCommand extends GraphCommand {
       throw 'The specified channel does not exist in the Microsoft Teams team';
     }
 
-    if (channelItem.membershipType !== "private") {
-      throw 'The specified channel is not a private channel';
+    if (channelItem.membershipType !== "private" && channelItem.membershipType !== "shared") {
+      throw 'The specified channel is not a private or shared channel';
     }
 
     return channelItem.id!;

--- a/src/m365/teams/commands/channel/channel-member-set.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-set.spec.ts
@@ -429,7 +429,7 @@ describe(commands.CHANNEL_MEMBER_SET, () => {
     } as any), new CommandError('The specified channel does not exist in the Microsoft Teams team'));
   });
 
-  it('fails to get channel when channel does is not private', async () => {
+  it('fails to get channel when channel is not a private or shared channel', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/teams/${formatting.encodeQueryParameter('00000000-0000-0000-0000-000000000000')}/channels?$filter=displayName eq '${formatting.encodeQueryParameter('Other Channel')}'`) {
@@ -453,7 +453,42 @@ describe(commands.CHANNEL_MEMBER_SET, () => {
         id: '00000',
         role: 'owner'
       }
-    } as any), new CommandError('The specified channel is not a private channel'));
+    } as any), new CommandError('The specified channel is not a private or shared channel'));
+  });
+
+  it('correctly get channel id by channel name of a shared channel', async () => {
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf(`/v1.0/teams/00000000-0000-0000-0000-000000000000/channels?$filter=displayName eq '`) > -1) {
+        return {
+          value: [
+            {
+              "id": "19:00000000000000000000000000000000@thread.skype",
+              "membershipType": "shared"
+            }
+          ]
+        };
+      }
+
+      throw 'Invalid request';
+    });
+
+    sinon.stub(request, 'patch').callsFake(async (opts) => {
+      if ((opts.url as string).indexOf('/v1.0/teams/00000000-0000-0000-0000-000000000000/channels/19:00000000000000000000000000000000@thread.skype/members/00000') > -1) {
+        return memberResponse;
+      }
+
+      throw 'Invalid request';
+    });
+
+    await command.action(logger, {
+      options: {
+        teamId: '00000000-0000-0000-0000-000000000000',
+        channelName: 'Shared Channel',
+        id: '00000',
+        role: 'owner'
+      }
+    });
+    assert(loggerLogSpy.calledWith(memberResponse));
   });
 
   it('correctly get channel id by channel name', async () => {

--- a/src/m365/teams/commands/channel/channel-member-set.ts
+++ b/src/m365/teams/commands/channel/channel-member-set.ts
@@ -190,8 +190,8 @@ class TeamsChannelMemberSetCommand extends GraphCommand {
       throw 'The specified channel does not exist in the Microsoft Teams team';
     }
 
-    if (channelItem.membershipType !== "private") {
-      throw 'The specified channel is not a private channel';
+    if (channelItem.membershipType !== "private" && channelItem.membershipType !== "shared") {
+      throw 'The specified channel is not a private or shared channel';
     }
 
     return channelItem.id!;


### PR DESCRIPTION
Closes #7132

The three `teams channel member` commands were rejecting any channel that wasn't marked as private when looking it up by name. However, Microsoft Graph supports member management for both private and shared channels. Only standard channels are unsupported because their membership comes from the team.

This change updates all three commands to accept both private and shared channels, while continuing to reject standard channels. The error message is also updated consistently to: `The specified channel is not a private or shared channel`.

Docs pages are updated for all three commands, with shared-channel success coverage and updated standard-channel rejection coverage added to each.
