### PR TITLE
Use Teams util in Teams commands

### DIFF
--- a/src/m365/teams/commands/channel/channel-list.spec.ts
+++ b/src/m365/teams/commands/channel/channel-list.spec.ts
@@ -207,24 +207,19 @@ describe(commands.CHANNEL_LIST, () => {
     ));
   });
 
-  it('fails when group has no team', async () => {
+  it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": []
-            }
-          ]
+          "@odata.count": 0,
+          "value": []
         };
       }
       throw 'Invalid request';
     });
 
-    await assert.rejects(command.action(logger, { options: { teamName: 'Team Name' } } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    await assert.rejects(command.action(logger, { options: { teamName: 'Team Name' } } as any), new CommandError("The specified team 'Team Name' does not exist."));
   });
 
   it('correctly lists all channels in a Microsoft teams team with specified type parameter', async () => {
@@ -288,7 +283,7 @@ describe(commands.CHANNEL_LIST, () => {
 
   it('correctly lists all channels in a Microsoft teams team by team name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
         return {
           "value": [
             {

--- a/src/m365/teams/commands/channel/channel-list.ts
+++ b/src/m365/teams/commands/channel/channel-list.ts
@@ -1,15 +1,11 @@
-import { Channel, Group } from '@microsoft/microsoft-graph-types';
+import { Channel } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { odata } from '../../../../utils/odata.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
-}
 
 interface CommandArgs {
   options: Options;
@@ -92,12 +88,7 @@ class TeamsChannelListCommand extends GraphCommand {
       return args.options.teamId;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.teamName!);
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist in the Microsoft Teams';
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.teamName!);
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/teams/commands/channel/channel-member-add.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.spec.ts
@@ -213,7 +213,7 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
         return channelIdResponse;
       }
 
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter('Human Resources')}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq '${formatting.encodeQueryParameter('Human Resources')}'&$select=id`) {
         return singleTeamResponse;
       }
 
@@ -446,7 +446,7 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
   it('fails adding conversation members with invalid channelName', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter('Human Resources')}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq '${formatting.encodeQueryParameter('Human Resources')}'&$select=id`) {
         return singleTeamResponse;
       }
 
@@ -472,7 +472,7 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
   it('fails to get channel when channel does is not private', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter('Human Resources')}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq '${formatting.encodeQueryParameter('Human Resources')}'&$select=id`) {
         return singleTeamResponse;
       }
 
@@ -498,19 +498,14 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
     } as any), new CommandError('The specified channel is not a private channel'));
   });
 
-  it('fails when group has no team', async () => {
+  it('fails when team name does not exist', async () => {
     sinonUtil.restore(request.get);
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": []
-            }
-          ]
+          "@odata.count": 0,
+          "value": []
         };
       }
 
@@ -522,7 +517,7 @@ describe(commands.CHANNEL_MEMBER_ADD, () => {
         teamName: 'Team Name',
         channelName: "Other Channel"
       }
-    } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    } as any), new CommandError("The specified team 'Team Name' does not exist."));
   });
 
   it('fails adding conversation members with multiple userDisplayNames', async () => {

--- a/src/m365/teams/commands/channel/channel-member-add.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.spec.ts
@@ -18,53 +18,9 @@ import { settingsNames } from '../../../../settingsNames.js';
 describe(commands.CHANNEL_MEMBER_ADD, () => {
   //#region Mocked Responses 
   const singleTeamResponse: any = {
-    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups",
     "value": [
       {
-        "id": "47d6625d-a540-4b59-a4ab-19b787e40593",
-        "deletedDateTime": null,
-        "classification": null,
-        "createdDateTime": "2018-12-28T04:09:33Z",
-        "createdByAppId": null,
-        "description": "Human Resources",
-        "displayName": "Human Resources",
-        "expirationDateTime": null,
-        "groupTypes": [
-          "Unified"
-        ],
-        "infoCatalogs": [],
-        "isAssignableToRole": null,
-        "mail": "hr@contoso.onmicrosoft.com",
-        "mailEnabled": true,
-        "mailNickname": "hr",
-        "membershipRule": null,
-        "membershipRuleProcessingState": null,
-        "onPremisesDomainName": null,
-        "onPremisesLastSyncDateTime": null,
-        "onPremisesNetBiosName": null,
-        "onPremisesSamAccountName": null,
-        "onPremisesSecurityIdentifier": null,
-        "onPremisesSyncEnabled": null,
-        "preferredDataLocation": null,
-        "preferredLanguage": null,
-        "proxyAddresses": [
-          "SPO:SPO_c562a29c-2afd-4b53-ae4d-f94f200de3ef@SPO_d544d1e7-d321-494b-870a-1beac97967a2",
-          "SMTP:hr@sconsoto.onmicrosoft.com"
-        ],
-        "renewedDateTime": "2018-12-28T04:09:33Z",
-        "resourceBehaviorOptions": [],
-        "resourceProvisioningOptions": [
-          "Team"
-        ],
-        "securityEnabled": false,
-        "securityIdentifier": "S-1-12-1-1205232221-1264166208-3071912868-2466636935",
-        "theme": null,
-        "visibility": "Private",
-        "writebackConfiguration": {
-          "isEnabled": null,
-          "onPremisesGroupType": null
-        },
-        "onPremisesProvisioningErrors": []
+        "id": "47d6625d-a540-4b59-a4ab-19b787e40593"
       }
     ]
   };

--- a/src/m365/teams/commands/channel/channel-member-add.ts
+++ b/src/m365/teams/commands/channel/channel-member-add.ts
@@ -1,17 +1,13 @@
-import { Channel, Group } from '@microsoft/microsoft-graph-types';
+import { Channel } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
 import { cli } from '../../../../cli/cli.js';
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
-}
 
 interface CommandArgs {
   options: Options;
@@ -152,12 +148,7 @@ class TeamsChannelMemberAddCommand extends GraphCommand {
       return args.options.teamId;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.teamName!);
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist in the Microsoft Teams';
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.teamName!);
   }
 
   private async getChannelId(teamId: string, args: CommandArgs): Promise<string> {

--- a/src/m365/teams/commands/channel/channel-member-list.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-list.spec.ts
@@ -213,61 +213,10 @@ describe(commands.CHANNEL_MEMBER_LIST, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails when group has no team', async () => {
+  it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
-        return {
-          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups",
-          "value": [
-            {
-              "@odata.id": "https://graph.microsoft.com/v2/00000000-0000-0000-0000-000000000000/directoryObjects/00000000-0000-0000-0000-000000000000/Microsoft.DirectoryServices.Group",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "deletedDateTime": null,
-              "classification": null,
-              "createdDateTime": "2020-10-11T09:35:26Z",
-              "creationOptions": [
-                "ExchangeProvisioningFlags:3552"
-              ],
-              "description": "Team Description",
-              "displayName": "Team Name",
-              "expirationDateTime": null,
-              "groupTypes": [
-                "Unified"
-              ],
-              "isAssignableToRole": null,
-              "mail": "TeamName@contoso.com",
-              "mailEnabled": true,
-              "mailNickname": "TeamName",
-              "membershipRule": null,
-              "membershipRuleProcessingState": null,
-              "onPremisesDomainName": null,
-              "onPremisesLastSyncDateTime": null,
-              "onPremisesNetBiosName": null,
-              "onPremisesSamAccountName": null,
-              "onPremisesSecurityIdentifier": null,
-              "onPremisesSyncEnabled": null,
-              "preferredDataLocation": null,
-              "preferredLanguage": null,
-              "proxyAddresses": [
-                "SPO:SPO_97df7113-c3f3-447f-8010-9f88eb0fc7f1@SPO_00000000-0000-0000-0000-000000000000",
-                "SMTP:TeamName@contoso.com"
-              ],
-              "renewedDateTime": "2020-10-11T09:35:26Z",
-              "resourceBehaviorOptions": [
-                "HideGroupInOutlook",
-                "SubscribeMembersToCalendarEventsDisabled",
-                "WelcomeEmailDisabled"
-              ],
-              "resourceProvisioningOptions": [
-              ],
-              "securityEnabled": false,
-              "securityIdentifier": "S-1-12-1-1927732186-1159088485-2915259540-28248825",
-              "theme": null,
-              "visibility": "Private",
-              "onPremisesProvisioningErrors": []
-            }
-          ]
-        };
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
+        return { value: [] };
       }
 
       throw 'Invalid request';
@@ -278,12 +227,12 @@ describe(commands.CHANNEL_MEMBER_LIST, () => {
         debug: true,
         teamName: 'Team Name'
       }
-    } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    } as any), new CommandError("The specified team 'Team Name' does not exist."));
   });
 
   it('correctly get teams id by team name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups",
           "value": [

--- a/src/m365/teams/commands/channel/channel-member-list.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-list.spec.ts
@@ -234,56 +234,10 @@ describe(commands.CHANNEL_MEMBER_LIST, () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
       if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
         return {
-          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups",
           "value": [
             {
-              "@odata.id": "https://graph.microsoft.com/v2/00000000-0000-0000-0000-000000000000/directoryObjects/00000000-0000-0000-0000-000000000000/Microsoft.DirectoryServices.Group",
               "id": "00000000-0000-0000-0000-000000000000",
-              "deletedDateTime": null,
-              "classification": null,
-              "createdDateTime": "2020-10-11T09:35:26Z",
-              "creationOptions": [
-                "Team",
-                "ExchangeProvisioningFlags:3552"
-              ],
-              "description": "Team Description",
-              "displayName": "Team Name",
-              "expirationDateTime": null,
-              "groupTypes": [
-                "Unified"
-              ],
-              "isAssignableToRole": null,
-              "mail": "TeamName@contoso.com",
-              "mailEnabled": true,
-              "mailNickname": "TeamName",
-              "membershipRule": null,
-              "membershipRuleProcessingState": null,
-              "onPremisesDomainName": null,
-              "onPremisesLastSyncDateTime": null,
-              "onPremisesNetBiosName": null,
-              "onPremisesSamAccountName": null,
-              "onPremisesSecurityIdentifier": null,
-              "onPremisesSyncEnabled": null,
-              "preferredDataLocation": null,
-              "preferredLanguage": null,
-              "proxyAddresses": [
-                "SPO:SPO_97df7113-c3f3-447f-8010-9f88eb0fc7f1@SPO_00000000-0000-0000-0000-000000000000",
-                "SMTP:TeamName@contoso.com"
-              ],
-              "renewedDateTime": "2020-10-11T09:35:26Z",
-              "resourceBehaviorOptions": [
-                "HideGroupInOutlook",
-                "SubscribeMembersToCalendarEventsDisabled",
-                "WelcomeEmailDisabled"
-              ],
-              "resourceProvisioningOptions": [
-                "Team"
-              ],
-              "securityEnabled": false,
-              "securityIdentifier": "S-1-12-1-1927732186-1159088485-2915259540-28248825",
-              "theme": null,
-              "visibility": "Private",
-              "onPremisesProvisioningErrors": []
+              "displayName": "Team Name"
             }
           ]
         };

--- a/src/m365/teams/commands/channel/channel-member-list.ts
+++ b/src/m365/teams/commands/channel/channel-member-list.ts
@@ -1,17 +1,13 @@
-import { Channel, ConversationMember, Group } from '@microsoft/microsoft-graph-types';
+import { Channel, ConversationMember } from '@microsoft/microsoft-graph-types';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
 import { odata } from '../../../../utils/odata.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
-}
 
 interface CommandArgs {
   options: Options;
@@ -139,12 +135,7 @@ class TeamsChannelMemberListCommand extends GraphCommand {
       return args.options.teamId;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.teamName!);
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist in the Microsoft Teams';
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.teamName!);
   }
 
   private async getChannelId(args: CommandArgs): Promise<string> {

--- a/src/m365/teams/commands/channel/channel-member-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.spec.ts
@@ -132,18 +132,10 @@ describe(commands.CHANNEL_MEMBER_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails to get team when resourceprovisioning does not exist', async () => {
+  it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
-        return {
-          value: [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": [
-              ]
-            }
-          ]
-        };
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
+        return { value: [] };
       }
 
       throw 'Invalid request';
@@ -157,12 +149,12 @@ describe(commands.CHANNEL_MEMBER_REMOVE, () => {
         force: true,
         verbose: true
       }
-    } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    } as any), new CommandError("The specified team 'Team Name' does not exist."));
   });
 
   it('correctly get teams id by team name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
         return groupsResponse;
       }
 

--- a/src/m365/teams/commands/channel/channel-member-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.spec.ts
@@ -19,10 +19,7 @@ describe(commands.CHANNEL_MEMBER_REMOVE, () => {
   const groupsResponse = {
     value: [
       {
-        "id": "00000000-0000-0000-0000-000000000000",
-        "resourceProvisioningOptions": [
-          "Team"
-        ]
+        "id": "00000000-0000-0000-0000-000000000000"
       }
     ]
   };

--- a/src/m365/teams/commands/channel/channel-member-remove.ts
+++ b/src/m365/teams/commands/channel/channel-member-remove.ts
@@ -1,10 +1,10 @@
-import { Channel, ConversationMember, Group } from '@microsoft/microsoft-graph-types';
+import { Channel, ConversationMember } from '@microsoft/microsoft-graph-types';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
@@ -12,10 +12,6 @@ import commands from '../../commands.js';
 interface ExtendedConversationMember extends ConversationMember {
   userId?: string;
   email?: string;
-}
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
 }
 
 interface CommandArgs {
@@ -178,13 +174,7 @@ class TeamsChannelMemberRemoveCommand extends GraphCommand {
       return args.options.teamId;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.teamName!);
-
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist in the Microsoft Teams';
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.teamName!);
   }
 
   private async getChannelId(args: CommandArgs): Promise<string> {

--- a/src/m365/teams/commands/channel/channel-member-set.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-set.spec.ts
@@ -353,18 +353,10 @@ describe(commands.CHANNEL_MEMBER_SET, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('fails to get team when resourceprovisioning does not exist', async () => {
+  it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
-        return {
-          value: [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": [
-              ]
-            }
-          ]
-        };
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
+        return { value: [] };
       }
 
       throw 'Invalid request';
@@ -377,12 +369,12 @@ describe(commands.CHANNEL_MEMBER_SET, () => {
         id: '00000',
         role: 'owner'
       }
-    } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    } as any), new CommandError("The specified team 'Team Name' does not exist."));
   });
 
   it('correctly get teams id by team name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if ((opts.url as string).indexOf(`/v1.0/groups?$filter=displayName eq '`) > -1) {
+      if ((opts.url as string).indexOf(`/v1.0/teams?$filter=displayName eq '`) > -1) {
         return groupsResponse;
       }
 

--- a/src/m365/teams/commands/channel/channel-member-set.spec.ts
+++ b/src/m365/teams/commands/channel/channel-member-set.spec.ts
@@ -27,10 +27,7 @@ describe(commands.CHANNEL_MEMBER_SET, () => {
   const groupsResponse = {
     value: [
       {
-        "id": "00000000-0000-0000-0000-000000000000",
-        "resourceProvisioningOptions": [
-          "Team"
-        ]
+        "id": "00000000-0000-0000-0000-000000000000"
       }
     ]
   };

--- a/src/m365/teams/commands/channel/channel-member-set.ts
+++ b/src/m365/teams/commands/channel/channel-member-set.ts
@@ -1,9 +1,9 @@
-import { Channel, ConversationMember, Group } from '@microsoft/microsoft-graph-types';
+import { Channel, ConversationMember } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
@@ -12,10 +12,6 @@ import { cli } from '../../../../cli/cli.js';
 interface ExtendedConversationMember extends ConversationMember {
   userId?: string;
   email?: string;
-}
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
 }
 
 interface CommandArgs {
@@ -161,12 +157,7 @@ class TeamsChannelMemberSetCommand extends GraphCommand {
       return args.options.teamId;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.teamName!);
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw `The specified team does not exist in the Microsoft Teams`;
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.teamName!);
   }
 
   private async getChannelId(args: CommandArgs): Promise<string> {

--- a/src/m365/teams/commands/channel/channel-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-remove.spec.ts
@@ -163,18 +163,13 @@ describe(commands.CHANNEL_REMOVE, () => {
   });
 
   it('fails when team name does not exist', async () => {
-    const errorMessage = 'The specified team does not exist';
+    const errorMessage = `The specified team '${teamName}' does not exist.`;
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'&$select=id`) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": []
-            }
-          ]
+          "@odata.count": 0,
+          "value": []
         };
       }
 
@@ -225,7 +220,7 @@ describe(commands.CHANNEL_REMOVE, () => {
 
   it('removes the specified channel by name and teamName when prompt confirmed (debug)', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'&$select=id`) {
         return {
           value: [
             {
@@ -301,7 +296,7 @@ describe(commands.CHANNEL_REMOVE, () => {
 
   it('removes the specified channel by name without prompt', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'&$select=id`) {
         return {
           value: [
             {

--- a/src/m365/teams/commands/channel/channel-remove.spec.ts
+++ b/src/m365/teams/commands/channel/channel-remove.spec.ts
@@ -225,8 +225,7 @@ describe(commands.CHANNEL_REMOVE, () => {
           value: [
             {
               "id": teamId,
-              "displayName": teamName,
-              "resourceProvisioningOptions": ["Team"]
+              "displayName": teamName
             }
           ]
         };
@@ -301,8 +300,7 @@ describe(commands.CHANNEL_REMOVE, () => {
           value: [
             {
               "id": teamId,
-              "displayName": teamName,
-              "resourceProvisioningOptions": ["Team"]
+              "displayName": teamName
             }
           ]
         };

--- a/src/m365/teams/commands/channel/channel-remove.ts
+++ b/src/m365/teams/commands/channel/channel-remove.ts
@@ -1,17 +1,13 @@
-import { Channel, Group } from '@microsoft/microsoft-graph-types';
+import { Channel } from '@microsoft/microsoft-graph-types';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
-}
 
 interface CommandArgs {
   options: Options;
@@ -143,14 +139,7 @@ class TeamsChannelRemoveCommand extends GraphCommand {
       return args.options.teamId;
     }
 
-    const group: Group = await entraGroup.getGroupByDisplayName(args.options.teamName!);
-
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist';
-    }
-    else {
-      return group.id!;
-    }
+    return teams.getTeamIdByDisplayName(args.options.teamName!);
   }
 
   private async getChannelId(args: CommandArgs): Promise<string> {

--- a/src/m365/teams/commands/channel/channel-set.spec.ts
+++ b/src/m365/teams/commands/channel/channel-set.spec.ts
@@ -179,7 +179,7 @@ describe(commands.CHANNEL_SET, () => {
 
   it('correctly patches channel updates by teamName and id', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'&$select=id`) {
         return {
           value: [
             {
@@ -215,18 +215,13 @@ describe(commands.CHANNEL_SET, () => {
   });
 
   it('fails when team name does not exist', async () => {
-    const errorMessage = 'The specified team does not exist';
+    const errorMessage = `The specified team '${teamName}' does not exist.`;
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq '${formatting.encodeQueryParameter(teamName)}'&$select=id`) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": []
-            }
-          ]
+          "@odata.count": 0,
+          "value": []
         };
       }
 

--- a/src/m365/teams/commands/channel/channel-set.spec.ts
+++ b/src/m365/teams/commands/channel/channel-set.spec.ts
@@ -184,8 +184,7 @@ describe(commands.CHANNEL_SET, () => {
           value: [
             {
               "id": teamId,
-              "displayName": teamName,
-              "resourceProvisioningOptions": ["Team"]
+              "displayName": teamName
             }
           ]
         };

--- a/src/m365/teams/commands/channel/channel-set.ts
+++ b/src/m365/teams/commands/channel/channel-set.ts
@@ -1,16 +1,12 @@
-import { Channel, Group } from '@microsoft/microsoft-graph-types';
+import { Channel } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
-}
 
 interface CommandArgs {
   options: Options;
@@ -146,14 +142,7 @@ class TeamsChannelSetCommand extends GraphCommand {
       return args.options.teamId;
     }
 
-    const group: Group = await entraGroup.getGroupByDisplayName(args.options.teamName!);
-
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist';
-    }
-    else {
-      return group.id!;
-    }
+    return teams.getTeamIdByDisplayName(args.options.teamName!);
   }
 
   private async getChannelId(teamId: string, args: CommandArgs): Promise<string> {

--- a/src/m365/teams/commands/tab/tab-get.spec.ts
+++ b/src/m365/teams/commands/tab/tab-get.spec.ts
@@ -360,31 +360,11 @@ describe(commands.TAB_GET, () => {
 
   it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Team%20Name'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq 'Team%20Name'&$select=id`) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "createdDateTime": null,
-              "displayName": "Team Name",
-              "description": "Team Description",
-              "internalId": null,
-              "classification": null,
-              "specialization": null,
-              "visibility": null,
-              "webUrl": null,
-              "isArchived": false,
-              "isMembershipLimitedToOwners": null,
-              "memberSettings": null,
-              "guestSettings": null,
-              "messagingSettings": null,
-              "funSettings": null,
-              "discoverySettings": null,
-              "resourceProvisioningOptions": []
-            }
-          ]
+          "@odata.count": 0,
+          "value": []
         };
       }
       throw 'Invalid request';
@@ -397,12 +377,12 @@ describe(commands.TAB_GET, () => {
         channelName: 'Channel Name',
         name: 'Tab Name'
       }
-    } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    } as any), new CommandError("The specified team 'Team Name' does not exist."));
   });
 
   it('should get a Microsoft Teams Tab by Team name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Team%20Name'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq 'Team%20Name'&$select=id`) {
         return {
           "value": [
             {

--- a/src/m365/teams/commands/tab/tab-get.spec.ts
+++ b/src/m365/teams/commands/tab/tab-get.spec.ts
@@ -387,22 +387,9 @@ describe(commands.TAB_GET, () => {
           "value": [
             {
               "id": "00000000-0000-0000-0000-000000000000",
-              "createdDateTime": null,
               "displayName": "Team Name",
               "description": "Team Description",
-              "internalId": null,
-              "classification": null,
-              "specialization": null,
-              "visibility": null,
-              "webUrl": null,
-              "isArchived": false,
-              "isMembershipLimitedToOwners": null,
-              "memberSettings": null,
-              "guestSettings": null,
-              "messagingSettings": null,
-              "funSettings": null,
-              "discoverySettings": null,
-              "resourceProvisioningOptions": ["Team"]
+              "isArchived": false
             }
           ]
         };

--- a/src/m365/teams/commands/tab/tab-get.ts
+++ b/src/m365/teams/commands/tab/tab-get.ts
@@ -1,9 +1,9 @@
-import { Channel, Group, TeamsTab } from '@microsoft/microsoft-graph-types';
+import { Channel, TeamsTab } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
@@ -19,10 +19,6 @@ interface Options extends GlobalOptions {
   channelName?: string;
   id?: string;
   name?: string;
-}
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
 }
 
 class TeamsTabGetCommand extends GraphCommand {
@@ -115,13 +111,7 @@ class TeamsTabGetCommand extends GraphCommand {
       return args.options.teamId;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.teamName!);
-
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist in the Microsoft Teams';
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.teamName!);
   }
 
   private async getChannelId(args: CommandArgs): Promise<string> {

--- a/src/m365/teams/commands/team/team-archive.spec.ts
+++ b/src/m365/teams/commands/team/team-archive.spec.ts
@@ -101,16 +101,11 @@ describe(commands.TEAM_ARCHIVE, () => {
 
   it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq 'Finance'&$select=id`) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": []
-            }
-          ]
+          "@odata.count": 0,
+          "value": []
         };
       }
       throw 'Invalid request';
@@ -122,7 +117,7 @@ describe(commands.TEAM_ARCHIVE, () => {
         name: 'Finance',
         force: true
       }
-    } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    } as any), new CommandError("The specified team 'Finance' does not exist."));
   });
 
   it('archives a Microsoft Team by id', async () => {
@@ -143,7 +138,7 @@ describe(commands.TEAM_ARCHIVE, () => {
 
   it('archives a Microsoft Team by name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq 'Finance'&$select=id`) {
         return {
           "value": [
             {

--- a/src/m365/teams/commands/team/team-archive.spec.ts
+++ b/src/m365/teams/commands/team/team-archive.spec.ts
@@ -142,8 +142,7 @@ describe(commands.TEAM_ARCHIVE, () => {
         return {
           "value": [
             {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": ["Team"]
+              "id": "00000000-0000-0000-0000-000000000000"
             }
           ]
         };

--- a/src/m365/teams/commands/team/team-archive.ts
+++ b/src/m365/teams/commands/team/team-archive.ts
@@ -1,16 +1,11 @@
-import { Group } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
-}
 
 interface CommandArgs {
   options: Options;
@@ -87,13 +82,7 @@ class TeamsTeamArchiveCommand extends GraphCommand {
       return args.options.id;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.name!);
-
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist in the Microsoft Teams';
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.name!);
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/teams/commands/team/team-remove.spec.ts
+++ b/src/m365/teams/commands/team/team-remove.spec.ts
@@ -91,16 +91,11 @@ describe(commands.TEAM_REMOVE, () => {
 
   it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq 'Finance'&$select=id`) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": []
-            }
-          ]
+          "@odata.count": 0,
+          "value": []
         };
       }
       throw 'Invalid request';
@@ -111,7 +106,7 @@ describe(commands.TEAM_REMOVE, () => {
         name: 'Finance',
         force: true
       }
-    } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    } as any), new CommandError("The specified team 'Finance' does not exist."));
   });
 
   it('prompts before removing the specified team by id when force option not passed', async () => {
@@ -169,7 +164,7 @@ describe(commands.TEAM_REMOVE, () => {
 
   it('removes the specified team by name without prompting when confirmed specified', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq 'Finance'&$select=id`) {
         return {
           "value": [
             {

--- a/src/m365/teams/commands/team/team-remove.spec.ts
+++ b/src/m365/teams/commands/team/team-remove.spec.ts
@@ -168,8 +168,7 @@ describe(commands.TEAM_REMOVE, () => {
         return {
           "value": [
             {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": ["Team"]
+              "id": "00000000-0000-0000-0000-000000000000"
             }
           ]
         };

--- a/src/m365/teams/commands/team/team-remove.ts
+++ b/src/m365/teams/commands/team/team-remove.ts
@@ -1,17 +1,12 @@
-import { Group } from '@microsoft/microsoft-graph-types';
 import { cli } from '../../../../cli/cli.js';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
-}
 
 interface CommandArgs {
   options: Options;
@@ -84,12 +79,7 @@ class TeamsTeamRemoveCommand extends GraphCommand {
       return args.options.id;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.name!);
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw `The specified team does not exist in the Microsoft Teams`;
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.name!);
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/m365/teams/commands/team/team-unarchive.spec.ts
+++ b/src/m365/teams/commands/team/team-unarchive.spec.ts
@@ -120,16 +120,11 @@ describe(commands.TEAM_UNARCHIVE, () => {
 
   it('fails when team name does not exist', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq 'Finance'&$select=id`) {
         return {
           "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams",
-          "@odata.count": 1,
-          "value": [
-            {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": []
-            }
-          ]
+          "@odata.count": 0,
+          "value": []
         };
       }
       throw 'Invalid request';
@@ -141,7 +136,7 @@ describe(commands.TEAM_UNARCHIVE, () => {
         name: 'Finance',
         force: true
       }
-    } as any), new CommandError('The specified team does not exist in the Microsoft Teams'));
+    } as any), new CommandError("The specified team 'Finance' does not exist."));
   });
 
   it('restores an archived Microsoft Team by id', async () => {
@@ -162,7 +157,7 @@ describe(commands.TEAM_UNARCHIVE, () => {
 
   it('restores an archived Microsoft Team by name', async () => {
     sinon.stub(request, 'get').callsFake(async (opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/groups?$filter=displayName eq 'Finance'`) {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams?$filter=displayName eq 'Finance'&$select=id`) {
         return {
           "value": [
             {

--- a/src/m365/teams/commands/team/team-unarchive.spec.ts
+++ b/src/m365/teams/commands/team/team-unarchive.spec.ts
@@ -161,8 +161,7 @@ describe(commands.TEAM_UNARCHIVE, () => {
         return {
           "value": [
             {
-              "id": "00000000-0000-0000-0000-000000000000",
-              "resourceProvisioningOptions": ["Team"]
+              "id": "00000000-0000-0000-0000-000000000000"
             }
           ]
         };

--- a/src/m365/teams/commands/team/team-unarchive.ts
+++ b/src/m365/teams/commands/team/team-unarchive.ts
@@ -1,16 +1,11 @@
-import { Group } from '@microsoft/microsoft-graph-types';
 import { Logger } from '../../../../cli/Logger.js';
 import GlobalOptions from '../../../../GlobalOptions.js';
 import request, { CliRequestOptions } from '../../../../request.js';
-import { entraGroup } from '../../../../utils/entraGroup.js';
 import { formatting } from '../../../../utils/formatting.js';
+import { teams } from '../../../../utils/teams.js';
 import { validation } from '../../../../utils/validation.js';
 import GraphCommand from '../../../base/GraphCommand.js';
 import commands from '../../commands.js';
-
-interface ExtendedGroup extends Group {
-  resourceProvisioningOptions: string[];
-}
 
 interface CommandArgs {
   options: Options;
@@ -70,12 +65,7 @@ class TeamsTeamUnarchiveCommand extends GraphCommand {
       return args.options.id;
     }
 
-    const group = await entraGroup.getGroupByDisplayName(args.options.name!);
-    if ((group as ExtendedGroup).resourceProvisioningOptions.indexOf('Team') === -1) {
-      throw 'The specified team does not exist in the Microsoft Teams';
-    }
-
-    return group.id!;
+    return teams.getTeamIdByDisplayName(args.options.name!);
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {

--- a/src/utils/fsUtil.spec.ts
+++ b/src/utils/fsUtil.spec.ts
@@ -1,0 +1,71 @@
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+import sinon from 'sinon';
+import { fsUtil } from './fsUtil.js';
+
+describe('utils/fsUtil', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('copyRecursiveSync', () => {
+    it('copies a directory recursively creating dest if it does not exist', () => {
+      sinon.stub(fs, 'existsSync')
+        .withArgs('src').returns(true)
+        .withArgs('dest').returns(false);
+      sinon.stub(fs, 'statSync').returns({ isDirectory: () => true } as fs.Stats);
+      const mkdirStub = sinon.stub(fs, 'mkdirSync');
+      sinon.stub(fs, 'readdirSync').returns(['file1.txt'] as any);
+      const copyFileStub = sinon.stub(fs, 'copyFileSync');
+      // child is a file
+      (fs.existsSync as sinon.SinonStub)
+        .withArgs(path.join('src', 'file1.txt')).returns(true);
+      (fs.statSync as sinon.SinonStub)
+        .withArgs(path.join('src', 'file1.txt')).returns({ isDirectory: () => false } as fs.Stats);
+
+      fsUtil.copyRecursiveSync('src', 'dest');
+
+      assert(mkdirStub.calledWith('dest'));
+      assert(copyFileStub.calledWith(path.join('src', 'file1.txt'), path.join('dest', 'file1.txt')));
+    });
+
+    it('copies a directory recursively when dest already exists', () => {
+      sinon.stub(fs, 'existsSync').returns(true);
+      sinon.stub(fs, 'statSync')
+        .withArgs('src').returns({ isDirectory: () => true } as fs.Stats)
+        .withArgs(path.join('src', 'child.txt')).returns({ isDirectory: () => false } as fs.Stats);
+      const mkdirStub = sinon.stub(fs, 'mkdirSync');
+      sinon.stub(fs, 'readdirSync').returns(['child.txt'] as any);
+      const copyFileStub = sinon.stub(fs, 'copyFileSync');
+
+      fsUtil.copyRecursiveSync('src', 'dest');
+
+      assert(mkdirStub.notCalled);
+      assert(copyFileStub.calledWith(path.join('src', 'child.txt'), path.join('dest', 'child.txt')));
+    });
+
+    it('applies replaceTokens to destination path', () => {
+      sinon.stub(fs, 'existsSync')
+        .withArgs('src').returns(true)
+        .withArgs('replaced-dest').returns(false);
+      sinon.stub(fs, 'statSync').returns({ isDirectory: () => true } as fs.Stats);
+      const mkdirStub = sinon.stub(fs, 'mkdirSync');
+      sinon.stub(fs, 'readdirSync').returns([] as any);
+
+      fsUtil.copyRecursiveSync('src', 'dest', (s: string) => s === 'dest' ? 'replaced-dest' : s);
+
+      assert(mkdirStub.calledWith('replaced-dest'));
+    });
+
+    it('copies a single file', () => {
+      sinon.stub(fs, 'existsSync').returns(true);
+      sinon.stub(fs, 'statSync').returns({ isDirectory: () => false } as fs.Stats);
+      const copyFileStub = sinon.stub(fs, 'copyFileSync');
+
+      fsUtil.copyRecursiveSync('src/file.txt', 'dest/file.txt');
+
+      assert(copyFileStub.calledWith('src/file.txt', 'dest/file.txt'));
+    });
+  });
+});


### PR DESCRIPTION
Closes #7048

Replaces Entra group display-name lookups in Teams commands with `teams.getTeamIdByDisplayName`. This queries the Teams endpoint directly and removes duplicated checks that verified whether a group was team-enabled.

Updates the affected unit tests for the Teams lookup endpoint and not-found behavior.

## Validation

- `nrb`
- `nt` (16,096 passing; 100% coverage)