### PR TITLE
Recycle removed items by default

### DIFF
--- a/docs/docs/cmd/entra/m365group/m365group-remove.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-remove.mdx
@@ -24,8 +24,8 @@ m365 entra m365group remove [options]
 `-f, --force`
 : Don't prompt for confirming removing the group
 
-`--skipRecycleBin`
-: Set to directly remove the group without moving it to the Recycle Bin
+`--permanent`
+: Permanently remove the group without leaving it in the recycle bin.
 ```
 
 <Global />
@@ -53,7 +53,7 @@ m365 entra m365group remove [options]
 
 If the specified _id_ doesn't refer to an existing group, you will get a `Resource does not exist` error. Additionally, if you do not have access to the group or the associated group-connected site, you will get an `Access denied` error.
 
-When you use `--skipRecycleBin` flag to remove a Microsoft 365 group permanently, the process involves deleting the associated group-connected site and the group, and then checking if the group has been moved to the deleted groups list. In some cases, it may take a few seconds for the group to appear in the deleted groups list.
+When you use the `--permanent` flag to remove a Microsoft 365 group permanently, the process involves deleting the associated group-connected site and the group, and then checking if the group has been moved to the deleted groups list. In some cases, it may take a few seconds for the group to appear in the deleted groups list.
 
 To ensure a smooth deletion process, the command employs a retry mechanism with the following parameters:
 
@@ -80,7 +80,7 @@ m365 entra m365group remove --displayName Finance --force
 Remove group with id _28beab62-7540-4db1-a23f-29a6018a3848_ without prompting for confirmation and without moving it to the Recycle Bin
 
 ```sh
-m365 entra m365group remove --id 28beab62-7540-4db1-a23f-29a6018a3848 --force --skipRecycleBin
+m365 entra m365group remove --id 28beab62-7540-4db1-a23f-29a6018a3848 --force --permanent
 ```
 
 ## Response

--- a/docs/docs/cmd/entra/m365group/m365group-remove.mdx
+++ b/docs/docs/cmd/entra/m365group/m365group-remove.mdx
@@ -26,6 +26,9 @@ m365 entra m365group remove [options]
 
 `--permanent`
 : Permanently remove the group without leaving it in the recycle bin.
+
+`--skipRecycleBin`
+: Deprecated: use `--permanent` instead.
 ```
 
 <Global />

--- a/docs/docs/cmd/spe/container/container-remove.mdx
+++ b/docs/docs/cmd/spe/container/container-remove.mdx
@@ -27,8 +27,8 @@ m365 spe container remove [options]
 `--containerTypeName [containerTypeName]`
 : The name of the container type. Specify either `containerTypeId` or `containerTypeName` when using `name` but not both.
 
-`--recycle`
-: Recycle the container instance instead of permanently deleting it.
+`--permanent`
+: Permanently delete the container instance instead of moving it to the recycle bin.
 
 `-f, --force`
 : Do not prompt for confirmation.
@@ -67,16 +67,16 @@ The command is based on an API that is currently in preview and is subject to ch
 
 ## Examples
 
-Remove a container by ID.
+Move a container specified by ID to the recycle bin.
 
 ```sh
 m365 spe container remove --id "b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z"
 ```
 
-Move a container specified by ID to the recycle bin.
+Permanently remove a container by ID.
 
 ```sh
-m365 spe container remove --id "b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z" --recycle
+m365 spe container remove --id "b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z" --permanent
 ```
 
 Remove a container by name specifying the container type id.

--- a/docs/docs/cmd/spo/file/file-remove.mdx
+++ b/docs/docs/cmd/spo/file/file-remove.mdx
@@ -30,8 +30,8 @@ m365 spo page template remove
 `--url [url]`
 : The server- or site-relative decoded URL of the file to remove. Specify either `id` or `url` but not both.
 
-`--recycle`
-: Recycle the file instead of actually deleting it.
+`--permanent`
+: Permanently delete the file instead of moving it to the recycle bin.
 
 `--bypassSharedLock`
 : Remove the file even if it is locked for shared use.
@@ -75,10 +75,10 @@ Remove a file by site-relative URL.
 m365 spo file remove --webUrl https://contoso.sharepoint.com/sites/project-x --url "/Shared Documents/Test.docx"
 ```
 
-Remove a file by server-relative URL to the recycle bin.
+Permanently remove a file by server-relative URL.
 
 ```sh
-m365 spo file remove --webUrl https://contoso.sharepoint.com/sites/project-x --url "/sites/project-x/Shared Documents/Test.docx" --recycle
+m365 spo file remove --webUrl https://contoso.sharepoint.com/sites/project-x --url "/sites/project-x/Shared Documents/Test.docx" --permanent
 ```
 
 Remove a file that is locked

--- a/docs/docs/cmd/spo/folder/folder-remove.mdx
+++ b/docs/docs/cmd/spo/folder/folder-remove.mdx
@@ -21,8 +21,8 @@ m365 spo folder remove [options]
 `--url <url>`
 : The server- or site-relative decoded URL of the folder to delete.
 
-`--recycle`
-: Recycles the folder instead of actually deleting it.
+`--permanent`
+: Permanently deletes the folder instead of moving it to the recycle bin.
 
 `-f, --force`
 : Don't prompt for confirming deleting the folder.
@@ -61,10 +61,10 @@ Remove a folder with a specific site-relative URL.
 m365 spo folder remove --webUrl https://contoso.sharepoint.com/sites/project-x --url '/Shared Documents/My Folder'
 ```
 
-Remove a folder with a specific server relative URL to the site recycle bin.
+Permanently remove a folder with a specific server-relative URL.
 
 ```sh
-m365 spo folder remove --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/Shared Documents/My Folder' --recycle
+m365 spo folder remove --webUrl https://contoso.sharepoint.com/sites/project-x --url '/sites/project-x/Shared Documents/My Folder' --permanent
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/list/list-remove.mdx
+++ b/docs/docs/cmd/spo/list/list-remove.mdx
@@ -24,8 +24,8 @@ m365 spo list remove [options]
 `-t, --title [title]`
 : Title of the list to remove. Specify either `id` or `title` but not both.
 
-`--recycle`
-: Instead of permanently deleting, send the list to the recycle bin.
+`--permanent`
+: Permanently delete the list instead of moving it to the recycle bin.
 
 `-f, --force`
 : Don't prompt for confirming removing the list.
@@ -66,10 +66,10 @@ Remove the list with a specific title located in a specific site.
 m365 spo list remove --webUrl https://contoso.sharepoint.com/sites/project-x --title 'List 1'
 ```
 
-Remove a list specified by id by sending it to the recycle bin instead of permanently removing it
+Permanently remove a list specified by ID.
 
 ```sh
-m365 spo list remove --webUrl https://contoso.sharepoint.com/sites/project-x --id 0cd891ef-afce-4e55-b836-fce03286cccf --recycle
+m365 spo list remove --webUrl https://contoso.sharepoint.com/sites/project-x --id 0cd891ef-afce-4e55-b836-fce03286cccf --permanent
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/listitem/listitem-batch-remove.mdx
+++ b/docs/docs/cmd/spo/listitem/listitem-batch-remove.mdx
@@ -31,8 +31,8 @@ m365 spo listitem batch remove [options]
 `-i, --ids [ids]`
 : Comma separated list of list item IDs. Specify `filePath` or `ids`, but not both.
 
-`-r, --recycle`
-: Recycle the list items. Otherwise, they will be permanently deleted.
+`--permanent`
+: Permanently delete the list items instead of moving them to the recycle bin.
 
 `-f, --force`
 : Don't prompt for confirmation.
@@ -63,6 +63,12 @@ Remove a list of IDs from a list by specifying the IDs
 
 ```sh
 m365 spo listitem batch remove --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle "Demo List" --ids "123,234,345"
+```
+
+Permanently remove a list of IDs from a list.
+
+```sh
+m365 spo listitem batch remove --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle "Demo List" --ids "123,234,345" --permanent
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/listitem/listitem-remove.mdx
+++ b/docs/docs/cmd/spo/listitem/listitem-remove.mdx
@@ -28,8 +28,8 @@ m365 spo listitem remove [options]
 `--listUrl [listUrl]`
 : Server- or site-relative URL of the list. Specify either `listTitle`, `listId` or `listUrl`
 
-`--recycle`
-: Recycle the list item
+`--permanent`
+: Permanently delete the list item instead of moving it to the recycle bin.
 
 `-f, --force`
 : Don't prompt for confirming removing the list item
@@ -55,6 +55,12 @@ Remove the list item located in a given site based on the server-relative list u
 
 ```sh
 m365 spo listitem remove --webUrl https://contoso.sharepoint.com/sites/project-x --listUrl /sites/project-x/lists/TestList --id 1
+```
+
+Permanently remove a list item.
+
+```sh
+m365 spo listitem remove --webUrl https://contoso.sharepoint.com/sites/project-x --listTitle 'List 1' --id 1 --permanent
 ```
 
 ## Response

--- a/docs/docs/cmd/spo/page/page-remove.mdx
+++ b/docs/docs/cmd/spo/page/page-remove.mdx
@@ -19,8 +19,8 @@ m365 spo page remove [options]
 `-n, --name <name>`
 : Name of the page.
 
-`--recycle`
-: Send the page to the recycle bin instead of permanently deleting it.
+`--permanent`
+: Permanently delete the page instead of moving it to the recycle bin.
 
 `--bypassSharedLock`
 : Remove the page even if it is locked for shared use.
@@ -45,10 +45,10 @@ Remove a modern page without a confirmation prompt
 m365 spo page remove --name HR.aspx --webUrl https://contoso.sharepoint.com/sites/Marketing --force
 ```
 
-Send a page to the recycle bin
+Permanently remove a page
 
 ```sh
-m365 spo page remove --name HR.aspx --webUrl https://contoso.sharepoint.com/sites/Marketing --recycle
+m365 spo page remove --name HR.aspx --webUrl https://contoso.sharepoint.com/sites/Marketing --permanent
 ```
 
 Remove a page that is locked

--- a/docs/docs/cmd/spo/site/site-remove.mdx
+++ b/docs/docs/cmd/spo/site/site-remove.mdx
@@ -16,8 +16,8 @@ m365 spo site remove [options]
 `-u, --url <url>`
 : URL of the site.
 
-`--skipRecycleBin`
-: Set to directly remove the site without moving it to the recycle bin.
+`--permanent`
+: Permanently remove the site without leaving it in the recycle bin.
 
 `--fromRecycleBin`
 : Set to remove the site from the recycle bin.
@@ -49,7 +49,7 @@ m365 spo site remove --url https://contoso.sharepoint.com/sites/demosite
 Remove the site without moving it to the recycle bin.
 
 ```sh
-m365 spo site remove --url https://contoso.sharepoint.com/sites/demosite --skipRecycleBin
+m365 spo site remove --url https://contoso.sharepoint.com/sites/demosite --permanent
 ```
 
 Remove the previously deleted site from the recycle bin.

--- a/docs/docs/cmd/spo/site/site-remove.mdx
+++ b/docs/docs/cmd/spo/site/site-remove.mdx
@@ -19,6 +19,9 @@ m365 spo site remove [options]
 `--permanent`
 : Permanently remove the site without leaving it in the recycle bin.
 
+`--skipRecycleBin`
+: Deprecated: use `--permanent` instead.
+
 `--fromRecycleBin`
 : Set to remove the site from the recycle bin.
 

--- a/src/m365/entra/commands/m365group/m365group-remove.spec.ts
+++ b/src/m365/entra/commands/m365group/m365group-remove.spec.ts
@@ -212,7 +212,7 @@ describe(commands.M365GROUP_REMOVE, () => {
     defaultPostStub();
     const deleteStub: sinon.SinonStub = defaultDeleteStub();
 
-    await command.action(logger, { options: { id: groupId, verbose: true, skipRecycleBin: true, force: true } });
+    await command.action(logger, { options: { id: groupId, verbose: true, permanent: true, force: true } });
     assert(deleteStub.called);
     assert(loggerLogToStderrSpy.calledWith("Group has been deleted and is now available in the deleted groups list. Removing permanently..."));
   });
@@ -230,7 +230,7 @@ describe(commands.M365GROUP_REMOVE, () => {
     defaultPostStub();
     const deleteStub: sinon.SinonStub = defaultDeleteStub();
 
-    await command.action(logger, { options: { id: groupId, verbose: true, skipRecycleBin: true, force: true } });
+    await command.action(logger, { options: { id: groupId, verbose: true, permanent: true, force: true } });
     assert(deleteStub.called);
   });
 
@@ -274,7 +274,7 @@ describe(commands.M365GROUP_REMOVE, () => {
     });
     defaultDeleteStub();
 
-    await assert.rejects(command.action(logger, { options: { id: groupId, skipRecycleBin: true, force: true, debug: true } }),
+    await assert.rejects(command.action(logger, { options: { id: groupId, permanent: true, force: true, debug: true } }),
       new CommandError('An error has occurred.'));
   });
 
@@ -290,7 +290,7 @@ describe(commands.M365GROUP_REMOVE, () => {
     defaultPostStub();
     defaultDeleteStub();
 
-    await assert.rejects(command.action(logger, { options: { id: groupId, verbose: true, skipRecycleBin: true, force: true } }),
+    await assert.rejects(command.action(logger, { options: { id: groupId, verbose: true, permanent: true, force: true } }),
       new CommandError('Error'));
   });
 
@@ -306,7 +306,7 @@ describe(commands.M365GROUP_REMOVE, () => {
     defaultPostStub();
     const deleteStub: sinon.SinonStub = defaultDeleteStub();
 
-    await command.action(logger, { options: { id: groupId, verbose: true, skipRecycleBin: true, force: true } });
+    await command.action(logger, { options: { id: groupId, verbose: true, permanent: true, force: true } });
     assert(deleteStub.notCalled);
   });
 

--- a/src/m365/entra/commands/m365group/m365group-remove.spec.ts
+++ b/src/m365/entra/commands/m365group/m365group-remove.spec.ts
@@ -217,6 +217,17 @@ describe(commands.M365GROUP_REMOVE, () => {
     assert(loggerLogToStderrSpy.calledWith("Group has been deleted and is now available in the deleted groups list. Removing permanently..."));
   });
 
+  it('supports the deprecated skipRecycleBin option', async () => {
+    defaultGetStub();
+    defaultPostStub();
+    const deleteStub: sinon.SinonStub = defaultDeleteStub();
+
+    await command.action(logger, { options: { id: groupId, verbose: true, skipRecycleBin: true, force: true } });
+
+    assert(deleteStub.called);
+    assert(loggerLogToStderrSpy.calledWith(`Option 'skipRecycleBin' is deprecated. Please use 'permanent' instead.`));
+  });
+
   it('verifies if the group is deleted and available in the deleted groups list, retry and delete the group', async () => {
     const getCallStub: sinon.SinonStub = sinon.stub(request, 'get');
 

--- a/src/m365/entra/commands/m365group/m365group-remove.ts
+++ b/src/m365/entra/commands/m365group/m365group-remove.ts
@@ -19,7 +19,7 @@ interface Options extends GlobalOptions {
   id?: string;
   displayName?: string;
   force?: boolean;
-  skipRecycleBin: boolean;
+  permanent?: boolean;
 }
 
 class EntraM365GroupRemoveCommand extends GraphCommand {
@@ -48,7 +48,7 @@ class EntraM365GroupRemoveCommand extends GraphCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         force: (!(!args.options.force)).toString(),
-        skipRecycleBin: args.options.skipRecycleBin
+        permanent: !!args.options.permanent
       });
     });
   }
@@ -65,7 +65,7 @@ class EntraM365GroupRemoveCommand extends GraphCommand {
         option: '-f, --force'
       },
       {
-        option: '--skipRecycleBin'
+        option: '--permanent'
       }
     );
   }
@@ -88,6 +88,7 @@ class EntraM365GroupRemoveCommand extends GraphCommand {
 
   #initTypes(): void {
     this.types.string.push('id', 'displayName');
+    this.types.boolean.push('permanent');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -114,7 +115,7 @@ class EntraM365GroupRemoveCommand extends GraphCommand {
         // Delete the Microsoft 365 group site. This operation will also delete the group.
         await this.deleteM365GroupSite(logger, siteUrl, spoAdminUrl);
 
-        if (args.options.skipRecycleBin) {
+        if (args.options.permanent) {
           await this.deleteM365GroupFromRecycleBin(logger, groupId!);
           await this.deleteSiteFromRecycleBin(logger, siteUrl, spoAdminUrl);
         }

--- a/src/m365/entra/commands/m365group/m365group-remove.ts
+++ b/src/m365/entra/commands/m365group/m365group-remove.ts
@@ -20,6 +20,7 @@ interface Options extends GlobalOptions {
   displayName?: string;
   force?: boolean;
   permanent?: boolean;
+  skipRecycleBin?: boolean;
 }
 
 class EntraM365GroupRemoveCommand extends GraphCommand {
@@ -48,7 +49,7 @@ class EntraM365GroupRemoveCommand extends GraphCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         force: (!(!args.options.force)).toString(),
-        permanent: !!args.options.permanent
+        permanent: !!(args.options.permanent || args.options.skipRecycleBin)
       });
     });
   }
@@ -66,6 +67,9 @@ class EntraM365GroupRemoveCommand extends GraphCommand {
       },
       {
         option: '--permanent'
+      },
+      {
+        option: '--skipRecycleBin'
       }
     );
   }
@@ -88,10 +92,15 @@ class EntraM365GroupRemoveCommand extends GraphCommand {
 
   #initTypes(): void {
     this.types.string.push('id', 'displayName');
-    this.types.boolean.push('permanent');
+    this.types.boolean.push('permanent', 'skipRecycleBin');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (args.options.skipRecycleBin) {
+      await this.warn(logger, `Option 'skipRecycleBin' is deprecated. Please use 'permanent' instead.`);
+      args.options.permanent = true;
+    }
+
     const removeGroup = async (): Promise<void> => {
       if (this.verbose) {
         await logger.logToStderr(`Removing Microsoft 365 Group: ${args.options.id || args.options.displayName}...`);

--- a/src/m365/spe/commands/container/container-remove.spec.ts
+++ b/src/m365/spe/commands/container/container-remove.spec.ts
@@ -117,8 +117,8 @@ describe(commands.CONTAINER_REMOVE, () => {
     assert(confirmationPromptStub.calledOnce);
   });
 
-  it('prompts before recycling the container', async () => {
-    await command.action(logger, { options: { id: containerTypeId, recycle: true } });
+  it('prompts before permanently removing the container', async () => {
+    await command.action(logger, { options: { id: containerTypeId, permanent: true } });
     assert(confirmationPromptStub.calledOnce);
   });
 
@@ -140,11 +140,11 @@ describe(commands.CONTAINER_REMOVE, () => {
       throw 'Invalid DELETE request: ' + opts.url;
     });
 
-    await command.action(logger, { options: { id: containerId, recycle: true, force: true } });
+    await command.action(logger, { options: { id: containerId, force: true } });
     assert(deleteStub.calledOnce);
   });
 
-  it('correctly removes a container by id', async () => {
+  it('correctly permanently removes a container by id', async () => {
     const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/storage/fileStorage/containers/${containerId}/permanentDelete`) {
         return;
@@ -153,7 +153,7 @@ describe(commands.CONTAINER_REMOVE, () => {
       throw 'Invalid POST request: ' + opts.url;
     });
 
-    await command.action(logger, { options: { id: containerId, force: true } });
+    await command.action(logger, { options: { id: containerId, permanent: true, force: true } });
     assert(postStub.calledOnce);
   });
 
@@ -166,11 +166,11 @@ describe(commands.CONTAINER_REMOVE, () => {
       throw 'Invalid DELETE request: ' + opts.url;
     });
 
-    await command.action(logger, { options: { name: containerName, containerTypeId: containerTypeId, recycle: true, force: true } });
+    await command.action(logger, { options: { name: containerName, containerTypeId: containerTypeId, force: true } });
     assert(deleteStub.calledOnce);
   });
 
-  it('correctly removes a container by name', async () => {
+  it('correctly permanently removes a container by name', async () => {
     const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/storage/fileStorage/containers/${containerId}/permanentDelete`) {
         return;
@@ -179,7 +179,7 @@ describe(commands.CONTAINER_REMOVE, () => {
       throw 'Invalid POST request: ' + opts.url;
     });
 
-    await command.action(logger, { options: { name: containerName, containerTypeName: containerTypeName, verbose: true, force: true } });
+    await command.action(logger, { options: { name: containerName, containerTypeName: containerTypeName, permanent: true, verbose: true, force: true } });
     assert(postStub.calledOnce);
   });
 
@@ -192,7 +192,7 @@ describe(commands.CONTAINER_REMOVE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { id: containerId, force: true } }),
+    await assert.rejects(command.action(logger, { options: { id: containerId, permanent: true, force: true } }),
       new CommandError(errorMessage));
   });
 });

--- a/src/m365/spe/commands/container/container-remove.ts
+++ b/src/m365/spe/commands/container/container-remove.ts
@@ -13,7 +13,7 @@ export const options = z.strictObject({
   name: z.string().optional().alias('n'),
   containerTypeId: z.uuid().optional(),
   containerTypeName: z.string().optional(),
-  recycle: z.boolean().optional(),
+  permanent: z.boolean().optional(),
   force: z.boolean().optional().alias('f')
 });
 
@@ -59,7 +59,7 @@ class SpeContainerRemoveCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (!args.options.force) {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to remove container '${args.options.id || args.options.name}'${!args.options.recycle ? ' permanently' : ''}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to remove container '${args.options.id || args.options.name}'${args.options.permanent ? ' permanently' : ''}?` });
 
       if (!result) {
         return;
@@ -81,14 +81,13 @@ class SpeContainerRemoveCommand extends GraphCommand {
         responseType: 'json'
       };
 
-      if (args.options.recycle) {
-        await request.delete(requestOptions);
+      if (args.options.permanent) {
+        requestOptions.url += '/permanentDelete';
+        await request.post(requestOptions);
         return;
       }
 
-      // Container should be permanently deleted
-      requestOptions.url += '/permanentDelete';
-      await request.post(requestOptions);
+      await request.delete(requestOptions);
     }
     catch (err: any) {
       this.handleRejectedODataJsonPromise(err);

--- a/src/m365/spe/commands/container/container-remove.ts
+++ b/src/m365/spe/commands/container/container-remove.ts
@@ -59,7 +59,7 @@ class SpeContainerRemoveCommand extends GraphCommand {
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     if (!args.options.force) {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to remove container '${args.options.id || args.options.name}'${args.options.permanent ? ' permanently' : ''}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? 'permanently remove' : 'recycle'} container '${args.options.id || args.options.name}'?` });
 
       if (!result) {
         return;

--- a/src/m365/spo/commands/file/file-remove.spec.ts
+++ b/src/m365/spo/commands/file/file-remove.spec.ts
@@ -88,7 +88,7 @@ describe(commands.FILE_REMOVE, () => {
   });
 
   it('prompts before removing file when confirmation argument not passed (id)', async () => {
-    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf', permanent: true } });
 
     assert(promptIssued);
   });
@@ -157,7 +157,7 @@ describe(commands.FILE_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1 &&
@@ -189,7 +189,7 @@ describe(commands.FILE_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/' + fileUrl)}')`) > -1 &&
@@ -221,7 +221,7 @@ describe(commands.FILE_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
@@ -253,7 +253,7 @@ describe(commands.FILE_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
@@ -286,7 +286,7 @@ describe(commands.FILE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
@@ -318,7 +318,7 @@ describe(commands.FILE_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
@@ -351,7 +351,7 @@ describe(commands.FILE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
@@ -384,7 +384,7 @@ describe(commands.FILE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(fileUrl)}')`) > -1 &&
@@ -417,7 +417,7 @@ describe(commands.FILE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
@@ -450,7 +450,7 @@ describe(commands.FILE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl } });
+    await command.action(logger, { options: { webUrl: siteUrl, url: fileUrl, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter('/sites/subsite/' + fileUrl)}')`) > -1 &&
@@ -480,7 +480,7 @@ describe(commands.FILE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf', recycle: true } });
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', id: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`/recycle()`) > -1 &&
@@ -510,7 +510,7 @@ describe(commands.FILE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf', permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`/_api/web/GetFileByServerRelativePath(DecodedUrl='`) > -1 &&
@@ -540,7 +540,7 @@ describe(commands.FILE_REMOVE, () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
-    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf', recycle: true } });
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf' } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`/recycle()`) > -1 &&
@@ -561,7 +561,7 @@ describe(commands.FILE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf', force: true, bypassSharedLock: true } });
+    await command.action(logger, { options: { webUrl: 'https://contoso.sharepoint.com', url: '0cd891ef-afce-4e55-b836-fce03286cccf', permanent: true, force: true, bypassSharedLock: true } });
     assert.deepStrictEqual(postStub.firstCall.args[0].headers?.Prefer, 'bypass-shared-lock');
   });
 
@@ -638,7 +638,7 @@ describe(commands.FILE_REMOVE, () => {
     });
   });
 
-  it('uses correct API url when recycle option is passed', async () => {
+  it('uses correct recycle API URL by default', async () => {
     sinon.stub(request, 'post').callsFake(async (opts) => {
       if ((opts.url as string).indexOf('/recycle()') > -1) {
         return;
@@ -652,7 +652,6 @@ describe(commands.FILE_REMOVE, () => {
     await command.action(logger, {
       options: {
         id: actionId,
-        recycle: true,
         webUrl: 'https://contoso.sharepoint.com',
         force: true
       }

--- a/src/m365/spo/commands/file/file-remove.ts
+++ b/src/m365/spo/commands/file/file-remove.ts
@@ -16,7 +16,7 @@ export interface Options extends GlobalOptions {
   webUrl: string;
   id?: string;
   url?: string;
-  recycle?: boolean;
+  permanent?: boolean;
   bypassSharedLock?: boolean;
   force?: boolean;
 }
@@ -49,7 +49,7 @@ class SpoFileRemoveCommand extends SpoCommand {
       Object.assign(this.telemetryProperties, {
         id: typeof args.options.id !== 'undefined',
         url: typeof args.options.url !== 'undefined',
-        recycle: !!args.options.recycle,
+        permanent: !!args.options.permanent,
         bypassSharedLock: !!args.options.bypassSharedLock,
         force: !!args.options.force
       });
@@ -68,7 +68,7 @@ class SpoFileRemoveCommand extends SpoCommand {
         option: '--url [url]'
       },
       {
-        option: '--recycle'
+        option: '--permanent'
       },
       {
         option: '--bypassSharedLock'
@@ -103,7 +103,7 @@ class SpoFileRemoveCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push('webUrl', 'id', 'url');
-    this.types.boolean.push('recycle', 'bypassSharedLock', 'force');
+    this.types.boolean.push('permanent', 'bypassSharedLock', 'force');
   }
 
   protected getExcludedOptionsWithUrls(): string[] | undefined {
@@ -126,7 +126,7 @@ class SpoFileRemoveCommand extends SpoCommand {
         requestUrl = `${args.options.webUrl}/_api/web/GetFileByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')`;
       }
 
-      if (args.options.recycle) {
+      if (!args.options.permanent) {
         requestUrl += `/recycle()`;
       }
 
@@ -157,7 +157,7 @@ class SpoFileRemoveCommand extends SpoCommand {
       await removeFile();
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.recycle ? 'recycle' : 'remove'} the file ${args.options.id || args.options.url} located in site ${args.options.webUrl}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? 'permanently remove' : 'recycle'} the file ${args.options.id || args.options.url} located in site ${args.options.webUrl}?` });
 
       if (result) {
         await removeFile();

--- a/src/m365/spo/commands/folder/folder-remove.spec.ts
+++ b/src/m365/spo/commands/folder/folder-remove.spec.ts
@@ -101,7 +101,8 @@ describe(commands.FOLDER_REMOVE, () => {
       options:
       {
         webUrl: 'https://contoso.sharepoint.com',
-        url: '/Shared Documents/Folder1'
+        url: '/Shared Documents/Folder1',
+        permanent: true
       }
     });
     assert(stubPost.called);
@@ -114,6 +115,7 @@ describe(commands.FOLDER_REMOVE, () => {
         verbose: true,
         webUrl: 'https://contoso.sharepoint.com',
         url: '/Shared Documents/Folder1',
+        permanent: true,
         force: true
       }
     });
@@ -132,7 +134,8 @@ describe(commands.FOLDER_REMOVE, () => {
       {
         verbose: true,
         webUrl: 'https://contoso.sharepoint.com/sites/test1',
-        url: '/Shared Documents/Folder1'
+        url: '/Shared Documents/Folder1',
+        permanent: true
       }
     });
     const lastCall: any = stubPost.lastCall.args[0];
@@ -141,7 +144,7 @@ describe(commands.FOLDER_REMOVE, () => {
     assert.strictEqual(lastCall.headers['X-HTTP-Method'], 'DELETE');
   });
 
-  it('should send params for recycle request when recycle is set to true', async () => {
+  it('should send params for recycle request by default', async () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
 
@@ -150,8 +153,7 @@ describe(commands.FOLDER_REMOVE, () => {
       {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
-        url: '/Shared Documents/Folder1',
-        recycle: true
+        url: '/Shared Documents/Folder1'
       }
     });
     const lastCall: any = stubPost.lastCall.args[0];
@@ -183,8 +185,7 @@ describe(commands.FOLDER_REMOVE, () => {
       {
         debug: true,
         webUrl: 'https://contoso.sharepoint.com',
-        url: '/Shared Documents/Folder1',
-        recycle: true
+        url: '/Shared Documents/Folder1'
       }
     } as any), new CommandError(error.error['odata.error'].message.value));
   });

--- a/src/m365/spo/commands/folder/folder-remove.ts
+++ b/src/m365/spo/commands/folder/folder-remove.ts
@@ -15,7 +15,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   webUrl: string;
   url: string;
-  recycle?: boolean;
+  permanent?: boolean;
   force?: boolean;
 }
 
@@ -40,7 +40,7 @@ class SpoFolderRemoveCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        recycle: !!args.options.recycle,
+        permanent: !!args.options.permanent,
         force: !!args.options.force
       });
     });
@@ -55,7 +55,7 @@ class SpoFolderRemoveCommand extends SpoCommand {
         option: '--url <url>'
       },
       {
-        option: '--recycle'
+        option: '--permanent'
       },
       {
         option: '-f, --force'
@@ -71,7 +71,7 @@ class SpoFolderRemoveCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push('webUrl', 'url');
-    this.types.boolean.push('recycle', 'force');
+    this.types.boolean.push('permanent', 'force');
   }
 
   protected getExcludedOptionsWithUrls(): string[] | undefined {
@@ -83,7 +83,7 @@ class SpoFolderRemoveCommand extends SpoCommand {
       await this.removeFolder(logger, args.options);
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.recycle ? "recycle" : "remove"} the folder ${args.options.url} located in site ${args.options.webUrl}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? "permanently remove" : "recycle"} the folder ${args.options.url} located in site ${args.options.webUrl}?` });
 
       if (result) {
         await this.removeFolder(logger, args.options);
@@ -98,7 +98,7 @@ class SpoFolderRemoveCommand extends SpoCommand {
 
     const serverRelativePath: string = urlUtil.getServerRelativePath(options.webUrl, options.url);
     let requestUrl: string = `${options.webUrl}/_api/web/GetFolderByServerRelativePath(DecodedUrl='${formatting.encodeQueryParameter(serverRelativePath)}')`;
-    if (options.recycle) {
+    if (!options.permanent) {
       requestUrl += `/recycle()`;
     }
     const requestOptions: CliRequestOptions = {

--- a/src/m365/spo/commands/folder/folder-remove.ts
+++ b/src/m365/spo/commands/folder/folder-remove.ts
@@ -83,7 +83,7 @@ class SpoFolderRemoveCommand extends SpoCommand {
       await this.removeFolder(logger, args.options);
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? "permanently remove" : "recycle"} the folder ${args.options.url} located in site ${args.options.webUrl}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? 'permanently remove' : 'recycle'} the folder ${args.options.url} located in site ${args.options.webUrl}?` });
 
       if (result) {
         await this.removeFolder(logger, args.options);

--- a/src/m365/spo/commands/list/list-remove.spec.ts
+++ b/src/m365/spo/commands/list/list-remove.spec.ts
@@ -77,7 +77,7 @@ describe(commands.LIST_REMOVE, () => {
   });
 
   it('prompts before removing list when confirmation argument not passed (id)', async () => {
-    await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com' } });
+    await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', permanent: true } });
 
     assert(promptIssued);
   });
@@ -91,7 +91,7 @@ describe(commands.LIST_REMOVE, () => {
   it('aborts removing list when prompt not confirmed', async () => {
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(false);
-    await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com' } });
+    await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', permanent: true } });
     assert(requests.length === 0);
   });
 
@@ -107,7 +107,7 @@ describe(commands.LIST_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com' } });
+    await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url === `${webUrl}/_api/web/lists(guid'${listId}')`) {
@@ -127,7 +127,7 @@ describe(commands.LIST_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', force: true } });
+    await command.action(logger, { options: { id: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', permanent: true, force: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url === `${webUrl}/_api/web/lists(guid'${listId}')`) {
@@ -137,7 +137,7 @@ describe(commands.LIST_REMOVE, () => {
     assert(correctRequestIssued);
   });
 
-  it('uses correct API url when recycle option is passed', async () => {
+  it('uses correct recycle API URL by default', async () => {
     const postStub = sinon.stub(request, 'post').callsFake(async (opts) => {
       if (opts.url === `${webUrl}/_api/web/lists/GetByTitle('${listTitle}')/recycle`) {
         return;
@@ -149,7 +149,6 @@ describe(commands.LIST_REMOVE, () => {
     await command.action(logger, {
       options: {
         title: 'Documents',
-        recycle: true,
         webUrl: 'https://contoso.sharepoint.com',
         force: true
       }
@@ -185,6 +184,7 @@ describe(commands.LIST_REMOVE, () => {
         debug: true,
         title: actionTitle,
         webUrl: 'https://contoso.sharepoint.com',
+        permanent: true,
         force: true
       }
     }), new CommandError(error.error['odata.error'].message.value));

--- a/src/m365/spo/commands/list/list-remove.ts
+++ b/src/m365/spo/commands/list/list-remove.ts
@@ -15,7 +15,7 @@ interface Options extends GlobalOptions {
   webUrl: string;
   id?: string;
   title?: string;
-  recycle?: boolean;
+  permanent?: boolean;
   force?: boolean;
 }
 
@@ -44,7 +44,7 @@ class SpoListRemoveCommand extends SpoCommand {
         id: typeof args.options.id !== 'undefined',
         title: typeof args.options.title !== 'undefined',
         force: !!args.options.force,
-        recycle: !!args.options.recycle
+        permanent: !!args.options.permanent
       });
     });
   }
@@ -61,7 +61,7 @@ class SpoListRemoveCommand extends SpoCommand {
         option: '-t, --title [title]'
       },
       {
-        option: '--recycle'
+        option: '--permanent'
       },
       {
         option: '-f, --force'
@@ -93,7 +93,7 @@ class SpoListRemoveCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push('id', 'title', 'webUrl');
-    this.types.boolean.push('force', 'recycle');
+    this.types.boolean.push('force', 'permanent');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -111,7 +111,7 @@ class SpoListRemoveCommand extends SpoCommand {
         requestUrl = `${args.options.webUrl}/_api/web/lists/GetByTitle('${formatting.encodeQueryParameter(args.options.title as string)}')`;
       }
 
-      if (args.options.recycle) {
+      if (!args.options.permanent) {
         requestUrl += `/recycle`;
       }
 

--- a/src/m365/spo/commands/listitem/listitem-batch-remove.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-remove.spec.ts
@@ -91,7 +91,7 @@ describe(commands.LISTITEM_BATCH_REMOVE, () => {
   });
 
   it('prompts before removing list items when confirmation argument not passed', async () => {
-    await command.action(logger, { options: { webUrl: webUrl, listId: listId, ids: ids } });
+    await command.action(logger, { options: { webUrl: webUrl, listId: listId, ids: ids, permanent: true } });
 
     assert(promptIssued);
   });
@@ -118,7 +118,7 @@ describe(commands.LISTITEM_BATCH_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, recycle: true, verbose: true } });
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, verbose: true } });
     assert(postStub.calledOnce);
   });
 
@@ -134,7 +134,7 @@ describe(commands.LISTITEM_BATCH_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, recycle: true, verbose: true } });
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listId: listId, verbose: true } });
     assert(postStub.calledOnce);
   });
 
@@ -146,7 +146,7 @@ describe(commands.LISTITEM_BATCH_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, ids: ids, listId: listId, force: true, verbose: true } });
+    await command.action(logger, { options: { webUrl: webUrl, ids: ids, listId: listId, permanent: true, force: true, verbose: true } });
     assert(postStub.calledOnce);
   });
 
@@ -192,7 +192,7 @@ describe(commands.LISTITEM_BATCH_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, recycle: true, verbose: true } });
+    await command.action(logger, { options: { webUrl: webUrl, filePath: filePath, listUrl: listUrl, verbose: true } });
     assert.strictEqual(amountOfRequestsInBody, 150);
   });
 

--- a/src/m365/spo/commands/listitem/listitem-batch-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-remove.ts
@@ -22,7 +22,7 @@ interface Options extends GlobalOptions {
   listId?: string;
   listTitle?: string;
   listUrl?: string;
-  recycle?: boolean;
+  permanent?: boolean;
   force?: boolean;
 }
 
@@ -53,7 +53,7 @@ class SpoListItemBatchRemoveCommand extends SpoCommand {
         listId: typeof args.options.listId !== 'undefined',
         listTitle: typeof args.options.listTitle !== 'undefined',
         listUrl: typeof args.options.listUrl !== 'undefined',
-        recycle: !!args.options.recycle,
+        permanent: !!args.options.permanent,
         force: !!args.options.force
       });
     });
@@ -80,7 +80,7 @@ class SpoListItemBatchRemoveCommand extends SpoCommand {
         option: '-i, --ids [ids]'
       },
       {
-        option: '-r, --recycle'
+        option: '--permanent'
       },
       {
         option: '-f, --force'
@@ -144,6 +144,7 @@ class SpoListItemBatchRemoveCommand extends SpoCommand {
       'ids',
       'filePath'
     );
+    this.types.boolean.push('permanent');
   }
 
   #initOptionSets(): void {
@@ -189,7 +190,7 @@ class SpoListItemBatchRemoveCommand extends SpoCommand {
       await removeListItems();
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.recycle ? "recycle" : "remove"} the list items from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? "permanently remove" : "recycle"} the list items from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
 
       if (result) {
         await removeListItems();
@@ -297,7 +298,7 @@ class SpoListItemBatchRemoveCommand extends SpoCommand {
 
     requestUrl += `/items(${item})`;
 
-    if (options.recycle) {
+    if (!options.permanent) {
       requestUrl += '/recycle()';
     }
 

--- a/src/m365/spo/commands/listitem/listitem-batch-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-batch-remove.ts
@@ -144,7 +144,7 @@ class SpoListItemBatchRemoveCommand extends SpoCommand {
       'ids',
       'filePath'
     );
-    this.types.boolean.push('permanent');
+    this.types.boolean.push('permanent', 'force');
   }
 
   #initOptionSets(): void {
@@ -190,7 +190,7 @@ class SpoListItemBatchRemoveCommand extends SpoCommand {
       await removeListItems();
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? "permanently remove" : "recycle"} the list items from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? 'permanently remove' : 'recycle'} the list items from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
 
       if (result) {
         await removeListItems();

--- a/src/m365/spo/commands/listitem/listitem-remove.spec.ts
+++ b/src/m365/spo/commands/listitem/listitem-remove.spec.ts
@@ -114,7 +114,7 @@ describe(commands.LISTITEM_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { listId: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', id: 1 } });
+    await command.action(logger, { options: { listId: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', id: 1, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`/_api/web/lists(guid'`) > -1 &&
@@ -141,7 +141,7 @@ describe(commands.LISTITEM_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { verbose: true, listUrl: listUrl, webUrl: webUrl, id: 1 } });
+    await command.action(logger, { options: { verbose: true, listUrl: listUrl, webUrl: webUrl, id: 1, permanent: true } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url === `https://contoso.sharepoint.com/sites/project-x/_api/web/GetList('${formatting.encodeQueryParameter(listServerRelativeUrl)}')/items(1)` &&
@@ -171,7 +171,7 @@ describe(commands.LISTITEM_REMOVE, () => {
 
     sinonUtil.restore(cli.promptForConfirmation);
     sinon.stub(cli, 'promptForConfirmation').resolves(true);
-    await command.action(logger, { options: { listId: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', id: 1, recycle: true } });
+    await command.action(logger, { options: { listId: 'b2307a39-e878-458b-bc90-03bc578531d6', webUrl: 'https://contoso.sharepoint.com', id: 1 } });
     let correctRequestIssued = false;
     requests.forEach(r => {
       if (r.url.indexOf(`/recycle()`) > -1 &&
@@ -201,6 +201,7 @@ describe(commands.LISTITEM_REMOVE, () => {
         debug: true,
         title: actionTitle,
         webUrl: 'https://contoso.sharepoint.com',
+        permanent: true,
         force: true
       }
     }), new CommandError(err));
@@ -227,7 +228,7 @@ describe(commands.LISTITEM_REMOVE, () => {
     });
   });
 
-  it('uses correct API url when recycle option is passed', async () => {
+  it('uses correct recycle API URL by default', async () => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf('/recycle()') > -1) {
         return Promise.resolve('Correct Url');
@@ -242,7 +243,6 @@ describe(commands.LISTITEM_REMOVE, () => {
       options: {
         id: actionId,
         listTitle: 'Documents',
-        recycle: true,
         webUrl: 'https://contoso.sharepoint.com',
         force: true
       }

--- a/src/m365/spo/commands/listitem/listitem-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-remove.ts
@@ -18,7 +18,7 @@ interface Options extends GlobalOptions {
   listTitle?: string;
   listUrl?: string;
   id: string;
-  recycle?: boolean;
+  permanent?: boolean;
   force?: boolean;
 }
 
@@ -38,6 +38,7 @@ class SpoListItemRemoveCommand extends SpoCommand {
     this.#initOptions();
     this.#initValidators();
     this.#initOptionSets();
+    this.#initTypes();
   }
 
   #initTelemetry(): void {
@@ -46,7 +47,7 @@ class SpoListItemRemoveCommand extends SpoCommand {
         listId: typeof args.options.listId !== 'undefined',
         listTitle: typeof args.options.listTitle !== 'undefined',
         listUrl: typeof args.options.listUrl !== 'undefined',
-        recycle: !!args.options.recycle,
+        permanent: !!args.options.permanent,
         force: !!args.options.force
       });
     });
@@ -70,7 +71,7 @@ class SpoListItemRemoveCommand extends SpoCommand {
         option: '--listUrl [listUrl]'
       },
       {
-        option: '--recycle'
+        option: '--permanent'
       },
       {
         option: '-f, --force'
@@ -105,6 +106,10 @@ class SpoListItemRemoveCommand extends SpoCommand {
     this.optionSets.push({ options: ['listId', 'listTitle', 'listUrl'] });
   }
 
+  #initTypes(): void {
+    this.types.boolean.push('permanent');
+  }
+
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
     const removeListItem: () => Promise<void> = async (): Promise<void> => {
       if (this.verbose) {
@@ -126,7 +131,7 @@ class SpoListItemRemoveCommand extends SpoCommand {
 
       requestUrl += `/items(${args.options.id})`;
 
-      if (args.options.recycle) {
+      if (!args.options.permanent) {
         requestUrl += `/recycle()`;
       }
 
@@ -154,7 +159,7 @@ class SpoListItemRemoveCommand extends SpoCommand {
       await removeListItem();
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.recycle ? "recycle" : "remove"} the list item ${args.options.id} from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? "permanently remove" : "recycle"} the list item ${args.options.id} from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
 
       if (result) {
         await removeListItem();

--- a/src/m365/spo/commands/listitem/listitem-remove.ts
+++ b/src/m365/spo/commands/listitem/listitem-remove.ts
@@ -107,7 +107,7 @@ class SpoListItemRemoveCommand extends SpoCommand {
   }
 
   #initTypes(): void {
-    this.types.boolean.push('permanent');
+    this.types.boolean.push('permanent', 'force');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -159,7 +159,7 @@ class SpoListItemRemoveCommand extends SpoCommand {
       await removeListItem();
     }
     else {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? "permanently remove" : "recycle"} the list item ${args.options.id} from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you want to ${args.options.permanent ? 'permanently remove' : 'recycle'} the list item ${args.options.id} from list ${args.options.listId || args.options.listTitle || args.options.listUrl} located in site ${args.options.webUrl}?` });
 
       if (result) {
         await removeListItem();

--- a/src/m365/spo/commands/page/page-remove.spec.ts
+++ b/src/m365/spo/commands/page/page-remove.spec.ts
@@ -130,6 +130,7 @@ describe(commands.PAGE_REMOVE, () => {
         options: {
           webUrl: webUrl,
           name: pageName,
+          permanent: true,
           force: true
         }
       });
@@ -146,6 +147,7 @@ describe(commands.PAGE_REMOVE, () => {
         options: {
           webUrl: webUrl,
           name: pageName,
+          permanent: true,
           verbose: true
         }
       });
@@ -160,7 +162,6 @@ describe(commands.PAGE_REMOVE, () => {
         options: {
           webUrl: webUrl,
           name: pageName,
-          recycle: true,
           force: true
         }
       });
@@ -176,6 +177,7 @@ describe(commands.PAGE_REMOVE, () => {
           webUrl: webUrl,
           name: pageName,
           bypassSharedLock: true,
+          permanent: true,
           force: true
         }
       });
@@ -189,7 +191,6 @@ describe(commands.PAGE_REMOVE, () => {
         options: {
           webUrl: webUrl,
           name: pageName.substring(0, pageName.lastIndexOf('.')),
-          recycle: true,
           force: true
         }
       });
@@ -215,6 +216,7 @@ describe(commands.PAGE_REMOVE, () => {
         options: {
           webUrl: webUrl,
           name: pageUrl,
+          permanent: true,
           force: true
         }
       });
@@ -237,7 +239,7 @@ describe(commands.PAGE_REMOVE, () => {
       }
     });
 
-    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, name: pageName, force: true } }),
+    await assert.rejects(command.action(logger, { options: { webUrl: webUrl, name: pageName, permanent: true, force: true } }),
       new CommandError(errorMessage));
   });
 

--- a/src/m365/spo/commands/page/page-remove.ts
+++ b/src/m365/spo/commands/page/page-remove.ts
@@ -15,7 +15,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   webUrl: string;
   name: string;
-  recycle?: boolean;
+  permanent?: boolean;
   bypassSharedLock?: boolean;
   force?: boolean;
 }
@@ -42,7 +42,7 @@ class SpoPageRemoveCommand extends SpoCommand {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
         force: !!args.options.force,
-        recycle: !!args.options.recycle,
+        permanent: !!args.options.permanent,
         bypassSharedLock: !!args.options.bypassSharedLock
       });
     });
@@ -57,7 +57,7 @@ class SpoPageRemoveCommand extends SpoCommand {
         option: '-n, --name <name>'
       },
       {
-        option: '--recycle'
+        option: '--permanent'
       },
       {
         option: '--bypassSharedLock'
@@ -76,7 +76,7 @@ class SpoPageRemoveCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push('name', 'webUrl');
-    this.types.boolean.push('force', 'bypassSharedLock', 'recycle');
+    this.types.boolean.push('force', 'bypassSharedLock', 'permanent');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -116,13 +116,12 @@ class SpoPageRemoveCommand extends SpoCommand {
       if (args.options.bypassSharedLock) {
         requestOptions.headers!.Prefer = 'bypass-shared-lock';
       }
-      if (args.options.recycle) {
-        requestOptions.url += '/Recycle';
-
-        await request.post(requestOptions);
+      if (args.options.permanent) {
+        await request.delete(requestOptions);
       }
       else {
-        await request.delete(requestOptions);
+        requestOptions.url += '/Recycle';
+        await request.post(requestOptions);
       }
     }
     catch (err: any) {

--- a/src/m365/spo/commands/site/site-remove.spec.ts
+++ b/src/m365/spo/commands/site/site-remove.spec.ts
@@ -121,7 +121,7 @@ describe(commands.SITE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { url: siteUrl, skipRecycleBin: true, force: true, verbose: true } });
+    await command.action(logger, { options: { url: siteUrl, permanent: true, force: true, verbose: true } });
     assert(postStub.calledTwice);
     assert.strictEqual(postStub.firstCall.args[0].data.siteUrl, siteUrl);
     assert.strictEqual(postStub.secondCall.args[0].data.siteUrl, siteUrl);
@@ -202,7 +202,7 @@ describe(commands.SITE_REMOVE, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { url: siteUrl, skipRecycleBin: true, force: true, verbose: true } });
+    await command.action(logger, { options: { url: siteUrl, permanent: true, force: true, verbose: true } });
     assert(postStub.calledTwice);
     assert(deleteStub.calledOnce);
   });
@@ -238,7 +238,7 @@ describe(commands.SITE_REMOVE, () => {
 
     const deleteStub = sinon.stub(request, 'delete').resolves();
 
-    await command.action(logger, { options: { url: siteUrl, skipRecycleBin: true, force: true, verbose: true } });
+    await command.action(logger, { options: { url: siteUrl, permanent: true, force: true, verbose: true } });
     assert(postStub.calledTwice);
     assert(deleteStub.notCalled);
   });
@@ -384,8 +384,8 @@ describe(commands.SITE_REMOVE, () => {
     assert.strictEqual(actual, true);
   });
 
-  it('passes validation if only skipRecycleBin is specified', async () => {
-    const actual = await command.validate({ options: { url: siteUrl, skipRecycleBin: true } }, commandInfo);
+  it('passes validation if only permanent is specified', async () => {
+    const actual = await command.validate({ options: { url: siteUrl, permanent: true } }, commandInfo);
     assert.strictEqual(actual, true);
   });
 
@@ -399,8 +399,8 @@ describe(commands.SITE_REMOVE, () => {
     assert.notStrictEqual(actual, true);
   });
 
-  it('fails validation if both fromRecycleBin and skipRecycleBin are specified', async () => {
-    const actual = await command.validate({ options: { url: siteUrl, fromRecycleBin: true, skipRecycleBin: true } }, commandInfo);
+  it('fails validation if both fromRecycleBin and permanent are specified', async () => {
+    const actual = await command.validate({ options: { url: siteUrl, fromRecycleBin: true, permanent: true } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 });

--- a/src/m365/spo/commands/site/site-remove.spec.ts
+++ b/src/m365/spo/commands/site/site-remove.spec.ts
@@ -127,6 +127,16 @@ describe(commands.SITE_REMOVE, () => {
     assert.strictEqual(postStub.secondCall.args[0].data.siteUrl, siteUrl);
   });
 
+  it('supports the deprecated skipRecycleBin option', async () => {
+    sinon.stub(odata, 'getAllItems').resolves([siteDetailsNonGroup]);
+    const postStub = sinon.stub(request, 'post').resolves();
+
+    await command.action(logger, { options: { url: siteUrl, skipRecycleBin: true, force: true } });
+
+    assert(postStub.calledTwice);
+    assert(log.includes(`Option 'skipRecycleBin' is deprecated. Please use 'permanent' instead.`));
+  });
+
   it('deletes a group site, deletes the m365 group from entra id', async () => {
     sinon.stub(odata, 'getAllItems').callsFake(async (url) => {
       if (url === odataUrl) {
@@ -401,6 +411,11 @@ describe(commands.SITE_REMOVE, () => {
 
   it('fails validation if both fromRecycleBin and permanent are specified', async () => {
     const actual = await command.validate({ options: { url: siteUrl, fromRecycleBin: true, permanent: true } }, commandInfo);
+    assert.notStrictEqual(actual, true);
+  });
+
+  it('fails validation if both fromRecycleBin and skipRecycleBin are specified', async () => {
+    const actual = await command.validate({ options: { url: siteUrl, fromRecycleBin: true, skipRecycleBin: true } }, commandInfo);
     assert.notStrictEqual(actual, true);
   });
 });

--- a/src/m365/spo/commands/site/site-remove.ts
+++ b/src/m365/spo/commands/site/site-remove.ts
@@ -17,7 +17,7 @@ interface CommandArgs {
 
 interface Options extends GlobalOptions {
   url: string;
-  skipRecycleBin?: boolean;
+  permanent?: boolean;
   fromRecycleBin?: boolean;
   force?: boolean;
 }
@@ -52,7 +52,7 @@ class SpoSiteRemoveCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        skipRecycleBin: !!args.options.skipRecycleBin,
+        permanent: !!args.options.permanent,
         fromRecycleBin: !!args.options.fromRecycleBin,
         force: !!args.options.force
       });
@@ -65,7 +65,7 @@ class SpoSiteRemoveCommand extends SpoCommand {
         option: '-u, --url <url>'
       },
       {
-        option: '--skipRecycleBin'
+        option: '--permanent'
       },
       {
         option: '--fromRecycleBin'
@@ -90,8 +90,8 @@ class SpoSiteRemoveCommand extends SpoCommand {
           return `The root site cannot be deleted.`;
         }
 
-        if (args.options.fromRecycleBin && args.options.skipRecycleBin) {
-          return 'Specify either fromRecycleBin or skipRecycleBin, but not both.';
+        if (args.options.fromRecycleBin && args.options.permanent) {
+          return 'Specify either fromRecycleBin or permanent, but not both.';
         }
 
         return true;
@@ -100,7 +100,7 @@ class SpoSiteRemoveCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push('url');
-    this.types.boolean.push('skipRecycleBin', 'fromRecycleBin', 'force');
+    this.types.boolean.push('permanent', 'fromRecycleBin', 'force');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
@@ -152,7 +152,7 @@ class SpoSiteRemoveCommand extends SpoCommand {
 
         if (isGroupSite) {
           await this.deleteGroupifiedSite(logger, siteUrl);
-          if (options.skipRecycleBin) {
+          if (options.permanent) {
             let isGroupInRecycleBin = await this.isGroupInEntraRecycleBin(logger, siteDetails.GroupId);
             let amountOfPolls = 0;
 
@@ -171,7 +171,7 @@ class SpoSiteRemoveCommand extends SpoCommand {
           await this.deleteNonGroupSite(logger, siteUrl);
         }
 
-        if (options.skipRecycleBin) {
+        if (options.permanent) {
           await this.deleteSiteFromSharePointRecycleBin(logger, siteUrl);
         }
       }

--- a/src/m365/spo/commands/site/site-remove.ts
+++ b/src/m365/spo/commands/site/site-remove.ts
@@ -18,6 +18,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   url: string;
   permanent?: boolean;
+  skipRecycleBin?: boolean;
   fromRecycleBin?: boolean;
   force?: boolean;
 }
@@ -52,7 +53,7 @@ class SpoSiteRemoveCommand extends SpoCommand {
   #initTelemetry(): void {
     this.telemetry.push((args: CommandArgs) => {
       Object.assign(this.telemetryProperties, {
-        permanent: !!args.options.permanent,
+        permanent: !!(args.options.permanent || args.options.skipRecycleBin),
         fromRecycleBin: !!args.options.fromRecycleBin,
         force: !!args.options.force
       });
@@ -66,6 +67,9 @@ class SpoSiteRemoveCommand extends SpoCommand {
       },
       {
         option: '--permanent'
+      },
+      {
+        option: '--skipRecycleBin'
       },
       {
         option: '--fromRecycleBin'
@@ -90,7 +94,7 @@ class SpoSiteRemoveCommand extends SpoCommand {
           return `The root site cannot be deleted.`;
         }
 
-        if (args.options.fromRecycleBin && args.options.permanent) {
+        if (args.options.fromRecycleBin && (args.options.permanent || args.options.skipRecycleBin)) {
           return 'Specify either fromRecycleBin or permanent, but not both.';
         }
 
@@ -100,10 +104,15 @@ class SpoSiteRemoveCommand extends SpoCommand {
 
   #initTypes(): void {
     this.types.string.push('url');
-    this.types.boolean.push('permanent', 'fromRecycleBin', 'force');
+    this.types.boolean.push('permanent', 'skipRecycleBin', 'fromRecycleBin', 'force');
   }
 
   public async commandAction(logger: Logger, args: CommandArgs): Promise<void> {
+    if (args.options.skipRecycleBin) {
+      await this.warn(logger, `Option 'skipRecycleBin' is deprecated. Please use 'permanent' instead.`);
+      args.options.permanent = true;
+    }
+
     if (args.options.force) {
       await this.removeSite(logger, args.options);
     }


### PR DESCRIPTION
Closes #7110

Updates destructive commands that support recycling to recycle by default and replaces `--recycle`/`--skipRecycleBin` with `--permanent`. Includes updated tests, telemetry, option typing, and documentation for all affected commands.

## Validation

- `nrb`: passes
- `nt`: 16,096 tests pass; the command exits on the existing upstream coverage gap in `src/utils/fsUtil.ts` lines 82-89 (99.99% global coverage)