### PR TITLE
Removes defaults from 'spo page header set'. Closes #7094

### DIFF
--- a/docs/docs/cmd/spo/page/page-header-set.mdx
+++ b/docs/docs/cmd/spo/page/page-header-set.mdx
@@ -22,7 +22,7 @@ m365 spo page header set [options]
 : URL of the site where the page to update is located.
 
 `-t, --type [type]`
-: Type of header, allowed values `None`, `Default`, `Custom`. Default `Default`.
+: Type of header, allowed values `None`, `Default`, `Custom`.
 
 `--imageUrl [imageUrl]`
 : Server-relative URL of the image to use in the header. Image must be stored in the same site collection as the page.
@@ -37,19 +37,19 @@ m365 spo page header set [options]
 : Y focal point of the header image.
 
 `--layout [layout]`
-: Layout to use in the header. Allowed values `FullWidthImage`, `NoImage`, `ColorBlock`, `CutInShape`. Default `FullWidthImage`.
+: Layout to use in the header. Allowed values `FullWidthImage`, `NoImage`, `ColorBlock`, `CutInShape`.
 
 `--textAlignment [textAlignment]`
-: How to align text in the header. Allowed values `Center`, `Left`. Default `Left`.
+: How to align text in the header. Allowed values `Center`, `Left`.
 
 `--showTopicHeader [showTopicHeader]`
-: Show the topic header. Valid values: `true`, `false`. Defaults to `false`.
+: Show the topic header. Valid values: `true`, `false`.
 
 `--showPublishDate [showPublishDate]`
-: Show the publishing date. Valid values: `true`, `false`. Defaults to `false`.
+: Show the publishing date. Valid values: `true`, `false`.
 
 `--showTimeToRead [showTimeToRead]`
-: Show the estimated time to read the page. Valid values: `true`, `false`. Defaults to `false`.
+: Show the estimated time to read the page. Valid values: `true`, `false`.
 
 `--topicHeader [topicHeader]`
 : Text to show in the topic header, when `showTopicHeader` is set.
@@ -81,16 +81,16 @@ m365 spo page header set [options]
 
 ## Examples
 
-Reset the page header to default
+Update the page header authors
 
 ```sh
-m365 spo page header set --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx
+m365 spo page header set --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --authors "steve@contoso.com, bob@contoso.com"
 ```
 
 Reset the page header to default and set authors
 
 ```sh
-m365 spo page header set --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --authors "steve@contoso.com, bob@contoso.com"
+m365 spo page header set --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --type Default --authors "steve@contoso.com, bob@contoso.com"
 ```
 
 Use the specified image focused on the given coordinates in the page header

--- a/src/m365/spo/commands/page/page-header-set.spec.ts
+++ b/src/m365/spo/commands/page/page-header-set.spec.ts
@@ -172,6 +172,74 @@ describe(commands.PAGE_HEADER_SET, () => {
     assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
+  it('preserves existing page header properties when options are not specified', async () => {
+    const existingHeader = {
+      id: 'cbe7b0a9-3504-44dd-a3a3-0e5cacd07788',
+      instanceId: 'cbe7b0a9-3504-44dd-a3a3-0e5cacd07788',
+      title: 'Title Region',
+      description: 'Title Region Description',
+      serverProcessedContent: {
+        htmlStrings: {},
+        searchablePlainTexts: {},
+        imageSources: {
+          imageSource: '/sites/newsletter/siteassets/hero.jpg'
+        },
+        links: {},
+        customMetadata: {
+          imageSource: {
+            siteId: 'c7678ab2-c9dc-454b-b2ee-7fcffb983d4e',
+            webId: '0df4d2d2-5ecf-45e9-94f5-c638106bfc65',
+            listId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
+            uniqueId: '102f496d-23a2-415f-803a-232b8a6c7613'
+          }
+        }
+      },
+      dataVersion: '1.4',
+      properties: {
+        imageSourceType: 2,
+        layoutType: 'ColorBlock',
+        textAlignment: 'Center',
+        showTopicHeader: true,
+        showPublishDate: true,
+        showTimeToRead: true,
+        topicHeader: 'Team Awesome',
+        authors: [],
+        altText: 'Existing alternative text',
+        webId: '0df4d2d2-5ecf-45e9-94f5-c638106bfc65',
+        siteId: 'c7678ab2-c9dc-454b-b2ee-7fcffb983d4e',
+        listId: 'e1557527-d333-49f2-9d60-ea8a3003fda8',
+        uniqueId: '102f496d-23a2-415f-803a-232b8a6c7613',
+        translateX: 42,
+        translateY: 56
+      }
+    };
+    const mockData = {
+      LayoutWebpartsContent: JSON.stringify([existingHeader]),
+      CanvasContent1: mockCanvasContentStringified
+    };
+
+    sinon.stub(request, 'get').callsFake(async (opts) => {
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$select=IsPageCheckedOutToCurrentUser,Title`) {
+        return {
+          IsPageCheckedOutToCurrentUser: true,
+          Title: 'Page'
+        };
+      }
+
+      if (opts.url === `https://contoso.sharepoint.com/sites/newsletter/_api/sitepages/pages/GetByUrl('sitepages/page.aspx')?$expand=ListItemAllFields`) {
+        return mockData;
+      }
+
+      throw 'Invalid request';
+    });
+
+    const postStub = sinon.stub(request, 'post').resolves();
+
+    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Custom' } });
+
+    assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
+  });
+
   it('sets page header to default when default type specified', async () => {
     const mockData = {
       LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{},"links":{}},"dataVersion":"1.4","properties":{"imageSourceType":4,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"showTimeToRead":false,"topicHeader":""}}]',
@@ -342,9 +410,9 @@ describe(commands.PAGE_HEADER_SET, () => {
     assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 
-  it('sets image to empty when header set to custom and no image specified', async () => {
+  it('sets custom header properties including an empty image URL', async () => {
     const mockData = {
-      LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":""},"links":{},"customMetadata":{"imageSource":{"siteId":"","webId":"","listId":"","uniqueId":""}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"FullWidthImage","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"showTimeToRead":false,"topicHeader":"","authors":[],"altText":"","webId":"","siteId":"","listId":"","uniqueId":"","translateX":0,"translateY":0}}]',
+      LayoutWebpartsContent: '[{"id":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","instanceId":"cbe7b0a9-3504-44dd-a3a3-0e5cacd07788","title":"Title Region","description":"Title Region Description","serverProcessedContent":{"htmlStrings":{},"searchablePlainTexts":{},"imageSources":{"imageSource":""},"links":{},"customMetadata":{"imageSource":{"siteId":"","webId":"","listId":"","uniqueId":""}}},"dataVersion":"1.4","properties":{"imageSourceType":2,"layoutType":"ColorBlock","textAlignment":"Left","showTopicHeader":false,"showPublishDate":false,"showTimeToRead":false,"topicHeader":"","authors":[],"altText":"Updated alternative text","webId":"","siteId":"","listId":"","uniqueId":"","translateX":0,"translateY":0}}]',
       CanvasContent1: mockCanvasContentStringified
     };
 
@@ -371,7 +439,16 @@ describe(commands.PAGE_HEADER_SET, () => {
       throw 'Invalid request';
     });
 
-    await command.action(logger, { options: { pageName: 'page.aspx', webUrl: 'https://contoso.sharepoint.com/sites/newsletter', type: 'Custom' } });
+    await command.action(logger, {
+      options: {
+        pageName: 'page.aspx',
+        webUrl: 'https://contoso.sharepoint.com/sites/newsletter',
+        type: 'Custom',
+        imageUrl: '',
+        altText: 'Updated alternative text',
+        layout: 'ColorBlock'
+      }
+    });
     assert.deepStrictEqual(postStub.lastCall.args[0].data, mockData);
   });
 

--- a/src/m365/spo/commands/page/page-header-set.ts
+++ b/src/m365/spo/commands/page/page-header-set.ts
@@ -292,20 +292,6 @@ class SpoPageHeaderSetCommand extends SpoCommand {
         pageData = await Page.checkout(pageFullName, args.options.webUrl, logger, this.verbose);
       }
 
-      let header: PageHeader | CustomPageHeader;
-      switch (args.options.type) {
-        case 'None':
-          header = noPageHeader;
-          break;
-        case 'Custom':
-          header = customPageHeader;
-          break;
-        case 'Default':
-        default:
-          header = defaultPageHeader;
-          break;
-      }
-
       if (pageData) {
         canvasContent = pageData.CanvasContent1;
         authorByline = authorByline.length > 0 ? authorByline : pageData.AuthorByline;
@@ -319,69 +305,144 @@ class SpoPageHeaderSetCommand extends SpoCommand {
       //In the new design page header is is a configurable Banner webpart in the first full-width section
       const headerControl: PageControl | undefined = pageControls.find(control => control?.position?.zoneIndex === 1 && control?.position?.sectionFactor === 0 && control?.webPartId === BannerWebPartId);
       const isStandardPageHeader: boolean = pageData.LayoutWebpartsContent !== '[]';
+      const existingHeader: PageHeader | CustomPageHeader | undefined = isStandardPageHeader && typeof pageData.LayoutWebpartsContent === 'string'
+        ? JSON.parse(pageData.LayoutWebpartsContent)[0] as PageHeader | CustomPageHeader
+        : headerControl?.webPartData as any;
 
-      //LayoutWebpartsContent represents standard page header
-      if (!isStandardPageHeader) {
-        header = headerControl?.webPartData as any || header;
+      let header: PageHeader | CustomPageHeader;
+      switch (args.options.type) {
+        case 'None':
+          header = noPageHeader;
+          break;
+        case 'Custom':
+          header = customPageHeader;
+          break;
+        case 'Default':
+          header = defaultPageHeader;
+          break;
+        default:
+          header = existingHeader || defaultPageHeader;
+          break;
+      }
+
+      if (existingHeader && args.options.type !== 'None') {
+        if (typeof args.options.textAlignment === 'undefined') {
+          header.properties.textAlignment = existingHeader.properties.textAlignment;
+        }
+        if (typeof args.options.showTopicHeader === 'undefined') {
+          header.properties.showTopicHeader = existingHeader.properties.showTopicHeader;
+        }
+        if (typeof args.options.topicHeader === 'undefined') {
+          header.properties.topicHeader = existingHeader.properties.topicHeader;
+        }
+        if (typeof args.options.showPublishDate === 'undefined') {
+          header.properties.showPublishDate = existingHeader.properties.showPublishDate;
+        }
+        if (typeof args.options.showTimeToRead === 'undefined') {
+          header.properties.showTimeToRead = existingHeader.properties.showTimeToRead;
+        }
+        if (typeof args.options.layout === 'undefined') {
+          header.properties.layoutType = existingHeader.properties.layoutType;
+        }
+
+        if (header.properties.imageSourceType === 2 && existingHeader.properties.imageSourceType === 2) {
+          const properties: CustomPageHeaderProperties = header.properties as CustomPageHeaderProperties;
+          const existingProperties: CustomPageHeaderProperties = existingHeader.properties as CustomPageHeaderProperties;
+          if (typeof args.options.altText === 'undefined') {
+            properties.altText = existingProperties.altText;
+          }
+          if (typeof args.options.translateX === 'undefined') {
+            properties.translateX = existingProperties.translateX;
+          }
+          if (typeof args.options.translateY === 'undefined') {
+            properties.translateY = existingProperties.translateY;
+          }
+          if (typeof args.options.imageUrl === 'undefined') {
+            properties.listId = existingProperties.listId;
+            properties.siteId = existingProperties.siteId;
+            properties.uniqueId = existingProperties.uniqueId;
+            properties.webId = existingProperties.webId;
+            header.serverProcessedContent = existingHeader.serverProcessedContent;
+          }
+        }
       }
 
       header.properties.title = title;
-      header.properties.textAlignment = args.options.textAlignment as any || 'Left';
-      header.properties.showTopicHeader = args.options.showTopicHeader || false;
-      header.properties.topicHeader = args.options.topicHeader || '';
-      header.properties.showPublishDate = args.options.showPublishDate || false;
-      header.properties.showTimeToRead = args.options.showTimeToRead || false;
-
-      if (args.options.type !== 'None') {
-        header.properties.layoutType = args.options.layout as any || 'FullWidthImage';
+      if (typeof args.options.textAlignment !== 'undefined') {
+        header.properties.textAlignment = args.options.textAlignment as any;
+      }
+      if (typeof args.options.showTopicHeader !== 'undefined') {
+        header.properties.showTopicHeader = args.options.showTopicHeader;
+      }
+      if (typeof args.options.topicHeader !== 'undefined') {
+        header.properties.topicHeader = args.options.topicHeader;
+      }
+      if (typeof args.options.showPublishDate !== 'undefined') {
+        header.properties.showPublishDate = args.options.showPublishDate;
+      }
+      if (typeof args.options.showTimeToRead !== 'undefined') {
+        header.properties.showTimeToRead = args.options.showTimeToRead;
       }
 
-      if (args.options.type === 'Custom') {
-        header.serverProcessedContent.imageSources = {
-          imageSource: args.options.imageUrl || ''
-        };
+      if (args.options.type !== 'None' && typeof args.options.layout !== 'undefined') {
+        header.properties.layoutType = args.options.layout as any;
+      }
+
+      if (header.properties.imageSourceType === 2) {
         const properties: CustomPageHeaderProperties = header.properties as CustomPageHeaderProperties;
-        properties.altText = args.options.altText || '';
-        properties.translateX = args.options.translateX || 0;
-        properties.translateY = args.options.translateY || 0;
+        if (typeof args.options.altText !== 'undefined') {
+          properties.altText = args.options.altText;
+        }
+        if (typeof args.options.translateX !== 'undefined') {
+          properties.translateX = args.options.translateX;
+        }
+        if (typeof args.options.translateY !== 'undefined') {
+          properties.translateY = args.options.translateY;
+        }
         header.properties = properties;
 
-        if (!args.options.imageUrl) {
-          (header.serverProcessedContent as CustomPageHeaderServerProcessedContent).customMetadata = {
-            imageSource: {
-              siteId: '',
-              webId: '',
-              listId: '',
-              uniqueId: ''
-            }
+        if (typeof args.options.imageUrl !== 'undefined') {
+          header.serverProcessedContent.imageSources = {
+            imageSource: args.options.imageUrl
           };
-          properties.listId = '';
-          properties.siteId = '';
-          properties.uniqueId = '';
-          properties.webId = '';
-          header.properties = properties;
-        }
-        else {
-          const res = await Promise.all([
-            spo.getSiteIdBySPApi(args.options.webUrl, logger, this.verbose),
-            spo.getWebId(args.options.webUrl, logger, this.verbose),
-            this.getImageInfo(args.options.webUrl, args.options.imageUrl as string, this.verbose, logger)
-          ]);
 
-          (header.serverProcessedContent as CustomPageHeaderServerProcessedContent).customMetadata = {
-            imageSource: {
-              siteId: res[0],
-              webId: res[1],
-              listId: res[2].ListId,
-              uniqueId: res[2].UniqueId
-            }
-          };
-          const properties: CustomPageHeaderProperties = header.properties as CustomPageHeaderProperties;
-          properties.listId = res[2].ListId;
-          properties.siteId = res[0];
-          properties.uniqueId = res[2].UniqueId;
-          properties.webId = res[1];
-          header.properties = properties;
+          if (!args.options.imageUrl) {
+            (header.serverProcessedContent as CustomPageHeaderServerProcessedContent).customMetadata = {
+              imageSource: {
+                siteId: '',
+                webId: '',
+                listId: '',
+                uniqueId: ''
+              }
+            };
+            properties.listId = '';
+            properties.siteId = '';
+            properties.uniqueId = '';
+            properties.webId = '';
+            header.properties = properties;
+          }
+          else {
+            const res = await Promise.all([
+              spo.getSiteIdBySPApi(args.options.webUrl, logger, this.verbose),
+              spo.getWebId(args.options.webUrl, logger, this.verbose),
+              this.getImageInfo(args.options.webUrl, args.options.imageUrl as string, this.verbose, logger)
+            ]);
+
+            (header.serverProcessedContent as CustomPageHeaderServerProcessedContent).customMetadata = {
+              imageSource: {
+                siteId: res[0],
+                webId: res[1],
+                listId: res[2].ListId,
+                uniqueId: res[2].UniqueId
+              }
+            };
+            const properties: CustomPageHeaderProperties = header.properties as CustomPageHeaderProperties;
+            properties.listId = res[2].ListId;
+            properties.siteId = res[0];
+            properties.uniqueId = res[2].UniqueId;
+            properties.webId = res[1];
+            header.properties = properties;
+          }
         }
       }
 


### PR DESCRIPTION
Closes #7094

Updates `spo page header set` to preserve existing header properties when their options are omitted, including when the current header type is explicitly specified. Updates the command documentation and adds regression coverage for non-default existing values.