### PR TITLE
Updates item archive warning

### DIFF
--- a/docs/docs/cmd/spo/file/file-archive.mdx
+++ b/docs/docs/cmd/spo/file/file-archive.mdx
@@ -30,6 +30,14 @@ m365 spo file archive [options]
 
 <Global />
 
+## Remarks
+
+:::warning
+
+You will be able to reactivate an archived file instantly for the first 7 days. After that, it will take up to 24 hours to reactivate.
+
+:::
+
 ## Permissions
 
 <Tabs>

--- a/docs/docs/cmd/spo/file/file-unarchive.mdx
+++ b/docs/docs/cmd/spo/file/file-unarchive.mdx
@@ -30,6 +30,14 @@ m365 spo file unarchive [options]
 
 <Global />
 
+## Remarks
+
+:::warning
+
+Reactivation could take up to 24 hours. Files that are reactivated cannot be archived again for **120 days**.
+
+:::
+
 ## Permissions
 
 <Tabs>

--- a/docs/docs/cmd/spo/folder/folder-archive.mdx
+++ b/docs/docs/cmd/spo/folder/folder-archive.mdx
@@ -32,6 +32,12 @@ m365 spo folder archive [options]
 
 ## Remarks
 
+:::warning
+
+You will be able to reactivate an archived folder instantly for the first 7 days. After that, it will take up to 24 hours to reactivate.
+
+:::
+
 Folder archival can take some time to complete, as the status might not be reflected immediately.
 
 ## Permissions

--- a/src/m365/spo/commands/file/file-archive.ts
+++ b/src/m365/spo/commands/file/file-archive.ts
@@ -55,7 +55,7 @@ class SpoFileArchiveCommand extends SpoCommand {
     const { webUrl, url, id, force, verbose } = args.options;
 
     if (!force) {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you would like to archive this item? You will be able to reactivate it instantly for the first 7 days. After that, it will take up to 24 hours to reactivate.` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you would like to archive this file? You will be able to reactivate it instantly for the first 7 days. After that, it will take up to 24 hours to reactivate.` });
       if (!result) {
         return;
       }

--- a/src/m365/spo/commands/file/file-unarchive.ts
+++ b/src/m365/spo/commands/file/file-unarchive.ts
@@ -55,7 +55,7 @@ class SpoFileUnarchiveCommand extends SpoCommand {
     const { webUrl, url, id, force, verbose } = args.options;
 
     if (!force) {
-      const result = await cli.promptForConfirmation({ message: `Reactivation could take up to 24 hours. Files that are reactivated cannot be archived again for 30 days. Are you sure you would like to unarchive this item?` });
+      const result = await cli.promptForConfirmation({ message: `Reactivation could take up to 24 hours. Files that are reactivated cannot be archived again for a period of time. Are you sure you would like to unarchive this file?` });
       if (!result) {
         return;
       }

--- a/src/m365/spo/commands/folder/folder-archive.ts
+++ b/src/m365/spo/commands/folder/folder-archive.ts
@@ -55,7 +55,7 @@ class SpoFolderArchiveCommand extends SpoCommand {
     const { webUrl, url, id, force } = args.options;
 
     if (!force) {
-      const result = await cli.promptForConfirmation({ message: `Are you sure you would like to archive this item? You will be able to reactivate it instantly for the first 7 days. After that, it will take up to 24 hours to reactivate.` });
+      const result = await cli.promptForConfirmation({ message: `Are you sure you would like to archive this folder? You will be able to reactivate it instantly for the first 7 days. After that, it will take up to 24 hours to reactivate.` });
       if (!result) {
         return;
       }


### PR DESCRIPTION
The cooldown time for file-level archiving seems to be changing quite frequently. Therefore, let's pull the warning with the exact amount of dates to the docs so the CLI warning is not getting outdated.